### PR TITLE
travis: Add build cache configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ install:
 os:
   - linux
 
+# Cache installed python packages
+cache:
+  directories:
+    - $HOME/virtualenv/python${TRAVIS_PYTHON_VERSION}/lib/python${TRAVIS_PYTHON_VERSION}/site-packages
+    - $HOME/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin
+
 matrix:
   include:
   - os: osx
@@ -20,12 +26,33 @@ matrix:
     env:
         - PYTHON=3.5.4
         - PYTHON_PKG_VERSION=macosx10.6
+    # Cache installed python packages
+    cache:
+        directories:
+          - venv/lib/python3.5/site-packages
+          - venv/bin
+    # The pip update script below overwrites (and thus modifies) cached entries.
+    # Remove them to avoid reuploading the cache on every build
+    before_cache:
+        - rm -rvf venv/lib/python3.5/site-packages/pip*
+        - rm -rvf venv/bin/pip*
+
   - os: osx
     python: 3.6
     language: generic
     env:
         - PYTHON=3.6.5
         - PYTHON_PKG_VERSION=macosx10.9
+    # Cache installed python packages
+    cache:
+        directories:
+          - venv/lib/python3.6/site-packages
+          - venv/bin
+    # The pip update script below overwrites (and thus modifies) cached entries.
+    # Remove them to avoid reuploading the cache on every build
+    before_cache:
+        - rm -rvf venv/lib/python3.6/site-packages/pip*
+        - rm -rvf venv/bin/pip*
 
 addons:
   apt:


### PR DESCRIPTION
This cashes just python packages. Caching homebrew did not lead to speed up.

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>