### PR TITLE
requirements: don't upgrade to pytest 4 due to pytest-benchmark incompatibility

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-pytest
+pytest<4
 pytest-benchmark
 pytest-cov
 pytest-profiling


### PR DESCRIPTION


	- ionelmc/pytest-benchmark#122