### PR TITLE
docstrings for System in Numpy format;  internal method name changes for consistency

### DIFF
--- a/PsyNeuLink/Functions/System.py
+++ b/PsyNeuLink/Functions/System.py
@@ -36,7 +36,6 @@ Mechanisms within a system are designated as:
     note: designations are stored in the mechanism.systems attribute (see _instantiate_graph below, and Mechanism)
     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-
 Systems are represented by a graph (in the graph attribute) that can be passed to graph theoretical tools for analysis.
 
 Execution


### PR DESCRIPTION
• Project:
   - prependend internal methods with _:
       Function:
       _validate_variable
       _validate_params
       _validate_function
       _deferred_init
       _assign_args_to_param_dicts
       _create_attributes_for_user_params
       _check_args
       _check_kwFunction
       _instantiate_attributes_before_function
       _instantiate_function
       _instantiate_attributes_after_function
       _update_value
      Process:
       _instantiate_processes
       _instantiate_graph
       _assign_output_states
       _report_system_initiation
       _report_system_completion

• System:
  - fixed bug in MechanismList.mechanismNames
  - deprecated ProcessMechanismList and SystemMechanismList (consolidated under MechanismList)
  - docstrings fully formatted in Numpy format

[IN PROCESS:
• Process:
   - changed process.mechanismList to process.mech_tuples

• META Test Script:
   - changed f to file (to avoid homonymy with other objects called f)
