### PR TITLE
functions/DistanceFunction: Don't return vector for CROSS_ENTROPY metric

### DIFF
--- a/psyneulink/components/functions/function.py
+++ b/psyneulink/components/functions/function.py
@@ -9818,7 +9818,7 @@ class Distance(ObjectiveFunction):
             # MODIFIED CW 3/20/18: avoid divide by zero error by plugging in two zeros
             # FIX: unsure about desired behavior when v2 = 0 and v1 != 0
             # JDC: returns [inf]; leave, and let it generate a warning or error message for user
-            result = np.where(np.logical_and(v1==0, v2==0), 0, -np.sum(v1*np.log(v2)))
+            result = -np.sum(np.where(np.logical_and(v1==0, v2==0), 0, v1*np.log(v2)))
 
         # Energy
         elif self.metric is ENERGY:

--- a/tests/functions/test_distance.py
+++ b/tests/functions/test_distance.py
@@ -61,3 +61,4 @@ def test_basic(variable, metric, normalize, fail, expected, benchmark):
     benchmark.group = "DistanceFunction " + metric + ("-normalized" if normalize else "")
     res = benchmark(f.function, variable)
     assert np.allclose(res, expected)
+    assert np.isscalar(res) or len(res) == 1 or (metric == kw.PEARSON and res.size == 4)


### PR DESCRIPTION
Add test to make sure we return scalar
Fixes daebb626b4 ("Linear Combination Fix")

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>