### PR TITLE
travis, macos: Hardcode python macos version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ matrix:
     language: minimal
     env:
         - PYTHON=3.6.8
-        - PYTHON_PKG_VERSION=macosx10.9
     # Cache installed python virtual env and homebrew downloads
     cache:
         directories:
@@ -45,7 +44,6 @@ matrix:
     language: minimal
     env:
         - PYTHON=3.7.2
-        - PYTHON_PKG_VERSION=macosx10.9
         - PYTHONWARNINGS="ignore::DeprecationWarning"
     # Cache installed python virtual env and homebrew downloads
     cache:
@@ -59,7 +57,7 @@ addons:
 
 before_install: |
   if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    FILE=python-$PYTHON-$PYTHON_PKG_VERSION.pkg
+    FILE=python-$PYTHON-macosx10.9.pkg
     if [ ! -f $HOME/Library/Caches/$FILE ]; then
       curl -#  https://www.python.org/ftp/python/$PYTHON/$FILE -o $HOME/Library/Caches/$FILE
     fi


### PR DESCRIPTION
macos10.6 was dropped with python3.5
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>