### PR TITLE
Fix/control/various

### DIFF
--- a/.idea/runConfigurations/Scratch_Pad.xml
+++ b/.idea/runConfigurations/Scratch_Pad.xml
@@ -1,12 +1,12 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Scratch Pad" type="PythonConfigurationType" factoryName="Python" singleton="true">
-    <module name="PsyNeuLink (Dropbox)" />
+  <configuration default="false" factoryName="Python" name="Scratch Pad" singleton="true" type="PythonConfigurationType">
+    <module name="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python35/bin/python" />
+    <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Scripts" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/.idea/runConfigurations/Scratch_Pad.xml
+++ b/.idea/runConfigurations/Scratch_Pad.xml
@@ -1,12 +1,12 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" factoryName="Python" name="Scratch Pad" singleton="true" type="PythonConfigurationType">
-    <module name="" />
+  <configuration default="false" name="Scratch Pad" type="PythonConfigurationType" factoryName="Python" singleton="true">
+    <module name="PsyNeuLink (Dropbox)" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="" />
+    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python35/bin/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Scripts" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
+++ b/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
@@ -356,7 +356,6 @@ class ControlMechanism(AdaptiveMechanism_Base):
     ControlMechanism(                              \
         system=None                                \
         objective_mechanism=None,                  \
-        monitor_for_control=None,                  \
         function=Linear,                           \
         control_signals=None,                      \
         modulation=ModulationParam.MULTIPLICATIVE  \
@@ -577,13 +576,6 @@ class ControlMechanism(AdaptiveMechanism_Base):
                                                     function=function,
                                                     prefs=prefs,
                                                     context=ContextFlags.CONSTRUCTOR)
-
-        try:
-            self.monitored_output_states
-        except AttributeError:
-            raise ControlMechanismError("{} (subclass of {}) must implement a \'monitored_output_states\' attribute".
-                                              format(self.__class__.__name__,
-                                                     self.__class__.__bases__[0].__name__))
 
     def _validate_params(self, request_set, target_set=None, context=None):
         """Validate SYSTEM, MONITOR_FOR_CONTROL and CONTROL_SIGNALS
@@ -1020,7 +1012,8 @@ class ControlMechanism(AdaptiveMechanism_Base):
 
         # Add all other monitored_output_states to the ControlMechanism's monitored_output_states attribute
         #    and to its ObjectiveMechanisms monitored_output_states attribute
-        self.add_monitored_output_states(monitored_output_states)
+        if monitored_output_states:
+            self.add_monitored_output_states(monitored_output_states)
 
         # The system does NOT already have a controller,
         #    so assign it ControlSignals for any parameters in the System specified for control

--- a/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
+++ b/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
@@ -356,6 +356,7 @@ class ControlMechanism(AdaptiveMechanism_Base):
     ControlMechanism(                              \
         system=None                                \
         objective_mechanism=None,                  \
+        monitor_for_control=None,                  \
         function=Linear,                           \
         control_signals=None,                      \
         modulation=ModulationParam.MULTIPLICATIVE  \

--- a/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
+++ b/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
@@ -329,21 +329,6 @@ ALLOCATION_POLICY = 'allocation_policy'
 
 ControlMechanismRegistry = {}
 
-# MODIFIED 11/28/17 OLD:
-# def _is_control_spec(spec):
-#     from psyneulink.components.projections.modulatory.controlprojection import ControlProjection
-#     if isinstance(spec, tuple):
-#         return _is_control_spec(spec[1])
-#     elif isinstance(spec, (ControlMechanism, ControlSignal, ControlProjection)):
-#         return True
-#     elif isinstance(spec, type) and issubclass(spec, ControlSignal):
-#         return True
-#     elif isinstance(spec, str) and spec in {CONTROL, CONTROL_PROJECTION, CONTROL_SIGNAL}:
-#         return True
-#     else:
-#         return False
-
-# MODIFIED 11/28/17 NEW:
 def _is_control_spec(spec):
     from psyneulink.components.projections.modulatory.controlprojection import ControlProjection
     if isinstance(spec, tuple):
@@ -358,7 +343,6 @@ def _is_control_spec(spec):
         return True
     else:
         return False
-# MODIFIED 11/28/17 END
 
 
 class ControlMechanismError(Exception):
@@ -369,7 +353,7 @@ class ControlMechanismError(Exception):
 # class ControlMechanism(Mechanism_Base):
 class ControlMechanism(AdaptiveMechanism_Base):
     """
-    ControlMechanism(                         \
+    ControlMechanism(                              \
         system=None                                \
         objective_mechanism=None,                  \
         function=Linear,                           \

--- a/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
+++ b/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
@@ -1056,7 +1056,7 @@ class ControlMechanism(AdaptiveMechanism_Base):
         self.system = system
 
         # Flag ObjectiveMechanism as associated with a ControlMechanism that is a controller for the System
-        self._objective_mechanism.controller = True
+        self._objective_mechanism.for_controller = True
 
         if context != ContextFlags.PROPERTY:
             system._controller = self

--- a/psyneulink/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/components/mechanisms/processing/objectivemechanism.py
@@ -590,6 +590,10 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
                          prefs=prefs,
                          context=ContextFlags.CONSTRUCTOR)
 
+        # This is used to specify whether the ObjectiveMechanism is associated with a ControlMechanism that is
+        #    the controller for a System;  it is set by the ControlMechanism when it creates the ObjectiveMechanism
+        self.for_controller = False
+
     def _validate_params(self, request_set, target_set=None, context=None):
         """Validate **role**, **monitored_output_states**, amd **input_states** arguments
 

--- a/psyneulink/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/components/mechanisms/processing/objectivemechanism.py
@@ -594,29 +594,6 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
         #    the controller for a System;  it is set by the ControlMechanism when it creates the ObjectiveMechanism
         self.controller = False
 
-    def _validate_variable(self, variable, context=None):
-        """Validate that default_variable (if specified) matches in number of values the monitored_output_states
-
-        """
-        # # MODIFIED 10/8/17 OLD: [OBVIATED BY ALIASING OF monitored_output_states TO input_states]
-        # # NOTE 6/29/17: (CW)
-        # # This is a very questionable check. The problem is that TransferMechanism (if default_variable is passed as
-        # # None) expects variable to be initialized to ClassDefaults.variable ([[0]]) while ObjectiveMechanism expects
-        # # variable to be initialized to ClassDefaults.variable ([[0]]) AFTER this check has occurred. The problem is,
-        # # my solution to this has been to write (in each subclass of ProcessingMechanism) specific behavior on how to
-        # # react if both variable and size are None. This is fine but potentially cumbersome for future developers.
-        # # We should consider deleting this check entirely, and allowing ProcessingMechanism (or a further parent class)
-        # # to always set variable to ClassDefaults.variable if variable and size are both None.
-        # # IMPLEMENTATION NOTE:  use self.user_params (i.e., values specified in constructor)
-        # #                       since params have not yet been validated and so self.params is not yet available
-        # if variable is not None and len(variable) != len(self.user_params[MONITORED_OUTPUT_STATES]):
-        #     raise ObjectiveMechanismError("The number of items specified for the default_variable arg ({}) of {} "
-        #                                   "must match the number of items specified for its monitored_output_states arg ({})".
-        #                                   format(len(variable), self.name, len(self.user_params[MONITORED_OUTPUT_STATES])))
-        # MODIFIED 10/8/17 END
-
-        return super()._validate_variable(variable=variable, context=context)
-
     def _validate_params(self, request_set, target_set=None, context=None):
         """Validate **role**, **monitored_output_states**, amd **input_states** arguments
 
@@ -629,20 +606,6 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
         if ROLE in target_set and target_set[ROLE] and not target_set[ROLE] in {LEARNING, CONTROL}:
             raise ObjectiveMechanismError("\'role\'arg ({}) of {} must be either \'LEARNING\' or \'CONTROL\'".
                                           format(target_set[ROLE], self.name))
-
-        if (INPUT_STATES in target_set and target_set[INPUT_STATES] is not None and
-                not all(input_state is None for input_state in target_set[INPUT_STATES])):
-            # FIX: 10/3/17 - ??ARE THESE DOING ANYTHING:  INTEGRATE THEM... HERE OR BELOW (IN _instantiate_input_states)
-            if MONITORED_OUTPUT_STATES in target_set:
-                monitored_output_states = target_set[MONITORED_OUTPUT_STATES]
-            elif hasattr(self, 'monitored_output_states'):
-                monitored_output_states = self.monitored_output_states
-            else:
-                pass
-
-        # FIX: 10/3/17 ->
-        if MONITORED_OUTPUT_STATES in target_set and target_set[MONITORED_OUTPUT_STATES] is not None:
-            pass
 
     def _instantiate_input_states(self, monitored_output_states_specs=None, reference_value=None, context=None):
         """Instantiate InputStates specified in **input_states** argument of constructor or each OutputState
@@ -659,7 +622,7 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
         """
         from psyneulink.components.states.inputstate import InputState
         # If call is for initialization
-        if self.context.initialization_status == ContextFlags.UNSET:
+        if self.context.initialization_status == ContextFlags.INITIALIZING:
             # Use self.input_states (containing specs from **input_states** arg of constructor) or default InputState
             input_states = self.input_states or [{STATE_TYPE: InputState, VARIABLE: [0]}]
             return super()._instantiate_input_states(input_states=input_states, context=context)
@@ -736,8 +699,8 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
                 reference_value.append(projection_tuple.state.value)
 
         input_states = self._instantiate_input_states(monitored_output_states_specs=monitored_output_states_specs,
-                                              reference_value=reference_value,
-                                              context = ContextFlags.METHOD)
+                                                      reference_value=reference_value,
+                                                      context = ContextFlags.METHOD)
 
         output_states = [[projection.sender for projection in state.path_afferents] for state in input_states]
 

--- a/psyneulink/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/components/mechanisms/processing/objectivemechanism.py
@@ -590,10 +590,6 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
                          prefs=prefs,
                          context=ContextFlags.CONSTRUCTOR)
 
-        # This is used to specify whether the ObjectiveMechanism is associated with a ControlMechanism that is
-        #    the controller for a System;  it is set by the ControlMechanism when it creates the ObjectiveMechanism
-        self.controller = False
-
     def _validate_params(self, request_set, target_set=None, context=None):
         """Validate **role**, **monitored_output_states**, amd **input_states** arguments
 

--- a/psyneulink/components/states/state.py
+++ b/psyneulink/components/states/state.py
@@ -1621,7 +1621,7 @@ class State_Base(State):
             # Validate that State to be connected to specified in receiver is same as any one specified in connection
             def _get_receiver_state(spec):
                 """Get state specification from ProjectionTuple, which itself may be a ProjectionTuple"""
-                if isinstance(spec, ProjectionTuple):
+                if isinstance(spec, (tuple, ProjectionTuple)):
                     spec = _parse_connection_specs(connectee_state_type=self.__class__,
                                                    owner=self.owner,
                                                    connections=receiver)

--- a/psyneulink/components/system.py
+++ b/psyneulink/components/system.py
@@ -1234,15 +1234,18 @@ class System(System_Base):
                         (isinstance(sender_mech, ObjectiveMechanism) and sender_mech._role is LEARNING)):
                     sender_mech.systems[self] = LEARNING
                     return
-                # System's controller or ObjectiveMechanism that projects *only* to it:  label as CONTROL and return
-                # IMPLEMENTATION NOTE:  This the permits an ObjectiveMechanism to project to other Mechanisms
-                #                       that can be included in the System's execution_graph
+                # System's controller, or ObjectiveMechanism that projects *only* to it or _role is CONTROL
+                #     label as CONTROL and return
+                # IMPLEMENTATION NOTE:  This allows ObjectiveMechanisms to be included in the System's execution_graph
+                #                       that project to Mechanisms other than the System's controller
                 elif (sender_mech is self.controller or
                           (isinstance(sender_mech, ObjectiveMechanism) and
-                               all(
+                           (all(
                                    all(projection.receiver.owner is self.controller
                                        for projection in output_state.efferents)
-                                   for output_state in sender_mech.output_states))):
+                                   for output_state in sender_mech.output_states)) or
+                              sender_mech._role is CONTROL
+                          )):
                     sender_mech.systems[self] = CONTROL
                     return
                 # If sender is a ControlMechanism that is not the controller for the System,

--- a/psyneulink/components/system.py
+++ b/psyneulink/components/system.py
@@ -873,6 +873,10 @@ class System(System_Base):
             processes = [processes]
         monitor_for_control = monitor_for_control or [MonitoredOutputStatesOption.PRIMARY_OUTPUT_STATES]
         self.control_signals_arg = control_signals or []
+        if not isinstance(self.control_signals_arg, list):
+            self.control_signals_arg = [self.control_signals_arg]
+        if not isinstance(monitor_for_control, list):
+            monitor_for_control = [monitor_for_control]
 
         # Assign args to params and functionParams dicts (kwConstants must == arg names)
         params = self._assign_args_to_param_dicts(processes=processes,

--- a/psyneulink/components/system.py
+++ b/psyneulink/components/system.py
@@ -1243,8 +1243,8 @@ class System(System_Base):
                            (all(
                                    all(projection.receiver.owner is self.controller
                                        for projection in output_state.efferents)
-                                   for output_state in sender_mech.output_states)) or
-                              sender_mech._role is CONTROL
+                                   for output_state in sender_mech.output_states)
+                           or sender_mech.controller)
                           )):
                     sender_mech.systems[self] = CONTROL
                     return
@@ -2069,16 +2069,14 @@ class System(System_Base):
             warnings.warn("The existing {} for {} ({}) is being replaced by {}".
                           format(CONTROLLER, self.name, self.controller.name, controller.name))
 
-        # Make assignment (and assign controller's ControlSignals to self.control_signals)
+        # Make assignment
         self._controller = controller
-        # if self.control_signals is None:
-        #     self.control_signals = controller.control_signals
-        # else:
-        #     self.control_signals.append(controller.control_signals)
 
         # Add controller's ObjectiveMechanism to the System's execution_list and execution_graph
+        #    and identify it as associated with a controller
         self.execution_list.append(self.controller.objective_mechanism)
         self.execution_graph[self.controller.objective_mechanism] = set(self.execution_list[:-1])
+        self.controller.objective_mechanism.controller = True
 
         # Check whether controller has input, and if not then disable
         has_input_states = isinstance(self.controller.input_states, ContentAddressableList)

--- a/psyneulink/components/system.py
+++ b/psyneulink/components/system.py
@@ -879,10 +879,11 @@ class System(System_Base):
         if not isinstance(monitor_for_control, list):
             monitor_for_control = [monitor_for_control]
 
-        # # If controller has already been instantiated, assign self to its system attribute so that it
-        # #    and its ObjectiveMechanism are recognized as the controller for the System in _instantiate_system_graph()
-        # if isinstance(controller, ControlMechanism):
-        #     controller.system = self
+        # If controller has already been instantiated, flag its ObjectiveMechanism as belonging to a controller
+        #    so that it is recognized as such the System in _instantiate_system_graph()
+        #    (can't actually assign ControlMechanism as controller here, as _instantiate_controller needs parsed graph)
+        if isinstance(controller, ControlMechanism):
+            controller.objective_mechanism.for_controller = True
 
         # Assign args to params and functionParams dicts (kwConstants must == arg names)
         params = self._assign_args_to_param_dicts(processes=processes,
@@ -1223,38 +1224,31 @@ class System(System_Base):
 
             # DEAL WITH LEARNING AND CONTROL MECHANISMS -----------------------------------------------------------
 
-            # # MODIFIED 9/18/17 OLD:
-            # # If sender is an ObjectiveMechanism being used for learning or control,
-            # #     or a LearningMechanism or a ControlMechanism,
-            # # Assign as LEARNING and move on
-            # if is_monitoring_mech(sender_mech):
-            #     sender_mech.systems[self] = LEARNING
-            # MODIFIED 9/18/17 NEW:
-            # Label Mechanisms used for Learning and System's controller, then return
-            #    (i.e., don't include their dependents in the System execution_graph;
-            #     they will be added to the System's learning_graph or run as the controller)
-            #    EXCEPT ObjectiveMechanisms used for control but not the System's controller
             if is_monitoring_mech(sender_mech):
                 # LearningMechanisms or ObjectiveMechanism used for learning:  label as LEARNING and return
                 if (isinstance(sender_mech, LearningMechanism) or
                         (isinstance(sender_mech, ObjectiveMechanism) and sender_mech._role is LEARNING)):
                     sender_mech.systems[self] = LEARNING
                     return
-                # System's controller, or ObjectiveMechanism that projects *only* to it or _role is CONTROL
-                #     label as CONTROL and return
+                # System's controller or ObjectiveMechanism that projects it: label as CONTROL and return
                 # IMPLEMENTATION NOTE:  This allows ObjectiveMechanisms to be included in the System's execution_graph
-                #                       that project to Mechanisms other than the System's controller
+                #                           that project to Mechanisms other than the System's controller.
+                #                       If the ObjectiveMechanism projects to the controller and other Mechanisms
+                #                           a warning is issued and those other projections are ignored.
                 elif (sender_mech is self.controller or
-                          (isinstance(sender_mech, ObjectiveMechanism) and
-                           (all(
-                                   all((       # controller for self is ControlMechanism to which sender_mech projects
-                                               (projection.receiver.owner is self.controller) or
-                                               # system attrib of ControlMechanism to which sender_mech projects is self
-                                               (projection.receiver.owner.system is self))
-                                       for projection in output_state.efferents)
-                                   for output_state in sender_mech.output_states)
-                           ))):
+                          (isinstance(sender_mech, ObjectiveMechanism) and sender_mech.for_controller)):
                     sender_mech.systems[self] = CONTROL
+                    obj_mech_rcvrs = [[projection.receiver.owner for projection in output_state.efferents]
+                             for output_state in sender_mech.output_states]
+                    if len(obj_mech_rcvrs) > 1:
+                        warnings.warning("{0} projects to multiple {1}s {2}. If an {3} projects to the controller"
+                                         "of a {4}, its projection to any other {1}s is not currently supported; "
+                                         "these have been ignored in the System graph".
+                                         format(sender_mech.name,
+                                                Mechanism.__name__ ,
+                                                obj_mech_rcvrs,
+                                                ObjectiveMechanism.__name__,
+                                                System.__name__))
                     return
                 # If sender is a ControlMechanism that is not the controller for the System,
                 #    assign its dependency to its ObjectiveMechanism and label as INTERNAL
@@ -1262,8 +1256,6 @@ class System(System_Base):
                     sender_mech.systems[self] = INTERNAL
                     # FIX:  ALLOW TO CONTINUE FROM ControlMechanism TO RECIPIENT OF ITS ControlProjections?
                     # FIX:  I.E., **DON'T** RETURN
-            # MODIFIED 9/18/17 END
-
 
             # PRUNE ANY NON-SYSTEM COMPONENTS ---------------------------------------------------------------------
 
@@ -1294,15 +1286,7 @@ class System(System_Base):
             # Note:  SINGLETON is assigned if mechanism is already a TERMINAL;  indicates that it is both
             #        an ORIGIN AND A TERMINAL and thus must be the only mechanism in its process
             if (
-
-                # # MODIFIED 9/18/17 OLD:
-                # # It is not a ControlMechanism
-                # not (isinstance(sender_mech, ControlMechanism) or
-                # MODIFIED 9/18/17 NEW:
-                # It is not the controller for the System
-                # not (sender_mech is self.controller or
                 not (isinstance(sender_mech, ControlMechanism) or
-                # MODIFIED 9/18/17 END
                 # FIX: ALLOW IT TO BE TERMINAL IF IT PROJECTS ONLY TO A ControlMechanism or ObjectiveMechanism for one
                     # It is not an ObjectiveMechanism used for Learning or for the controller of the System
                     (isinstance(sender_mech, ObjectiveMechanism) and sender_mech._role in (LEARNING,CONTROL)))
@@ -1327,9 +1311,6 @@ class System(System_Base):
                         sender_mech.systems[self] = TERMINAL
                 except KeyError:
                     sender_mech.systems[self] = TERMINAL
-                # MODIFIED 9/19/17 OLD:
-                # return
-                # MODIFIED 9/19/17 NEW:
                 # If sender_mech has projections to ControlMechanism and/or Objective Mechanisms used for control
                 #    that are NOT the System's controller, then continue to track those projections
                 #    for dependents to add to the execution_graph;
@@ -1350,8 +1331,6 @@ class System(System_Base):
                 # Otherwise, don't track any of the TERMINAL Mechanism's projections
                 else:
                     return
-                # MODIFIED 9/19/17 END
-
 
             # FIND DEPENDENTS AND ADD TO GRAPH ---------------------------------------------------------------------
 
@@ -1367,16 +1346,12 @@ class System(System_Base):
                     if not receiver or (receiver is sender_mech):
                         continue
                     if is_monitoring_mech(receiver):
-                        # # MODIFIED 9/18/19 OLD:
-                        # continue
-                        # MODIFIED 9/18/19 NEW:
                         # Don't include receiver if it is the controller for the System,
                         if (receiver is self.controller
                             or isinstance(receiver, LearningMechanism)
                             or self.controller is not None and isinstance(receiver, self.controller.objective_mechanism)
                             or (isinstance(receiver, ObjectiveMechanism) and receiver._role is LEARNING)):
                             continue
-                        # MODIFIED 9/18/19 END
                     try:
                         self.graph[receiver].add(sender_mech)
                     except KeyError:
@@ -1460,16 +1435,7 @@ class System(System_Base):
                 if all(
                         all(
                                 # All projections must be from a process (i.e., ProcessInputState) to which it belongs
-                                # # MODIFIED 2/8/17 OLD:
-                                # #          [THIS CHECKED FOR PROCESS IN SYSTEM'S LIST OF PROCESSES
-                                # #           IT CRASHED IF first_mech WAS ASSIGNED TO ANY PROCESS THAT WAS NOT ALSO
-                                # #           ASSIGNED TO THE SYSTEM TO WHICH THE first_mech BELONGS
-                                #  projection.sender.owner in sorted_processes or
-                                # MODIFIED 2/8/17 NEW:
-                                #      [THIS CHECKS THAT PROJECTION IS FROM A PROCESS IN first_mech's LIST OF PROCESSES]
-                                #       PROBABLY ISN"T NECESSARY, AS IT SHOULD BE COVERED BY INITIAL ASSIGNMENT OF PROJ]
                                 projection.sender.owner in first_mech.processes or
-                                # MODIFIED 2/8/17 END
                                 # or from mechanisms within its own process (e.g., [a, b, a])
                                 projection.sender.owner in list(process.mechanisms) or
                                 # or from Mechanisms in other processes for which it is also an ORIGIN ([a,b,a],[a,c,a])
@@ -1573,10 +1539,6 @@ class System(System_Base):
         # Create instance of sequential (execution) list:
         self.execution_list = self._toposort_with_ordered_mechs(self.execution_graph)
 
-        # MODIFIED 6/27/17 NEW: (CW)
-        # changed "orig_mech_input.extend(input_state.value)" to "orig_mech_input.append(input_state.value)"
-        # this is accompanied by a change to the code around line 1510 where a for loop was added.
-        # MODIFIED 2/8/17 NEW:
         # Construct self.instance_defaults.variable from inputs to ORIGIN mechanisms
         self.instance_defaults.variable = []
         for mech in self.origin_mechanisms:
@@ -1586,12 +1548,10 @@ class System(System_Base):
             self.instance_defaults.variable.append(orig_mech_input)
         self.instance_defaults.variable = convert_to_np_array(self.instance_defaults.variable, 2)
         # should add Utility to allow conversion to 3D array
-        # MODIFIED 2/8/17 END
         # An example: when input state values are vectors, then self.instance_defaults.variable is a 3D array because
         # an origin mechanism could have multiple input states if there is a recurrent input state. However,
         # if input state values are all non-vector objects, such as strings, then self.instance_defaults.variable
         # would be a 2D array. so we should convert that to a 3D array
-        # MODIFIED 6/27/17 END
 
         # Instantiate StimulusInputStates
         self._instantiate_stimulus_inputs(context=context)
@@ -1717,7 +1677,7 @@ class System(System_Base):
                     raise SystemError("{} in {} does not project to a LearningMechanism".
                                       format(obj_mech.name, process.name))
 
-                # Make sure sample_mech is refference by learning_mech as is output_source
+                # Make sure sample_mech is referenced by learning_mech as is output_source
                 sample_mech = obj_mech.input_states[SAMPLE].path_afferents[0].sender.owner
                 if sample_mech != learning_mech.output_source:
                     raise SystemError("PROGRAM ERROR: learning_mecch ({}) does not properly reference sample_mech ({})"

--- a/psyneulink/library/subsystems/evc/evcauxiliary.py
+++ b/psyneulink/library/subsystems/evc/evcauxiliary.py
@@ -810,9 +810,9 @@ class PredictionMechanism(IntegratorMechanism):
                  prefs:is_pref_set=None,
                  context=None):
 
-        if context != ContextFlags.COMPOSITION:
+        if not context in {ContextFlags.COMPONENT, ContextFlags.COMPOSITION, ContextFlags.COMMAND_LINE}:
             warnings.warn("PredictionMechanism should not be constructed on its own.  If you insist,"
-                          "set context=ContextFlags.Composition, but proceed at your peril!")
+                          "set context=ContextFlags.COMMAND_LINE, but proceed at your peril!")
             return
 
         if params and FUNCTION in params:

--- a/psyneulink/library/subsystems/evc/evcauxiliary.py
+++ b/psyneulink/library/subsystems/evc/evcauxiliary.py
@@ -644,7 +644,9 @@ class PredictionMechanism(IntegratorMechanism):
 
     PredictionMechanisms are created automatically when an `EVCControlMechanism` is created, one for each `ORIGIN`
     Mechanism in the `system <EVCControlMechanism.system>` for which the EVCControlMechanism is a `controller
-    <System.controller>`.
+    <System.controller>`. PredictionMechanisms should not be created on their own, as execution requires
+    tight integration with an EVCControlMechanism and the System to which it belongs, are unlikely to function
+    properly if this is not properly configured.
 
     **Structure**
 

--- a/psyneulink/library/subsystems/evc/evcauxiliary.py
+++ b/psyneulink/library/subsystems/evc/evcauxiliary.py
@@ -15,6 +15,7 @@ Auxiliary functions for `EVCControlMechanism`.
 
 import numpy as np
 import typecheck as tc
+import warnings
 
 from psyneulink.components.functions.function import Function_Base, Buffer, Integrator
 from psyneulink.components.mechanisms.processing.objectivemechanism import OUTCOME
@@ -644,9 +645,9 @@ class PredictionMechanism(IntegratorMechanism):
 
     PredictionMechanisms are created automatically when an `EVCControlMechanism` is created, one for each `ORIGIN`
     Mechanism in the `system <EVCControlMechanism.system>` for which the EVCControlMechanism is a `controller
-    <System.controller>`. PredictionMechanisms should not be created on their own, as execution requires
-    tight integration with an EVCControlMechanism and the System to which it belongs, are unlikely to function
-    properly if this is not properly configured.
+    <System.controller>`. PredictionMechanisms should not be created on their own, as their execution requires
+    tight integration with an EVCControlMechanism and the System to which it belongs, and they will not function
+    properly if this is not insured.
 
     **Structure**
 
@@ -806,7 +807,13 @@ class PredictionMechanism(IntegratorMechanism):
                  filter_function:tc.optional(callable)=None,
                  params=None,
                  name=None,
-                 prefs:is_pref_set=None):
+                 prefs:is_pref_set=None,
+                 context=None):
+
+        if context != ContextFlags.COMPOSITION:
+            warnings.warn("PredictionMechanism should not be constructed on its own.  If you insist,"
+                          "set context=ContextFlags.Composition, but proceed at your peril!")
+            return
 
         if params and FUNCTION in params:
             function = params[FUNCTION]

--- a/psyneulink/library/subsystems/evc/evccontrolmechanism.py
+++ b/psyneulink/library/subsystems/evc/evccontrolmechanism.py
@@ -852,58 +852,6 @@ class EVCControlMechanism(ControlMechanism):
         # List of prediction Mechanism tuples (used by System to execute them)
         self.prediction_mechs = []
 
-        # MODIFIED 6/16/18 OLD:
-        # # Get any params specified for predictionMechanism(s) by EVCControlMechanism
-        # try:
-        #     prediction_mechanism_params = self.paramsCurrent[PREDICTION_MECHANISM_PARAMS]
-        # except KeyError:
-        #     prediction_mechanism_params = {}
-        #
-        # for origin_mech in system.origin_mechanisms.mechanisms:
-        #     state_names = []
-        #     variable = []
-        #     for state_name in origin_mech.input_states.names:
-        #         state_names.append(state_name)
-        #         # variable.append(origin_mech.input_states[state_name].instance_defaults.variable)
-        #         variable.append(origin_mech.input_states[state_name].value)
-        #
-        #     # Instantiate PredictionMechanism
-        #     prediction_mechanism = self.prediction_mechanism_type(
-        #             name=origin_mech.name + " " + PREDICTION_MECHANISM,
-        #             default_variable=variable,
-        #             input_states=state_names,
-        #             params = prediction_mechanism_params)
-        #     prediction_mechanism._role = CONTROL
-        #     prediction_mechanism.origin_mech = origin_mech
-        #
-        #     # Assign projections to prediction_mechanism that duplicate those received by origin_mech
-        #     #    (this includes those from ProcessInputState, SystemInputState and/or recurrent ones
-        #     for orig_input_state, prediction_input_state in zip(origin_mech.input_states,
-        #                                                     prediction_mechanism.input_states):
-        #         for projection in orig_input_state.path_afferents:
-        #             MappingProjection(sender=projection.sender,
-        #                               receiver=prediction_input_state,
-        #                               matrix=projection.matrix)
-        #
-        #     # Assign list of processes for which prediction_mechanism will provide input during the simulation
-        #     # - used in _get_simulation_system_inputs()
-        #     # - assign copy,
-        #     #       since don't want to include the prediction process itself assigned to origin_mech.processes below
-        #     prediction_mechanism.use_for_processes = list(origin_mech.processes.copy())
-        #
-        #     # # FIX: REPLACE REFERENCE TO THIS ELSEWHERE WITH REFERENCE TO MECH_TUPLES BELOW
-        #     self.origin_prediction_mechanisms[origin_mech] = prediction_mechanism
-        #
-        #     # Add to list of EVCControlMechanism's prediction_object_items
-        #     # prediction_object_item = prediction_mechanism
-        #     self.prediction_mechs.append(prediction_mechanism)
-        #
-        #     # Add to system execution_graph and execution_list
-        #     system.execution_graph[prediction_mechanism] = set()
-        #     system.execution_list.append(prediction_mechanism)
-
-        # MODIFIED 6/16/18 NEW:
-
         # IF IT IS A MECHANISM, PUT IT IN A LIST
         # IF IT IS A CLASS, PUT IT IN A TUPLE WITH NONE
         # NOW IF IT IS TUPLE,
@@ -988,9 +936,6 @@ class EVCControlMechanism(ControlMechanism):
             # Add to system execution_graph and execution_list
             system.execution_graph[prediction_mechanism] = set()
             system.execution_list.append(prediction_mechanism)
-
-        # MODIFIED 6/16/18 END
-
 
         self.prediction_mechanisms = MechanismList(self, self.prediction_mechs)
 

--- a/psyneulink/library/subsystems/evc/evccontrolmechanism.py
+++ b/psyneulink/library/subsystems/evc/evccontrolmechanism.py
@@ -810,10 +810,6 @@ class EVCControlMechanism(ControlMechanism):
             self._instantiate_prediction_mechanisms(system=self.system, context=context)
         super()._instantiate_input_states(context=context)
 
-    def _instantiate_objective_mechanism(self, context=None):
-        super()._instantiate_objective_mechanism(context=context)
-        self.objective_mechanism.controller = True
-
     def _instantiate_prediction_mechanisms(self, system:System_Base, context=None):
         """Add prediction Mechanism and associated process for each `ORIGIN` (input) Mechanism in system
 

--- a/psyneulink/library/subsystems/evc/evccontrolmechanism.py
+++ b/psyneulink/library/subsystems/evc/evccontrolmechanism.py
@@ -953,7 +953,8 @@ class EVCControlMechanism(ControlMechanism):
                         default_variable=variable,
                         input_states=state_names,
                         # params = mech_params
-                        **mech_params
+                        **mech_params,
+                        context=context
                 )
             else:
                 raise EVCError("PROGRAM ERROR: Unexpected item ({}) in list for {} arg of constructor for {}".

--- a/psyneulink/library/subsystems/evc/evccontrolmechanism.py
+++ b/psyneulink/library/subsystems/evc/evccontrolmechanism.py
@@ -750,15 +750,15 @@ class EVCControlMechanism(ControlMechanism):
     @tc.typecheck
     def __init__(self,
                  system:tc.optional(System_Base)=None,
-                 objective_mechanism:tc.optional(tc.any(ObjectiveMechanism, list))=None,
                  prediction_mechanisms:tc.any(is_iterable, Mechanism, type)=PredictionMechanism,
-                 control_signals:tc.optional(list) = None,
-                 modulation:tc.optional(_is_modulation_param)=ModulationParam.MULTIPLICATIVE,
+                 objective_mechanism:tc.optional(tc.any(ObjectiveMechanism, list))=None,
                  function=ControlSignalGridSearch,
                  value_function=ValueFunction,
                  cost_function=LinearCombination(operation=SUM),
                  combine_outcome_and_cost_function=LinearCombination(operation=SUM),
                  save_all_values_and_policies:bool=False,
+                 control_signals:tc.optional(list) = None,
+                 modulation:tc.optional(_is_modulation_param)=ModulationParam.MULTIPLICATIVE,
                  params=None,
                  name=None,
                  prefs:is_pref_set=None):
@@ -766,26 +766,20 @@ class EVCControlMechanism(ControlMechanism):
         # Assign args to params and functionParams dicts (kwConstants must == arg names)
         params = self._assign_args_to_param_dicts(system=system,
                                                   prediction_mechanisms=prediction_mechanisms,
-                                                  objective_mechanism=objective_mechanism,
-                                                  function=function,
-                                                  control_signals=control_signals,
-                                                  modulation=modulation,
                                                   value_function=value_function,
                                                   cost_function=cost_function,
                                                   combine_outcome_and_cost_function=combine_outcome_and_cost_function,
                                                   save_all_values_and_policies=save_all_values_and_policies,
                                                   params=params)
 
-        super(EVCControlMechanism, self).__init__(# default_variable=default_variable,
-                                           # size=size,
-                                           system=system,
-                                           objective_mechanism=objective_mechanism,
-                                           function=function,
-                                           control_signals=control_signals,
-                                           modulation=modulation,
-                                           params=params,
-                                           name=name,
-                                           prefs=prefs)
+        super().__init__(system=system,
+                         objective_mechanism=objective_mechanism,
+                         function=function,
+                         control_signals=control_signals,
+                         modulation=modulation,
+                         params=params,
+                         name=name,
+                         prefs=prefs)
 
     def _validate_params(self, request_set, target_set=None, context=None):
         '''Validate prediction_mechanisms'''

--- a/psyneulink/library/subsystems/evc/evccontrolmechanism.py
+++ b/psyneulink/library/subsystems/evc/evccontrolmechanism.py
@@ -752,6 +752,7 @@ class EVCControlMechanism(ControlMechanism):
                  system:tc.optional(System_Base)=None,
                  prediction_mechanisms:tc.any(is_iterable, Mechanism, type)=PredictionMechanism,
                  objective_mechanism:tc.optional(tc.any(ObjectiveMechanism, list))=None,
+                 monitor_for_control:tc.any(is_iterable, Mechanism)=None,
                  function=ControlSignalGridSearch,
                  value_function=ValueFunction,
                  cost_function=LinearCombination(operation=SUM),
@@ -774,6 +775,7 @@ class EVCControlMechanism(ControlMechanism):
 
         super().__init__(system=system,
                          objective_mechanism=objective_mechanism,
+                         monitor_for_control=monitor_for_control,
                          function=function,
                          control_signals=control_signals,
                          modulation=modulation,

--- a/psyneulink/library/subsystems/evc/evccontrolmechanism.py
+++ b/psyneulink/library/subsystems/evc/evccontrolmechanism.py
@@ -752,7 +752,7 @@ class EVCControlMechanism(ControlMechanism):
                  system:tc.optional(System_Base)=None,
                  prediction_mechanisms:tc.any(is_iterable, Mechanism, type)=PredictionMechanism,
                  objective_mechanism:tc.optional(tc.any(ObjectiveMechanism, list))=None,
-                 monitor_for_control:tc.any(is_iterable, Mechanism)=None,
+                 # monitor_for_control:tc.optional(tc.any(is_iterable, Mechanism))=None,
                  function=ControlSignalGridSearch,
                  value_function=ValueFunction,
                  cost_function=LinearCombination(operation=SUM),
@@ -775,7 +775,7 @@ class EVCControlMechanism(ControlMechanism):
 
         super().__init__(system=system,
                          objective_mechanism=objective_mechanism,
-                         monitor_for_control=monitor_for_control,
+                         # monitor_for_control=monitor_for_control,
                          function=function,
                          control_signals=control_signals,
                          modulation=modulation,

--- a/psyneulink/library/subsystems/evc/evccontrolmechanism.py
+++ b/psyneulink/library/subsystems/evc/evccontrolmechanism.py
@@ -810,6 +810,10 @@ class EVCControlMechanism(ControlMechanism):
             self._instantiate_prediction_mechanisms(system=self.system, context=context)
         super()._instantiate_input_states(context=context)
 
+    def _instantiate_objective_mechanism(self, context=None):
+        super()._instantiate_objective_mechanism(context=context)
+        self.objective_mechanism.controller = True
+
     def _instantiate_prediction_mechanisms(self, system:System_Base, context=None):
         """Add prediction Mechanism and associated process for each `ORIGIN` (input) Mechanism in system
 


### PR DESCRIPTION
• System
  __init__:  modified control_signals and monitor_for_control atttributes
             to accept single items and embeds in a list
  _instantiate_graph: fixed bug in which ObjectiveMechanism speciied
    in constructor for controller was not being identified as such
  _instantiate_graph: fixed bug in which ObjectiveMechanism specified
    in constructor for controller was not being identified as such
    (note:  only fixed for EVCControlMechanism, which assumes these
            are always controllers;  not fixed for ControlMechanism
            in general because not all ControlMechanisms are controllers)

• State [line 1624]:
  _instantiate_projections_from_state:  
      fixed bug preventing ControlSignal projections argument 
      from being specified as (<ParameterState name>, Mechanism>) tuple

• ControlMechanism
  _assign_as_controller:  fixed bug in which attempt was being made
     to call add_monitored_output_states with empty list

• EVCAuxiliary
  PredictionMechanism:
  - docstring revs
  - added warning for creating on its own
