### PR TITLE
travis: Update macos python versions to 3.6.8 and 3.7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
     python: 3.6
     language: minimal
     env:
-        - PYTHON=3.6.7
+        - PYTHON=3.6.8
         - PYTHON_PKG_VERSION=macosx10.9
     # Cache installed python virtual env and homebrew downloads
     cache:
@@ -62,7 +62,7 @@ matrix:
     python: 3.7
     language: minimal
     env:
-        - PYTHON=3.7.1
+        - PYTHON=3.7.2
         - PYTHON_PKG_VERSION=macosx10.9
         - PYTHONWARNINGS="ignore::DeprecationWarning"
     # Cache installed python virtual env and homebrew downloads


### PR DESCRIPTION
Released on 12/24/2018
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>