### PR TITLE
Devel

### DIFF
--- a/psyneulink/components/functions/function.py
+++ b/psyneulink/components/functions/function.py
@@ -4680,6 +4680,10 @@ class Integrator(IntegratorFunction):  # ---------------------------------------
         #     self._validate_initializer(target_set[INITIALIZER])
 
         if NOISE in target_set:
+            noise = target_set[NOISE]
+            if isinstance(noise, DistributionFunction):
+                noise.owner = self
+                target_set[NOISE] = noise._execute
             self._validate_noise(target_set[NOISE])
 
     def _validate_rate(self, rate):
@@ -4746,11 +4750,12 @@ class Integrator(IntegratorFunction):  # ---------------------------------------
                         "must be specified as a float, a function, or an array of the appropriate shape ({})."
                             .format(noise, self.instance_defaults.variable, self.name, np.shape(np.array(self.instance_defaults.variable))))
             else:
-                for noise_item in noise:
-                    if not isinstance(noise_item, (float, int)) and not callable(noise_item):
-                        raise FunctionError(
-                            "The elements of a noise list or array must be floats or functions. "
-                            "{} is not a valid noise element for {}".format(noise_item, self.name))
+                for i in range(len(noise)):
+                    if isinstance(noise[i], DistributionFunction):
+                        noise[i] = noise[i]._execute
+                    if not isinstance(noise[i], (float, int)) and not callable(noise[i]):
+                        raise FunctionError("The elements of a noise list or array must be floats or functions. "
+                                            "{} is not a valid noise element for {}".format(noise[i], self.name))
 
         # Otherwise, must be a float, int or function
         elif not isinstance(noise, (float, int)) and not callable(noise):
@@ -5688,6 +5693,10 @@ class AdaptiveIntegrator(Integrator):  # ---------------------------------------
                     raise FunctionError(rate_value_msg.format(rate, self.name))
 
         if NOISE in target_set:
+            noise = target_set[NOISE]
+            if isinstance(noise, DistributionFunction):
+                noise.owner = self
+                target_set[NOISE] = noise._execute
             self._validate_noise(target_set[NOISE])
         # if INITIALIZER in target_set:
         #     self._validate_initializer(target_set[INITIALIZER])
@@ -7649,6 +7658,10 @@ class AGTUtilityIntegrator(Integrator):  # -------------------------------------
                         "1.0 when integration_type is set to ADAPTIVE.".format(target_set[RATE], self.name))
 
         if NOISE in target_set:
+            noise = target_set[NOISE]
+            if isinstance(noise, DistributionFunction):
+                noise.owner = self
+                target_set[NOISE] = noise._execute
             self._validate_noise(target_set[NOISE])
             # if INITIALIZER in target_set:
             #     self._validate_initializer(target_set[INITIALIZER])

--- a/psyneulink/library/projections/pathway/maskedmappingprojection.py
+++ b/psyneulink/library/projections/pathway/maskedmappingprojection.py
@@ -72,7 +72,8 @@ from psyneulink.globals.preferences.componentpreferenceset import is_pref_set
 from psyneulink.globals.preferences.preferenceset import PreferenceLevel
 
 __all__ = [
-    'MaskedMappingProjection', 'MASK', 'MASK_OPERATION', 'ADD', 'MULTIPLY', 'EXPONENTIATE'
+    'MaskedMappingProjection', 'MaskedMappingProjectionError',
+    'MASK', 'MASK_OPERATION', 'ADD', 'MULTIPLY', 'EXPONENTIATE'
 ]
 
 MASK = 'mask'

--- a/psyneulink/library/projections/pathway/maskedmappingprojection.py
+++ b/psyneulink/library/projections/pathway/maskedmappingprojection.py
@@ -15,8 +15,8 @@ Overview
 --------
 
 A MaskedMappingProjection is a subclass of `MappingProjection` that applies a specified mask array
-(either additively multipicatively, or exponentially) to the MappingProjection's `matrix <MappingProjection>`
-each time the MappingProjection is executed.  The mask is assigned a ParameterState and can thus be modulated
+(either additively, multiplicatively, or exponentially) to the MappingProjection's `matrix <MappingProjection.matrix>`
+each time the MappingProjection is executed.  The mask is assigned a `ParameterState` and can thus be modulated
 by a `ControlMechanism <ControlMechanism>`.
 
 .. _Masked_MappingProjection_Creation:
@@ -28,7 +28,7 @@ A MaskedMappingProjection is created in the same way as a `MappingProjection`, w
 includes **mask** and **mask_operation** arguments that can be used to configure the mask and how it is applied to the
 Projection's `matrix <MaskedMappingProjection.matrix>`.  The **mask** attribute must be an array that has the same
 shape as the the `matrix <MaskedMappingProjection.matrix>` attribute, and the **mask_operation** argument must be the
-keyword *ADD*, *MULTIPLY*, or *EXPONENTIATE* (see `Masked_MappingProjection_Execution below`).
+keyword *ADD*, *MULTIPLY*, or *EXPONENTIATE* (see `Masked_MappingProjection_Execution` below).
 
 .. _Masked_MappingProjection_Structure:
 
@@ -44,10 +44,10 @@ Execution
 ---------
 
 A MaskedMappingProjection executes in the same manner as a `MappingProjection`, with the exception that,
-each time the Projection is executed, its `mask MaskedMappingProjection.mask` is applied to its `matrix
+each time the Projection is executed, its `mask <MaskedMappingProjection.mask>` is applied to its `matrix
 <MaskedMappingProjection.matrix>` parameter as specified by its `mask_operation
 <MaskedMappingProjection.mask_operation>` attribute, before generating the Projection's `value
-<MappingProjection.value>`.
+<MaskedMappingProjection.value>`.
 
 .. _Masked_MappingProjection_Class_Reference:
 
@@ -91,7 +91,6 @@ class MaskedMappingProjectionError(Exception):
 class MaskedMappingProjection(MappingProjection):
     """
     MaskedMappingProjection(     \
-        owner=None,              \
         sender=None,             \
         receiver=None,           \
         matrix=DEFAULT_MATRIX,   \
@@ -105,10 +104,6 @@ class MaskedMappingProjection(MappingProjection):
 
     Arguments
     ---------
-
-    owner : Optional[Mechanism]
-        simply specifies both the sender and receiver of the AutoAssociativeProjection. Setting owner=myMechanism is
-        identical to setting sender=myMechanism and receiver=myMechanism.
 
     sender : Optional[OutputState or Mechanism]
         specifies the source of the Projection's input. If a Mechanism is specified, its
@@ -128,7 +123,7 @@ class MaskedMappingProjection(MappingProjection):
         specifies a mask to be applied to the `matrix <MaskedMappingProjection.matrix>` each time the Projection is
         executed, in a manner specified by the **mask_operation** argument.
 
-    mask_operation : ADD, MULTPLY or EXPONENTIATE : default MULTIPLY
+    mask_operation : ADD, MULTIPLY, or EXPONENTIATE : default MULTIPLY
         specifies the manner in which the `mask <MaskedMappingProjection.mask>` is applied to the `matrix
         <MaskedMappingProjection.matrix>` each time the Projection is executed.
 
@@ -166,7 +161,7 @@ class MaskedMappingProjection(MappingProjection):
         mask applied to the `matrix <MaskedMappingProjection.matrix>` each time the Projection is executed,
         in a manner specified by `mask_operation <MaskedMappingProjection.mask_operation>`.
 
-    mask_operation : ADD, MULTPLY or EXPONENTIATE : default MULTIPLY
+        mask_operation : ADD, MULTIPLY, or EXPONENTIATE : default MULTIPLY
         determines the manner in which the `mask <MaskedMappingProjection.mask>` is applied to the `matrix
         <MaskedMappingProjection.matrix>` when the Projection is executed.
 
@@ -195,7 +190,6 @@ class MaskedMappingProjection(MappingProjection):
 
     @tc.typecheck
     def __init__(self,
-                 owner=None,
                  sender=None,
                  receiver=None,
                  matrix=DEFAULT_MATRIX,
@@ -204,18 +198,7 @@ class MaskedMappingProjection(MappingProjection):
                  function=None,
                  params=None,
                  name=None,
-                 prefs: is_pref_set = None,
-                 context=None,
-                 ):
-
-        if owner is not None:
-            if not isinstance(owner, Mechanism):
-                raise MaskedMappingProjectionError('Owner of AutoAssociative Mechanism '
-                                                   'must either be \'None\' or a Mechanism')
-            if sender is None:
-                sender = owner
-            if receiver is None:
-                receiver = owner
+                 prefs: is_pref_set = None):
 
         params = self._assign_args_to_param_dicts(mask=mask,
                                                   mask_operation=mask_operation,

--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -302,7 +302,7 @@ def test_DDM_noise_fn():
             name='DDM',
             function=DriftDiffusionIntegrator(
 
-                noise=NormalDist().function,
+                noise=NormalDist(),
                 rate=1.0,
                 time_step_size=1.0
             ),
@@ -405,7 +405,7 @@ def test_DDM_input_list_len_2():
 
 def test_DDM_input_fn():
     with pytest.raises(TypeError) as error_text:
-        stim = NormalDist().function
+        stim = NormalDist()
         T = DDM(
             name='DDM',
             function=DriftDiffusionIntegrator(

--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -840,7 +840,7 @@ class TestIntegratorNoise:
         I = IntegratorMechanism(
             name='IntegratorMechanism',
             function=SimpleIntegrator(
-                noise=NormalDist().function
+                noise=NormalDist()
             ),
         )
 
@@ -860,7 +860,7 @@ class TestIntegratorNoise:
             name='IntegratorMechanism',
             default_variable=[0, 0, 0, 0],
             function=SimpleIntegrator(
-                noise=NormalDist().function,
+                noise=NormalDist(),
             ),
         )
 
@@ -874,7 +874,7 @@ class TestIntegratorNoise:
         I = IntegratorMechanism(
             name='IntegratorMechanism',
             function=AccumulatorIntegrator(
-                noise=NormalDist().function
+                noise=NormalDist()
             ),
         )
 
@@ -889,7 +889,7 @@ class TestIntegratorNoise:
             name='IntegratorMechanism',
             default_variable=[0, 0, 0, 0],
             function=AccumulatorIntegrator(
-                noise=NormalDist().function,
+                noise=NormalDist(),
             ),
         )
 
@@ -902,7 +902,7 @@ class TestIntegratorNoise:
         I = IntegratorMechanism(
             name='IntegratorMechanism',
             function=ConstantIntegrator(
-                noise=NormalDist().function
+                noise=NormalDist()
             ),
         )
 
@@ -917,7 +917,7 @@ class TestIntegratorNoise:
             name='IntegratorMechanism',
             default_variable=[0, 0, 0, 0],
             function=ConstantIntegrator(
-                noise=NormalDist().function,
+                noise=NormalDist(),
             ),
         )
 
@@ -931,7 +931,7 @@ class TestIntegratorNoise:
         I = IntegratorMechanism(
             name='IntegratorMechanism',
             function=AdaptiveIntegrator(
-                noise=NormalDist().function
+                noise=NormalDist()
             ),
         )
 
@@ -946,7 +946,7 @@ class TestIntegratorNoise:
             name='IntegratorMechanism',
             default_variable=[0, 0, 0, 0],
             function=AdaptiveIntegrator(
-                noise=NormalDist().function,
+                noise=NormalDist(),
             ),
         )
 

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -141,7 +141,7 @@ class TestTransferMechanismNoise:
             name='T',
             default_variable=[0, 0, 0, 0],
             function=Linear(),
-            noise=NormalDist().function,
+            noise=NormalDist(),
             smoothing_factor=1.0,
             integrator_mode=True
         )
@@ -156,7 +156,7 @@ class TestTransferMechanismNoise:
             name='T',
             default_variable=[0, 0, 0, 0],
             function=Linear(),
-            noise=[NormalDist().function, NormalDist().function, NormalDist().function, NormalDist().function],
+            noise=[NormalDist(), NormalDist(), NormalDist(), NormalDist()],
             smoothing_factor=1.0,
             integrator_mode=True
         )
@@ -224,7 +224,7 @@ class TestDistributionFunctions:
             name='T',
             default_variable=[0, 0, 0, 0],
             function=Linear(),
-            noise=NormalDist().function,
+            noise=NormalDist(),
             smoothing_factor=1.0,
             integrator_mode=True
         )
@@ -240,7 +240,7 @@ class TestDistributionFunctions:
                 name="T",
                 default_variable=[0, 0, 0, 0],
                 function=Linear(),
-                noise=NormalDist(standard_dev=standard_deviation).function,
+                noise=NormalDist(standard_dev=standard_deviation),
                 smoothing_factor=1.0,
                 integrator_mode=True
             )
@@ -255,7 +255,7 @@ class TestDistributionFunctions:
             name='T',
             default_variable=[0, 0, 0, 0],
             function=Linear(),
-            noise=ExponentialDist().function,
+            noise=ExponentialDist(),
             smoothing_factor=1.0,
             integrator_mode=True
         )
@@ -271,7 +271,7 @@ class TestDistributionFunctions:
                 name='T',
                 default_variable=[0, 0, 0, 0],
                 function=Linear(),
-                noise=UniformToNormalDist().function,
+                noise=UniformToNormalDist(),
                 smoothing_factor=1.0
             )
             np.random.seed(22)
@@ -283,7 +283,7 @@ class TestDistributionFunctions:
                     name='T',
                     default_variable=[0, 0, 0, 0],
                     function=Linear(),
-                    noise=UniformToNormalDist().function,
+                    noise=UniformToNormalDist(),
                     smoothing_factor=1.0
                 )
             assert "The UniformToNormalDist function requires the SciPy package." in str(error_text)
@@ -297,7 +297,7 @@ class TestDistributionFunctions:
             name='T',
             default_variable=[0, 0, 0, 0],
             function=Linear(),
-            noise=UniformDist().function,
+            noise=UniformDist(),
             smoothing_factor=1.0,
             integrator_mode=True
         )
@@ -312,7 +312,7 @@ class TestDistributionFunctions:
             name='T',
             default_variable=[0, 0, 0, 0],
             function=Linear(),
-            noise=GammaDist().function,
+            noise=GammaDist(),
             smoothing_factor=1.0,
             integrator_mode=True
         )
@@ -327,7 +327,7 @@ class TestDistributionFunctions:
             name='T',
             default_variable=[0, 0, 0, 0],
             function=Linear(),
-            noise=WaldDist().function,
+            noise=WaldDist(),
             smoothing_factor=1.0,
             integrator_mode=True
         )
@@ -903,7 +903,7 @@ class TestTransferMechanismMultipleInputStates:
         T = TransferMechanism(
             name='T',
             function=Linear(slope=2.0, intercept=1.0),
-            noise=NormalDist().function,
+            noise=NormalDist(),
             default_variable=[[0.0, 0.0], [0.0, 0.0]]
         )
         val = T.execute([[1.0, 2.0], [3.0, 4.0]])


### PR DESCRIPTION
Merge branch 'devel'

* devel:
  Tests/projections/maskedmappingprojection (#779)
  Fix/docs/maskedmappingprojection (#778)
  handling array of DistributionFunctions case for new noise._execute rule
  adding replacing noise with noise._execute in function validation (to allow for noise=DistributionFunction())
  removing use of noise=DistributionFunction().function from constructors in pytests
  swapping .function with ._execute in noise validation to comply with the standard that functions are always executed through ._execute

