### PR TITLE
docs/mechanism/targets_in_output_labels_dict

### DIFF
--- a/.idea/runConfigurations/Make_HTML.xml
+++ b/.idea/runConfigurations/Make_HTML.xml
@@ -1,9 +1,9 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" factoryName="Sphinx task" name="Make HTML" singleton="true" type="docs">
-    <module name="" />
+  <configuration default="false" name="Make HTML" type="docs" factoryName="Sphinx task" singleton="true">
+    <module name="PsyNeuLink (Dropbox)" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
-    <option name="SDK_HOME" value="" />
+    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python35/bin/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/docs" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/psyneulink/components/mechanisms/mechanism.py
+++ b/psyneulink/components/mechanisms/mechanism.py
@@ -687,12 +687,19 @@ OutputState(s):
 The labels specified in these dictionaries can be used to specify items in the `inputs <Run_Inputs>` and `targets
 <Run_Targets>` arguments of the `run <System.run>` method of a `System`, and to report the values of the InputState(s)
 and OutputState(s) of a Mechanism in a System's `show_graph <System.show_graph>` method (using its **use_values**
-option).  The labels for the current value(s) of the Mechanism's InputState(s) and OutputState(s) are listed in its
-`input_labels <Mechanism_Base.input_labels>` and `output_labels <Mechanism_Base.output_labels>`, respectively.
+option).  If they are used to specify `targets <Run_Targets>`, they must be included in the `output_labels_dict
+<Mechanism_Base.output_labels_dict>` of the Mechanism that projects to the `TARGET` Mechanism (see `TARGET Mechanisms
+<LearningMechanism_Targets>`,  the last one in a `learning sequence <Process_Learning_Sequence>`.
+
+The labels for the current value(s) of the Mechanism's InputState(s) and OutputState(s) are listed in its
+`input_labels <Mechanism_Base.input_labels>` and `output_labels <Mechanism_Base.output_labels>` attributes,
+respectively.
+
+*Specifying label dictionaries*
 
 Label dictionaries can only be specified in a parameters dictionary assigned to the **params** argument of the
-Mechanism's constructor, using the keywords listed above.  A given label dictionary must contain entries *all* of which
-use *only one* of the two following formats for the *key:value* pair of each entry:
+Mechanism's constructor, using the keywords described above.  A given label dictionary must contain entries *all*
+of which use *only one* of the two following formats for the *key:value* pair of each entry:
 
     * *label:value* -- the *label* is a string to be associated with the specified value of the State. If the
       Mechanism has more than one State of the type corresponding to the dictionary, then the label will be used for
@@ -710,7 +717,7 @@ use *only one* of the two following formats for the *key:value* pair of each ent
       `output_states <Mechanism_Base.output_states>`), and the value a subdictionary containing *label:value* entries
       to be used for that State.  For example, if a Mechanism has two InputStates, named *SAMPLE* and *TARGET*, then
       *INPUT_LABELS_DICT* could be assigned two entries, *SAMPLE*:<dict> and *TARGET*:<dict> or, correspondingly,
-      0:<dict> and 1:<dict>, in which each dict contained separate *label:value* entries for each of the two
+      0:<dict> and 1:<dict>, in which each dict contained separate *label:value* entries for the *SAMPLE* and *TARGET*
       InputStates.
       COMMENT:
           ADD EXAMPLE HERE

--- a/psyneulink/composition.py
+++ b/psyneulink/composition.py
@@ -126,7 +126,8 @@ class MechanismRole(Enum):
         `run <ComparatorMechanism.ComparatorMechanism.execute>` method.  It must be associated with the `TERMINAL`
         Mechanism of the Process or System. The `TARGET` Mechanisms of a Process or System are listed in its
         :keyword:`target_mechanisms` attribute, and can be displayed using its :keyword:`show` method.  For additional
-        details, see `TARGET mechanisms <LearningProjection_Targets>` and specifying `target values <Run_Targets>`.
+        details, see `TARGET Mechanisms <LearningMechanism_Targets>`, `learning sequence <Process_Learning_Sequence>`,
+        and specifying `target values <Run_Targets>`.
 
     - RECURRENT_INIT
         .

--- a/psyneulink/globals/keywords.py
+++ b/psyneulink/globals/keywords.py
@@ -149,10 +149,11 @@ class MechanismRoles:
     TARGET
         A `ComparatorMechanism` of a `Process` and/or `System` configured for learning that receives a target value
         from its `execute <ComparatorMechanism.ComparatorMechanism.execute>` or
-        `run <ComparatorMechanism.ComparatorMechanism.execute>` method.  It must be associated with the `TERMINAL`
-        Mechanism of the Process or System. The `TARGET` Mechanisms of a Process or System are listed in its
-        :keyword:`target_mechanisms` attribute, and can be displayed using its :keyword:`show` method.  For additional
-        details, see `TARGET Mechanisms <LearningMechanism_Targets>` and specifying `target values <Run_Targets>`.
+        `run <ComparatorMechanism.ComparatorMechanism.execute>` method.  It is usually (but not necessarily)
+        associated with the `TERMINAL` Mechanism of the Process or System. The `TARGET` Mechanisms of a Process or
+        System are listed in its :keyword:`target_mechanisms` attribute, and can be displayed using its
+        :keyword:`show` method.  For additional details, see `TARGET Mechanisms <LearningMechanism_Targets>`,
+        `learning sequence <Process_Learning_Sequence>`, and specifying `target values <Run_Targets>`.
 
 
     """


### PR DESCRIPTION
• Mechanism
  docstring:  added explanation of assignment of target labels to
              output_labels_dict for Mechanism that projects to
              TARGET Mechanism