### PR TITLE
Feat/mechanism and input state/external internal

### DIFF
--- a/.idea/runConfigurations/Scratch_Pad.xml
+++ b/.idea/runConfigurations/Scratch_Pad.xml
@@ -1,12 +1,12 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" factoryName="Python" name="Scratch Pad" singleton="true" type="PythonConfigurationType">
-    <module name="" />
+  <configuration default="false" name="Scratch Pad" type="PythonConfigurationType" factoryName="Python" singleton="true">
+    <module name="PsyNeuLink" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="" />
+    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python35/bin/python3.5" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Scripts" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/.idea/runConfigurations/_RL_DDM.xml
+++ b/.idea/runConfigurations/_RL_DDM.xml
@@ -1,12 +1,12 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="• RL-DDM" type="PythonConfigurationType" factoryName="Python" folderName="Examples" singleton="true">
-    <module name="PsyNeuLink" />
+  <configuration default="false" factoryName="Python" folderName="Examples" name="&#8226; RL-DDM" singleton="true" type="PythonConfigurationType">
+    <module name="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python35/bin/python3.5" />
+    <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Scripts/Examples" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/psyneulink/components/mechanisms/mechanism.py
+++ b/psyneulink/components/mechanisms/mechanism.py
@@ -2948,6 +2948,13 @@ class Mechanism_Base(Mechanism):
             return None
 
     @property
+    def external_input_values(self):
+        try:
+            return [input_state.value for input_state in self.input_states if not input_state.internal_only]
+        except (TypeError, AttributeError):
+            return None
+
+    @property
     def input_labels(self):
         """
         Returns a list with as many items as there are InputStates of the Mechanism. Each list item represents the value
@@ -3219,3 +3226,4 @@ class MechanismList(UserList):
             for output_state in item.output_states:
                 values.append(output_state.value)
         return values
+

--- a/psyneulink/components/states/inputstate.py
+++ b/psyneulink/components/states/inputstate.py
@@ -510,6 +510,7 @@ class InputState(State_Base):
         projections=None,                          \
         weight=None,                               \
         exponent=None,                             \
+        internal_only=False,                       \
         params=None,                               \
         name=None,                                 \
         prefs=None)
@@ -592,6 +593,11 @@ class InputState(State_Base):
     exponent : number : default 1
         specifies the value of the `exponent <InputState.exponent>` attribute of the InputState.
 
+    internal_only : bool : False
+        specifies whether external input is required by the InputState's `owner <InputState.owner>` if its `role
+        <Mechanism_Role_In_Processes_And_Systems>` is *EXTERNAL_INPUT*  (see `internal_only <InputState.internal_only>`
+        for details).
+
     params : Dict[param keyword: param value] : default None
         a `parameter dictionary <ParameterState_Specification>` that can be used to specify the parameters for
         the InputState or its function, and/or a custom function and its parameters. Values specified for parameters in
@@ -650,6 +656,12 @@ class InputState(State_Base):
 
     exponent : number
         see `weight and exponent <InputState_Weights_And_Exponents>` for description.
+
+    internal_only : bool
+        determines whether input is required for this InputState from `Run` or another `Composition` when the
+        InputState's `owner <InputState.owner>` is executed, and its `role <Mechanism_Role_In_Processes_And_Systems>`
+        is designated as *EXTERNAL_INPUT*;  if `True`, external input is *not* required or allowed;  otherwise,
+        external input is required.
 
     name : str
         the name of the InputState; if it is not specified in the **name** argument of the constructor, a default is
@@ -722,6 +734,7 @@ class InputState(State_Base):
                  combine:tc.optional(tc.enum(SUM,PRODUCT))=None,
                  weight=None,
                  exponent=None,
+                 internal_only:bool=False,
                  params=None,
                  name=None,
                  prefs:is_pref_set=None,
@@ -747,6 +760,7 @@ class InputState(State_Base):
         params = self._assign_args_to_param_dicts(function=function,
                                                   weight=weight,
                                                   exponent=exponent,
+                                                  internal_only=internal_only,
                                                   params=params)
 
         # If owner or reference_value has not been assigned, defer init to State._instantiate_projection()


### PR DESCRIPTION
• Mechanism
  added external_input_values property  
      returns values only of InputStates that are not marked as internal_only            

• InputState
  added internal_only attribute
      used to designate that input should not be required for this InputState
      when owner Mechanism's role is EXTERNAL_INPUT 
       