### PR TITLE
Drop aenum module.

### DIFF
--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -92,7 +92,7 @@ Class Reference
 
 """
 
-import aenum
+import enum
 import warnings
 
 from collections import namedtuple
@@ -119,7 +119,7 @@ class ContextError(Exception):
         self.error_value = error_value
 
 
-class ContextFlags(aenum.IntFlag):
+class ContextFlags(enum.IntFlag):
     """Used to identify the initialization and execution status of a `Component <Component>`.
 
     Used when a Component's `value <Component.value>` or one of its attributes is being accessed.
@@ -264,7 +264,7 @@ SOURCE_FLAGS = {ContextFlags.CONSTRUCTOR,
                 ContextFlags.COMPOSITION}
 
 # For backward compatibility
-class ContextStatus(aenum.IntFlag):
+class ContextStatus(enum.IntFlag):
     """Used to identify the status of a `Component` when its value or one of its attributes is being accessed.
     Also used to specify the context in which a value of the Component or its attribute is `logged <Log_Conditions>`.
     """

--- a/psyneulink/core/globals/log.py
+++ b/psyneulink/core/globals/log.py
@@ -380,7 +380,7 @@ Class Reference
 ---------------
 
 """
-import aenum
+import enum
 import inspect
 import warnings
 
@@ -402,7 +402,7 @@ __all__ = [
 LogEntry = namedtuple('LogEntry', 'time, context, value')
 
 
-class LogCondition(aenum.IntFlag):
+class LogCondition(enum.IntFlag):
     """Used to specify the context in which a value of the Component or its attribute is `logged <Log_Conditions>`.
 
     .. note::
@@ -1055,7 +1055,7 @@ class Log:
         if not entries:
             return None
 
-        class options(aenum.IntFlag):
+        class options(enum.IntFlag):
             NONE = 0
             TIME = 2
             CONTEXT = 4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ toposort==1.4
 numpy<1.16
 pillow
 typecheck-decorator==1.2
-aenum
 llvmlite


### PR DESCRIPTION
The functionality is available in core enum model since python 3.6.
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>