### PR TITLE
travis: Bump macos python 3.6 version to 3.6.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     python: 3.6
     language: generic
     env:
-        - PYTHON=3.6.5
+        - PYTHON=3.6.6
         - PYTHON_PKG_VERSION=macosx10.9
     # Cache installed python packages
     cache:


### PR DESCRIPTION
Released on June 27 2018.
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>