### PR TITLE
Fix docstrings to be python3.6 compatible

### DIFF
--- a/PsyNeuLink/Components/Mechanisms/AdaptiveMechanisms/ControlMechanisms/ControlMechanism.py
+++ b/PsyNeuLink/Components/Mechanisms/AdaptiveMechanisms/ControlMechanisms/ControlMechanism.py
@@ -249,7 +249,7 @@ class ControlMechanism_Base(AdaptiveMechanism_Base):
 
     monitored_output_states : List[OutputState]
         each item is an `OutputState` of a `Mechanism` specified in the **monitor_for_control** argument of the
-        ControlMechanism's constructor, the `value <OutputState.value>` \s of which serve as the items of the
+        ControlMechanism's constructor, the `value <OutputState.value>` \\s of which serve as the items of the
         ControlMechanism's `variable <Mechanism_Base.variable>`.
 
     control_signals : List[ControlSignal]
@@ -261,7 +261,7 @@ class ControlMechanism_Base(AdaptiveMechanism_Base):
         list of `ControlProjections <ControlProjection>`, one for each `ControlSignal` in `control_signals`.
 
     function : TransferFunction : default Linear(slope=1, intercept=0)
-        determines how the `value <OuputState.value>` \s of the `OutputStates <OutputState>` specified in the
+        determines how the `value <OuputState.value>` \\s of the `OutputStates <OutputState>` specified in the
         **monitor_for_control** argument of the ControlMechanism's constructor are used to generate its
         `allocation_policy <ControlMechanism_Base.allocation_policy>`.
 

--- a/PsyNeuLink/Components/Mechanisms/AdaptiveMechanisms/ControlMechanisms/EVCMechanism.py
+++ b/PsyNeuLink/Components/Mechanisms/AdaptiveMechanisms/ControlMechanisms/EVCMechanism.py
@@ -40,7 +40,7 @@ The EVCMechanism uses it `function <EVCMechanism.function>` to select an `alloca
 exhaustive evaluation of allocation policies, simulating its `system <EVCMechanism.system>` under each, and using an
 `ObjectiveMechanism` and several `auxiliary functions <EVCMechanism_Auxiliary_Functions>` to calculate the **expected
 value of control (EVC)** for each `allocation_policy`: a cost-benefit analysis that weighs the `cost
-<ControlSignal.cost> of the ControlSignals against the outcome of the `system <EVCMechanism.system>` \s performance for
+<ControlSignal.cost> of the ControlSignals against the outcome of the `system <EVCMechanism.system>` \\s performance for
 a given `allocation_policy`. The EVCMechanism selects the `allocation_policy` that generates the maximum EVC, and
 implements that for the next `TRIAL`. Each step of this procedure can be modified, or replaced entirely, by assigning
 custom functions to corresponding parameters of the EVCMechanism, as described `below <EVCMechanism_Functions>`.
@@ -178,7 +178,7 @@ are determined by its `allocation_samples` attribute.  For each `allocation_poli
     selected `allocation_policy` specifies for each ControlSignal, and then simulate these System using the
     corresponding parameter values.
 
-  * **Calculate outcome** - combine the `value <OutputState.value>` \s of the OutputStates listed in the
+  * **Calculate outcome** - combine the `value <OutputState.value>` \\s of the OutputStates listed in the
     EVCMechanism's `monitored_output_states <EVCMechanism.monitored_output_states>` attribute using the function
     specified by its `outcome_function <EVCMechanism.outcome_function>` attribute (this is done by the EVCMechanism's
     `monitoring_mechanism <EVCMechanism.monitoring_mechanism>`, and passed to the EVCMechanism's `primary InputState
@@ -187,7 +187,7 @@ are determined by its `allocation_samples` attribute.  For each `allocation_poli
     <EVCMechanism.outcome_function>`).
   ..
   * **Calculate EVC** - by calling the EVCMechanism's `value_function <EVCMechanism.value_function>` with the
-    outcome (received from the `monitoring_mechanism`) and a list of the `costs <ControlSignal.cost>` \s of its
+    outcome (received from the `monitoring_mechanism`) and a list of the `costs <ControlSignal.cost>` \\s of its
     `ControlSignals <EVCMechanism_ControlSignals>`; default `value_function <EVCMechanism.value_function>` calls
     to additional auxiliary functions:  first it calls the `cost_function <EVCMechanism.cost_function>` which sums
     the costs, though this can be configured to weight and/or exponentiate individual costs (see `cost_function
@@ -248,10 +248,10 @@ An EVCMechanism, like any `ControlMechanism`, is always the last `Mechanism` to 
 `system <EVCMechanism.system>` (see `System Control <System_Execution_Control>` and `Execution <System_Execution>`).
 When an EVCMechanism is executed, it updates the value of its `prediction_mechanisms` and `monitoring_mechanism`,
 and then calls its `function <EVCMechanism.function>`, which determines and implements the `allocation_policy` for
-the next `TRIAL` of its `system <EVCMechanism.system>` \s execution.  The default `function <EVCMechanism.function>`
+the next `TRIAL` of its `system <EVCMechanism.system>` \\s execution.  The default `function <EVCMechanism.function>`
 executes the following steps (described in greater detailed `above <EVC_Default_Configuration>`):
 
-* samples every allocation_policy (i.e., every combination of the `allocation` \s specified for the EVCMechanism's
+* samples every allocation_policy (i.e., every combination of the `allocation` \\s specified for the EVCMechanism's
   ControlSignals specified by their `allocation_samples` attributes);  for each `allocation_policy`, it:
 
   * Executes the EVCMechanism's `system <EVCMechanism.system>` with the parameter values specified by that

--- a/PsyNeuLink/Components/Mechanisms/AdaptiveMechanisms/LearningMechanisms/LearningMechanism.py
+++ b/PsyNeuLink/Components/Mechanisms/AdaptiveMechanisms/LearningMechanisms/LearningMechanism.py
@@ -735,7 +735,7 @@ class LearningMechanism(AdaptiveMechanism_Base):
 
     output_values : 2d np.array
         the first item is the `value <OutputState.value>` of the LearningMechanism's *ERROR_SIGNAL* `OutputState
-        <LearningMechanism_Output_Error_Signal>`, followed by the `value <LearningSignal.value>` \(s) of its
+        <LearningMechanism_Output_Error_Signal>`, followed by the `value <LearningSignal.value>` \\(s) of its
         `LearningSignal(s) <LearningMechanism_LearningSignal>`, and then those of any additional (e.g., user-specified)
         `OutputStates <OutputState>`.
 

--- a/PsyNeuLink/Components/Process.py
+++ b/PsyNeuLink/Components/Process.py
@@ -225,7 +225,7 @@ Execution
 A Process can be executed as part of a `System <System>` or on its own.  On its own, it is executed by calling
 either its `execute <Process_Base.execute>` or `run <Process_Base.run>` method.  `execute <Process.execute>`
 executes the Process once (that is, it executes a single `TRIAL`);  `run <Process.run>` allows a series of
-`TRIAL` \s to be executed. When a Process is executed, its `input` is conveyed to the `ORIGIN` Mechanism (first
+`TRIAL` \\s to be executed. When a Process is executed, its `input` is conveyed to the `ORIGIN` Mechanism (first
 Mechanism in the pathway).  By default, the the input is presented only once.  If the `ORIGIN` Mechanism is
 executed again in the same `PASS` of execution (e.g., if it appears again in the pathway, or receives recurrent
 projections), the input is not presented again. However, the input can be "clamped" on using the **clamp_input**

--- a/PsyNeuLink/Components/States/ModulatorySignals/ControlSignal.py
+++ b/PsyNeuLink/Components/States/ModulatorySignals/ControlSignal.py
@@ -94,7 +94,7 @@ Modulation
 ~~~~~~~~~~
 
 A ControlSignal has a `modulation <GatingSignal.modulation>` attribute that determines how its ControlSignal's
-`value <ControlSignal.value>` is used by the States to which it projects to modify their `value <State_Base.value>` \s
+`value <ControlSignal.value>` is used by the States to which it projects to modify their `value <State_Base.value>` \\s
 (see `ModulatorySignal_Modulation` for an explanation of how the `modulation <ControlSignal.modulation>`  attribute is
 specified and used to modulate the `value <State_Base.value>` of a State). The `modulation <ControlSignal.modulation>`
 attribute can be specified in the **modulation** argument of the constructor for a ControlSignal, or in a specification
@@ -121,8 +121,8 @@ at the end of the previous `TRIAL` (i.e., when the ControlMechanism last execute
 
 *Function*. A ControlSignal's `allocation <ControlSignal.alloction>` serves as its`variable <ControlSignal.variable>`,
 and is used by its `function <ControlSignal.function>` to generate an `intensity`. The default `function
-<ControlSignal.function>` for a ControlSignal is an identity function (`Linear` with `slope <Linear.slope>` \=1 and
-`intercept <Linear.intercept>`\=0), that simply assigns the `allocation <ControlSignal.allocation>` as the
+<ControlSignal.function>` for a ControlSignal is an identity function (`Linear` with `slope <Linear.slope>` \\=1 and
+`intercept <Linear.intercept>`\\=0), that simply assigns the `allocation <ControlSignal.allocation>` as the
 ControlSignal's `intensity <ControlSignal.intensity>`. However, another `TransferFunction` can be assigned
 (e.g., `Exponential`), or any other function that takes and returns a scalar value or 1d array.
 
@@ -182,7 +182,7 @@ A ControlSignal cannot be executed directly.  It is executed whenever the `Contr
 executed.  When this occurs, the ControlMechanism provides the ControlSignal with an
 `allocation <ControlSignal.allocation>`, that is used by its `function <ControlSignal.function>` to compute its
 `intensity` for that `TRIAL`.  The `intensity` is used by the ControlSignal's `ControlProjections <ControlProjection>`
-to set the `value <ParameterState.value>` \(s) of the `ParameterState(s) <ParameterState>` to which the ControlSignal
+to set the `value <ParameterState.value>` \\(s) of the `ParameterState(s) <ParameterState>` to which the ControlSignal
 projects. Each ParameterState uses that value to modify the value(s) of the parameter(s) that the ControlSignal
 controls. See `ModulatorySignal_Modulation` for a more detailed description of how modulation operates).  The
 ControlSignal's `intensity` is also used  by its `cost functions <ControlSignal_Costs>` to compute its

--- a/PsyNeuLink/Components/States/ModulatorySignals/GatingSignal.py
+++ b/PsyNeuLink/Components/States/ModulatorySignals/GatingSignal.py
@@ -13,7 +13,7 @@ Overview
 --------
 
 A GatingSignal is a type of `ModulatorySignal` that is specialized for use with a `GatingMechanism` and one or more
-`GatingProjections <GatingProjection>`, to modify the `value <State_Base.value>` \(s) of the InputState(s) and/or
+`GatingProjections <GatingProjection>`, to modify the `value <State_Base.value>` \\(s) of the InputState(s) and/or
 OutputState(s) to which they project. A GatingSignal receives the value from the
 `gating_policy <GatingMechanism.gating_policy>` of the GatingMechanism to which it belongs, and assigns that as
 the value of its `gating_signal <GatingSignal.gating_signal>` to its `GatingProjection(s) <GatingProjection>`, each
@@ -105,7 +105,7 @@ Modulation
 
 Each GatingSignal has a `modulation <GatingSignal.modulation>` attribute that determines how the GatingSignal's
 `value <GatingSignal.value>` (i.e., its `gating_signal <GatingSignal.gating_signal>`) is used by the States to which it
-projects to modify their `value <State_Base.value>` \s (see `ModulatorySignal_Modulation` for an explanation of how the
+projects to modify their `value <State_Base.value>` \\s (see `ModulatorySignal_Modulation` for an explanation of how the
 `modulation <GatingSignal.modulation>` attribute is specified and used to modulate the `value <State_Base.value>` of a
 State). The `modulation <GatingSignal.modulation>` attribute can be specified in the **modulation** argument of the
 constructor for a GatingSignal, or in a specification dictionary as described `above <GatingSignal_Specification>`.

--- a/PsyNeuLink/Components/States/OutputState.py
+++ b/PsyNeuLink/Components/States/OutputState.py
@@ -657,7 +657,7 @@ class OutputState(State_Base):
             try:
                 self.owner.default_value[target_set[INDEX]]
             except IndexError:
-                raise OutputStateError("Value of \`{}\` argument for {} is greater than the number of items in "
+                raise OutputStateError("Value of \\`{}\\` argument for {} is greater than the number of items in "
                                        "the output_values ({}) for its owner Mechanism ({})".
                                        format(INDEX, self.name, self.owner.default_value, self.owner.name))
 

--- a/PsyNeuLink/Components/States/State.py
+++ b/PsyNeuLink/Components/States/State.py
@@ -23,7 +23,7 @@ as summarized in the table below:
 | *State Type*     | *Owner*           |      *Description*     |    *Modulated by*    |      *Specification*          |
 +==================+===================+========================+======================+===============================+
 | `InputState`     |  `Mechanism`      |receives input from     | `GatingSignal`       |`InputState` constructor;      |
-|                  |                   |`MappingProjection` \   |                      |`Mechanism` constructor or     |
+|                  |                   |`MappingProjection` \\  |                      |`Mechanism` constructor or     |
 |                  |                   |(s)                     |                      |its `add_states` method        |
 +------------------+-------------------+------------------------+----------------------+-------------------------------+
 |`ParameterState`  |  `Mechanism` or   |represents parameter    |`LearningSignal`      |Implicitly whenever a          |
@@ -32,11 +32,11 @@ as summarized in the table below:
 |                  |                   |                        |                      |<ParameterState_Specification>`|
 +------------------+-------------------+------------------------+----------------------+-------------------------------+
 | `OutputState`    |  `Mechanism`      |provides output to      | `GatingSignal`       |`OutputState` constructor;     |
-|                  |                   |`MappingProjection` \   |                      |`Mechanism` constructor or     |
+|                  |                   |`MappingProjection` \\  |                      |`Mechanism` constructor or     |
 |                  |                   |(s)                     |                      |its `add_states` method        |
 +------------------+-------------------+------------------------+----------------------+-------------------------------+
 |`ModulatorySignal`|`AdaptiveMechanism`|provides value for      |                      |`AdaptiveMechanism`            |
-|                  |                   |`ModulatoryProjection` \|                      |constructor; tuple in State    |
+|                  |                   |`ModulatoryProjection` \\|                      |constructor; tuple in State    |
 |                  |                   |(s)                     |                      |or parameter specification     |
 +------------------+-------------------+------------------------+----------------------+-------------------------------+
 

--- a/PsyNeuLink/Composition.py
+++ b/PsyNeuLink/Composition.py
@@ -196,7 +196,7 @@ class Graph(object):
         ----------
 
         comp_to_vertex : dict{`Component` : `Vertex`}
-            maps `Component`\ s in the graph to the `Vertices <Vertex>` that represent them
+            maps `Component`\\ s in the graph to the `Vertices <Vertex>` that represent them
 
         vertices : list[Vertex]
             the `Vertices <Vertex>` contained in this Graph
@@ -306,11 +306,11 @@ class Composition(object):
         ----------
 
         graph : `Graph`
-            The full `Graph` associated with this Composition. Contains both `Mechanism`\ s and `Projection`\ s used in processing \
+            The full `Graph` associated with this Composition. Contains both `Mechanism`\\ s and `Projection`\\ s used in processing \
             or learning.
 
         mechanisms : `list[Mechanism]`
-            A list of all `Mechanism`\ s contained in this Composition
+            A list of all `Mechanism`\\ s contained in this Composition
     '''
 
     def __init__(self):

--- a/PsyNeuLink/Globals/Run.py
+++ b/PsyNeuLink/Globals/Run.py
@@ -97,10 +97,10 @@ description of the two formats.
 .. _Run_Nesting_Factors:
 
 * **Number of TRIALS**.  If the **inputs** argument contains the input for more than one `TRIAL`, then the outermost
-  level of the list, or axis 0 of the ndarray, is used for the `TRIAL` \s, each item of which contains the
+  level of the list, or axis 0 of the ndarray, is used for the `TRIAL` \\s, each item of which contains the
   set inputs for a given `TRIAL`.  Otherwise, it is used for the next relevant factor in the list below.  If the
-  number of inputs specified is less than the number of `TRIAL` \s, then the input list is cycled until the full
-  number of `TRIAL` \s is completed.
+  number of inputs specified is less than the number of `TRIAL` \\s, then the input list is cycled until the full
+  number of `TRIAL` \\s is completed.
 ..
 * **Number of Mechanisms.** If :keyword:`run` is used for a System, and it has more than one `ORIGIN` Mechanism, then
   the next level of nesting of a list, or next higher axis of an ndarray, is used for the `ORIGIN` Mechanisms, with
@@ -192,7 +192,7 @@ Process or System being run.  The key for each entry is the `ORIGIN` Mechanism, 
 or ndarray specifying the sequence of inputs for that Mechanism, one for each `TRIAL` to be run.  If a list is used,
 and the Mechanism has more than one InputState, then a sublist is used in each item of the list to specify the inputs
 for each of the Mechanism's InputStates for that `TRIAL`.  If an ndarray is used, axis 0 is used for the sequence of
-`TRIAL` \s. If the Mechanism has a single InputState, then axis 1 is used for the input for each `TRIAL.  If the
+`TRIAL` \\s. If the Mechanism has a single InputState, then axis 1 is used for the input for each `TRIAL.  If the
 Mechanism has multiple InputStates, then axis 1 is used for the InputStates, and axis 2 is used for the input to each
 InputState for each `TRIAL`.
 
@@ -233,8 +233,8 @@ Details concerning the use of the `Sequence <Run_Targets_Sequence_Format>`  and
 as a `function <Run_Targets_Function_Format>` (for example, to allow the target to depend on the outcome of processing).
 
 If either the Sequence or Mechanism format is used, then the number of targets specified for each Mechanism must equal
-the number specified for the **inputs** argument;  as with **inputs**, if the number of `TRIAL` \s specified is greater
-than the number of inputs (and targets), then the list will be cycled until the number of `TRIAL` \s specified is
+the number specified for the **inputs** argument;  as with **inputs**, if the number of `TRIAL` \\s specified is greater
+than the number of inputs (and targets), then the list will be cycled until the number of `TRIAL` \\s specified is
 completed.  If a function is used for the **targets**, then it will be used to generate a target for each `TRIAL`.
 
 The number of targets specified in the Sequence or Mechanism formats for each `TRIAL`, or generated using
@@ -255,7 +255,7 @@ Sequence Format
 ^^^^^^^^^^^^^^^
 
 *(List[values] or ndarray):* -- there are at most three levels of nesting (or dimensions) required for
-targets:  one for `TRIAL` \s, one for Mechanisms, and one for the elements of each input.  For a System
+targets:  one for `TRIAL` \\s, one for Mechanisms, and one for the elements of each input.  For a System
 with more than one `TARGET` Mechanism, the targets must be specified in the same order as they appear in the System's
 `target_mechanisms <System.System_Base.target_mechanisms>` attribute.  This should be the same order in which
 they are declared, and can be displayed using the System's `show <System.System_Base.show>` method). All
@@ -408,12 +408,12 @@ def run(object,
         requirements and options).
 
     num_trials : int : default None
-        the number of `TRIAL` \s to run.  If it is `None` (the default), then a number of `TRIAL` \s run will be equal
+        the number of `TRIAL` \\s to run.  If it is `None` (the default), then a number of `TRIAL` \\s run will be equal
         equal to the number of items specified in the **inputs** argument.  If **num_trials** exceeds the number of
-        inputs, then the inputs will be cycled until the number of `TRIAL` \s specified have been run.
+        inputs, then the inputs will be cycled until the number of `TRIAL` \\s specified have been run.
 
     reset_clock : bool : default True
-        if `True`, resets `CentralClock` to 0 before a sequence of `TRIAL` \s.
+        if `True`, resets `CentralClock` to 0 before a sequence of `TRIAL` \\s.
 
     initialize : bool default False
         calls the `initialize <System.System_Base.initialize>` method of the System prior to the first `TRIAL`.

--- a/PsyNeuLink/Scheduling/Condition.py
+++ b/PsyNeuLink/Scheduling/Condition.py
@@ -161,12 +161,12 @@ COMMENT
 
 **Generic Conditions** (used to construct `custom Conditions <Condition_Custom>`):
 
-    * `While`\ (func, *args, **kwargs)
+    * `While`\\ (func, *args, **kwargs)
       \
       satisfied whenever the specified function (or callable) called with args and/or kwargs evaluates to `True`. \
       Equivalent to `Condition(func, *args, **kwargs)`
 
-    * `WhileNot`\ (func, *args, **kwargs)
+    * `WhileNot`\\ (func, *args, **kwargs)
       \
       satisfied whenever the specified function (or callable) called with args and/or kwargs evaluates to `False`. \
       Equivalent to `Not(Condition(func, *args, **kwargs))`
@@ -188,19 +188,19 @@ COMMENT
 
 **Composite Conditions** (based on one or more other Conditions):
 
-    * `All`\ (*Conditions)
+    * `All`\\ (*Conditions)
       \
       satisfied whenever all of the specified Conditions are satisfied.
 
-    * `Any`\ (*Conditions)
+    * `Any`\\ (*Conditions)
       \
       satisfied whenever any of the specified Conditions are satisfied.
 
-    * `Not`\ (Condition)
+    * `Not`\\ (Condition)
       \
       satisfied whenever the specified Condition is not satisfied.
 
-    * `NWhen`\ (Condition, int)
+    * `NWhen`\\ (Condition, int)
       \
       satisfied the first specified number of times the specified Condition is satisfied.
 
@@ -210,41 +210,41 @@ COMMENT
 **Time-Based Conditions** (based on the count of units of time at a specified `TimeScale`):
 
 
-    * `BeforePass`\ (int[, TimeScale])
+    * `BeforePass`\\ (int[, TimeScale])
       \
       satisfied any time before the specified `PASS` occurs.
 
-    * `AtPass`\ (int[, TimeScale])
+    * `AtPass`\\ (int[, TimeScale])
       \
       satisfied only during the specified `PASS`.
 
-    * `AfterPass`\ (int[, TimeScale])
+    * `AfterPass`\\ (int[, TimeScale])
       \
       satisfied any time after the specified `PASS` has occurred.
 
-    * `AfterNPasses`\ (int[, TimeScale])
+    * `AfterNPasses`\\ (int[, TimeScale])
       \
-      satisfied when or any time after the specified number of `PASS`\es has occurred.
+      satisfied when or any time after the specified number of `PASS`\\es has occurred.
 
-    * `EveryNPasses`\ (int[, TimeScale])
+    * `EveryNPasses`\\ (int[, TimeScale])
       \
-      satisfied every time the specified number of `PASS`\ es occurs.
+      satisfied every time the specified number of `PASS`\\ es occurs.
 
-    * `BeforeTrial`\ (int[, TimeScale])
+    * `BeforeTrial`\\ (int[, TimeScale])
       \
       satisfied any time before the specified `TRIAL` occurs.
 
-    * `AtTrial`\ (int[, TimeScale])
+    * `AtTrial`\\ (int[, TimeScale])
       \
       satisfied any time during the specified `TRIAL`.
 
-    * `AfterTrial`\ (int[, TimeScale])
+    * `AfterTrial`\\ (int[, TimeScale])
       \
       satisfied any time after the specified `TRIAL` occurs.
 
-    * `AfterNTrials`\ (int[, TimeScale])
+    * `AfterNTrials`\\ (int[, TimeScale])
       \
-      satisfied any time after the specified number of `TRIAL`\s has occurred.
+      satisfied any time after the specified number of `TRIAL`\\s has occurred.
 
 
 .. _Conditions_Component_Based:
@@ -252,49 +252,49 @@ COMMENT
 **Component-Based Conditions** (based on the execution or state of other Components):
 
 
-    * `BeforeNCalls`\ (Component, int[, TimeScale])
+    * `BeforeNCalls`\\ (Component, int[, TimeScale])
       \
       satisfied any time before the specified Component has executed the specified number of times.
 
-    * `AtNCalls`\ (Component, int[, TimeScale])
+    * `AtNCalls`\\ (Component, int[, TimeScale])
       \
       satisfied when the specified Component has executed the specified number of times.
 
-    * `AfterCall`\ (Component, int[, TimeScale])
+    * `AfterCall`\\ (Component, int[, TimeScale])
       \
       satisfied any time after the Component has executed the specified number of times.
 
-    * `AfterNCalls`\ (Component, int[, TimeScale])
+    * `AfterNCalls`\\ (Component, int[, TimeScale])
       \
       satisfied when or any time after the Component has executed the specified number of times.
 
-    * `AfterNCallsCombined`\ (*Components, int[, TimeScale])
+    * `AfterNCallsCombined`\\ (*Components, int[, TimeScale])
       \
       satisfied when or any time after the specified Components have executed the specified number \
       of times among themselves, in total.
 
-    * `EveryNCalls`\ (Component, int[, TimeScale])
+    * `EveryNCalls`\\ (Component, int[, TimeScale])
       \
       satisfied when the specified Component has executed the specified number of times since the \
       last time `owner` has run.
 
-    * `JustRan`\ (Component)
+    * `JustRan`\\ (Component)
       \
       satisfied if the specified Component was assigned to run in the previous `TIME_STEP`.
 
-    * `AllHaveRun`\ (*Components)
+    * `AllHaveRun`\\ (*Components)
       \
       satisfied when all of the specified Components have executed at least once.
 
-    * `WhenFinished`\ (Component)
+    * `WhenFinished`\\ (Component)
       \
       satisfied when the specified Component has set its `is_finished` attribute to `True`.
 
-    * `WhenFinishedAny`\ (*Components)
+    * `WhenFinishedAny`\\ (*Components)
       \
       satisfied when any of the specified Components has set their `is_finished` attribute to `True`.
 
-    * `WhenFinishedAll`\ (*Components)
+    * `WhenFinishedAll`\\ (*Components)
       \
       satisfied when all of the specified Components have set their `is_finished` attributes to `True`.
 
@@ -737,11 +737,11 @@ class BeforePass(Condition):
 
         n(int): the 'PASS' before which the Condition is satisfied
 
-        time_scale(TimeScale): the TimeScale used as basis for counting `PASS`\ es (default: TimeScale.TRIAL)
+        time_scale(TimeScale): the TimeScale used as basis for counting `PASS`\\ es (default: TimeScale.TRIAL)
 
     Satisfied when:
 
-        - at most n-1 `PASS`\ es have occurred within one unit of time at the `TimeScale` specified by **time_scale**.
+        - at most n-1 `PASS`\\ es have occurred within one unit of time at the `TimeScale` specified by **time_scale**.
 
     Notes:
 
@@ -765,17 +765,17 @@ class AtPass(Condition):
 
         n(int): the `PASS` at which the Condition is satisfied
 
-        time_scale(TimeScale): the TimeScale used as basis for counting `PASS`\ es (default: TimeScale.TRIAL)
+        time_scale(TimeScale): the TimeScale used as basis for counting `PASS`\\ es (default: TimeScale.TRIAL)
 
     Satisfied when:
 
-        - exactly n `PASS`\ es have occurred within one unit of time at the `TimeScale` specified by **time_scale**.
+        - exactly n `PASS`\\ es have occurred within one unit of time at the `TimeScale` specified by **time_scale**.
 
     Notes:
 
         - Counts of TimeScales are zero-indexed (that is, the first 'PASS' is pass 0, the second 'PASS' is 1, etc.);
           so, `AtPass(1)` is satisfied when a single `PASS` (`PASS` 0) has occurred, and `AtPass(2) is satisfied
-          when two `PASS`\ es have occurred (`PASS` 0 and `PASS` 1), etc..
+          when two `PASS`\\ es have occurred (`PASS` 0 and `PASS` 1), etc..
 
     """
     def __init__(self, n, time_scale=TimeScale.TRIAL):
@@ -798,16 +798,16 @@ class AfterPass(Condition):
 
         n(int): the `PASS` after which the Condition is satisfied
 
-        time_scale(TimeScale): the TimeScale used as basis for counting `PASS`\ es (default: TimeScale.TRIAL)
+        time_scale(TimeScale): the TimeScale used as basis for counting `PASS`\\ es (default: TimeScale.TRIAL)
 
     Satisfied when:
 
-        - at least n+1 `PASS`\ es have occurred within one unit of time at the `TimeScale` specified by **time_scale**.
+        - at least n+1 `PASS`\\ es have occurred within one unit of time at the `TimeScale` specified by **time_scale**.
 
     Notes:
 
         - Counts of TimeScales are zero-indexed (that is, the first `PASS` is 0, the second `PASS` is 1, etc.); so,
-          `AfterPass(1)` is satisfied after `PASS` 1 has occurred and thereafter (i.e., in `PASS`\ es 2, 3, 4, etc.).
+          `AfterPass(1)` is satisfied after `PASS` 1 has occurred and thereafter (i.e., in `PASS`\\ es 2, 3, 4, etc.).
 
     """
     def __init__(self, n, time_scale=TimeScale.TRIAL):
@@ -824,14 +824,14 @@ class AfterNPasses(Condition):
 
     Parameters:
 
-        n(int): the number of `PASS`\ es after which the Condition is satisfied
+        n(int): the number of `PASS`\\ es after which the Condition is satisfied
 
-        time_scale(TimeScale): the TimeScale used as basis for counting `PASS`\ es (default: TimeScale.TRIAL)
+        time_scale(TimeScale): the TimeScale used as basis for counting `PASS`\\ es (default: TimeScale.TRIAL)
 
 
     Satisfied when:
 
-        - at least n `PASS`\ es have occurred within one unit of time at the `TimeScale` specified by **time_scale**.
+        - at least n `PASS`\\ es have occurred within one unit of time at the `TimeScale` specified by **time_scale**.
 
     """
     def __init__(self, n, time_scale=TimeScale.TRIAL):
@@ -850,13 +850,13 @@ class EveryNPasses(Condition):
 
         n(int): the frequency of passes with which this condition is satisfied
 
-        time_scale(TimeScale): the TimeScale used as basis for counting `PASS`\ es (default: TimeScale.TRIAL)
+        time_scale(TimeScale): the TimeScale used as basis for counting `PASS`\\ es (default: TimeScale.TRIAL)
 
     Satisfied when:
 
         - `PASS` 0
 
-        - the specified number of `PASS`\ es that has occurred within a unit of time (at the `TimeScale` specified by
+        - the specified number of `PASS`\\ es that has occurred within a unit of time (at the `TimeScale` specified by
           **time_scale**) is evenly divisible by n.
 
     """
@@ -876,11 +876,11 @@ class BeforeTrial(Condition):
 
         n(int): the `TRIAL` before which the Condition is satisfied
 
-        time_scale(TimeScale): the TimeScale used as basis for counting `TRIAL`\ s (default: TimeScale.RUN)
+        time_scale(TimeScale): the TimeScale used as basis for counting `TRIAL`\\ s (default: TimeScale.RUN)
 
     Satisfied when:
 
-        - at most n-1 `TRIAL`\ s have occurred within one unit of time at the `TimeScale` specified by **time_scale**.
+        - at most n-1 `TRIAL`\\ s have occurred within one unit of time at the `TimeScale` specified by **time_scale**.
 
     Notes:
 
@@ -908,11 +908,11 @@ class AtTrial(Condition):
 
         n(int): the `TRIAL` at which the Condition is satisfied
 
-        time_scale(TimeScale): the TimeScale used as basis for counting `TRIAL`\ s (default: TimeScale.RUN)
+        time_scale(TimeScale): the TimeScale used as basis for counting `TRIAL`\\ s (default: TimeScale.RUN)
 
     Satisfied when:
 
-        - exactly n `TRIAL`\ s have occurred within one unit of time at the `TimeScale` specified by **time_scale**.
+        - exactly n `TRIAL`\\ s have occurred within one unit of time at the `TimeScale` specified by **time_scale**.
 
     Notes:
 
@@ -940,16 +940,16 @@ class AfterTrial(Condition):
 
         n(int): the `TRIAL` after which the Condition is satisfied
 
-        time_scale(TimeScale): the TimeScale used as basis for counting `TRIAL`\ s. (default: TimeScale.RUN)
+        time_scale(TimeScale): the TimeScale used as basis for counting `TRIAL`\\ s. (default: TimeScale.RUN)
 
     Satisfied when:
 
-        - at least n+1 `TRIAL`\ s have occurred within one unit of time at the `TimeScale` specified by **time_scale**.
+        - at least n+1 `TRIAL`\\ s have occurred within one unit of time at the `TimeScale` specified by **time_scale**.
 
     Notes:
 
         - Counts of TimeScales are zero-indexed (that is, the first `TRIAL` is 0, the second `TRIAL` is 1, etc.);
-          so,  `AfterPass(1)` is satisfied after `TRIAL` 1 has occurred and thereafter (i.e., in `TRIAL`\ s 2, 3, 4,
+          so,  `AfterPass(1)` is satisfied after `TRIAL` 1 has occurred and thereafter (i.e., in `TRIAL`\\ s 2, 3, 4,
           etc.).
 
     """
@@ -971,13 +971,13 @@ class AfterNTrials(Condition):
 
     Parameters:
 
-        n(int): the number of `TRIAL`\ s after which the Condition is satisfied
+        n(int): the number of `TRIAL`\\ s after which the Condition is satisfied
 
-        time_scale(TimeScale): the TimeScale used as basis for counting `TRIAL`\ s (default: TimeScale.RUN)
+        time_scale(TimeScale): the TimeScale used as basis for counting `TRIAL`\\ s (default: TimeScale.RUN)
 
     Satisfied when:
 
-        - at least n `TRIAL`\ s have occured  within one unit of time at the `TimeScale` specified by **time_scale**.
+        - at least n `TRIAL`\\ s have occured  within one unit of time at the `TimeScale` specified by **time_scale**.
 
     """
     def __init__(self, n, time_scale=TimeScale.RUN):

--- a/PsyNeuLink/Scheduling/Scheduler.py
+++ b/PsyNeuLink/Scheduling/Scheduler.py
@@ -50,7 +50,7 @@ COMMENT
   each entry of the dictionary must be a Component of a Composition, and the value of each entry must be a set of
   zero or more Components that project directly to the key.  The graph must be acyclic; an error is generated if any
   cycles (e.g., recurrent dependencies) are detected.  The Scheduler computes a `toposort` from the graph that is
-  used as the default order of executions, subject to any `Condition`\ s that have been specified
+  used as the default order of executions, subject to any `Condition`\\ s that have been specified
   (see `below <Scheduler_Algorithm>`).
 
 If both a System and a graph are specified, the System takes precedence, and the graph is ignored.
@@ -154,7 +154,7 @@ execution, over which every Component in the Composition has been considered for
 `consideration_sets <consideration_set>` in the same order as previously. Different subsets of Components within the
 same `consideration_set` may be assigned to execute on each `PASS`, since different Conditions may be satisfied.
 
-The Scheduler continues to make `PASS`\ es through the `consideration_queue` until a
+The Scheduler continues to make `PASS`\\ es through the `consideration_queue` until a
 `termination Condition <Scheduler_Termination_Conditions>` is satisfied. If no termination Conditions are specified,
 the Scheduler terminates a `TRIAL` when every Component has been specified for execution at least once (corresponding
 to the `AllHaveRun` Condition).  However, other termination Conditions can be specified, that may cause the Scheduler
@@ -338,7 +338,7 @@ class Scheduler(object):
 
     times: dict{TimeScale: dict{TimeScale: int}}
         a structure counting the number of occurrences of a certain `TimeScale` within the scope of another `TimeScale`.
-        For example, `times[TimeScale.RUN][TimeScale.PASS]` is the number of `PASS`\ es that have occurred in the
+        For example, `times[TimeScale.RUN][TimeScale.PASS]` is the number of `PASS`\\ es that have occurred in the
         current `RUN` that the Scheduler is scheduling at the time it is accessed
     """
     def __init__(
@@ -468,7 +468,7 @@ class Scheduler(object):
 
     def add_condition_set(self, conditions):
         '''
-        :param conditions: a `dict` mapping `Component`\ s to `Condition`\ s,
+        :param conditions: a `dict` mapping `Component`\\ s to `Condition`\\ s,
                which can be added later with `add_condition`
         '''
         self.condition_set.add_condition_set(conditions)
@@ -498,7 +498,7 @@ class Scheduler(object):
         run is a python generator, that when iterated over provides the next `TIME_STEP` of
         executions at each iteration
 
-        :param termination_conds: (dict) - a mapping from `TimeScale`\ s to `Condition`\ s that when met
+        :param termination_conds: (dict) - a mapping from `TimeScale`\\ s to `Condition`\\ s that when met
                terminate the execution of the specified `TimeScale`
         '''
         self._validate_run_state()

--- a/PsyNeuLink/Scheduling/TimeScale.py
+++ b/PsyNeuLink/Scheduling/TimeScale.py
@@ -23,7 +23,7 @@ class TimeScale(Enum):
     ----------
 
     TIME_STEP
-        the nuclear unit of time, corresponding to the execution of all `Mechanism <Mechanism>`\ s allowed to execute
+        the nuclear unit of time, corresponding to the execution of all `Mechanism <Mechanism>`\\ s allowed to execute
         from a single `consideration_set` of a `Scheduler`, and which are considered to have executed simultaneously.
 
     PASS


### PR DESCRIPTION
These are the changes necessary to make pytest tests/ pass using python3.6.
Python <3.5 automagically fixes invalid escape sequences, python 3.6 stopped doing that. In most situations esaping backslash '\\' should give the expected outcome.