### PR TITLE
limiting DDM.plot() to time step mode because of 'rate' vs 'drift_rat…

### DIFF
--- a/PsyNeuLink/Components/Mechanisms/ProcessingMechanisms/DDM.py
+++ b/PsyNeuLink/Components/Mechanisms/ProcessingMechanisms/DDM.py
@@ -505,9 +505,9 @@ class DDM(ProcessingMechanism_Base):
                                                   params=params,
                                                   context=context
                                                   )
-
-        self.get_axes_function = DDMIntegrator(rate=self.function_params['rate'], noise=self.function_params['noise'], context='plot').function
-        self.plot_function = DDMIntegrator(rate=self.function_params['rate'], noise=self.function_params['noise'], context='plot').function
+        if time_scale == TimeScale.TIME_STEP:
+            self.get_axes_function = DDMIntegrator(rate=self.function_params['rate'], noise=self.function_params['noise'], context='plot').function
+            self.plot_function = DDMIntegrator(rate=self.function_params['rate'], noise=self.function_params['noise'], context='plot').function
 
         self.variableClassDefault = self.paramClassDefaults[FUNCTION_PARAMS][STARTING_POINT]
 


### PR DESCRIPTION
…e' naming difference