### PR TITLE
Feat multiple gating projs per signal

### DIFF
--- a/PsyNeuLink/Globals/Keywords.py
+++ b/PsyNeuLink/Globals/Keywords.py
@@ -509,6 +509,7 @@ MAKE_DEFAULT_GATING_MECHANISM = "make_default_gating_mechanism"
 GATING_SIGNAL = 'gating_signal'
 GATING_SIGNALS = 'gating_signals'
 GATING_SIGNAL_SPECS = 'GATING_SIGNAL_SPECS'
+GATE = 'GATE'
 GATED_STATE = "gated_state"
 GATING_PROJECTIONS = 'GatingProjections'
 GATING_POLICY = 'gating_policy'

--- a/Scripts/DEBUGGING SCRIPTS/Multilayer Learning Test Script [WITH GATING].py
+++ b/Scripts/DEBUGGING SCRIPTS/Multilayer Learning Test Script [WITH GATING].py
@@ -29,11 +29,12 @@ random_weight_matrix = lambda sender, receiver : random_matrix(sender, receiver,
 Gating_Mechanism = GatingMechanism(default_gating_policy=1.0,
                                    gating_signals=[
                                        # THIS GENERATES ONE GATING SIGNAL WITH THREE PROJECTIONS:
-                                       {NAME: 'Hidden Layers',
-                                        STATE: [Hidden_Layer_1,
-                                                Hidden_Layer_2,
-                                                Output_Layer]
-                                        },
+                                       {
+                                       # NAME: 'GATING SIGNAL EXPLICIT NAME',
+                                        'GATE_ALL': [Hidden_Layer_1,
+                                                     Hidden_Layer_2,
+                                                     Output_Layer]
+},
                                        # THIS GENERATES THREE GATING SIGNALS EACH WITH ONE PROJECTION:
                                        # Hidden_Layer_1,
                                        # Hidden_Layer_2,


### PR DESCRIPTION
Multilayer Learning Test Script [WITH GATING] modified to show example with multiple GatingProjections from a single GatingSignal

GatingSignal modified to allow value of NAME entry in GatingSignal specification dictionary to override use of the key for the GatingSignals entry as name of the GatingSignal (examples in Multilayer Learning Test Script [WITH GATING] 
