### PR TITLE
Individual prefs now attributes of an object;  fixed bug in use of lambda fct as param spec

### DIFF
--- a/PsyNeuLink/Functions/Process.py
+++ b/PsyNeuLink/Functions/Process.py
@@ -742,7 +742,7 @@ class Process_Base(Process):
                             if self.learning:
                                 # Make sure projection includes a learningSignal and add one if it doesn't
                                 try:
-                                    matrix_param_state = projection.parameterStates['matrix']
+                                    matrix_param_state = projection.parameterStates[MATRIX]
 
                                 # projection doesn't have a parameterStates attrib, so assign one with self.learning
                                 except AttributeError:

--- a/PsyNeuLink/Functions/Utility.py
+++ b/PsyNeuLink/Functions/Utility.py
@@ -48,6 +48,31 @@ class UtilityFunctionOutputType(IntEnum):
     NP_1D_ARRAY = 1
     NP_2D_ARRAY = 2
 
+# *******************************   get_param_value_for_keyword ********************************************************
+#
+def get_param_value_for_keyword(owner, keyword):
+    try:
+        return owner.paramsCurrent[FUNCTION].keyword(keyword)
+    except UtilityError as e:
+        if owner.prefs.verbosePref:
+            print ("{} of {}".format(e, owner.name))
+        return None
+    except AttributeError:
+        if owner.prefs.verbosePref:
+            print ("Keyword ({}) not recognized for {}".format(keyword, owner.name))
+        return None
+
+def get_param_value_for_function(owner, function):
+    try:
+        return owner.paramsCurrent[FUNCTION].param_function(owner, function)
+    except UtilityError as e:
+        if owner.prefs.verbosePref:
+            print ("{} of {}".format(e, owner.name))
+        return None
+    except AttributeError:
+        if owner.prefs.verbosePref:
+            print ("Function ({}) can't be evaluated for {}".format(function, owner.name))
+        return None
 
 # class Utility_Base(Function):
 class Utility_Base(Utility):
@@ -1638,6 +1663,11 @@ class LinearMatrix(Utility_Base):  # -------------------------------------------
             raise UtilityError("Unrecognized keyword ({}) specified for LinearMatrix Utility Function".format(keyword))
         else:
             return matrix
+
+    def param_function(owner, function):
+        sender_len = len(owner.sender.value)
+        receiver_len = len(owner.receiver.variable)
+        return function(sender_len, receiver_len)
 
 def get_matrix(specification, rows=1, cols=1, context=NotImplemented):
     """Returns matrix conforming to specification with dimensions = rows x cols or None

--- a/PsyNeuLink/Globals/Keywords.py
+++ b/PsyNeuLink/Globals/Keywords.py
@@ -6,20 +6,22 @@
 # See the License for the specific language governing permissions and limitations under the License.
 #
 #
-# *******************************   get_param_value_for_keyword ********************************************************
+# # *******************************   get_param_value_for_keyword ******************************************************
+# #
+# def get_param_value_for_keyword(owner, keyword):
+#     from PsyNeuLink.Functions.Utility import UtilityError
+#     try:
+#         return owner.paramsCurrent[FUNCTION].keyword(keyword)
+#     except UtilityError as e:
+#         if owner.prefs.verbosePref:
+#             print ("{} of {}".format(e, owner.name))
+#         return None
+#     except AttributeError:
+#         if owner.prefs.verbosePref:
+#             print ("Keyword ({}) not recognized for {}".format(keyword, owner.name))
+#         return None
 #
-def get_param_value_for_keyword(owner, keyword):
-    from PsyNeuLink.Functions.Utility import UtilityError
-    try:
-        return owner.paramsCurrent[FUNCTION].keyword(keyword)
-    except UtilityError as e:
-        if owner.prefs.verbosePref:
-            print ("{} of {}".format(e, owner.name))
-        return None
-    except AttributeError:
-        if owner.prefs.verbosePref:
-            print ("Keyword ({}) not recognized for {}".format(keyword, owner.name))
-        return None
+
 
 # ********************************************  Keywords ***************************************************************
 #

--- a/Scripts/Multilayer Learning Test Script.py
+++ b/Scripts/Multilayer Learning Test Script.py
@@ -23,6 +23,7 @@ Output_Layer = Transfer(name='Output Layer',
                         function=Logistic(),
                         default_input_value = [0,0,0])
 
+# randomized_matrix = lambda sender, receiver, range, offset: ((range * np.random.rand(sender, receiver)) + offset)
 random_weight_matrix = lambda sender, receiver : random_matrix(sender, receiver, .2, -.1)
 
 # TEST PROCESS.LEARNING WITH:
@@ -34,11 +35,13 @@ random_weight_matrix = lambda sender, receiver : random_matrix(sender, receiver,
 Input_Weights = Mapping(name='Input Weights',
                         sender=Input_Layer,
                         receiver=Hidden_Layer_1,
-                        # matrix=(random_weight_matrix, LearningSignal()),
+                        # matrix=(random_weight_matrix),
+                        # matrix=(random_weight_matrix, LearningSignal),
+                        matrix=(random_weight_matrix, LearningSignal()),
                         # matrix=random_weight_matrix,
                         # matrix=(RANDOM_CONNECTIVITY_MATRIX),
                         # matrix=(RANDOM_CONNECTIVITY_MATRIX, LearningSignal),
-                        matrix=FULL_CONNECTIVITY_MATRIX
+                        # matrix=FULL_CONNECTIVITY_MATRIX
                         # matrix=(FULL_CONNECTIVITY_MATRIX, LearningSignal())
                         )
 

--- a/TODO List.py
+++ b/TODO List.py
@@ -178,6 +178,10 @@
 
 #region CURRENT: -------------------------------------------------------------------------------------------------------
 
+# 9/11/16:
+
+# IMPLEMENT: Add owner to Util functions (similar to states)
+
 # 8/25/16:
 
 # FIX: MAKE SURE LEARNING SIGNALS ON PROCESS ARE ALWAYS ADDED AS COPIES
@@ -677,6 +681,10 @@
 #  CLEAN UP THE FOLLOWING
 # - Combine "Parameters" section with "Initialization arguments" section in:
 #              Utility, Mapping, ControlSignal, and DDM documentation:
+
+# DOCUMENT: UTILITY FUNCTIONS:
+#           To use keywords for params, Utility Function must implement .keyword method that resolves it to value
+#           To use lambda functions for params, Utility Function must implement .lambda method that resolves it to value
 
 # DOCUMENT: kwCamelCase -> programmatic (internal use) keywords
 #           KEY_WORD -> user accessible (scripting use) keywords


### PR DESCRIPTION
• Function:
- added prefs as properties on Function objects 
     individual prefs can now be referenced and set directly as attributes of objects: object.pref
     (vs. object.prefs.pref)

• Process:
- fixed bug involving import of LearningSignal
  
  • State:
- fixed bug in parsing lambda function when used as specification of a param value
