### PR TITLE
Improve travis macos environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ python:
     - 3.6
 
 install:
-  - python -m pip install -U pip
-  - python -m easy_install -U setuptools
   - pip install git+https://github.com/benureau/leabra.git@master
   - pip install -e .[dev]
 
@@ -16,11 +14,17 @@ os:
 matrix:
   include:
   - os: osx
+    python: 3.5
     language: generic
-    env: PYTHON=3.5.5
+    env:
+        - PYTHON=3.5.4
+        - PYTHON_PKG_VERSION=macosx10.6
   - os: osx
+    python: 3.6
     language: generic
-    env: PYTHON=3.6.5
+    env:
+        - PYTHON=3.6.5
+        - PYTHON_PKG_VERSION=macosx10.9
 
 addons:
   apt:
@@ -29,21 +33,26 @@ addons:
 
 before_install: |
   if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    brew update
-    # Per the `pyenv homebrew recommendations <https://github.com/yyuu/pyenv/wiki#suggested-build-environment>`_.
-    brew install openssl readline
-    brew outdated pyenv
-    brew upgrade pyenv
-    brew install graphviz
-    # use `pyenv-virtualenv <https://github.com/yyuu/pyenv-virtualenv/blob/master/README.md>`_.
-    brew install pyenv-virtualenv
-    pyenv install $PYTHON
-    export PYENV_VERSION=$PYTHON
-    export PATH="$HOME/.pyenv/shims:${PATH}"
-    pyenv-virtualenv venv
+    FILE=python-$PYTHON-$PYTHON_PKG_VERSION.pkg
+    curl -O -#  https://www.python.org/ftp/python/$PYTHON/$FILE
+    sudo installer -pkg $FILE -target /
+    python3 --version
+    # This sidesteps TLSv1.1 issue when using pip
+    curl https://bootstrap.pypa.io/get-pip.py | python3
+    python3 -m pip  install virtualenv
+    python3 -m venv venv
     source venv/bin/activate
-    # A manual check that the correct version of Python is running.
     python --version
+    # virtualenv installs default pip even if we updated it above.
+    # update it again.
+    curl https://bootstrap.pypa.io/get-pip.py | python
+
+    # setuptools also face the same TLS deprecation issue.
+    # Update them explicitly
+    python -m pip install -U setuptools
+    python -m pip install -U setuptools-git
+
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install graphviz
   fi
 
 script:


### PR DESCRIPTION
Compiling from source takes time.
Download binary from python.org instead.
Do not autoupdate brew when installing graphviz
Saves 2-3mins on travis ci run
