### PR TITLE
dev_requirements: Restrict ipython to version 6.5.0

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -9,3 +9,4 @@ sphinx_rtd_theme
 matplotlib
 ipykernel>=4.6.1
 graphviz
+ipython==6.5.0


### PR DESCRIPTION
prevent jupyter failures
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>