### PR TITLE
appveyor: Don't build 'devel-' prefixed branches

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,8 +3,7 @@ branches:
     - master
     - devel
     - appveyor
-    - /.*-apy/
-    - /devel-.*/
+    - /.*-avy/
 version: '{build}'
 clone_depth: 25
 


### PR DESCRIPTION
Rename suffix to '-avy'
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>