### PR TITLE
Convergent process does not require comparator or target

### DIFF
--- a/PsyNeuLink/Globals/Utilities.py
+++ b/PsyNeuLink/Globals/Utilities.py
@@ -125,7 +125,7 @@ class AutoNumber(IntEnum):
 TEST_CONDTION = False
 
 def is_numeric_or_none(x):
-    if not x:
+    if x is None:
         return True
     return is_numeric(x)
 

--- a/TODO List.py
+++ b/TODO List.py
@@ -1732,9 +1732,9 @@
 #
 # FIX: WHICH IS CORRECT (SEBASTIAN):
 #             # MODIFIED 12/4/16 OLD:
-#             self._mech_tuples.extend(self._monitoring__mech_tuples)
+#             self._mech_tuples.extend(self._monitoring_mech_tuples)
 #             # # MODIFIED 12/4/16 NEW:
-#             # self._mech_tuples.extend(reversed(self._monitoring__mech_tuples))
+#             # self._mech_tuples.extend(reversed(self._monitoring_mech_tuples))
 #             # MODIFIED 12/4/16 END
 
 # NOTE:  Can implement reward rate valuation by:


### PR DESCRIPTION
• Process:
   - added LEARNING for specification of ``learning`` argument/attribute
   - no longer require target if TERMINAL_MECHANISM belongs to another process that has a comparator mechanism
   - removed type-checking for target attribute (was interfereing with assignment of np.array)