### PR TITLE
Misc docstring revs

### DIFF
--- a/PsyNeuLink/Components/Projections/PathwayProjections/MappingProjection.py
+++ b/PsyNeuLink/Components/Projections/PathwayProjections/MappingProjection.py
@@ -14,21 +14,11 @@
 Overview
 --------
 
-COMMENT:
-    VERSION WITH MORE LINKS:
-    A MappingProjection transmits the `value <OutputState.OutputState.value>` of an `OutputState <OutputState>` of one
-    `ProcessingMechanism` (its `sender <MappingProjection.sender>`) to the `InputState <InputState>` of another
-    (its `receiver <MappingProjection.receiver>`).  The default `function <MappingProjection.function>` for a
-    MappingProjection is  `LinearMatrix`, which uses the MappingProjection's `matrix <MappingProjection.matrix>`
-    attribute to transform the value received from its `sender <MappingProjection.sender>` and provide the result to its
-    `receiver <MappingProjection.receiver>`.
-COMMENT
-
-A MappingProjection transmits the `value <OutputState.OutputState.value>` of an `OutputState <OutputState>` of one
-`ProcessingMechanism` (its sender) to the `InputState <InputState>` of another (its receiver).  The default function
-for a MappingProjection is  `LinearMatrix`, which uses the MappingProjection's `matrix <MappingProjection.matrix>`
-attribute to transform the value received from its sender and provide the result to its receiver.
-
+A MappingProjection transmits the `value <OutputState.value>` of an `OutputState` of one `ProcessingMechanism` (its
+`sender <MappingProjection.sender>`) to the `InputState` of another (its `receiver <MappingProjection.receiver>`).
+The default `function <MappingProjection.function>` for a MappingProjection is  `LinearMatrix`, which uses the
+MappingProjection's `matrix <MappingProjection.matrix>` attribute to transform the value received from its `sender
+<MappingProjection.sender>` and provide the result to its `receiver <MappingProjection.receiver>`.
 
 .. _Mapping_Creation:
 

--- a/PsyNeuLink/Components/States/ParameterState.py
+++ b/PsyNeuLink/Components/States/ParameterState.py
@@ -364,13 +364,6 @@ class ParameterState(State_Base):
     owner : Mechanism or MappingProjection
         the `Mechanism` or `MappingProjection` to which the ParameterState belongs.
 
-    mod_afferents : List[GatingProjection]
-        a list of the `GatingProjections <GatingProjection>` received by the ParameterState.
-
-    variable : number, list or np.ndarray
-        the parameter's attribute value — that is, the value of the attribute of the
-        ParameterState's owner or its `function <Component.function>` assigned to the parameter.
-
     mod_afferents : Optional[List[Projection]]
         a list of the `ModulatoryProjection <ModulatoryProjection>` that project to the ParameterState (i.e.,
         for which it is a `receiver <Projection.Projection.receiver>`); these can be
@@ -378,6 +371,10 @@ class ParameterState(State_Base):
         but not `GatingProjection <GatingProjection>`.  The `value <ModulatoryProjection.value>` of each
         must match the format (number and types of elements) of the ParameterState's
         `variable <ParameterState.variable>`.
+
+    variable : number, list or np.ndarray
+        the parameter's attribute value — that is, the value of the attribute of the
+        ParameterState's owner or its `function <Component.function>` assigned to the parameter.
 
     function : Function : default Linear
         converts the parameter's attribute value (same as the ParameterState's `variable <ParameterState.variable>`)

--- a/docs/source/Function.rst
+++ b/docs/source/Function.rst
@@ -36,5 +36,4 @@ Functions
              LearningFunction,
              Reinforcement,
              BackPropagation,
-..
-    :exclude-members: function
+   :exclude-members: MappingProjection, ParameterState


### PR DESCRIPTION
• Function
  - added exclude-members for MappingProjection and ParameterState

• ParameterState
  - eliminated redundant entry for mod_afferents attribute in docstring

• MappingProjection
  - docstring revs: Overview