### PR TITLE
Name/project/replace assign index calculate

### DIFF
--- a/Scripts/Examples/EVC-Gratton.py
+++ b/Scripts/Examples/EVC-Gratton.py
@@ -74,8 +74,8 @@ Decision = pnl.DDM(
         pnl.PROBABILITY_UPPER_THRESHOLD,
         {
             pnl.NAME: 'OFFSET RT',
-            pnl.INDEX: 2,
-            pnl.ASSIGN: pnl.Linear(0, slope=0.3, intercept=1)
+            pnl.VARIABLE: (pnl.OWNER_VALUE, 2),
+            pnl.FUNCTION: pnl.Linear(0, slope=0.3, intercept=1)
             # pnl.VARIABLE:[(pnl.OWNER_VALUE,2)],
             # pnl.FUNCTION: pnl.Linear(0, slope=0.3, intercept=1)
         }

--- a/Scripts/Examples/EVC-Gratton.py
+++ b/Scripts/Examples/EVC-Gratton.py
@@ -76,8 +76,6 @@ Decision = pnl.DDM(
             pnl.NAME: 'OFFSET RT',
             pnl.VARIABLE: (pnl.OWNER_VALUE, 2),
             pnl.FUNCTION: pnl.Linear(0, slope=0.3, intercept=1)
-            # pnl.VARIABLE:[(pnl.OWNER_VALUE,2)],
-            # pnl.FUNCTION: pnl.Linear(0, slope=0.3, intercept=1)
         }
     ],
 )

--- a/Scripts/Examples/EVC_MARKUS_control.py
+++ b/Scripts/Examples/EVC_MARKUS_control.py
@@ -46,8 +46,8 @@ Decision = pnl.DDM(function=pnl.BogaczEtAl(
         pnl.PROBABILITY_UPPER_THRESHOLD,
         {
             pnl.NAME: 'OFFSET RT',
-            pnl.INDEX: 2,
-            pnl.ASSIGN: pnl.Linear(0, slope=1.0, intercept=1)
+            pnl.VARIABLE: (pnl.OWNER_VALUE, 2),
+            pnl.FUNCTION: pnl.Linear(0, slope=1.0, intercept=1)
         }
     ],) #drift_rate=(1.0),threshold=(0.2645),noise=(0.5),starting_point=(0), t0=0.15
 Decision.set_log_conditions('DECISION_VARIABLE')

--- a/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
+++ b/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
@@ -1059,7 +1059,7 @@ class ControlMechanism(AdaptiveMechanism_Base):
                 and not self.control_signals[0].efferents):
             del self._output_states[0]
             del self.control_signals[0]
-            self.allocation_policy = None
+            self.value = None
 
         # Add any ControlSignals specified for System
         for control_signal_spec in system_control_signals:

--- a/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
+++ b/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
@@ -311,7 +311,7 @@ from psyneulink.components.mechanisms.adaptive.adaptivemechanism import Adaptive
 from psyneulink.components.mechanisms.mechanism import Mechanism_Base
 from psyneulink.components.shellclasses import System_Base
 from psyneulink.components.states.modulatorysignals.controlsignal import ControlSignal
-from psyneulink.components.states.outputstate import INDEX, SEQUENTIAL
+from psyneulink.components.states.outputstate import SEQUENTIAL
 from psyneulink.globals.defaults import defaultControlAllocation
 from psyneulink.globals.keywords import AUTO_ASSIGN_MATRIX, COMMAND_LINE, CONTROL, CONTROLLER, CONTROL_PROJECTION, \
     CONTROL_PROJECTIONS, CONTROL_SIGNAL, CONTROL_SIGNALS, EXPONENT, INIT__EXECUTE__METHOD_ONLY, NAME, \
@@ -886,19 +886,14 @@ class ControlMechanism(AdaptiveMechanism_Base):
         self.value = self.instance_defaults.value
 
         # Assign ControlSignal's variable to appended item of owner's value
-        # control_signal._variable = (OWNER_VALUE, len(self.instance_defaults.value) - 1)
         if control_signal.owner_value_index is None:
             control_signal._variable = [(OWNER_VALUE, len(self.instance_defaults.value) - 1)]
         if not isinstance(control_signal.owner_value_index, int):
             raise ControlMechanismError(
-                "PROGRAM ERROR: {} attribute of {} for {} is not {} or an int".format(
-                    INDEX, ControlSignal.__name__, SEQUENTIAL, self.name
-                )
-            )
-
+                    "PROGRAM ERROR: The \'owner_value_index\' attribute for {} of {} ({})is not an int."
+                        .format(control_signal.name, self.name, control_signal.owner_value_index))
         # Validate index
         try:
-
             self.value[control_signal.owner_value_index]
         except IndexError:
             raise ControlMechanismError(

--- a/psyneulink/components/mechanisms/adaptive/learning/learningmechanism.py
+++ b/psyneulink/components/mechanisms/adaptive/learning/learningmechanism.py
@@ -549,10 +549,10 @@ from psyneulink.components.states.state import ADD_STATES
 from psyneulink.components.states.inputstate import InputState
 from psyneulink.components.states.parameterstate import ParameterState
 from psyneulink.components.states.modulatorysignals.learningsignal import LearningSignal
-from psyneulink.globals.keywords import ASSERT, CONTROL_PROJECTIONS, ENABLED, IDENTITY_MATRIX, INDEX, INITIALIZING, \
+from psyneulink.globals.keywords import ASSERT, CONTROL_PROJECTIONS, ENABLED, IDENTITY_MATRIX, INITIALIZING, \
     INPUT_STATES, LEARNED_PARAM, LEARNING, LEARNING_MECHANISM, LEARNING_PROJECTION, LEARNING_SIGNAL, LEARNING_SIGNALS, \
     MATRIX, MATRIX_KEYWORD_SET, NAME, OUTPUT_STATE, OUTPUT_STATES, OWNER_VALUE, PARAMS, \
-    PROJECTIONS, SAMPLE, STATE_TYPE, TARGET
+    PROJECTIONS, SAMPLE, STATE_TYPE, TARGET, VARIABLE
 from psyneulink.globals.preferences.componentpreferenceset import is_pref_set
 from psyneulink.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.globals.utilities import ContentAddressableList, is_numeric, parameter_spec
@@ -893,9 +893,9 @@ class LearningMechanism(AdaptiveMechanism_Base):
         INPUT_STATES:input_state_names,
         OUTPUT_STATES:[{NAME:ERROR_SIGNAL,
                         STATE_TYPE:OUTPUT_STATE,
-                        INDEX:1},
+                        VARIABLE: (OWNER_VALUE, 1)},
                        {NAME:LEARNING_SIGNAL,  # NOTE: This is the default, but is overridden by any LearningSignal arg
-                        INDEX:0}
+                        VARIABLE: (OWNER_VALUE, 0)}
                        ]})
 
     @tc.typecheck

--- a/psyneulink/components/mechanisms/adaptive/learning/learningmechanism.py
+++ b/psyneulink/components/mechanisms/adaptive/learning/learningmechanism.py
@@ -1017,17 +1017,16 @@ class LearningMechanism(AdaptiveMechanism_Base):
             for spec in target_set[LEARNING_SIGNALS]:
                 learning_signal = _parse_state_spec(state_type=LearningSignal, owner=self, state_spec=spec)
 
-
                 # Validate that the receiver of the LearningProjection (if specified)
                 #     is a MappingProjection and in the same System as self (if specified)
-                try:
+                if learning_signal[PARAMS] and PROJECTIONS in learning_signal[PARAMS]:
                     for learning_projection in  learning_signal[PARAMS][PROJECTIONS]:
                         _validate_receiver(sender_mech=self,
                                            projection=learning_projection,
                                            expected_owner_type=MappingProjection,
                                            spec_type=LEARNING_SIGNAL,
                                            context=context)
-                except KeyError:
+                else:
                     pass
 
     def _instantiate_attributes_before_function(self, context=None):

--- a/psyneulink/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/components/mechanisms/processing/transfermechanism.py
@@ -311,9 +311,9 @@ from psyneulink.components.mechanisms.mechanism import Mechanism, MechanismError
 from psyneulink.components.mechanisms.processing.processingmechanism import ProcessingMechanism_Base
 from psyneulink.components.states.inputstate import InputState
 from psyneulink.components.states.outputstate import OutputState, PRIMARY, StandardOutputStates, standard_output_states
-from psyneulink.globals.keywords import FUNCTION, INDEX, INITIALIZER, INITIALIZING, \
+from psyneulink.globals.keywords import FUNCTION, INITIALIZER, INITIALIZING, OWNER_VALUE, \
     MAX_VAL, MAX_ABS_VAL, MAX_INDICATOR, MAX_ABS_INDICATOR, MEAN, MEDIAN, NAME, NOISE, NORMALIZING_FUNCTION_TYPE, \
-    PROB,RATE, RESULT, RESULTS, STANDARD_DEVIATION, TRANSFER_FUNCTION_TYPE, TRANSFER_MECHANISM, VARIANCE, \
+    PROB,RATE, RESULT, RESULTS, STANDARD_DEVIATION, TRANSFER_FUNCTION_TYPE, TRANSFER_MECHANISM, VARIABLE, VARIANCE, \
     kwPreferenceSetName
 from psyneulink.globals.preferences.componentpreferenceset import is_pref_set, \
     kpReportOutputPref, kpRuntimeParamStickyAssignmentPref
@@ -871,7 +871,7 @@ class TransferMechanism(ProcessingMechanism_Base):
         if len(self.instance_defaults.variable) > 1 and len(self.output_states) == 1 and self.output_states[0] == RESULTS:
             self.output_states = []
             for i, item in enumerate(self.instance_defaults.variable):
-                self.output_states.append({NAME: RESULT, INDEX: i})
+                self.output_states.append({NAME: RESULT, VARIABLE: (OWNER_VALUE, i)})
         super()._instantiate_output_states(context=context)
 
     def _execute(self,

--- a/psyneulink/components/states/modulatorysignals/gatingsignal.py
+++ b/psyneulink/components/states/modulatorysignals/gatingsignal.py
@@ -66,9 +66,9 @@ InputState(s) and/or OutputState(s) it gates must be specified. This can take an
 
     The dictionary can also contain entries for any other GatingSignal attributes to be specified
     (e.g., a *MODULATION* entry, the value of which determines how the GatingSignal modulates the
-    `value <State_Base.value>` of the State(s) that it gates; or an *INDEX* entry specifying which item
+    `value <State_Base.value>` of the State(s) that it gates; or a *VARIABLE* entry specifying which item
     of the GatingMechanism's `gating_policy <GatingMechanism.gating_policy>` it should use as its `value
-    <GatingSignal,value>`).
+    <GatingSignal,value>`;  see `OutputState_Customization`).
   ..
   * **2-item tuple** -- the 1st item must be the name of the State (or list of State names), and the 2nd item the
     Mechanism to which it (they) belong(s); this is a convenience format, which is simpler to use than a specification

--- a/psyneulink/components/states/outputstate.py
+++ b/psyneulink/components/states/outputstate.py
@@ -1564,9 +1564,9 @@ class StandardOutputStates():
     def names(self):
         return [item[NAME] for item in self.data]
 
-    @property
-    def indices(self):
-        return [item[INDEX] for item in self.data]
+    # @property
+    # def indices(self):
+    #     return [item[INDEX] for item in self.data]
 
 
 def  _parse_output_state_variable(owner, variable, output_state_name=None):
@@ -1712,10 +1712,12 @@ def _maintain_backward_compatibility(d:dict, name, owner):
                       "dictionary for {} of {} should be changed to \'VARIABLE: (OWNER_VALUE, <index int>)\' "
                       " for future compatibility.".
                       format(OutputState.__name__, name, owner.name))
+        assert False
     if a:
         warnings.warn("The use of \'ASSIGN\' has been deprecated; it is still supported, but entry in {} specification "
                       "dictionary for {} of {} should be changed to \'FUNCTION\' for future compatibility.".
                       format(OutputState.__name__, name, owner.name))
+        assert False
     if c:
         warnings.warn("The use of \'CALCULATE\' has been deprecated; it is still supported, but entry in {} "
                       "specification dictionary for {} of {} should be changed to \'FUNCTION\' "
@@ -1725,5 +1727,6 @@ def _maintain_backward_compatibility(d:dict, name, owner):
         warnings.warn("The name of the \'MECHANISM_VALUE\' StandardOutputState has been changed to \'OWNER_VALUE\';  "
                       "it will still work, but should be changed in {} specification of {} for future compatibility.".
                       format(OUTPUT_STATES, owner.name))
+        assert False
 
 

--- a/psyneulink/components/states/outputstate.py
+++ b/psyneulink/components/states/outputstate.py
@@ -866,8 +866,6 @@ class OutputState(State_Base):
 
     paramClassDefaults = State_Base.paramClassDefaults.copy()
     paramClassDefaults.update({PROJECTION_TYPE: MAPPING_PROJECTION})
-                               # ASSIGN: None,
-                               # INDEX: PRIMARY})
     #endregion
 
     @tc.typecheck
@@ -1090,7 +1088,7 @@ class OutputState(State_Base):
 
         Returns:
              - state_spec:  1st item of tuple
-             - params dict with INDEX and/or PROJECTIONS entries if either of them was specified
+             - params dict with VARIABLE and/or PROJECTIONS entries if either of them was specified
 
         """
         # FIX: ADD FACILITY TO SPECIFY WEIGHTS AND/OR EXPONENTS FOR INDIVIDUAL OutputState SPECS
@@ -1420,20 +1418,20 @@ class StandardOutputStates():
 
     indices : PRIMARY,
     SEQUENTIAL, list of ints
-        specifies how to assign the INDEX entry for each dict listed in `output_state_dicts`;
+        specifies how to assign the (OWNER_VALUE, int) entry for each dict listed in `output_state_dicts`;
 
         The effects of each value of indices are as follows:
 
-            * *PRIMARY* -- assigns the INDEX for the owner's primary OutputState to all output_states
-              for which an INDEX entry is not already specified;
+            * *PRIMARY* -- assigns (OWNER_VALUE, PRIMARY) to all output_states for which a VARIABLE entry is not
+              specified;
 
-            * *SEQUENTIAL* -- assigns sequentially incremented int to each INDEX entry,
-              ignoring any INDEX entries previously specified for individual OutputStates;
+            * *SEQUENTIAL* -- assigns sequentially incremented int to (OWNER_VALUE, int) spec of each OutputState,
+              ignoring any VARIABLE entries previously specified for individual OutputStates;
 
-            * list of ints -- assigns each int to the corresponding entry in `output_state_dicts`;
-              ignoring any INDEX entries previously specified for individual OutputStates;
+            * list of ints -- assigns each int to an (OWNER_VALUE, int) entry of the corresponding OutputState in
+              `output_state_dicts, ignoring any VARIABLE entries previously specified for individual OutputStates;
 
-            * None -- assigns `None` to INDEX entries for all OutputStates for which it is not already specified.
+            * None -- assigns `None` to VARIABLE entries for all OutputStates for which it is not already specified.
 
     Attributes
     ----------
@@ -1478,7 +1476,7 @@ class StandardOutputStates():
         # List was provided, so check that:
         # - it has the appropriate number of items
         # - they are all ints
-        # and then assign each int to the INDEX entry in the corresponding dict
+        # and then assign each int to an (OWNER_VALUE, int) VARIABLE entry in the corresponding dict
         # in output_state_dicts
         # OutputState
         if isinstance(indices, list):
@@ -1705,27 +1703,27 @@ def _maintain_backward_compatibility(d:dict, name, owner):
     if PARAMS in d and isinstance(d[PARAMS], dict):
         p, i, a, c = replace_entries(d[PARAMS])
         recursive_update(d, p, non_destructive=True)
-        for i in {VARIABLE, FUNCTION}:
-            if i in d[PARAMS]:
-                del d[PARAMS][i]
+        for spec in {VARIABLE, FUNCTION}:
+            if spec in d[PARAMS]:
+                del d[PARAMS][spec]
 
-    # if i:
-    #     warnings.warn("The use of \'INDEX\' has been deprecated; it is still supported, but entry in {} specification "
-    #                   "dictionary for {} of {} should be changed to \'VARIABLE: (OWNER_VALUE, <index int>)\' "
-    #                   " for future compatibility.".
-    #                   format(OutputState.__name__, name, owner.name))
-    # if a:
-    #     warnings.warn("The use of \'ASSIGN\' has been deprecated; it is still supported, but entry in {} specification "
-    #                   "dictionary for {} of {} should be changed to \'FUNCTION\' for future compatibility.".
-    #                   format(OutputState.__name__, name, owner.name))
-    # if c:
-    #     warnings.warn("The use of \'CALCULATE\' has been deprecated; it is still supported, but entry in {} "
-    #                   "specification dictionary for {} of {} should be changed to \'FUNCTION\' "
-    #                   "for future compatibility.".format(OutputState.__name__, name, owner.name))
-    #
-    # if name is MECHANISM_VALUE:
-    #     warnings.warn("The name of the \'MECHANISM_VALUE\' StandardOutputState has been changed to \'OWNER_VALUE\';  "
-    #                   "it will still work, but should be changed in {} specification of {} for future compatibility.".
-    #                   format(OUTPUT_STATES, owner.name))
+    if i:
+        warnings.warn("The use of \'INDEX\' has been deprecated; it is still supported, but entry in {} specification "
+                      "dictionary for {} of {} should be changed to \'VARIABLE: (OWNER_VALUE, <index int>)\' "
+                      " for future compatibility.".
+                      format(OutputState.__name__, name, owner.name))
+    if a:
+        warnings.warn("The use of \'ASSIGN\' has been deprecated; it is still supported, but entry in {} specification "
+                      "dictionary for {} of {} should be changed to \'FUNCTION\' for future compatibility.".
+                      format(OutputState.__name__, name, owner.name))
+    if c:
+        warnings.warn("The use of \'CALCULATE\' has been deprecated; it is still supported, but entry in {} "
+                      "specification dictionary for {} of {} should be changed to \'FUNCTION\' "
+                      "for future compatibility.".format(OutputState.__name__, name, owner.name))
+
+    if name is MECHANISM_VALUE:
+        warnings.warn("The name of the \'MECHANISM_VALUE\' StandardOutputState has been changed to \'OWNER_VALUE\';  "
+                      "it will still work, but should be changed in {} specification of {} for future compatibility.".
+                      format(OUTPUT_STATES, owner.name))
 
 

--- a/psyneulink/components/states/outputstate.py
+++ b/psyneulink/components/states/outputstate.py
@@ -1125,7 +1125,7 @@ class OutputState(State_Base):
         elif isinstance(state_specific_spec, tuple):
             tuple_spec = state_specific_spec
             state_spec = None
-            INDEX_INDEX = 1
+            TUPLE_VARIABLE_INDEX = 1
 
             if is_numeric(tuple_spec[0]):
                 state_spec = tuple_spec[0]
@@ -1161,43 +1161,29 @@ class OutputState(State_Base):
             # Get INDEX specification from (state_spec, index, connections) tuple:
             if len(tuple_spec) == 3:
 
-                # MODIFIED 3/8/18 OLD:
-                index = tuple_spec[INDEX_INDEX]
+                tuple_variable_spec = tuple_spec[TUPLE_VARIABLE_INDEX]
 
-                if index is not None and not isinstance(index, numbers.Number):
-                    raise OutputStateError("The {} (2nd) item of the {} specification tuple for {} ({}) "
-                                           "must be a number".format(INDEX, OutputState.__name__, owner.name, index))
-                try:
-                    owner.instance_defaults.value[index]
-                except IndexError:
-                    raise OutputStateError("The {0} (2nd) item of the {1} specification tuple for {2} ({3}) is out "
-                                           "of bounds for the number of items in {4}'s value ({5}, max index: {6})".
-                                           format(INDEX, OutputState.__name__, owner.name, index,
-                                                  owner.name, owner.instance_defaults.value, len(owner.instance_defaults.value)-1))
-                params_dict[INDEX] = index
-                # # MODIFIED 3/8/18 NEW:
-                # assert False
-                # tuple_variable_spec = tuple_spec[INDEX_INDEX]
-                # if VARIABLE in params_dict:
-                #     dict_variable_spec = params_dict[VARIABLE]
-                # elif VARIABLE in state_dict:
-                #     dict_variable_spec = params_dict[VARIABLE]
-                #
-                # # if isinstance(index, int):
-                # index = tuple_variable_spec
-                #
-                # if index is not None and not isinstance(index, numbers.Number):
-                #     raise OutputStateError("The {} (2nd) item of the {} specification tuple for {} ({}) "
-                #                            "must be a number".format(INDEX, OutputState.__name__, owner.name, index))
-                # try:
-                #     owner.instance_defaults.value[index]
-                # except IndexError:
-                #     raise OutputStateError("The {0} (2nd) item of the {1} specification tuple for {2} ({3}) is out "
-                #                            "of bounds for the number of items in {4}'s value ({5}, max index: {6})".
-                #                            format(INDEX, OutputState.__name__, owner.name, index,
-                #                                   owner.name, owner.instance_defaults.value, len(owner.instance_defaults.value)-1))
-                # params_dict[INDEX] = index
-                # MODIFIED 3/8/18 END
+                # Make sure OutputState's variable has not already been specified
+                dict_variable_spec = None
+                if VARIABLE in params_dict and params_dict[VARIABLE] is not None:
+                    dict_variable_spec = params_dict[VARIABLE]
+                elif VARIABLE in state_dict and state_dict[VARIABLE] is not None:
+                    dict_variable_spec = params_dict[VARIABLE]
+                if dict_variable_spec:
+                    name = state_dict[NAME] or self.__name__
+                    raise OutputStateError("Specification of {} in item 2 of 3-item tuple for {} ({})"
+                                           "conflicts with its specification elsewhere in the constructor for {} ({})".
+                                           format(VARIABLE, name, tuple_spec[TUPLE_VARIABLE_INDEX],
+                                                  owner.name, dict_variable_spec))
+
+                # if isinstance(index, int) Included for backwward compatibility with INDEX
+                if isinstance(tuple_variable_spec, int):
+                    tuple_variable_spec = (OWNER_VALUE, tuple_variable_spec)
+
+                # validate that it is a legitimate spec
+                _parse_output_state_variable(owner, tuple_variable_spec)
+
+                params_dict[VARIABLE] = tuple_variable_spec
 
 
         elif state_specific_spec is not None:

--- a/psyneulink/components/states/outputstate.py
+++ b/psyneulink/components/states/outputstate.py
@@ -852,7 +852,7 @@ class OutputState(State_Base):
     componentType = OUTPUT_STATE
     paramsType = OUTPUT_STATE_PARAMS
 
-    stateAttributes = State_Base.stateAttributes | {INDEX, ASSIGN}
+    # stateAttributes = State_Base.stateAttributes | {INDEX, ASSIGN}
 
     connectsWith = [INPUT_STATE, GATING_SIGNAL]
     connectsWithAttribute = [INPUT_STATES]
@@ -867,9 +867,9 @@ class OutputState(State_Base):
     #     kp<pref>: <setting>...}
 
     paramClassDefaults = State_Base.paramClassDefaults.copy()
-    paramClassDefaults.update({PROJECTION_TYPE: MAPPING_PROJECTION,
-                               ASSIGN: None,
-                               INDEX: PRIMARY})
+    paramClassDefaults.update({PROJECTION_TYPE: MAPPING_PROJECTION})
+                               # ASSIGN: None,
+                               # INDEX: PRIMARY})
     #endregion
 
     @tc.typecheck
@@ -1112,34 +1112,21 @@ class OutputState(State_Base):
         state_spec = state_specific_spec
 
         if isinstance(state_specific_spec, dict):
-            # MODIFIED 2/24/18 OLD:
             return None, state_specific_spec
-            # MODIFIED 2/24/18 NEW:
-            # # CHECK IF FUNCTION IS IN state_specific_spec
-            # # CHECK IF VARIABLE IS IN state_dict (ERROR IF IT IS A DICT AND THERE IS NO FCT IN state_specific_spec)
             state_dict[VARIABLE] = _parse_output_state_variable(owner, state_dict[VARIABLE])
-            # state_specific_spec[FUNCTION] = _parse_output_state_function(owner,
-            #                                                              state_dict[NAME],
-            #                                                              state_specific_spec[FUNCTION],
-            #                                                              state_dict[VARIABLE]==PARAMS_DICT)
             return None, state_specific_spec
-            # MODIFIED 2/24/18 END
 
         elif isinstance(state_specific_spec, ProjectionTuple):
-            # MODIFIED 11/25/17 NEW:
             state_spec = None
-            # MODIFIED 11/25/17 END:
             params_dict[PROJECTIONS] = _parse_connection_specs(self,
                                                                owner=owner,
                                                                connections=[state_specific_spec])
 
         elif isinstance(state_specific_spec, tuple):
-
             tuple_spec = state_specific_spec
             state_spec = None
             INDEX_INDEX = 1
 
-            # MODIFIED 11/23/17 NEW:
             if is_numeric(tuple_spec[0]):
                 state_spec = tuple_spec[0]
                 reference_value = state_dict[REFERENCE_VALUE]
@@ -1152,14 +1139,8 @@ class OutputState(State_Base):
                                      "is not compatible with its {} ({})".
                                      format(OutputState.__name__, owner.name, state_spec,
                                             REFERENCE_VALUE, reference_value))
-                # # MODIFIED 11/28/17 OLD:
                 projection_spec = tuple_spec[1]
-                # MODIFIED 11/28/17 NEW:
-                # projection_spec =
-                # MODIFIED 11/28/17 END:
-            # MODIFIED 11/23/17 END
 
-            # MODIFIED 11/23/17 NEW: ADDED ELSE AND INDENTED
             else:
                 projection_spec = state_specific_spec if len(state_specific_spec)==2 else (state_specific_spec[0],
                                                                                            state_specific_spec[-1])
@@ -1180,6 +1161,7 @@ class OutputState(State_Base):
             # Get INDEX specification from (state_spec, index, connections) tuple:
             if len(tuple_spec) == 3:
 
+                # MODIFIED 3/8/18 OLD:
                 index = tuple_spec[INDEX_INDEX]
 
                 if index is not None and not isinstance(index, numbers.Number):
@@ -1193,6 +1175,30 @@ class OutputState(State_Base):
                                            format(INDEX, OutputState.__name__, owner.name, index,
                                                   owner.name, owner.instance_defaults.value, len(owner.instance_defaults.value)-1))
                 params_dict[INDEX] = index
+                # # MODIFIED 3/8/18 NEW:
+                # assert False
+                # tuple_variable_spec = tuple_spec[INDEX_INDEX]
+                # if VARIABLE in params_dict:
+                #     dict_variable_spec = params_dict[VARIABLE]
+                # elif VARIABLE in state_dict:
+                #     dict_variable_spec = params_dict[VARIABLE]
+                #
+                # # if isinstance(index, int):
+                # index = tuple_variable_spec
+                #
+                # if index is not None and not isinstance(index, numbers.Number):
+                #     raise OutputStateError("The {} (2nd) item of the {} specification tuple for {} ({}) "
+                #                            "must be a number".format(INDEX, OutputState.__name__, owner.name, index))
+                # try:
+                #     owner.instance_defaults.value[index]
+                # except IndexError:
+                #     raise OutputStateError("The {0} (2nd) item of the {1} specification tuple for {2} ({3}) is out "
+                #                            "of bounds for the number of items in {4}'s value ({5}, max index: {6})".
+                #                            format(INDEX, OutputState.__name__, owner.name, index,
+                #                                   owner.name, owner.instance_defaults.value, len(owner.instance_defaults.value)-1))
+                # params_dict[INDEX] = index
+                # MODIFIED 3/8/18 END
+
 
         elif state_specific_spec is not None:
             raise OutputStateError("PROGRAM ERROR: Expected tuple or dict for {}-specific params but, got: {}".
@@ -1525,7 +1531,8 @@ class StandardOutputStates():
             for index, state_dict in enumerate(self.data):
                 state_dict.update({VARIABLE:(OWNER_VALUE, index)})
 
-        # Assign PRIMARY as INDEX for all OutputStates in output_state_dicts that don't already have an index specified
+        # Assign (OWNER_VALUE, PRIMARY) as VARIABLE for all OutputStates in output_state_dicts that don't
+        #    have VARIABLE (or INDEX) specified (INDEX is included here for backward compatibility)
         elif indices is PRIMARY:
             for state_dict in self.data:
                 if INDEX in state_dict or VARIABLE in state_dict:

--- a/psyneulink/components/states/outputstate.py
+++ b/psyneulink/components/states/outputstate.py
@@ -116,7 +116,7 @@ that serve as the OutputState's `variable <OutputState.variable>`, and are used 
 to generate the OutputState's `value <OutputState.value>`.  By default, it uses the first item of its `owner
 <OutputState.owner>` Mechanism's `value <Mechanism_Base.value>`.  However, other attributes (or combinations of them)
 can be specified in the **variable** argument of the OutputState's constructor, or the *VARIABLE* entry in an
-`OutputState Specification Dictionary <OutputState_Specification_Dictionary>` (see `OutputState_Customization`).
+`OutputState specification dictionary <OutputState_Specification_Dictionary>` (see `OutputState_Customization`).
 The specification must be compatible (in the number and type of items it generates) with the input expected by the
 OutputState's `function <OutputState.function>`. The OutputState's `variable <OutputState.variable>` is used as the
 input to its `function <OutputState.function>` to generate the OutputState's `value <OutputState.value>`, possibly
@@ -268,9 +268,9 @@ which it should project. Each of these is described below:
         * **2-item tuple:** *(<State, Mechanism, or list of them>, Projection specification)* -- this is a contracted
           form of the 3-item tuple described below
         |
-        * **3-item tuple:** *(<value, State spec, or list of State specs>, index, Projection specification)* -- this
-          allows the specification of State(s) to which the OutputState should project, together with a
-          specification of its `index <OutputState.index>` attribute, and (optionally) parameters of the
+        * **3-item tuple:** *(<value, State spec, or list of State specs>, variable spec, Projection specification)* --
+          this allows the specification of State(s) to which the OutputState should project, together with a
+          specification of its `variable <OutputState.variable>` attribute, and (optionally) parameters of the
           Projection(s) to use (e.g., their `weight <Projection_Base.weight>` and/or `exponent
           <Projection_Base.exponent>` attributes.  Each tuple must have at least the first two items (in the
           order listed), and can include the third:
@@ -282,7 +282,8 @@ which it should project. Each of these is described below:
               consistent with (that is, their `value <State_Base.value>` must be compatible with the `variable
               <Projection_Base.variable>` of) the Projection specified in the fourth item if that is included.
             |
-            * **index** -- must be an integer; specifies the `index <OutputState.index>` for the OutputState.
+            * **variable spec** -- specifies the attributes of the OutputState's `owner <OutputState.owner>` Mechanism
+              used for its `variable <OutputState.variable>` (see `OutputState_Customization`).
             |
             * **Projection specification** (optional) -- `specifies a Projection <Projection_Specification>` that
               must be compatible with the State specification(s) in the 1st item; if there is more than one
@@ -382,17 +383,18 @@ OutputState Customization
 
 An OutputState's `value <OutputState.value>` can be customized by specifying its `variable <OutputState.variable>`
 and/or `function <OutputState.function>` in the **variable** and **function** arguments of the OutputState's
-constructor, respectively, or the corresponding entries (*VARIABLE* and *FUNCTION*) of an
-`OutputState_Specification_Dictionary`.
+constructor, respectively, the corresponding entries (*VARIABLE* and *FUNCTION*) of an `OutputState specification
+dictionary <OutputState_Specification_Dictionary>`, or in the variable spec item of a `3-item tuple
+<OutputState_Tuple_Specification>` for the OutputState.
 
 *OutputState* `variable <OutputState.variable>`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 By default, an OutputState uses the first (and usually only) item of the owner Mechanism's `value
-<Mechanism_Base.value>` as its `variable <OutputState.variable>`.  However, this can be customized by assigning it
-any other item of its `owner <OutputState.owner>`\\s `value <Mechanism_Base.value>`, the full
-`value <Mechanism_Base.value>` itself, other attributes of the `owner <OutputState.owner>`, or any combination of these
-uing the following keywords:
+<Mechanism_Base.value>` as its `variable <OutputState.variable>`.  However, this can be customized by specifying
+any other item of its `owner <OutputState.owner>`\\s `value <Mechanism_Base.value>`, the full `value
+<Mechanism_Base.value>` itself, other attributes of the `owner <OutputState.owner>`, or any combination of these
+using the following keywords:
 
     *OWNER_VALUE* -- the entire `value <Mechanism_Base.value>` of the OutputState's `owner <OutputState.owner>`.
 
@@ -565,16 +567,13 @@ Execution
 ---------
 
 An OutputState cannot be executed directly.  It is executed when the Mechanism to which it belongs is executed.
-When the Mechanism is executed, it places the results of its execution in its `value <Mechanism_Base.value>`
-attribute. The OutputState's `index <OutputState.index>` attribute designates the item of the Mechanism's
-`value <Mechanism_Base.value>` for use by the OutputState.  The OutputState is updated by calling the function
-specified by its `assign <OutputState_Assign>` attribute with the designated item of the Mechanism's
-`value <Mechanism_Base.value>` as its input.  This is used by the Mechanism's
-`function <Mechanism_Base.function>`, modified by any `GatingProjections <GatingProjection>` it receives (listed in
-its `mod_afferents <OutputState.mod_afferents>` attribute), to generate the `value <OutputState.value>` of the
-OutputState.  This is assigned to a corresponding item of the Mechanism's `output_values
-<Mechanism_Base.output_values>` attribute, and is used as the input to any projections for which the
-OutputState is the `sender <Projection_Base.sender>`.
+When the Mechanism is executed, the values of its attributes specified for the OutputState's `variable
+<OutputState.variable>` (see `OutputState_Customization`) are used as the input to the OutputState's `function
+<OutputState.function>`. The OutputState is updated by calling its `function <OutputState.function>`.  The result,
+modified by any `GatingProjections <GatingProjection>` the OutputState receives (listed in its `mod_afferents
+<OutputState.mod_afferents>` attribute), is assigned as the `value <OutputState.value>` of the OutputState.  This is
+assigned to a corresponding item of the Mechanism's `output_values <Mechanism_Base.output_values>` attribute,
+and is used as the input to any projections for which the OutputState is the `sender <Projection_Base.sender>`.
 
 .. _OutputState_Class_Reference:
 
@@ -725,11 +724,10 @@ class OutputState(State_Base):
         context in which the OutputState is created.
 
     reference_value : number, list or np.ndarray
-        a template that specifies the format of the item of the owner Mechanism's
-        `value <Mechanism_Base.value>` attribute to which the OutputState will be assigned (specified by
-        the **index** argument).  This must match (in number and type of elements) the OutputState's
-        **variable** argument.  It is used to insure the compatibility of the source of the
-        input for the OutputState with its `variable <OutputState.variable>`.
+        a template that specifies the format of the OutputState's `variable <OutputState.variable>`;  if it is
+        specified in addition to the **variable** argument, then these must be compatible (both in the number and
+        type of elements).  It is used to insure the compatibility of the source of the input for the OutputState
+        with its `function <OutputState.function>`.
 
     variable : number, list or np.ndarray
         specifies the attributes of the  OutputState's `owner <OutputState.owner>` Mechanism to be used by the
@@ -792,8 +790,8 @@ class OutputState(State_Base):
 
     variable : value, list or np.ndarray
         the value(s) of the item(s) of the `owner <OutputState.owner>` Mechanism's attributes specified in the
-        **variable** argument of the constructor or *VARIABLE* entry of the `OutputState_Specification_Dictionary`
-        used to construct the OutputState.
+        **variable** argument of the constructor, or a *VARIABLE* entry in the `OutputState specification dictionary
+        <OutputState_Specification_Dictionary>` used to construct the OutputState.
 
     COMMENT:
     index : int
@@ -879,8 +877,6 @@ class OutputState(State_Base):
                  variable=None,
                  size=None,
                  function=Linear(),
-                 # index=PRIMARY,
-                 # assign:tc.optional(is_function_type)=None,
                  projections=None,
                  params=None,
                  name=None,
@@ -901,8 +897,6 @@ class OutputState(State_Base):
 
         # Assign args to params and functionParams dicts (kwConstants must == arg names)
         params = self._assign_args_to_param_dicts(
-                # index=index,
-                # assign=assign,
                 function=function,
                 params=params)
 
@@ -1086,11 +1080,11 @@ class OutputState(State_Base):
 
     @tc.typecheck
     def _parse_state_specific_specs(self, owner, state_dict, state_specific_spec):
-        """Get index and/or connections specified in an OutputState specification tuple
+        """Get variable spec and/or connections specified in an OutputState specification tuple
 
         Tuple specification can be:
             (state_spec, connections)
-            (state_spec, index, connections)
+            (state_spec, variable spec, connections)
 
         See State._parse_state_specific_spec for additional info.
 
@@ -1150,7 +1144,7 @@ class OutputState(State_Base):
                                        "either 2 ({} and {}) or 3 (optional additional {}) items, "
                                        "or must be a {}".
                                        format(OutputState.__name__, owner.name, tuple_spec,
-                                              STATE, PROJECTION, INDEX, ProjectionTuple.__name__))
+                                              STATE, PROJECTION, 'variable spec', ProjectionTuple.__name__))
 
 
             params_dict[PROJECTIONS] = _parse_connection_specs(connectee_state_type=self,
@@ -1158,7 +1152,7 @@ class OutputState(State_Base):
                                                                connections=projection_spec)
 
 
-            # Get INDEX specification from (state_spec, index, connections) tuple:
+            # Get VARIABLE specification from (state_spec, variable spec, connections) tuple:
             if len(tuple_spec) == 3:
 
                 tuple_variable_spec = tuple_spec[TUPLE_VARIABLE_INDEX]
@@ -1176,7 +1170,7 @@ class OutputState(State_Base):
                                            format(VARIABLE, name, tuple_spec[TUPLE_VARIABLE_INDEX],
                                                   owner.name, dict_variable_spec))
 
-                # if isinstance(index, int) Included for backwward compatibility with INDEX
+                # Included for backward compatibility with INDEX
                 if isinstance(tuple_variable_spec, int):
                     tuple_variable_spec = (OWNER_VALUE, tuple_variable_spec)
 
@@ -1270,21 +1264,19 @@ def _instantiate_output_states(owner, output_states=None, context=None):
         - if owner.output_states is empty, use owner.value to create a default OutputState
 
     For each OutputState:
-         check for index param:
-             if it is a State, get from index attribute
-             if it is dict, look for INDEX entry
-             if it is anything else, assume index is PRIMARY
-         get indexed value from output.value
-         append the indexed value to reference_value
+         check for VARIABLE and FUNCTION specifications:
+             if it is a State, get from variable and function attributes
+             if it is dict, look for VARIABLE and FUNCTION entries (and INDEX and ASSIGN for backward compatibility)
+             if it is anything else, assume variable spec is (OWNER_VALUE, 0) and FUNCTION is Linear
+         get OutputState's value using _parse_output_state_variable() and append to reference_value
              so that it matches specification of OutputStates (by # and function return values)
-         instantiate assign function if specified
 
     When completed:
         - self.output_states contains a ContentAddressableList of one or more OutputStates;
         - self.output_state contains first or only OutputState in list;
         - paramsCurrent[OUTPUT_STATES] contains the same ContentAddressableList (of one or more OutputStates)
-        - each OutputState corresponds to an item in the output of the owner's function
-        - if there is only one OutputState, it is assigned the full value
+        - each OutputState properly references, for its variable, the specified attributes of its owner Mechanism
+        - if there is only one OutputState, it is assigned the full value of its owner.
 
     (See State._instantiate_state_list() for additional details)
 

--- a/psyneulink/components/states/state.py
+++ b/psyneulink/components/states/state.py
@@ -2263,7 +2263,7 @@ def _instantiate_state(state_type:_is_state_class,           # State's type
         # # variable:
         # #   InputState: set of projections it receives
         # #   ParameterState: value of its sender
-        # #   OutputState: value[INDEX] of its owner
+        # #   OutputState: _parse_output_state_variable()
         # # FIX: ----------------------------------------------------------
 
         # FIX: THIS SHOULD ONLY APPLY TO InputState AND ParameterState; WHAT ABOUT OutputState?

--- a/psyneulink/library/mechanisms/adaptive/learning/autoassociativelearningmechanism.py
+++ b/psyneulink/library/mechanisms/adaptive/learning/autoassociativelearningmechanism.py
@@ -84,7 +84,7 @@ from psyneulink.components.mechanisms.processing.objectivemechanism import Objec
 from psyneulink.components.projections.pathway.mappingprojection import MappingProjection
 from psyneulink.components.projections.projection import Projection_Base, _is_projection_spec, _validate_receiver, projection_keywords
 from psyneulink.components.shellclasses import Projection
-from psyneulink.globals.keywords import AUTOASSOCIATIVE_LEARNING_MECHANISM, CONTROL_PROJECTIONS, FUNCTION_PARAMS, INDEX, INITIALIZING, INPUT_STATES, LEARNING, LEARNING_PROJECTION, LEARNING_SIGNAL, LEARNING_SIGNALS, MAPPING_PROJECTION, MATRIX, NAME, OUTPUT_STATES, PROJECTION
+from psyneulink.globals.keywords import AUTOASSOCIATIVE_LEARNING_MECHANISM, CONTROL_PROJECTIONS, FUNCTION_PARAMS, INITIALIZING, INPUT_STATES, LEARNING, LEARNING_PROJECTION, LEARNING_SIGNAL, LEARNING_SIGNALS, MAPPING_PROJECTION, MATRIX, NAME, OUTPUT_STATES, OWNER_VALUE, PROJECTION, VARIABLE
 from psyneulink.globals.preferences.componentpreferenceset import is_pref_set
 from psyneulink.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.globals.utilities import is_numeric, parameter_spec
@@ -285,7 +285,7 @@ class AutoAssociativeLearningMechanism(LearningMechanism):
         CONTROL_PROJECTIONS: None,
         INPUT_STATES:input_state_names,
         OUTPUT_STATES:[{NAME:LEARNING_SIGNAL,  # NOTE: This is the default, but is overridden by any LearningSignal arg
-                        INDEX:0}
+                        VARIABLE: (OWNER_VALUE,0)}
                        ]})
 
     @tc.typecheck

--- a/psyneulink/library/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/mechanisms/processing/integrator/ddm.py
@@ -345,7 +345,7 @@ from psyneulink.components.mechanisms.processing.processingmechanism import Proc
 from psyneulink.components.mechanisms.adaptive.control.controlmechanism import _is_control_spec
 from psyneulink.components.states.modulatorysignals.controlsignal import ControlSignal
 from psyneulink.components.states.outputstate import SEQUENTIAL, StandardOutputStates
-from psyneulink.globals.keywords import ALLOCATION_SAMPLES, ASSIGN, FUNCTION, FUNCTION_PARAMS, \
+from psyneulink.globals.keywords import ALLOCATION_SAMPLES, FUNCTION, FUNCTION_PARAMS, \
     INDEX, INITIALIZING, INPUT_STATE_VARIABLES, NAME, OUTPUT_STATES,  OWNER_VALUE, VALUE, VARIABLE, kwPreferenceSetName
 from psyneulink.globals.preferences.componentpreferenceset import is_pref_set, kpReportOutputPref
 from psyneulink.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel

--- a/psyneulink/library/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/mechanisms/processing/integrator/ddm.py
@@ -346,7 +346,7 @@ from psyneulink.components.mechanisms.adaptive.control.controlmechanism import _
 from psyneulink.components.states.modulatorysignals.controlsignal import ControlSignal
 from psyneulink.components.states.outputstate import SEQUENTIAL, StandardOutputStates
 from psyneulink.globals.keywords import ALLOCATION_SAMPLES, FUNCTION, FUNCTION_PARAMS, \
-    INDEX, INITIALIZING, INPUT_STATE_VARIABLES, NAME, OUTPUT_STATES,  OWNER_VALUE, VALUE, VARIABLE, kwPreferenceSetName
+    INITIALIZING, INPUT_STATE_VARIABLES, NAME, OUTPUT_STATES,  OWNER_VALUE, VALUE, VARIABLE, kwPreferenceSetName
 from psyneulink.globals.preferences.componentpreferenceset import is_pref_set, kpReportOutputPref
 from psyneulink.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
 from psyneulink.globals.utilities import is_numeric, object_has_single_value

--- a/psyneulink/library/mechanisms/processing/objective/comparatormechanism.py
+++ b/psyneulink/library/mechanisms/processing/objective/comparatormechanism.py
@@ -138,7 +138,7 @@ from psyneulink.components.shellclasses import Mechanism
 from psyneulink.components.states.inputstate import InputState
 from psyneulink.components.states.outputstate import OutputState, PRIMARY, StandardOutputStates
 from psyneulink.components.states.state import _parse_state_spec
-from psyneulink.globals.keywords import ASSIGN, COMPARATOR_MECHANISM, INPUT_STATES, NAME, SAMPLE, TARGET, VARIABLE, kwPreferenceSetName
+from psyneulink.globals.keywords import COMPARATOR_MECHANISM, FUNCTION, INPUT_STATES, NAME, SAMPLE, TARGET, VARIABLE, kwPreferenceSetName
 from psyneulink.globals.preferences.componentpreferenceset import is_pref_set, kpReportOutputPref
 from psyneulink.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
 from psyneulink.globals.utilities import is_numeric, is_value_spec, iscompatible, kwCompatibilityLength, kwCompatibilityNumeric, recursive_update
@@ -317,9 +317,9 @@ class ComparatorMechanism(ObjectiveMechanism):
 
     standard_output_states = ObjectiveMechanism.standard_output_states.copy()
     standard_output_states.extend([{NAME: SSE,
-                                    ASSIGN: lambda x: np.sum(x*x)},
+                                    FUNCTION: lambda x: np.sum(x*x)},
                                    {NAME: MSE,
-                                    ASSIGN: lambda x: np.sum(x*x)/len(x)}])
+                                    FUNCTION: lambda x: np.sum(x*x)/len(x)}])
 
     # MODIFIED 10/10/17 OLD:
     @tc.typecheck

--- a/psyneulink/library/mechanisms/processing/transfer/lca.py
+++ b/psyneulink/library/mechanisms/processing/transfer/lca.py
@@ -141,7 +141,9 @@ import typecheck as tc
 
 from psyneulink.components.functions.function import LCAIntegrator, Logistic, max_vs_avg, max_vs_next
 from psyneulink.components.states.outputstate import PRIMARY, StandardOutputStates
-from psyneulink.globals.keywords import BETA, ASSIGN, ENERGY, ENTROPY, INITIALIZER, INITIALIZING, LCA, MEAN, MEDIAN, NAME, NOISE, RATE, RESULT, STANDARD_DEVIATION, TIME_STEP_SIZE, VARIANCE
+from psyneulink.globals.keywords import \
+    BETA, ENERGY, ENTROPY, FUNCTION, INITIALIZER, INITIALIZING, LCA, MEAN, \
+    MEDIAN, NAME, NOISE, RATE, RESULT, STANDARD_DEVIATION, TIME_STEP_SIZE, VARIANCE
 from psyneulink.globals.preferences.componentpreferenceset import is_pref_set
 from psyneulink.globals.utilities import is_numeric_or_none
 from psyneulink.library.mechanisms.processing.transfer.recurrenttransfermechanism import RecurrentTransferMechanism
@@ -506,9 +508,9 @@ class LCA(RecurrentTransferMechanism):
     # paramClassDefaults[OUTPUT_STATES].append({NAME:MAX_VS_AVG})
     standard_output_states = RecurrentTransferMechanism.standard_output_states.copy()
     standard_output_states.extend([{NAME:MAX_VS_NEXT,
-                                    ASSIGN:max_vs_next},
+                                    FUNCTION:max_vs_next},
                                    {NAME:MAX_VS_AVG,
-                                    ASSIGN:max_vs_avg}])
+                                    FUNCTION:max_vs_avg}])
 
     @tc.typecheck
     def __init__(self,

--- a/psyneulink/library/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -594,8 +594,6 @@ class RecurrentTransferMechanism(TransferMechanism):
 
     standard_output_states = TransferMechanism.standard_output_states.copy()
     standard_output_states.extend([{NAME:ENERGY}, {NAME:ENTROPY}])
-    # FIX: 11/19/17 ??SHOULD THE ABOVE BE:
-    # standard_output_states.extend([{NAME:ENERGY, INDEX:PRIMARY}, {NAME:ENTROPY, INDEX:PRIMARY}])
 
     @tc.typecheck
     def __init__(self,

--- a/tests/projections/test_projections_specifications.py
+++ b/tests/projections/test_projections_specifications.py
@@ -97,13 +97,13 @@ class TestProjectionSpecificationFormats:
         assert T2.output_states[0].efferents[1].receiver.name == 'InputState-1'
         assert T2.output_states[0].efferents[1].matrix.shape == (1,3)
 
-    def test_mapping_projection_using_2_item_tuple_with_index_specs(self):
+    def test_mapping_projection_using_2_item_tuple_and_3_item_tuples_with_index_specs(self):
 
         T1 = pnl.TransferMechanism(name='T1', input_states=[[0,0],[0,0,0]])
         T2 = pnl.TransferMechanism(name='T2',
                                    input_states=['a','b','c'],
                                    output_states=[(['InputState-0','InputState-1'], T1),
-                                                  ('InputState-0', 2, T1),
+                                                  ('InputState-0', (pnl.OWNER_VALUE, 2), T1),
                                                   (['InputState-0','InputState-1'], 1, T1)])
         assert len(T2.output_states)==3
         assert T2.output_states[0].efferents[0].receiver.name == 'InputState-0'


### PR DESCRIPTION
• Project
  - Delete ASSIGN, INDEX and CALCULATE everywhere except where retained for backward compatibility (in OutputState and Keywords)
  - Restored warnings for use of ASSIGN, INDEX and CALCULATE 
     (no longer triggered by tests or example scripts)

• LearningMechanism
  _validate_params:
      replaced try and except for learning_signal[PARAMS][PROJECTIONS]
      with if-else
