### PR TITLE
dev requirements: restrict pytest-xdist version

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,7 +3,7 @@ pytest-benchmark
 pytest-cov
 pytest-profiling
 pytest-helpers-namespace
-pytest-xdist
+pytest-xdist<1.28.0
 jupyter
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
	- 1.28.0 now requires at least pytest 4
	- pytest-profiling is currently incompatible with pytest 4,
	but is introduced in https://github.com/manahl/pytest-plugins/pull/134