### PR TITLE
Travis enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ matrix:
   - python: 3.7
     dist: xenial # Python 3.7 is only available on xenial because of deps
     sudo: required
+    env:
+        - PYTHONWARNINGS="ignore::DeprecationWarning"
 
   - os: osx
     python: 3.5
@@ -69,6 +71,7 @@ matrix:
         - PYTHON=3.7.1
         - PYTHON_PKG_VERSION=macosx10.9
         - PRIV=sudo
+        - PYTHONWARNINGS="ignore::DeprecationWarning"
     # Cache installed python virtual env and homebrew downloads
     cache:
         directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,16 @@ cache:
   directories:
     - $HOME/virtualenv/python${TRAVIS_PYTHON_VERSION}/lib/python${TRAVIS_PYTHON_VERSION}/site-packages
     - $HOME/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin
+# These files are provided by travis do not overwrite them with cached version.
+# We need to preserve them because after_script still needs working python environment
+before_cache:
+    - mkdir -p $HOME/venv-bak/{bin,site-packages}
+    - mv -vf $HOME/virtualenv/python${TRAVIS_PYTHON_VERSION}/lib/python${TRAVIS_PYTHON_VERSION}/site-packages/pip* $HOME/venv-bak/site-packages
+    - mv -vf $HOME/virtualenv/python${TRAVIS_PYTHON_VERSION}/lib/python${TRAVIS_PYTHON_VERSION}/site-packages/easy-intall* $HOME/venv-bak/site-packages
+    - mv -vf $HOME/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/pip* $HOME/venv-bak/bin
+    - mv -vf $HOME/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/easy-install* $HOME/venv-bak/bin
+    - mv -vf $HOME/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/python* $HOME/vevn-bak/bin
+    - mv -vf $HOME/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/activate* $HOME/venv-bak/bin
 
 matrix:
   include:
@@ -106,4 +116,7 @@ script:
   - python -m pytest -p no:logging --cov=psyneulink tests/
 
 after_script:
+  # Restore python environment
+  - mv -vf $HOME/venv-bak/site-packages/* $HOME/virtualenv/python${TRAVIS_PYTHON_VERSION}/lib/python${TRAVIS_PYTHON_VERSION}/site-packages/
+  - mv -vf $HOME/venv-bak/bin/* $HOME/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/
   - coveralls


### PR DESCRIPTION
Don't cache Travis provided files.
Drop python 3.7 deprecation warnings.