### PR TITLE
Revert "dev_requirements: Allow pytest-4"

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-pytest
+pytest<4
 pytest-benchmark
 pytest-cov
 pytest-profiling


### PR DESCRIPTION
Reverts PrincetonUniversity/PsyNeuLink#1023

The tests take too long and timeout, need to investigate further.