### PR TITLE
travis: Restrict built branches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,14 @@ python:
     - 3.6
     - 3.7
 
+branches:
+  only:
+    - master
+    - devel
+    - /devel-.*/
+    - /travis.*/
+
+
 install:
   - if [ "x$COVERALLS_REPO_TOKEN" != "x" ]; then pip install coveralls; fi
   - pip install git+https://github.com/benureau/leabra.git@master


### PR DESCRIPTION
This should ease pressure on travis and allow PRs to start building
earlier.
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>