### PR TITLE
jvesely/pytest/registry cleanup

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -38,6 +38,31 @@ def pytest_runtest_call(item):
     random.seed(seed)
     np.random.seed(seed)
 
+def pytest_runtest_teardown(item):
+    from psyneulink import clear_registry
+    from psyneulink.components.functions.function import FunctionRegistry
+    from psyneulink.components.mechanisms.adaptive.control.controlmechanism import ControlMechanismRegistry
+    from psyneulink.components.mechanisms.adaptive.gating.gatingmechanism import GatingMechanismRegistry
+    from psyneulink.components.mechanisms.mechanism import MechanismRegistry
+    from psyneulink.components.projections.projection import ProjectionRegistry
+    from psyneulink.components.states.state import StateRegistry
+    from psyneulink.components.system import SystemRegistry
+    from psyneulink.components.component import DeferredInitRegistry
+    from psyneulink.components.process import ProcessRegistry
+    from psyneulink.globals.preferences.preferenceset import PreferenceSetRegistry
+
+    # Clear Registry to have a stable reference for indexed suffixes of default names
+    clear_registry(FunctionRegistry)
+    clear_registry(ControlMechanismRegistry)
+    clear_registry(GatingMechanismRegistry)
+    clear_registry(MechanismRegistry)
+    clear_registry(ProjectionRegistry)
+    clear_registry(StateRegistry)
+    clear_registry(SystemRegistry)
+    clear_registry(DeferredInitRegistry)
+    clear_registry(ProcessRegistry)
+    clear_registry(PreferenceSetRegistry)
+
 
 @pytest.helpers.register
 def expand_np_ndarray(arr):

--- a/tests/learning/test_rumelhart_semantic_network.py
+++ b/tests/learning/test_rumelhart_semantic_network.py
@@ -1,21 +1,6 @@
 import pytest
 import psyneulink as pnl
 
-@pytest.fixture(scope='module')
-def clear_registry():
-    # Clear Registry to have a stable reference for indexed suffixes of default names
-    from psyneulink.components.component import DeferredInitRegistry
-    from psyneulink.components.system import SystemRegistry
-    from psyneulink.components.process import ProcessRegistry
-    from psyneulink.components.mechanisms.mechanism import MechanismRegistry
-    from psyneulink.components.projections.projection import ProjectionRegistry
-    pnl.clear_registry(DeferredInitRegistry)
-    pnl.clear_registry(SystemRegistry)
-    pnl.clear_registry(ProcessRegistry)
-    pnl.clear_registry(MechanismRegistry)
-    pnl.clear_registry(ProjectionRegistry)
-
-
 def validate_learning_mechs(sys):
 
     def get_learning_mech(name):
@@ -113,10 +98,8 @@ class TestRumelhartSemanticNetwork:
               #          act_out: [[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]}
               )
 
-    # @pytest.mark.usefixtures('clear_registry')
     def test_rumelhart_semantic_network_convergent(self):
 
-        clear_registry()
         rep_in = pnl.TransferMechanism(size=10, name='REP_IN')
         rel_in = pnl.TransferMechanism(size=11, name='REL_IN')
         rep_hidden = pnl.TransferMechanism(size=4, function=pnl.Logistic, name='REP_HIDDEN')
@@ -157,10 +140,8 @@ class TestRumelhartSemanticNetwork:
               #          qual_out: [[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]],
               #          act_out: [[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]}
               )
-    # @pytest.mark.usefixtures('clear_registry')
     def test_rumelhart_semantic_network_crossing(self):
 
-        clear_registry()
         rep_in = pnl.TransferMechanism(size=10, name='REP_IN')
         rel_in = pnl.TransferMechanism(size=11, name='REL_IN')
         rep_hidden = pnl.TransferMechanism(size=4, function=pnl.Logistic, name='REP_HIDDEN')

--- a/tests/mechanisms/test_input_state_spec.py
+++ b/tests/mechanisms/test_input_state_spec.py
@@ -17,22 +17,6 @@ mismatches_default_variable_format_error_text = 'is not compatible with its expe
 mismatches_size_error_text = 'not compatible with the default variable determined from size parameter'
 belongs_to_another_mechanism_error_text = 'that belongs to another Mechanism'
 
-
-@pytest.fixture(scope='module')
-def clear_registry():
-    # Clear Registry to have a stable reference for indexed suffixes of default names
-    from psyneulink.components.component import DeferredInitRegistry
-    from psyneulink.components.system import SystemRegistry
-    from psyneulink.components.process import ProcessRegistry
-    from psyneulink.components.mechanisms.mechanism import MechanismRegistry
-    from psyneulink.components.projections.projection import ProjectionRegistry
-    pnl.clear_registry(DeferredInitRegistry)
-    pnl.clear_registry(SystemRegistry)
-    pnl.clear_registry(ProcessRegistry)
-    pnl.clear_registry(MechanismRegistry)
-    pnl.clear_registry(ProjectionRegistry)
-
-
 class TestInputStateSpec:
     # ------------------------------------------------------------------------------------------------
 

--- a/tests/naming/test_naming.py
+++ b/tests/naming/test_naming.py
@@ -2,23 +2,6 @@ import pytest
 
 import psyneulink as pnl
 
-
-@pytest.fixture
-def clear_registry():
-    # Clear Registry to have a stable reference for indexed suffixes of default names
-    from psyneulink.components.component import DeferredInitRegistry
-    from psyneulink.components.mechanisms.mechanism import MechanismRegistry
-    from psyneulink.components.projections.projection import ProjectionRegistry
-    from psyneulink.components.process import ProcessRegistry
-    from psyneulink.components.system import SystemRegistry
-    pnl.clear_registry(DeferredInitRegistry)
-    pnl.clear_registry(MechanismRegistry)
-    pnl.clear_registry(ProjectionRegistry)
-    pnl.clear_registry(ProcessRegistry)
-    pnl.clear_registry(SystemRegistry)
-
-
-@pytest.mark.usefixtures('clear_registry')
 class TestNaming:
     # ------------------------------------------------------------------------------------------------
 

--- a/tests/projections/test_projections_specifications.py
+++ b/tests/projections/test_projections_specifications.py
@@ -2,20 +2,6 @@ import psyneulink as pnl
 import numpy as np
 import pytest
 
-def clear_registry():
-    from psyneulink.components.component import DeferredInitRegistry
-    from psyneulink.components.system import SystemRegistry
-    from psyneulink.components.process import ProcessRegistry
-    from psyneulink.components.mechanisms.mechanism import MechanismRegistry
-    from psyneulink.components.projections.projection import ProjectionRegistry
-    # Clear Registry to have a stable reference for indexed suffixes of default names
-    pnl.clear_registry(DeferredInitRegistry)
-    pnl.clear_registry(SystemRegistry)
-    pnl.clear_registry(ProcessRegistry)
-    pnl.clear_registry(MechanismRegistry)
-    pnl.clear_registry(ProjectionRegistry)
-
-
 class TestProjectionSpecificationFormats:
 
     def test_multiple_modulatory_projection_specs(self):
@@ -166,8 +152,6 @@ class TestProjectionSpecificationFormats:
 
     def test_formats_for_control_specification_for_mechanism_and_function_params(self):
 
-        clear_registry()
-
         control_spec_list = [
             pnl.CONTROL,
             pnl.CONTROL_SIGNAL,
@@ -209,8 +193,6 @@ class TestProjectionSpecificationFormats:
                    'ControlProjection for RecurrentTransferMechanism-{}[gain]'.format(i)
 
     def test_formats_for_gating_specification_of_input_and_output_states(self):
-
-        clear_registry()
 
         gating_spec_list = [
             pnl.GATING,
@@ -302,7 +284,7 @@ class TestProjectionSpecificationFormats:
                                         mask=[[1,2,3],[4,5,6]],
                                         mask_operation=pnl.MULTIPLY
                                         )
-        assert "Shape of the 'mask' for MaskedMappingProjection-3 ((2, 3)) must be the same as its 'matrix' ((2, 2))" \
+        assert "Shape of the 'mask' for MaskedMappingProjection-0 ((2, 3)) must be the same as its 'matrix' ((2, 2))" \
                in str(error_text.value)
 
     def test_duplicate_projection_detection_and_warning(self):


### PR DESCRIPTION
This consolidates ad-hoc cleaning efforts in several tests
It also lowers overall memory requirements of a full test run ~5x.

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>