### PR TITLE
Refactor/controlmechanism/monitor for control

### DIFF
--- a/.idea/runConfigurations/EVC_Gratton.xml
+++ b/.idea/runConfigurations/EVC_Gratton.xml
@@ -1,12 +1,12 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" factoryName="Python" name="EVC-Gratton" singleton="true" type="PythonConfigurationType">
-    <module name="" />
+  <configuration default="false" name="EVC-Gratton" type="PythonConfigurationType" factoryName="Python" singleton="true">
+    <module name="PsyNeuLink (Dropbox)" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="" />
+    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python35/bin/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Scripts/Examples" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/.idea/runConfigurations/Make_HTML.xml
+++ b/.idea/runConfigurations/Make_HTML.xml
@@ -1,9 +1,9 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" factoryName="Sphinx task" name="Make HTML" singleton="true" type="docs">
-    <module name="" />
+  <configuration default="false" name="Make HTML" type="docs" factoryName="Sphinx task" singleton="true">
+    <module name="PsyNeuLink (Dropbox)" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
-    <option name="SDK_HOME" value="" />
+    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python35/bin/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/docs" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/.idea/runConfigurations/Scratch_Pad.xml
+++ b/.idea/runConfigurations/Scratch_Pad.xml
@@ -1,12 +1,12 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Scratch Pad" type="PythonConfigurationType" factoryName="Python" singleton="true">
-    <module name="PsyNeuLink (Dropbox)" />
+  <configuration default="false" factoryName="Python" name="Scratch Pad" singleton="true" type="PythonConfigurationType">
+    <module name="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python35/bin/python" />
+    <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Scripts" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/.idea/runConfigurations/Scratch_Pad.xml
+++ b/.idea/runConfigurations/Scratch_Pad.xml
@@ -1,12 +1,12 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" factoryName="Python" name="Scratch Pad" singleton="true" type="PythonConfigurationType">
-    <module name="" />
+  <configuration default="false" name="Scratch Pad" type="PythonConfigurationType" factoryName="Python" singleton="true">
+    <module name="PsyNeuLink (Dropbox)" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="" />
+    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python35/bin/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Scripts" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/.idea/runConfigurations/Scratch_Pad.xml
+++ b/.idea/runConfigurations/Scratch_Pad.xml
@@ -1,12 +1,12 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Scratch Pad" type="PythonConfigurationType" factoryName="Python" singleton="true">
-    <module name="PsyNeuLink" />
+  <configuration default="false" factoryName="Python" name="Scratch Pad" singleton="true" type="PythonConfigurationType">
+    <module name="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python35/bin/python3.5" />
+    <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Scripts" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/.idea/runConfigurations/Scratch_Pad.xml
+++ b/.idea/runConfigurations/Scratch_Pad.xml
@@ -1,12 +1,12 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" factoryName="Python" name="Scratch Pad" singleton="true" type="PythonConfigurationType">
-    <module name="" />
+  <configuration default="false" name="Scratch Pad" type="PythonConfigurationType" factoryName="Python" singleton="true">
+    <module name="PsyNeuLink" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="" />
+    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python35/bin/python3.5" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Scripts" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/Scripts/Models/GilzenratModel.py
+++ b/Scripts/Models/GilzenratModel.py
@@ -114,42 +114,42 @@ decision_process = pnl.Process(
 # Monitor decision layer in order to modulate gain --------------------------------------------------------------------
 
 LC = pnl.LCControlMechanism(
-    integration_method="EULER",
-    threshold_FHN=a,
-    uncorrelated_activity_FHN=d,
-    base_level_gain=G,
-    scaling_factor_gain=k,
-    time_step_size_FHN=dt,
-    mode_FHN=C,
-    time_constant_v_FHN=tau_v,
-    time_constant_w_FHN=tau_u,
-    a_v_FHN=-1.0,
-    b_v_FHN=1.0,
-    c_v_FHN=1.0,
-    d_v_FHN=0.0,
-    e_v_FHN=-1.0,
-    f_v_FHN=1.0,
-    a_w_FHN=1.0,
-    b_w_FHN=-1.0,
-    c_w_FHN=0.0,
-    t_0_FHN=0.0,
-    initial_v_FHN=initial_v,
-    initial_w_FHN=initial_u,
-    objective_mechanism=pnl.ObjectiveMechanism(
-        function=pnl.Linear,
-        monitored_output_states=[(
-            decision_layer,
-            None,
-            None,
-            np.array([
-                [w_vX1],
-                [0.0]]
-            )
-        )],
-        name='LC ObjectiveMechanism'
-    ),
-    modulated_mechanisms=[decision_layer, response_layer],  # Modulate gain of decision & response layers
-    name='LC'
+        integration_method="EULER",
+        threshold_FHN=a,
+        uncorrelated_activity_FHN=d,
+        base_level_gain=G,
+        scaling_factor_gain=k,
+        time_step_size_FHN=dt,
+        mode_FHN=C,
+        time_constant_v_FHN=tau_v,
+        time_constant_w_FHN=tau_u,
+        a_v_FHN=-1.0,
+        b_v_FHN=1.0,
+        c_v_FHN=1.0,
+        d_v_FHN=0.0,
+        e_v_FHN=-1.0,
+        f_v_FHN=1.0,
+        a_w_FHN=1.0,
+        b_w_FHN=-1.0,
+        c_w_FHN=0.0,
+        t_0_FHN=0.0,
+        initial_v_FHN=initial_v,
+        initial_w_FHN=initial_u,
+        objective_mechanism=pnl.ObjectiveMechanism(
+                function=pnl.Linear,
+                monitored_output_states=[(
+                    decision_layer,
+                    None,
+                    None,
+                    np.array([
+                        [w_vX1],
+                        [0.0]]
+                    )
+                )],
+                name='LC ObjectiveMechanism'
+        ),
+        modulated_mechanisms=[decision_layer, response_layer],  # Modulate gain of decision & response layers
+        name='LC'
 )
 
 task = pnl.System(processes=[decision_process],
@@ -157,7 +157,6 @@ task = pnl.System(processes=[decision_process],
 
 # This displays a diagram of the System
 # task.show_graph()
-
 
 # Create Stimulus -----------------------------------------------------------------------------------------------------
 

--- a/psyneulink/components/component.py
+++ b/psyneulink/components/component.py
@@ -277,7 +277,7 @@ COMMENT
 
 ..
 COMMENT:
-  INCLUDE IN DEVELOPERS' MANUAL
+  FOR DEVELOPERS:
     * **paramClassDefaults**
 
     * **paramInstanceDefaults**
@@ -290,7 +290,7 @@ Component Methods
 ~~~~~~~~~~~~~~~~~
 
 COMMENT:
-   INCLUDE IN DEVELOPERS' MANUAL
+   FOR DEVELOPERS:
 
     There are two sets of methods that belong to every Component: one set that is called when it is initialized; and
     another set that can be called to perform various operations common to all Components.  Each of these is described

--- a/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
+++ b/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
@@ -82,6 +82,34 @@ below.
 ObjectiveMechanism and Monitored OutputStates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+COMMENT:
+    ADD DESCRIPTION OF HOW TO SPECIFY MONITOR_FOR_CONTROL / MONITORED-OUTPUTSTATES
+
+    * specifying a list of OutputStates to be monitored in the **monitor_for_control**
+      argument of the LCControlMechanism's constructor, using the `tuples format
+      <InputState_Tuple_Specification>` to specify weights and/or exponents for any of these;
+    ..
+    * specifying an `ObjectiveMechanism` in the **objective_mechanism** argument of the
+      LCControlMechanism's constructor, using its **monitored_output_states** and/or its **function** arguments
+      to customize its corresponding attributes.
+
+    * specifying a list of OutputStates to be monitored in the **monitor_for_control**
+      argument of the LCControlMechanism's constructor, using the `tuples format
+      <InputState_Tuple_Specification>` to specify weights and/or exponents for each;
+    ..
+    * specifying an `ObjectiveMechanism` in the **objective_mechanism** argument of the
+      LCControlMechanism's constructor, and specifying one or both of the following in the ObjectiveMechanism's
+      constructor:
+
+    * specifying a different `function <ObjectiveMechanism.function>` for the ObjectiveMechanism
+      (see `ObjectiveMechanism_Weights_and_Exponents_Example` for an example);
+    ..
+
+    * using the  **monitored_output_states** argument of the `objective_mechanism <LCControlMechanism.objective_mechanism>`'s
+      constructor;
+      **objective_mechanism** argument of the LCControlMechanism's constructor;
+COMMENT
+
 When a ControlMechanism is created, it is associated with an `ObjectiveMechanism` that is used to monitor and
 evaluate a set of `OutputStates <OutputState>` upon which it bases it `allocation_policy
 <ControlMechanism.allocation_policy>`.  If the ControlMechanism is created explicitly, its ObjectiveMechanism
@@ -456,12 +484,12 @@ class ControlMechanism(AdaptiveMechanism_Base):
         **objective_mechanism** argument, and transmits the result to the ControlMechanism's *ERROR_SIGNAL*
         `input_state <Mechanism_Base.input_state>`.
 
-    monitored_output_states : List[OutputState]
+    monitor_for_control : List[OutputState]
         each item is an `OutputState` monitored by the ObjectiveMechanism listed in the ControlMechanism's
         `objective_mechanism <ControlMechanism.objective_mechanism>` attribute;  it is the same as that
         ObjectiveMechanism's `monitored_output_states <ObjectiveMechanism.monitored_output_states>` attribute
         (see `ObjectiveMechanism_Monitored_Output_States` for specification).  The `value <OutputState.value>`
-        of the OutputStates listed are used by the ObjectiveMechanism to generate the ControlMechanism's `input
+        of the OutputStates in the list are used by the ObjectiveMechanism to generate the ControlMechanism's `input
         <ControlMechanism_Input>`.
 
     monitored_output_states_weights_and_exponents : List[Tuple(float, float)]
@@ -553,7 +581,6 @@ class ControlMechanism(AdaptiveMechanism_Base):
                  default_variable=None,
                  size=None,
                  system:tc.optional(System_Base)=None,
-                 # monitor_for_control=None,
                  monitor_for_control:tc.optional(tc.any(is_iterable, Mechanism, OutputState))=None,
                  objective_mechanism=None,
                  function=None,
@@ -776,6 +803,8 @@ class ControlMechanism(AdaptiveMechanism_Base):
                           receiver=self,
                           matrix=AUTO_ASSIGN_MATRIX,
                           name=name)
+
+        self.monitor_for_control = self.monitored_output_states
 
     def _instantiate_input_states(self, context=None):
         super()._instantiate_input_states(context=context)

--- a/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
+++ b/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
@@ -651,7 +651,9 @@ class ControlMechanism(AdaptiveMechanism_Base):
                 # If ControlMechanism has been assigned to a System, check that
                 #    all the items in the list used to specify objective_mechanism are in the same System
                 if self.system:
-                    self.system._validate_monitored_states_in_system([spec], context=context)
+                    if not isinstance(spec, (list, ContentAddressableList)):
+                        spec = [spec]
+                    self.system._validate_monitored_states_in_system(spec, context=context)
 
 
         if SYSTEM in target_set:

--- a/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
+++ b/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
@@ -682,16 +682,16 @@ class ControlMechanism(AdaptiveMechanism_Base):
         from psyneulink.components.states.inputstate import EXPONENT_INDEX, WEIGHT_INDEX
         from psyneulink.components.functions.function import FunctionError
 
-        monitored_output_states = None
-
         # GET OutputStates to Monitor (to specify as or add to ObjectiveMechanism's monitored_output_states attribute
+
+        monitored_output_states = []
 
         # If the ControlMechanism has already been assigned to a System
         #    get OutputStates in System specified as MONITOR_FOR_CONTROL
         #        do this by calling _get_monitored_output_states_for_system(),
         #        which also gets any OutputStates already being monitored by the ControlMechanism
         if self.system:
-            monitored_output_states = self.system._get_monitored_output_states_for_system(self, context=context)
+            monitored_output_states.extend(self.system._get_monitored_output_states_for_system(self,context=context))
 
         # Otherwise, if objective_mechanism argument was specified as a list, get the OutputStates specified in it
         # - IF ControlMechanism HAS NOT ALREADY BEEN ASSIGNED TO A SYSTEM:
@@ -701,9 +701,11 @@ class ControlMechanism(AdaptiveMechanism_Base):
         #      IF objective_mechanism IS ALREADY AN INSTANTIATED ObjectiveMechanism:
         #          JUST ASSIGN TO objective_mechanism ATTRIBUTE
         if isinstance(self.objective_mechanism, list):
-            monitored_output_states = [None] * len(self.objective_mechanism)
+            l = len(monitored_output_states)
+            monitored_output_states.extend([None] * len(self.objective_mechanism))
             for i, item in enumerate(self.objective_mechanism):
                 # If it is a 4-item tuple, convert to MonitoredOutputStateTuple for treatment below
+                n = i+l
                 if isinstance(item, tuple) and len(item)==4:
                     item = MonitoredOutputStateTuple(item[0],item[1],item[2],item[3])
                 # If it is a MonitoredOutputStateTuple, create InputState specification dictionary
@@ -716,13 +718,14 @@ class ControlMechanism(AdaptiveMechanism_Base):
                     else:
                         variable = item.output_state.value
                     # Create InputState specification dictionary:
-                    monitored_output_states[i] = {NAME: item.output_state.name,
-                                                  VARIABLE: variable,
-                                                  WEIGHT:item.weight,
-                                                  EXPONENT:item.exponent,
-                                                  PROJECTIONS:[(item.output_state, item.matrix)]}
+                    monitored_output_states[n] = {NAME: item.output_state.name,
+                                                            VARIABLE: variable,
+                                                            WEIGHT:item.weight,
+                                                            EXPONENT:item.exponent,
+                                                            PROJECTIONS:[(item.output_state, item.matrix)]}
                 else:
-                    monitored_output_states[i] = item
+                    monitored_output_states[n] = item
+
 
         # INSTANTIATE ObjectiveMechanism
 

--- a/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
+++ b/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
@@ -693,7 +693,7 @@ class ControlMechanism(AdaptiveMechanism_Base):
         if self.system:
             monitored_output_states.extend(self.system._get_monitored_output_states_for_system(self,context=context))
 
-        # Otherwise, if objective_mechanism argument was specified as a list, get the OutputStates specified in it
+        # If objective_mechanism argument was specified as a list, get the OutputStates specified in it
         # - IF ControlMechanism HAS NOT ALREADY BEEN ASSIGNED TO A SYSTEM:
         #      IF objective_mechanism IS SPECIFIED AS A LIST:
         #          CALL _parse_monitored_output_states_list() TO GET LIST OF OutputStates
@@ -701,11 +701,10 @@ class ControlMechanism(AdaptiveMechanism_Base):
         #      IF objective_mechanism IS ALREADY AN INSTANTIATED ObjectiveMechanism:
         #          JUST ASSIGN TO objective_mechanism ATTRIBUTE
         if isinstance(self.objective_mechanism, list):
-            l = len(monitored_output_states)
-            monitored_output_states.extend([None] * len(self.objective_mechanism))
             for i, item in enumerate(self.objective_mechanism):
                 # If it is a 4-item tuple, convert to MonitoredOutputStateTuple for treatment below
-                n = i+l
+                if item in monitored_output_states:
+                    continue
                 if isinstance(item, tuple) and len(item)==4:
                     item = MonitoredOutputStateTuple(item[0],item[1],item[2],item[3])
                 # If it is a MonitoredOutputStateTuple, create InputState specification dictionary
@@ -718,13 +717,13 @@ class ControlMechanism(AdaptiveMechanism_Base):
                     else:
                         variable = item.output_state.value
                     # Create InputState specification dictionary:
-                    monitored_output_states[n] = {NAME: item.output_state.name,
-                                                            VARIABLE: variable,
-                                                            WEIGHT:item.weight,
-                                                            EXPONENT:item.exponent,
-                                                            PROJECTIONS:[(item.output_state, item.matrix)]}
+                    monitored_output_states.extend(list({NAME: item.output_state.name,
+                                                        VARIABLE: variable,
+                                                        WEIGHT:item.weight,
+                                                        EXPONENT:item.exponent,
+                                                        PROJECTIONS:[(item.output_state, item.matrix)]}))
                 else:
-                    monitored_output_states[n] = item
+                    monitored_output_states.extend(list(item))
 
 
         # INSTANTIATE ObjectiveMechanism
@@ -735,7 +734,7 @@ class ControlMechanism(AdaptiveMechanism_Base):
                 self.objective_mechanism.add_monitored_output_states(
                                                               monitored_output_states_specs=monitored_output_states,
                                                               context=context)
-        # Otherwise, instantiate ObjectiveMechanism with list of states in *objective_mechanism* arg
+        # Otherwise, instantiate ObjectiveMechanism with list of states in *objective_mechanism* argument
         else:
             # Create specification for ObjectiveMechanism InputStates corresponding to
             #    monitored_output_states and their exponents and weights

--- a/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
+++ b/psyneulink/components/mechanisms/adaptive/control/controlmechanism.py
@@ -18,8 +18,8 @@ ObjectiveMechanism monitors a specified set of OutputStates, and from these gene
 used by the ControlMechanism's `function <ControlMechanism.function>` to calculate an `allocation_policy
 <ControlMechanism.allocation_policy>`: a list of `allocation <ControlSignal.allocation>` values for each of its
 `ControlSignals <ControlSignal>`.  Each ControlSignal uses its `allocation <ControlSignal.allocation>` to calculate its
-`intensity`, which is then conveyed by the ControlSignal's `ControlProjection(s) <ControlProjection>` to the
-`ParameterState(s) <ParameterState>` to which they project.  Each ParameterState then uses the value received by a
+`intensity`, which is then transmitted by the ControlSignal's `ControlProjection(s) <ControlProjection>` to the
+`ParameterState(s) <ParameterState>` to which they project.  Each ParameterState uses the value received by a
 ControlProjection to modify the value of the parameter for which it is responsible (see `ModulatorySignal_Modulation`
 for a more detailed description of how modulation operates).  A ControlMechanism can regulate only the parameters of
 Components in the `System` to which it belongs. The OutputStates used to determine the ControlMechanism's
@@ -79,72 +79,72 @@ below.
 
 .. _ControlMechanism_ObjectiveMechanism:
 
-ObjectiveMechanism and Monitored OutputStates
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ObjectiveMechanism
+~~~~~~~~~~~~~~~~~~
 
-COMMENT:
-    ADD DESCRIPTION OF HOW TO SPECIFY MONITOR_FOR_CONTROL / MONITORED-OUTPUTSTATES
-
-    * specifying a list of OutputStates to be monitored in the **monitor_for_control**
-      argument of the LCControlMechanism's constructor, using the `tuples format
-      <InputState_Tuple_Specification>` to specify weights and/or exponents for any of these;
-    ..
-    * specifying an `ObjectiveMechanism` in the **objective_mechanism** argument of the
-      LCControlMechanism's constructor, using its **monitored_output_states** and/or its **function** arguments
-      to customize its corresponding attributes.
-
-    * specifying a list of OutputStates to be monitored in the **monitor_for_control**
-      argument of the LCControlMechanism's constructor, using the `tuples format
-      <InputState_Tuple_Specification>` to specify weights and/or exponents for each;
-    ..
-    * specifying an `ObjectiveMechanism` in the **objective_mechanism** argument of the
-      LCControlMechanism's constructor, and specifying one or both of the following in the ObjectiveMechanism's
-      constructor:
-
-    * specifying a different `function <ObjectiveMechanism.function>` for the ObjectiveMechanism
-      (see `ObjectiveMechanism_Weights_and_Exponents_Example` for an example);
-    ..
-
-    * using the  **monitored_output_states** argument of the `objective_mechanism <LCControlMechanism.objective_mechanism>`'s
-      constructor;
-      **objective_mechanism** argument of the LCControlMechanism's constructor;
-COMMENT
-
-When a ControlMechanism is created, it is associated with an `ObjectiveMechanism` that is used to monitor and
-evaluate a set of `OutputStates <OutputState>` upon which it bases it `allocation_policy
-<ControlMechanism.allocation_policy>`.  If the ControlMechanism is created explicitly, its ObjectiveMechanism
-can be specified in the **objective_mechanism** argument of its constructor, using either of the following:
-
-  * an existing `ObjectiveMechanism`, or a constructor for one;  in this case the **monitored_output_states** argument
-    of the ObjectiveMechanism's constructor is used to specify the OutputStates to be `monitored and evaluated
-    <ObjectiveMechanism_Monitored_Output_States>` (see `ControlMechanism_Examples`); note that, in this case, the
-    default values for the attributes of the ObjectiveMechanism override any that ControlMechanism uses for its
-    default `objective_mechanism <ControlMechanism.objective_mechanism>`, including those of its `function
-    <ObjectiveMechanism.function>` (see `note <EVCControlMechanism_Objective_Mechanism_Function_Note>` in EVCControlMechanism for
-    an example);
-  ..
-  * a list of `OutputState specifications <ObjectiveMechanism_Monitored_Output_States>`;  in this case, a default
-    ObjectiveMechanism is created, using the list of OutputState specifications as the **monitored_output_states**
-    argument of the ObjectiveMechanism's constructor.
-
-If the **objective_mechanism** argument is not specified, a default ObjectiveMechanism is created that is not assigned
-any OutputStates to monitor; this must then be done explicitly after the ControlMechanism is created.
-
-When a ControlMechanism is created automatically as part of a `System <System_Creation>`:
-
-  * a default ObjectiveMechanism is created for the ControlMechanism, using the list of `OutputStates <OutputState>`
-    specified in the **monitor_for_control** argument of the System's contructor, and any others within the System that
-    have been specified to be monitored (using the MONITOR_FOR_CONTROL keyword), as the **monitored_output_states**
-    argument for the ObjectiveMechanism's constructor (see `System_Control_Specification`).
-
-In all cases, the ObjectiveMechanism is assigned to the ControlMechanism's `objective_mechanism
+Whenever a ControlMechanism is created, it automatically creates an `ObjectiveMechanism` that monitors and evaluates
+the `value <OutputState.value>`\\(s) of a set of `OutputState(s) <OutputState>`; this evaluation is used to determine
+the ControlMechanism's `allocation_policy <ControlMechanism.allocation_policy>`. The ObjectiveMechanism, the
+OutputStates that it monitors, and how it evaluates them can be specified in a variety of ways, that depend on the
+context in which the ControlMechanism is created, as described in the subsections below. In all cases,
+the ObjectiveMechanism is assigned to the ControlMechanism's `objective_mechanism
 <ControlMechanism.objective_mechanism>` attribute, and a `MappingProjection` is created that projects from the
 ObjectiveMechanism's *OUTCOME* `OutputState <ObjectiveMechanism_Output>` to the ControlMechanism's `primary
-InputState <InputState_Primary>`.
+InputState <InputState_Primary>`.  All of the OutputStates monitored by the ObjectiveMechanism are listed in its
+`monitored_output_States <ObjectiveMechanism.monitored_output_states>` attribute, and in the ControlMechanism's
+`monitor_for_control <ControlMechanism.montior_for_control>` attribute.
 
-OutputStates to be monitored can be added to an existing ControlMechanism by using the `add_monitored_output_states
+*When the ControlMechanism is created explicitly*
+
+When a ControlMechanism is created explicitly -- either on its own, or in the **controller** argument of the
+`constructor for a System <System_Control_Specification>`) -- the following arguments of the ControlMechanism's
+constructor can be used to specify its ObjectiveMechanism and/or the OutputStates it monitors:
+
+  * **objective_mechanism** -- this can be specified using any of the following:
+
+    - an existing `ObjectiveMechanism`;
+    |
+    - a constructor for an ObjectiveMechanism; its **monitored_output_states** argument can be used to specify
+      `the OutputStates to be monitored <ObjectiveMechanism_Monitored_Output_States>`, and its **function**
+      argument can be used to specify how those OutputStates are evaluated (see `ControlMechanism_Examples`).
+    |
+    - a list of `OutputState specifications <ObjectiveMechanism_Monitored_Output_States>`; a default ObjectiveMechanism
+      is created, using the list of OutputState specifications for its **monitored_output_states** argument.
+    |
+    Note that if the ObjectiveMechanism is explicitly (using either of the first two methods above), its
+    attributes override any attributes specified by the ControlMechanism for its default `objective_mechanism
+    <ControlMechanism.objective_mechanism>`, including those of its `function <ObjectiveMechanism.function>` (see
+    `note <EVCControlMechanism_Objective_Mechanism_Function_Note>` in EVCControlMechanism for an example);
+  ..
+  * **monitor_for_control** -- a list a list of `OutputState specifications
+    <ObjectiveMechanism_Monitored_Output_States>`;  a default ObjectiveMechanism is created, using the list of
+    OutputState specifications for its **monitored_output_states** argument.
+
+  If OutputStates to be monitored are specified in both the **objective_mechanism** argument (on their own, or within
+  the constructor for an ObjectiveMechanism) and the **monitor_for_control** argument of the ControlMechanism,
+  both sets are used in creating the ObjectiveMechanism.
+
+*When the ControlMechanism is created for or assigned as the controller a System*
+
+If a ControlMechanism is specified as the `controller <System.controller>` of a System (see
+`ControlMechanism_System_Controller`), any OutputStates specified to be monitored by the System are assigned as
+inputs to the ObjectiveMechanism.  This includes any specified in the **monitor_for_control** argument of the
+System's constructor, as well as any specified in a MONITOR_FOR_CONTROL entry of a Mechanism `parameter specification
+dictionary <ParameterState_Specification>` (see `Mechanism_Constructor_Arguments` and `System_Control_Specification`).
+
+COMMENT:
+FOR DEVELOPERS:
+    If the ObjectiveMechanism has not yet been created, these are added to the **monitored_output_states** of its
+    constructor called by ControlMechanism._instantiate_objective_mechanmism;  otherwise, they are created using the
+    ObjectiveMechanism.add_monitored_output_states method.
+COMMENT
+
+* Adding OutputStates to be monitored to a ControlMechanism*
+
+OutputStates to be monitored can also be added to an existing ControlMechanism by using the `add_monitored_output_states
 <ObjectiveMechanism.add_monitored_output_states>` method of the ControlMechanism's `objective_mechanism
 <ControlMechanism.objective_mechanism>`.
+
 
 .. _ControlMechanism_Control_Signals:
 
@@ -196,13 +196,12 @@ input to the ControlMechanism's `function <ControlMechanism.function>`, that det
 via a `MappingProjection` from the *OUTCOME* `OutputState <ObjectiveMechanism_Output>` of an `ObjectiveMechanism`.
 The Objective Mechanism is specified in the **objective_mechanism** argument of its constructor, and listed in its
 `objective_mechanism <EVCControlMechanism.objective_mechanism>` attribute.  The OutputStates monitored by the
-ObjectiveMechanism (listed in its `monitored_output_states <ObjectiveMechanism.monitored_output_states>`
-attribute) are also listed in the `monitored_output_states <ControlMechanism.monitored_output_states>`
-of the ControlMechanism (see `ControlMechanism_ObjectiveMechanism` for how the ObjectiveMechanism and the
-OutputStates it monitors are specified).  The OutputStates monitored by the ControlMechanism's `objective_mechanism
-<ControlMechanism.objective_mechanism>` can be displayed using its `show <ControlMechanism.show>` method.
-The ObjectiveMechanism's `function <ObjectiveMechanism>` evaluates the specified OutputStates, and the result is
-conveyed as the input to the ControlMechanism.
+ObjectiveMechanism (listed in its `monitored_output_states <ObjectiveMechanism.monitored_output_states>` attribute)
+are also listed in the `monitor_for_control <ControlMechanism.monitor_for_control>` of the ControlMechanism (see
+`ControlMechanism_ObjectiveMechanism` for how the ObjectiveMechanism and the OutputStates it monitors are specified).
+The OutputStates monitored by the ControlMechanism's `objective_mechanism <ControlMechanism.objective_mechanism>` can
+be displayed using its `show <ControlMechanism.show>` method. The ObjectiveMechanism's `function <ObjectiveMechanism>`
+evaluates the specified OutputStates, and the result is conveyed as the input to the ControlMechanism.
 
 
 .. _ControlMechanism_Function:
@@ -265,7 +264,8 @@ Examples
 ~~~~~~~~
 
 The following example creates a ControlMechanism by specifying its **objective_mechanism** using a constructor
-that specifies the OutputStates to be monitored by its `objective_mechanism <ControlMechanism.objective_mechanism>`::
+that specifies the OutputStates to be monitored by its `objective_mechanism <ControlMechanism.objective_mechanism>`
+and the function used to evaluated these::
 
     >>> import psyneulink as pnl
     >>> my_transfer_mech_A = pnl.TransferMechanism(name="Transfer Mech A")
@@ -493,9 +493,9 @@ class ControlMechanism(AdaptiveMechanism_Base):
         <ControlMechanism_Input>`.
 
     monitored_output_states_weights_and_exponents : List[Tuple(float, float)]
-        each tuple in the list contains the weight and exponent associated with a corresponding item of
-        `monitored_output_states <ControlMechanism.monitored_output_states>`;  these are the same as those in
-        the `monitored_output_states_weights_and_exponents
+        each tuple in the list contains the weight and exponent associated with a corresponding OutputState specified
+        in `monitor_for_control <ControlMechanism.monitor_for_control>`;  these are the same as those in the
+        `monitored_output_states_weights_and_exponents
         <ObjectiveMechanism.monitored_output_states_weights_and_exponents>` attribute of the `objective_mechanism
         <ControlMechanism.objective_mechanism>`, and are used by the ObjectiveMechanism's `function
         <ObjectiveMechanism.function>` to parametrize the contribution made to its output by each of the values that

--- a/psyneulink/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/components/mechanisms/processing/objectivemechanism.py
@@ -562,6 +562,7 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
                  prefs:is_pref_set=None,
                  **kwargs):
 
+        monitored_output_states = monitored_output_states or None # deal with possibility of empty list
         input_states = monitored_output_states
         if output_states is None or output_states is OUTCOME:
             output_states = [OUTCOME]

--- a/psyneulink/components/system.py
+++ b/psyneulink/components/system.py
@@ -2433,10 +2433,14 @@ class System(System_Base):
             # if not any((spec is mech.name or spec in mech.output_states.names)
             if not any((spec in {mech, mech.name} or spec in mech.output_states or spec in mech.output_states.names)
                        for mech in self.mechanisms):
+                if isinstance(spec, OutputState):
+                    spec_str = "{} {} of {}".format(spec.name, OutputState.__name__, spec.owner.name)
+                else:
+                    spec_str = spec
                 raise SystemError("Specification of {} arg for {} appears to be a list of "
                                             "Mechanisms and/or OutputStates to be monitored, but one "
                                             "of them ({}) is in a different System".
-                                            format(OBJECTIVE_MECHANISM, self.name, spec))
+                                            format(OBJECTIVE_MECHANISM, self.name, spec_str))
 
     def _get_control_signals_for_system(self, control_signals=None, context=None):
         """Generate and return a list of control_signal_specs for System

--- a/psyneulink/components/system.py
+++ b/psyneulink/components/system.py
@@ -3782,7 +3782,8 @@ class System(System_Base):
             if isinstance(rcvr, LearningMechanism):
                 return
             # if recvr is ObjectiveMechanism for ControlMechanism that is System's controller
-            if isinstance(rcvr, ObjectiveMechanism) and rcvr.controller is True:
+            if isinstance(rcvr, ObjectiveMechanism) and rcvr.for_controller is True:
+            # if isinstance(rcvr, ObjectiveMechanism) and rcvr._role is CONTROL:
                 return
 
             # loop through senders to implement edges
@@ -4179,7 +4180,8 @@ class System(System_Base):
                     pred_mech_color = active_color
                 else:
                     pred_mech_color = prediction_mechanism_color
-                if mech._role is CONTROL and hasattr(mech, 'origin_mech'):
+                # if mech._role is CONTROL and hasattr(mech, 'origin_mech'):
+                if mech.for_control is True and hasattr(mech, 'origin_mech'):
                     recvr = mech.origin_mech
                     recvr_label = self._get_label(recvr, show_dimensions, show_roles)
                     # IMPLEMENTATION NOTE:

--- a/psyneulink/components/system.py
+++ b/psyneulink/components/system.py
@@ -4181,7 +4181,7 @@ class System(System_Base):
                 else:
                     pred_mech_color = prediction_mechanism_color
                 # if mech._role is CONTROL and hasattr(mech, 'origin_mech'):
-                if mech.for_control is True and hasattr(mech, 'origin_mech'):
+                if hasattr(mech, 'for_control') and mech.for_control is True and hasattr(mech, 'origin_mech'):
                     recvr = mech.origin_mech
                     recvr_label = self._get_label(recvr, show_dimensions, show_roles)
                     # IMPLEMENTATION NOTE:

--- a/psyneulink/library/subsystems/agt/agtcontrolmechanism.py
+++ b/psyneulink/library/subsystems/agt/agtcontrolmechanism.py
@@ -89,6 +89,33 @@ ControlSignal's `ControlProjection`.   The `value <ControlProjection.value>` of 
 `ParameterState` to which it projects to modify the value of the parameter it controls (see
 `ControlSignal_Modulation` for description of how a ControlSignal modulates the value of a parameter).
 
+COMMENT:
+FROM LCControlMechanism
+If the **mode** argument of the LCControlMechanism's constructor is specified, the following Components are also
+automatically created and assigned to the LCControlMechanism when it is created:
+
+    * an `LCController` -- takes the output of the AGTUtilityIntegratorMechanism (see below) and uses this to
+      control the value of the LCControlMechanism's `mode <FHNIntegrator.mode>` attribute.  It is assigned a single
+      `ControlSignal` that projects to the `ParameterState` for the LCControlMechanism's `mode <FHNIntegrator.mode>`
+      attribute.
+    ..
+    * a `AGTUtilityIntegratorMechanism` -- monitors the `value <OutputState.value>` of any `OutputStates <OutputState>`
+      specified in the **mode** argument of the LCControlMechanism's constructor;  these are listed in the
+      LCControlMechanism's `monitored_output_states <LCControlMechanism.monitored_output_states>` attribute,
+      as well as that attribute of the AGTUtilityIntegratorMechanism and LCController.  They are evaluated by the
+      AGTUtilityIntegratorMechanism's `AGTUtilityIntegrator` Function, the result of whch is used by the LCControl to
+      control the value of the LCControlMechanism's `mode <FHNIntegrator.mode>` attribute.
+    ..
+    * `MappingProjections <MappingProjection>` from Mechanisms or OutputStates specified in **monitor_for_control** to
+      the AGTUtilityIntegratorMechanism's `primary InputState <InputState_Primary>`.
+    ..
+    * a `MappingProjection` from the AGTUtilityIntegratorMechanism's *UTILITY_SIGNAL* `OutputState
+      <AGTUtilityIntegratorMechanism_Structure>` to the LCControlMechanism's *MODE* <InputState_Primary>`.
+    ..
+    * a `ControlProjection` from the LCController's ControlSignal to the `ParameterState` for the LCControlMechanism's
+      `mode <FHNIntegrator.mode>` attribute.
+COMMENT
+
 
 .. _AGTControlMechanism_Execution:
 

--- a/psyneulink/library/subsystems/agt/lccontrolmechanism.py
+++ b/psyneulink/library/subsystems/agt/lccontrolmechanism.py
@@ -17,7 +17,7 @@ An LCControlMechanism is a `ControlMechanism <ControlMechanism>` that multiplica
 <Mechanism_Base.function>` of one or more `Mechanisms <Mechanism>` (usually `TransferMechanisms <TransferMechanism>`).
 It implements an abstract model of the `locus coeruleus (LC)  <https://www.ncbi.nlm.nih.gov/pubmed/12371518>`_ that
 uses an `FHNIntegrator` Function to generate its output.  This is modulated by a `mode <LCControlMechanism.mode_FHN>`
-parameter that regulates its functioning between `"tonic" and "phasic" modes of operation
+parameter that regulates its function between `"tonic" and "phasic" modes of operation
 <LCControlMechanism_Modes_Of_Operation>`.  The Mechanisms modulated by an LCControlMechanism can be listed using
 its `show <LCControlMechanism.show>` method.  When used with an `AGTControlMechanism` to regulate the `mode
 <FHNIntegrator.mode>` parameter of its `FHNIntegrator` Function, it implements a form of the `Adaptive Gain Theory
@@ -33,29 +33,28 @@ An LCControlMechanism can be created in any of the ways used to `create a Contro
 The following sections describe how to specify the inputs that drive the LCControlMechanism's response, and the
 Mechanisms that it controls.
 
-
-.. _LCControlMechanism_ObjectiveMechanism:
+.. _LCControlMechanism_ObjectiveMechanism_Creation:
 
 ObjectiveMechanism and Monitored OutputStates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Like all ControlMechanisms, an LCControlMechanism receives its `input <LCControlMechanism_Input>` from an
-`ObjectiveMechanism` that, in turn, receives its input from a specified list of `OutputStates <OutputState>`.  These
-are used to drive the `phasic response <LCControlMechanism_Modes_Of_Operation>` of the LCControlMechanism.  The
-ObjectiveMechanism and/or the OutputStates from which it gets its input can be `specified in the standard way for a
-ControlMechanism <ControlMechanism_ObjectiveMechanism>`).  By default, an LCControlMechanism creates an
-ObjectiveMechanism that uses a `CombineMeans` Function to sum the means of the `value <OutputState.value>`\\s of the
-OutputStates from which it gets its input.  However, this can be customized by specifying a different
-ObjectiveMechanism or its `function <ObjectiveMechanism.function>`, so long as these generate a result that is a
-scalar value.
+Like all ControlMechanisms, when an LCControlMechanism is created it automatically creates an `ObjectiveMechanism`,
+from which it receives its input. The ObjectiveMechanism receives its input from any `OutputStates <OutputState>`
+specified in **monitor_for_control** argument of the constructor for LCControlMechanism (or of a `System` for which
+it is assigned as a `controller <System.controller>`; see `ControlMechanism_ObjectiveMechanism`). By default,
+the ObjectiveMechanism is assigned a `CombineMeans` Function  as its `function <ObjectiveMechanism.function>` (see
+`LCControlMechanism_ObjectiveMechanism`).  The ObjectiveMechanism can be customized using the
+**objective_mechanism** argument of the LCControlMechanism's constructor; however, the `value <OutputState.value>`
+of its *OUTCOME* `OutputState` must be a scalar value (that is used as the input to the LCControlMechanism's
+`function <LCControlMechanism.function>` to drive its `phasic response <LCControlMechanism_Modes_Of_Operation>`.
 
 .. _LCControlMechanism_Modulated_Mechanisms:
 
-Specifying Mechanisms to Modulate
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Mechanisms to Modulate
+~~~~~~~~~~~~~~~~~~~~~~
 
-The Mechanisms to be modulated by an LCControlMechanism are specified in its **modulated_mechanisms** argument. An
-LCControlMechanism controls a `Mechanism <Mechanism>` by modifying the `multiplicative_param
+The Mechanisms to be modulated by an LCControlMechanism are specified in the **modulated_mechanisms** argument of its
+constructor. An LCControlMechanism controls a `Mechanism <Mechanism>` by modifying the `multiplicative_param
 <Function_Modulatory_Params>` of the Mechanism's `function <TransferMechanism.function>`.  Therefore, any Mechanism
 specified for control by an LCControlMechanism must be either a `TransferMechanism`, or a Mechanism that uses a
 `TransferFunction` or a class of `Function <Function>` that implements a `multiplicative_param
@@ -64,8 +63,9 @@ specified for control by an LCControlMechanism must be either a `TransferMechani
 `Compositions <Composition>` to which the LCControlMechanism belongs.  If a Mechanism specified in the
 **modulated_mechanisms** argument does not implement a multiplicative_param, it is ignored. A `ControlProjection` is
 automatically created that projects from the LCControlMechanism to the `ParameterState` for the `multiplicative_param
-<Function_Modulatory_Params>` of every Mechanism specified in the **modulated_mechanisms** argument (and listed in
-its `modulated_mechanisms <LCControlMechanism.modulated_mechanisms>` attribute).
+<Function_Modulatory_Params>` of every Mechanism specified in the **modulated_mechanisms** argument.  The Mechanisms
+modulated by an LCControlMechanism are listed in its `modulated_mechanisms <LCControlMechanism.modulated_mechanisms>`
+attribute).
 
 .. _LCControlMechanism_Structure:
 
@@ -77,194 +77,114 @@ Structure
 Input
 ~~~~~
 
-COMMENT:
+An LCControlMechanism has a single (primary) `InputState <InputState_Primary>`, the `value <InputState.value>` of
+which is a scalar that is provided by a `MappingProjection` from the *OUTCOME* `OutputState <ObjectiveMechanism_Output>`
+of the LCControlMechanism's `ObjectiveMechanism`.  That value is used as the input to the LCControlMechanism's
+`function <LCControlMechanism.function>`, which drives its `phasic response <LCControlMechanism_Modes_Of_Operation>`.
 
-An LCControlMechanism has a single (primary) `InputState <InputState_Primary>` that receives its input via a
-`MappingProjection` from the *OUTCOME* `OutputState <ObjectiveMechanism_Output>` of an `ObjectiveMechanism`.
-The Objective Mechanism is specified in the **objective_mechanism** argument of its constructor, and listed in its
-`objective_mechanism <EVCControlMechanism.objective_mechanism>` attribute.  The OutputStates monitored by the
-ObjectiveMechanism (listed in its `monitored_output_states <ObjectiveMechanism.monitored_output_states>`
-attribute) are also listed in the `monitored_output_states <ControlMechanism.monitored_output_states>`
-of the ControlMechanism (see `ControlMechanism_ObjectiveMechanism` for how the ObjectiveMechanism and the
-OutputStates it monitors are specified).  The OutputStates monitored by the ControlMechanism's `objective_mechanism
-<ControlMechanism.objective_mechanism>` can be displayed using its `show <ControlMechanism.show>` method.
-The ObjectiveMechanism's `function <ObjectiveMechanism>` evaluates the specified OutputStates, and the result is
-conveyed as the input to the ControlMechanism.
-
-
-Projections from any Mechanisms
-specified in the **input_states** argument of the LCControlMechanism's constructor;  its `value <InputState.value>` is a
-scalar, so the `matrix <MappingProjection.matrix>` parameter for any MappingProjection to the LCControlMechanism's InputState
-from an OutputStates with a `value <OutputState.value>` that is an array of greater than length 1 is assigned a
-`FULL_CONNECTIVITY_MATRIX`.  The `value <InputState.value>` of the LCControlMechanism's InputState is used as the `variable
-<FHNIntegrator.variable>` for the LCControlMechanism's `function <LCControlMechanism.function>`.
-
-
-.. _LCControlMechanism_ObjectiveMechanism
-
-   By default, the ObjectiveMechanism is assigned a CombineMeans Function that takes the mean of the `value
-   <InputState.value>` received from each OutputState specified in **monitored_output_states** (i.e., of each of its
-   `input_states <ObjectiveMechanism.input_states>`) and sums these; the result is provided as the input to the LCControlMechanism.
-   The contribution of each monitored_output_state can be weighted and/or exponentitaed in the standard way for the
-       monitored_output_states/input_states of an ObjectiveMechanism
-
-FROM CONTROL_MECHANISM:
-A ControlMechanism has a single *ERROR_SIGNAL* `InputState`, the `value <InputState.value>` of which is used as the
-input to the ControlMechanism's `function <ControlMechanism.function>`, that determines the ControlMechanism's
-`allocation_policy <ControlMechanism.allocation_policy>`. The *ERROR_SIGNAL* InputState receives its input
-via a `MappingProjection` from the *OUTCOME* `OutputState <ObjectiveMechanism_Output>` of an `ObjectiveMechanism`.
-The Objective Mechanism is specified in the **objective_mechanism** argument of its constructor, and listed in its
-`objective_mechanism <EVCControlMechanism.objective_mechanism>` attribute.  The OutputStates monitored by the
-ObjectiveMechanism (listed in its `monitored_output_states <ObjectiveMechanism.monitored_output_states>`
-attribute) are also listed in the `monitored_output_states <ControlMechanism.monitored_output_states>`
-of the ControlMechanism (see `ControlMechanism_ObjectiveMechanism` for how the ObjectiveMechanism and the
-OutputStates it monitors are specified).  The OutputStates monitored by the ControlMechanism's `objective_mechanism
-<ControlMechanism.objective_mechanism>` can be displayed using its `show <ControlMechanism.show>` method.
-The ObjectiveMechanism's `function <ObjectiveMechanism>` evaluates the specified OutputStates, and the result is
-conveyed as the input to the ControlMechanism.
-
-COMMENT
 
 .. _LCControlMechanism_ObjectiveMechanism:
 
 ObjectiveMechanism
 ^^^^^^^^^^^^^^^^^^
 
-Like any ControlMechanism, an LCControlMechanism receives its input from the *OUTCOME* `OutputState
-<ObjectiveMechanism_Output>` of an `ObjectiveMechanism`, via a MappingProjection to its `primary InputState
-<InputStatePrimary>`.  The ObjectiveFunction is listed in the LCControlMechanism's `objective_mechanism
-<LCControlMechanism.objective_mechanism>` attribute.  By default, the ObjectiveMechanism's function is a `CombineMeans`
-function with its default `operation <LinearCombination.operation>` of *SUM*; this takes the mean of the `value
-<OutputState.value>` of each of the OutputStates that it monitors (listed in its `monitored_output_states
-<ObjectiveMechanism.monitored_output_states>` attribute, and returns the sum of those means.  However, this can be
-customized in a variety of ways:
+The ObjectiveMechanism for an LCControlMechanism receives its inputs from the `OutputState(s) <OutputState>` specified
+the **monitor_for_control** argument of the LCControlMechanism constructor, or the **montiored_output_states** argument
+of the LCControlMechanism's `ObjectiveMechanism <ControlMechanism_ObjectiveMechanism>`.  By default, the
+ObjectiveMechanism is assigned a `CombineMeans` Function with a default `operation <LinearCombination.operation>` of
+*SUM*; this takes the mean of each array that the ObjectiveMechanism receives from the `value <OutputState.value>` of
+each of the OutputStates that it monitors, and returns the sum of these means.  The `value <OutputState.value>` of
+each OutputState can be weighted (multiplicatively and/or exponentially), by specifying this in the
+**monitor_for_control** argument of the LCControlMechanism (see `ControlMechanism_ObjectiveMechanism` for details).
+As with any ControlMechanism, its ObjectiveMechanism can be explicitly specified to customize its `function
+<ObjectiveMechanism.function>` or any of its other parameters, by specifyihng it in the **objective_mechanism**
+argument of the LCControlMechanism's constructor.
 
-    * by specifying a different `function <ObjectiveMechanism.function>` for the ObjectiveMechanism
-      (see `ObjectiveMechanism_Weights_and_Exponents_Example` for an example);
-    ..
-    * using a list to specify the OutputStates to be monitored  (and the `tuples format
-      <InputState_Tuple_Specification>` to specify weights and/or exponents for them) in the
-      **objective_mechanism** argument of the EVCControlMechanism's constructor;
-    ..
-    * using the  **monitored_output_states** argument of the `objective_mechanism <LCControlMechanism.objective_mechanism>`'s
-      constructor;
-    ..
-    * specifying a different `ObjectiveMechanism` in the LCControlMechanism's **objective_mechanism** argument of the
-      EVCControlMechanism's constructor. The result of the `objective_mechanism <LCControlMechanism.objective_mechanism>`'s
-      `function <ObjectiveMechanism.function>` is used as the input to the LCControlMechanism.
+.. _LCControlMechanism_Objective_Mechanism_Function_Note:
 
-    .. _LCControlMechanism_Objective_Mechanism_Function_Note:
+.. note::
+   If an `ObjectiveMechanism` is specified in the **objective_mechanism** argument of the LCControlMechanism's
+   constructor, then its attribute values (including any defaults) override those used by a LCControlMechanism for
+   creating its `objective_mechanism <LCControlMechanism.objective_mechanism>`.  In particular, whereas an
+   ObjectiveMechanism uses `LinearCombination` as the default for its `function <ObjectiveMechanism.function>`,
+   an LCControlMechanism uses `CombineMeans` as the `function <ObjectiveMechanism.function>` of its `objective_mechanism
+   <LCControlMechanism.objective_mechanism>`.  As a consequence, if an ObjectiveMechanism is explicitly specified in
+   the LCControlMechanism's **objective_mechanism** argument, and its **function** argument is not also
+   explicitly specified as `CombineMeans`, then `LinearCombination` will be used for the ObjectiveMechanism's `function
+   <ObjectiveMechanism.function>`.  To insure that `CombineMeans` is used, it must be specified explicitly in the
+   **function** argument of the constructor for the ObjectiveMechanism (for an example of a similar condition
+   for an EVCControlMechanism see 1st example under `System_Control_Examples`).
 
-    .. note::
-       If a constructor for an `ObjectiveMechanism` is used for the **objective_mechanism** argument of the
-       LCControlMechanism's constructor, then the default values of its attributes override any used by the LCControlMechanism
-       for its `objective_mechanism <EVCControlMechanism.objective_mechanism>`.  In particular, whereas an ObjectiveMechanism
-       uses `LinearCombination` as the default for its `function <ObjectiveMechanism.function>`, an LCControlMechanism
-       typically uses `CombineMeans` for the `function <ObjectiveMechanism.function>` of its `objective_mechanism
-       <LCControlMechanism.objective_mechanism>`.  As a consequence, if the constructor for an ObjectiveMechanism is used to
-       specify the LCControlMechanism's **objective_mechanism** argument, and the **function** argument is not specified,
-       `LinearCombination` rather than `CombineMeans` will be used for the ObjectiveMechanism's `function
-       <ObjectiveMechanism.function>`.  To insure that `CombineMeans` is used, it must be specified explicitly in the
-       **function** argument of the constructor for the ObjectiveMechanism (for an example of a similar condition
-       for an EVCControlMechanism see 1st example under `System_Control_Examples`).
-
-The OutputStates monitored by the LC's ObjectiveMechanism are listed in its `monitored_output_states
-<ObjectiveMechanism.monitored_output_states>` attribute), as well as in the `monitored_output_states
-<LCControlMechanism.monitored_output_states>` attribute of the LCControlMechanism itself.  These can be displayed using the
-LCControlMechanism's `show <LCControlMechanism.show>` method.
+The ObjectiveFunction is listed in the LCControlMechanism's `objective_mechanism
+<LCControlMechanism.objective_mechanism>` attribute.  The OutputStates it monitors are listed in the
+ObjectiveMechanism's `monitored_output_states <ObjectiveMechanism.monitored_output_states>` attribute) as well as the
+LCControlMechanism's `monitor_for_control <LCControlMechanism.monitor_for_control>` attribute.  These can be
+displayed using the LCControlMechanism's `show <LCControlMechanism.show>` method.
 
 .. _LCControlMechanism_Function:
 
 Function
 ~~~~~~~~
 
-COMMENT:
-XXX ADD MENTION OF allocation_policy HERE
-COMMENT
-
-An LCControlMechanism uses the `FHNIntegrator` as its `function <LCControlMechanism.function`; this implements a `FitzHugh-Nagumo
-model <https://en.wikipedia.org/wiki/FitzHugh–Nagumo_model>`_ often used to describe the spiking of a neuron,
-but in this case the population activity of the LC (see `Gilzenrat et al., 2002
+An LCControlMechanism uses the `FHNIntegrator` as its `function <LCControlMechanism.function>`; this implements a
+`FitzHugh-Nagumo model <https://en.wikipedia.org/wiki/FitzHugh–Nagumo_model>`_ often used to describe the spiking of
+a neuron, but in this case the population activity of the LC (see `Gilzenrat et al., 2002
 <http://www.sciencedirect.com/science/article/pii/S0893608002000552?via%3Dihub>`_). The `FHNIntegrator` Function
-takes the `input <LCControlMechanism_Input>` to the LCControlMechanism as its `variable <FHNIntegrator.variable>`. All
-of the `FHNIntegrator` function parameters are exposed on the LCControlMechanism.
+of an LCControlMechanism takes a scalar as its `variable <FHNIntegrator.variable>`, received from the
+the `input <LCControlMechanism_Input>` to the LCControlMechanism, and the result serves as the `allocation_policy
+<LCControlMechanism.allocation_policy>` for the LCControlMechanism. All of the parameters of the `FHNIntegrator`
+function are accessible as attributes of the LCControlMechanism.
 
 .. _LCControlMechanism_Modes_Of_Operation:
 
 LC Modes of Operation
 ^^^^^^^^^^^^^^^^^^^^^
 
-The `mode <FHNIntegrator.mode>` parameter of the LCControlMechanism's `FHNIntegrator` Function regulates its operation between
-`"tonic" and "phasic" modes <https://www.ncbi.nlm.nih.gov/pubmed/8027789>`_:
+The `mode <FHNIntegrator.mode>` parameter of the LCControlMechanism's `FHNIntegrator` Function regulates its operation
+between `"tonic" and "phasic" modes <https://www.ncbi.nlm.nih.gov/pubmed/8027789>`_:
 
-  * in the *tonic mode* (low value of `mode <FHNIntegrator.mode>`), the output of the LCControlMechanism is moderately low
-    and constant; that is, it is relatively unaffected by its `input <LCControlMechanism_Input`.  This blunts the response
-    of the Mechanisms that the LCControlMechanism controls to their inputs.
+  * in the *tonic mode* (low value of `mode <FHNIntegrator.mode>`), the output of the LCControlMechanism is moderately
+    low and constant; that is, it is relatively unaffected by its `input <LCControlMechanism_Input`.  This blunts the
+    response of the Mechanisms that the LCControlMechanism controls to their inputs.
 
-  * in the *phasic mode* (high value of `mode <FHNIntegrator.mode>`), when the `input to the LC <LC_Input>` is low,
-    its `output <LC_Output>` is even lower than when it is in the tonic regime, and thus the response of the
-    Mechanisms it controls to their outputs is even more blunted.  However, when the LCControlMechanism's input rises above
-    a certain value (determined by the `threshold <LCControlMechanism.threshold>` parameter), its output rises sharply
-    generating a "phasic response", and inducing a much sharper response of the Mechanisms it controls to their inputs.
-
-COMMENT:
-XXX MENTION AGT HERE
-COMMENT
-
-COMMENT:
-MOVE TO LCController
-If the **mode** argument of the LCControlMechanism's constructor is specified, the following Components are also
-automatically created and assigned to the LCControlMechanism when it is created:
-
-    * an `LCController` -- takes the output of the AGTUtilityIntegratorMechanism (see below) and uses this to
-      control the value of the LCControlMechanism's `mode <FHNIntegrator.mode>` attribute.  It is assigned a single
-      `ControlSignal` that projects to the `ParameterState` for the LCControlMechanism's `mode <FHNIntegrator.mode>` attribute.
-    ..
-    * a `AGTUtilityIntegratorMechanism` -- monitors the `value <OutputState.value>` of any `OutputStates <OutputState>`
-      specified in the **mode** argument of the LCControlMechanism's constructor;  these are listed in the LCControlMechanism's
-      `monitored_output_states <LCControlMechanism.monitored_output_states>` attribute, as well as that attribute of the
-      AGTUtilityIntegratorMechanism and LCController.  They are evaluated by the AGTUtilityIntegratorMechanism's
-      `AGTUtilityIntegrator` Function, the result of whch is used by the LCControl to control the value of the
-      LCControlMechanism's `mode <FHNIntegrator.mode>` attribute.
-    ..
-    * `MappingProjections <MappingProjection>` from Mechanisms or OutputStates specified in **monitor_for_control** to
-      the AGTUtilityIntegratorMechanism's `primary InputState <InputState_Primary>`.
-    ..
-    * a `MappingProjection` from the AGTUtilityIntegratorMechanism's *UTILITY_SIGNAL* `OutputState
-      <AGTUtilityIntegratorMechanism_Structure>` to the LCControlMechanism's *MODE* <InputState_Primary>`.
-    ..
-    * a `ControlProjection` from the LCController's ControlSignal to the `ParameterState` for the LCControlMechanism's
-      `mode <FHNIntegrator.mode>` attribute.
-COMMENT
+  * in the *phasic mode* (high value of `mode <FHNIntegrator.mode>`), when the `input to the LCControlMechanism
+    <LCControlMechanism_Input>` is low, its `output <LCControlMechanism_Output>` is even lower than when it is in the
+    tonic regime, and thus the response of the Mechanisms it controls to their outputs is even more blunted.  However,
+    when the LCControlMechanism's input rises above a certain value (determined by the `threshold
+    <LCControlMechanism.threshold>` parameter), its output rises sharply generating a "phasic response", and inducing a
+    much sharper response of the Mechanisms it controls to their inputs.
 
 .. _LCControlMechanism_Output:
 
 Output
 ~~~~~~
 
-COMMENT:
-VERSION FOR SINGLE ControlSignal
-An LCControlMechanism has a single `ControlSignal` used to modulate the function of the Mechanism(s) listed in its
-`modulated_mechanisms <LCControlMechanism.modulated_mechanisms>` attribute.  The ControlSignal is assigned a
-`ControlProjection` to the `ParameterState` for the `multiplicative_param <Function_Modulatory_Params>` of the
-`function <Mechanism_Base.function>` for each of those Mechanisms.
-COMMENT
+An LCControlMechanism has a single `ControlSignal`, that uses its `allocation_policy
+<LCControlMechanism.allocation_policy>` (the scalar value generated by its `function <LCControlMechanism.function>`)
+to modulate the function of the Mechanism(s) it controls.  The ControlSignal is assigned a `ControlProjection` to the
+`ParameterState` for the `multiplicative_param <Function_Modulatory_Params>` of the `function
+<Mechanism_Base.function>` for each of those Mechanisms.  The Mechanisms modulated by an LCControlMechanism are listed
+in its `modulated_mechanisms <LCControlMechanism.modulated_mechanisms>` attribute) and can be displayed using its
+:func:`show <LCControlMechanism.show>` method.
 
+COMMENT:
+VERSION FOR MULTIPLE CONTROL SIGNALS
 An LCControlMechanism has a `ControlSignal` for each Mechanism listed in its `modulated_mechanisms
-<LCControlMechanism.modulated_mechanisms>` attribute.  All of its ControlSignals are assigned the same value:  the result of
-the LCControlMechanism's `function <LCControlMechanism.function>`.  Each ControlSignal is assigned a `ControlProjection` to the
-`ParameterState` for the  `multiplicative_param <Function_Modulatory_Params>` of `function
-<Mechanism_Base.function>` for the Mechanism in `modulated_mechanisms <LCControlMechanism.modulate_mechanisms>` to which it
-corresponds. The Mechanisms modulated by an LCControlMechanism can be displayed using its :func:`show <LCControlMechanism.show>`
-method.
+<LCControlMechanism.modulated_mechanisms>` attribute.  All of its ControlSignals are assigned the same value:  the
+result of the LCControlMechanism's `function <LCControlMechanism.function>`.  Each ControlSignal is assigned a
+`ControlProjection` to the `ParameterState` for the  `multiplicative_param <Function_Modulatory_Params>` of `function
+<Mechanism_Base.function>` for the Mechanism in `modulated_mechanisms <LCControlMechanism.modulate_mechanisms>` to
+which it corresponds. The Mechanisms modulated by an LCControlMechanism can be displayed using its :func:`show
+<LCControlMechanism.show>` method.
+COMMENT
 
 .. _LCControlMechanism_Examples:
 
 Examples
 ~~~~~~~~
 
-The following example generates an LCControlMechanism that modulates the function of two TransferMechanisms, one that uses
-a `Linear` function and the other a `Logistic` function::
+The following example generates an LCControlMechanism that modulates the function of two TransferMechanisms, one that
+uses a `Linear` function and the other a `Logistic` function::
 
     >>> import psyneulink as pnl
     >>> my_mech_1 = pnl.TransferMechanism(function=pnl.Linear,
@@ -326,14 +246,14 @@ COMMENT
 Execution
 ---------
 
-An LCControlMechanism executes within a `Composition` at a point specified in the Composition's `Scheduler` or, if it is the
-`controller <System>` for a `Composition`, after all of the other Mechanisms in the Composition have `executed
-<Composition_Execution>` in a `TRIAL`. It's `function <LCControlMechanism.function>` takes the `value <InputState.value>` of
-the LCControlMechanism's `primary InputState <InputState_Primary>` as its input, and generates a response -- under the
-influence of its `mode <FHNIntegrator.mode>` parameter -- that is assigned as the `allocation
-<ControlSignal.allocation>` of its `ControlSignals <ControlSignal>`.  The latter are used by its `ControlProjections
-<ControlProjection>` to modulate the response -- in the next `TRIAL` of execution --  of the Mechanisms the LCControlMechanism
-controls.
+An LCControlMechanism executes within a `Composition` at a point specified in the Composition's `Scheduler` or, if it
+is the `controller <System>` for a `Composition`, after all of the other Mechanisms in the Composition have `executed
+<Composition_Execution>` in a `TRIAL`. It's `function <LCControlMechanism.function>` takes the `value
+<InputState.value>` of the LCControlMechanism's `primary InputState <InputState_Primary>` as its input, and generates a
+response -- under the influence of its `mode <FHNIntegrator.mode>` parameter -- that is assigned as the `allocation
+<LCControlSignal.allocation>` of its `ControlSignals <ControlSignal>`.  The latter are used by its `ControlProjections
+<ControlProjection>` to modulate the response -- in the next `TRIAL` of execution --  of the Mechanisms the
+LCControlMechanism controls.
 
 .. note::
    A `ParameterState` that receives a `ControlProjection` does not update its value until its owner Mechanism
@@ -420,7 +340,7 @@ class LCControlMechanism(ControlMechanism):
     system : System : default None
         specifies the `System` for which the LCControlMechanism should serve as a `controller <System.controller>`;
         the LCControlMechanism will inherit any `OutputStates <OutputState>` specified in the **monitor_for_control**
-        argument of the `system <EVCControlMechanism.system>`'s constructor, and any `ControlSignals <ControlSignal>`
+        argument of the `system <LCControlMechanism.system>`'s constructor, and any `ControlSignals <ControlSignal>`
         specified in its **control_signals** argument.
 
     objective_mechanism : ObjectiveMechanism, List[OutputState or Tuple[OutputState, list or 1d np.array, list or 1d
@@ -532,18 +452,19 @@ class LCControlMechanism(ControlMechanism):
     system : System_Base
         the `System` for which LCControlMechanism is the `controller <System.controller>`;
         the LCControlMechanism inherits any `OutputStates <OutputState>` specified in the **monitor_for_control**
-        argument of the `system <EVCControlMechanism.system>`'s constructor, and any `ControlSignals <ControlSignal>`
+        argument of the `system <LCControlMechanism.system>`'s constructor, and any `ControlSignals <ControlSignal>`
         specified in its **control_signals** argument.
 
     objective_mechanism : ObjectiveMechanism : ObjectiveMechanism(function=CombinedMeans))
         the 'ObjectiveMechanism' used by the LCControlMechanism to aggregate the `value <OutputState.value>`\\s of the
         OutputStates used to drive its `phasic response <LCControlMechanism_Modes_Of_Operation>`.
 
-    monitored_output_states : List[OutputState]
+    monitor_for_control : List[OutputState]
         list of the `OutputStates <OutputState>` that project to `objective_mechanism
-        <EVCControlMechanism.objective_mechanism>` (and listed in its `monitored_output_states
-        <ObjectiveMechanism.monitored_output_states>` attribute), and used to drive the
-        LCControlMechanism's `phasic response <LCControlMechanism_Modes_Of_Operation>`.
+        <LCControlMechanism.objective_mechanism>` (and also listed in the ObjectiveMechanism's `monitored_output_states
+        <ObjectiveMechanism.monitored_output_states>` attribute);  these are used by the ObjectiveMechanism to
+        generate the ControlMechanism's `input <ControlMechanism_Input>`, which drives the `phasic response
+        <LCControlMechanism_Modes_Of_Operation>` of its `function <LControlMechanism.function>`.
 
     monitored_output_states_weights_and_exponents : List[Tuple(float, float)]
         each tuple in the list contains the weight and exponent associated with a corresponding item of
@@ -558,6 +479,12 @@ class LCControlMechanism(ControlMechanism):
         takes the LCControlMechanism's `input <LCControlMechanism_Input>` and generates its response <LCControlMechanism_Output>` under
         the influence of the `FHNIntegrator` Function's `mode <FHNIntegrator.mode>` attribute
         (see `LCControlMechanism_Function` for additional details).
+
+    allocation_policy : 2d np.array
+        contains a single item — the result of the LCControlMechanism's `function <LCControlMechanism.function>` —
+        that is assigned as the `allocation <ControlSignal.allocation>` for the LCControlMechanism's single
+        `ControlSignal`, listed in its `control_signals` attribute;  the allocation_policy is the same as the
+        ControlMechanism's `value <Mechanism_Base.value>` attribute).
 
     control_signals : List[ControlSignal]
         contains the LCControlMechanism's single `ControlSignal`, which sends `ControlProjections

--- a/psyneulink/library/subsystems/agt/lccontrolmechanism.py
+++ b/psyneulink/library/subsystems/agt/lccontrolmechanism.py
@@ -350,14 +350,17 @@ Class Reference
 """
 import typecheck as tc
 
-from psyneulink.components.functions.function import FHNIntegrator, MULTIPLICATIVE_PARAM, ModulationParam, _is_modulation_param
+from psyneulink.components.functions.function import \
+    FHNIntegrator, MULTIPLICATIVE_PARAM, ModulationParam, _is_modulation_param
+from psyneulink.components.mechanisms.mechanism import Mechanism
 from psyneulink.components.mechanisms.adaptive.control.controlmechanism import ControlMechanism
 from psyneulink.components.mechanisms.processing.objectivemechanism import ObjectiveMechanism
 from psyneulink.components.projections.modulatory.controlprojection import ControlProjection
+from psyneulink.components.states.outputstate import OutputState
 from psyneulink.components.shellclasses import Mechanism, System_Base
-from psyneulink.globals.context import ContextFlags
 from psyneulink.globals.keywords import \
     ALL, CONTROL_PROJECTIONS, CONTROL_SIGNALS, FUNCTION, INIT__EXECUTE__METHOD_ONLY, PROJECTIONS
+from psyneulink.globals.utilities import is_iterable
 from psyneulink.globals.preferences.componentpreferenceset import is_pref_set
 from psyneulink.globals.preferences.preferenceset import PreferenceLevel
 
@@ -685,6 +688,7 @@ class LCControlMechanism(ControlMechanism):
                  system:tc.optional(System_Base)=None,
                  objective_mechanism:tc.optional(tc.any(ObjectiveMechanism, list))=None,
                  # modulated_mechanisms:tc.optional(tc.any(list,str)) = None,
+                 monitor_for_control:tc.optional(tc.any(is_iterable, Mechanism, OutputState))=None,
                  modulated_mechanisms=None,
                  modulation:tc.optional(_is_modulation_param)=ModulationParam.MULTIPLICATIVE,
                  integration_method="RK4",
@@ -715,7 +719,6 @@ class LCControlMechanism(ControlMechanism):
 
         # Assign args to params and functionParams dicts (kwConstants must == arg names)
         params = self._assign_args_to_param_dicts(system=system,
-                                                  objective_mechanism=objective_mechanism,
                                                   modulated_mechanisms=modulated_mechanisms,
                                                   modulation=modulation,
                                                   integration_method=integration_method,
@@ -743,6 +746,7 @@ class LCControlMechanism(ControlMechanism):
 
         super().__init__(system=system,
                          objective_mechanism=objective_mechanism,
+                         monitor_for_control=monitor_for_control,
                          function=FHNIntegrator(  integration_method=integration_method,
                                                   initial_v=initial_v_FHN,
                                                   initial_w=initial_w_FHN,

--- a/psyneulink/library/subsystems/evc/evccontrolmechanism.py
+++ b/psyneulink/library/subsystems/evc/evccontrolmechanism.py
@@ -383,11 +383,12 @@ from psyneulink.components.mechanisms.mechanism import MechanismList, Mechanism
 from psyneulink.components.mechanisms.adaptive.control.controlmechanism import ControlMechanism
 from psyneulink.components.mechanisms.processing.objectivemechanism import ObjectiveMechanism
 from psyneulink.components.projections.pathway.mappingprojection import MappingProjection
+from psyneulink.components.states.outputstate import OutputState
+from psyneulink.components.states.parameterstate import ParameterState
 from psyneulink.components.shellclasses import Function, System_Base
 from psyneulink.globals.context import ContextFlags
-from psyneulink.globals.keywords import CONTROL, CONTROLLER, COST_FUNCTION, EVC_MECHANISM, FUNCTION, FUNCTION_PARAMS,\
-    INIT_FUNCTION_METHOD_ONLY, PARAMETER_STATES, PREDICTION_MECHANISM, PREDICTION_MECHANISMS, \
-    PREDICTION_MECHANISM_PARAMS, PREDICTION_MECHANISM_TYPE, STATEFUL_ATTRIBUTES, SUM
+from psyneulink.globals.keywords import CONTROL, CONTROLLER, COST_FUNCTION, EVC_MECHANISM,\
+    INIT_FUNCTION_METHOD_ONLY, PARAMETER_STATES, PREDICTION_MECHANISM, PREDICTION_MECHANISMS, SUM
 from psyneulink.globals.preferences.componentpreferenceset import is_pref_set
 from psyneulink.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.globals.utilities import ContentAddressableList, is_iterable
@@ -752,13 +753,13 @@ class EVCControlMechanism(ControlMechanism):
                  system:tc.optional(System_Base)=None,
                  prediction_mechanisms:tc.any(is_iterable, Mechanism, type)=PredictionMechanism,
                  objective_mechanism:tc.optional(tc.any(ObjectiveMechanism, list))=None,
-                 # monitor_for_control:tc.optional(tc.any(is_iterable, Mechanism))=None,
+                 monitor_for_control:tc.optional(tc.any(is_iterable, Mechanism, OutputState))=None,
                  function=ControlSignalGridSearch,
                  value_function=ValueFunction,
                  cost_function=LinearCombination(operation=SUM),
                  combine_outcome_and_cost_function=LinearCombination(operation=SUM),
                  save_all_values_and_policies:bool=False,
-                 control_signals:tc.optional(list) = None,
+                 control_signals:tc.optional(tc.any(is_iterable, ParameterState))=None,
                  modulation:tc.optional(_is_modulation_param)=ModulationParam.MULTIPLICATIVE,
                  params=None,
                  name=None,
@@ -775,7 +776,7 @@ class EVCControlMechanism(ControlMechanism):
 
         super().__init__(system=system,
                          objective_mechanism=objective_mechanism,
-                         # monitor_for_control=monitor_for_control,
+                         monitor_for_control=monitor_for_control,
                          function=function,
                          control_signals=control_signals,
                          modulation=modulation,

--- a/tests/control/test_control_mechanism_assignment.py
+++ b/tests/control/test_control_mechanism_assignment.py
@@ -14,7 +14,8 @@ def test_control_mechanism_assignment():
     S = pnl.System(processes=P,
                    # controller=pnl.EVCControlMechanism,
                    controller=pnl.EVCControlMechanism(
-                           control_signals=[(pnl.GAIN, T2)]
+                           control_signals=[(pnl.GAIN, T2)],
+                           monitor_for_control=T4
                    ),
                    enable_controller=True,
                    # Test for use of 4-item tuple with matrix in monitor_for_control specification
@@ -22,7 +23,7 @@ def test_control_mechanism_assignment():
                                         ('O-1', 1, -1)],
                    control_signals=[(pnl.GAIN, T3)]
                    )
-    assert len(S.controller.objective_mechanism.monitored_output_states)==2
+    assert len(S.controller.objective_mechanism.monitored_output_states)==3
     assert len(S.control_signals)==2
 
     # Test for avoiding duplicate assignment of monitored_output_states and control_signals
@@ -48,40 +49,69 @@ def test_control_mechanism_assignment():
     assert len(S.control_signals)==4
     assert S.controller.name == 'C-2'
 
+
+# def test_control_mechanism_assignment_additional():
+#     '''Tests "free-standing" specifications of monitor_for_control and ControlSignal (i.e., outside of a list)'''
+#     T_1 = pnl.TransferMechanism(name='T_1')
+#     T_2 = pnl.TransferMechanism(name='T_2')
+#     T_3 = pnl.TransferMechanism(name='T_3')
+#     S = pnl.sys([T_1, T_2, T_3],
+#                 controller=pnl.EVCControlMechanism(
+#                         control_signals=(pnl.SLOPE, T_1),
+#                         monitor_for_control=[T_1],
+#                         objective_mechanism=[T_2]),
+#                 monitor_for_control=T_3,
+#                 control_signals=(pnl.SLOPE, T_2),
+#                 enable_controller=True)
+#     assert S.controller.objective_mechanism.input_state[0].path_afferents[0].sender.owner == T_1
+#     assert S.controller.objective_mechanism.input_state[1].path_afferents[0].sender.owner == T_2
+#     assert S.controller.objective_mechanism.input_state[2].path_afferents[0].sender.owner == T_3
+#     assert T_1.parameter_states[pnl.SLOPE].mod_afferents[0].sender.owner == S.controller
+#     assert T_2.parameter_states[pnl.SLOPE].mod_afferents[0].sender.owner == S.controller
+
+
+
 def test_control_mechanism_assignment_additional():
     '''Tests "free-standing" specifications of monitor_for_control and ControlSignal (i.e., outside of a list)'''
-    T = pnl.TransferMechanism(name='T')
-    S = pnl.sys(T,
-                controller=pnl.EVCControlMechanism(),
-                monitor_for_control=T,
-                control_signals=(pnl.SLOPE, T),
+    T_1 = pnl.TransferMechanism(name='T_1')
+    T_2 = pnl.TransferMechanism(name='T_2')
+    S = pnl.sys([T_1,T_2],
+                controller=pnl.EVCControlMechanism(control_signals=(pnl.SLOPE, T_1)),
+                monitor_for_control=T_1,
+                control_signals=(pnl.SLOPE, T_2),
                 enable_controller=True)
-    assert S.controller.objective_mechanism.input_state.path_afferents[0].sender.owner == T
-    assert T.parameter_states[pnl.SLOPE].mod_afferents[0].sender.owner == S.controller
+    assert S.controller.objective_mechanism.input_state.path_afferents[0].sender.owner == T_1
+    assert T_1.parameter_states[pnl.SLOPE].mod_afferents[0].sender.owner == S.controller
+    assert T_2.parameter_states[pnl.SLOPE].mod_afferents[0].sender.owner == S.controller
 
 def test_prediction_mechanism_assignment():
     '''Tests prediction mechanism assignment and more tests for ObjectiveMechanism and ControlSignal assignments'''
 
-    T = pnl.TransferMechanism(name='T')
+    T1 = pnl.TransferMechanism(name='T1')
+    T2 = pnl.TransferMechanism(name='T2')
+    T3 = pnl.TransferMechanism(name='T3')
 
-    S = pnl.sys(T,
+    S = pnl.sys([T1, T2, T3],
                 controller=pnl.EVCControlMechanism(name='EVC',
                                                    prediction_mechanisms=(pnl.PredictionMechanism,
                                                                           {pnl.FUNCTION:pnl.INPUT_SEQUENCE,
                                                                            pnl.RATE:1,
                                                                            pnl.WINDOW_SIZE:3,
                                                                            }),
-                                                   objective_mechanism=[T]
+                                                   monitor_for_control=[T1],
+                                                   objective_mechanism=[T2]
                                                    ),
                 control_signals=pnl.ControlSignal(allocation_samples=[1, 5, 10],
-                                                   projections=(pnl.SLOPE, T)),
+                                                   projections=(pnl.SLOPE, T1)),
+                monitor_for_control=T3,
                 enable_controller=True
                 )
+    assert len(S.controller.objective_mechanism.input_states)==3
 
     S.recordSimulationPref = True
-    input_dict = {T:[1,2,3,4]}
+    input_dict = {T1:[1,2,3,4]}
     results = S.run(inputs=input_dict)
-    assert results == [[[1.]], [[2.]], [[3.]], [[4.]]]
+    assert results == [[[1.]], [[2.]], [[15.]], [[20.]]]
     assert S.simulation_results ==  [[[1.]], [[5.]], [[10.]],
                                     [[1.]], [[2.]], [[5.]], [[10.]], [[10.]], [[20.]],
                                     [[1.]], [[2.]], [[3.]], [[5.]], [[10.]], [[15.]], [[10.]], [[20.]], [[30.]],


### PR DESCRIPTION
• ControlMechanism
  - __init__:
      added monitor_for_control argument
      monitor_for_control and control_signals:
          allow "exposed" specification (i.e., single item outside a list)
  - _instantiate_objective_mechanism: 
      refactored to build list of monitored_output_states from 
         specifications in objective_mechahnism and monitor_for_control arguments
         and any in system
      from various sources of specification:
         System monitor_for_control argument
         ControlMechanism objective_mechanism argument
         ControlMechanism monitor_for_control argument
      monitor_for_control is assigned value of monitored_output_states property
   - docstring revs re: ObjectiveMechanism and monitor_for_control

EVCControlMechanism, LCControlMechanism
  - __init__: added monitor_for_control argument

• LCControlMechanism
  - __init__: added monitor_for_control argument
  - docstring revs;  
    removed reference to pnl.ALL in modulated_mechanisms argument since it is not working
  - _validate_params, _instantiate_output_states: fixed error messages regarding use of pnl.ALL

• Tests
  test_control_mechanism_assignment:
  - added additional tests for monitor_for_control and control_signals arguments
        in ControlMechanism
  - added tests for exposed specification of above (i.e., single items outside a list)
  - added tests for PredictionMechanisms (including INPUT_SEQUENCE):
      test_prediction_mechanism_assignment
      test_prediction_mechanism_filter_function
