### PR TITLE
appveyor: Build all branches suffixed '-apy', or prefixed 'devel-'

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,6 +3,8 @@ branches:
     - master
     - devel
     - appveyor
+    - /.*-apy/
+    - /devel-.*/
 version: '{build}'
 clone_depth: 25
 


### PR DESCRIPTION
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>