### PR TITLE
LLVM cleanups and refactoring

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -3402,12 +3402,6 @@ class Component(object, metaclass=ComponentsMeta):
         """
         return self.__class__.defaults
 
-    # left in for compatibility with llvm, see note in builder_context.py (search for <_instance_defaults_note>)
-    # DEPRECATED
-    @property
-    def _instance_defaults(self):
-        return self.defaults
-
     @property
     def is_pnl_inherent(self):
         try:

--- a/psyneulink/core/components/functions/combinationfunctions.py
+++ b/psyneulink/core/components/functions/combinationfunctions.py
@@ -910,7 +910,7 @@ class LinearCombination(
         return ctx.convert_python_struct_to_llvm_ir(default_var)
 
     def __gen_llvm_combine(self, builder, index, ctx, vi, vo, params):
-        scale_ptr, builder = ctx.get_param_ptr(self, builder, params, SCALE)
+        scale_ptr = ctx.get_param_ptr(self, builder, params, SCALE)
         scale_type = scale_ptr.type.pointee
         if isinstance(scale_type, pnlvm.ir.ArrayType):
             if len(scale_type) == 1:
@@ -918,7 +918,7 @@ class LinearCombination(
             else:
                 scale_ptr = builder.gep(scale_ptr, [ctx.int32_ty(0), index])
 
-        offset_ptr, builder = ctx.get_param_ptr(self, builder, params, OFFSET)
+        offset_ptr = ctx.get_param_ptr(self, builder, params, OFFSET)
         offset_type = offset_ptr.type.pointee
         if isinstance(offset_type, pnlvm.ir.ArrayType):
             if len(offset_type) == 1:
@@ -926,10 +926,10 @@ class LinearCombination(
             else:
                 offset_ptr = builder.gep(offset_ptr, [ctx.int32_ty(0), index])
 
-        exponent_param_ptr, builder = ctx.get_param_ptr(self, builder, params, EXPONENTS)
+        exponent_param_ptr = ctx.get_param_ptr(self, builder, params, EXPONENTS)
         exponent_type = exponent_param_ptr.type.pointee
 
-        weights_ptr, builder = ctx.get_param_ptr(self, builder, params, WEIGHTS)
+        weights_ptr = ctx.get_param_ptr(self, builder, params, WEIGHTS)
         weights_type = weights_ptr.type.pointee
 
         scale = ctx.float_ty(1.0) if isinstance(scale_type, pnlvm.ir.LiteralStructType) and len(scale_type.elements) == 0 else builder.load(scale_ptr)

--- a/psyneulink/core/components/functions/interfacefunctions.py
+++ b/psyneulink/core/components/functions/interfacefunctions.py
@@ -180,11 +180,10 @@ class Identity(InterfaceFunction):  # ------------------------------------------
 
     def _get_output_struct_type(self, ctx):
         #FIXME: Workaround for CompositionInterfaceMechanism that
-        #       does not udpate its defaults shape
-        from psyneulink.core.components.mechanisms.processing.compositioninterfacemechanism import CompositionInterfaceMechanism
-        if isinstance(self.owner, CompositionInterfaceMechanism):
-            return ctx.get_input_struct_type(self)
-        return ctx.get_output_struct_type(super())
+        #       does not update its defaults shape
+        #       Standalone function works OK with defaults as well as this
+        #       workaround.
+        return ctx.get_input_struct_type(self)
 
     def _gen_llvm_function_body(self, ctx, builder, _1, _2, arg_in, arg_out):
         val = builder.load(arg_in)

--- a/psyneulink/core/components/functions/interfacefunctions.py
+++ b/psyneulink/core/components/functions/interfacefunctions.py
@@ -176,7 +176,8 @@ class Identity(InterfaceFunction):  # ------------------------------------------
                 variable = tuple(variable)
 
             return ctx.convert_python_struct_to_llvm_ir(variable)
-        return ctx.get_input_struct_type(super())
+        default_var = self.defaults.variable
+        return ctx.convert_python_struct_to_llvm_ir(default_var)
 
     def _get_output_struct_type(self, ctx):
         #FIXME: Workaround for CompositionInterfaceMechanism that

--- a/psyneulink/core/components/functions/objectivefunctions.py
+++ b/psyneulink/core/components/functions/objectivefunctions.py
@@ -378,7 +378,7 @@ COMMENT
         # Dot product
         dot_out = builder.alloca(arg_in.type.pointee)
         my_params = builder.gep(params, [ctx.int32_ty(0), ctx.int32_ty(0)])
-        matrix, builder = ctx.get_param_ptr(self, builder, my_params, MATRIX)
+        matrix = ctx.get_param_ptr(self, builder, my_params, MATRIX)
 
         # Convert array pointer to pointer to the fist element
         matrix = builder.gep(matrix, [ctx.int32_ty(0), ctx.int32_ty(0)])

--- a/psyneulink/core/components/functions/selectionfunctions.py
+++ b/psyneulink/core/components/functions/selectionfunctions.py
@@ -301,15 +301,15 @@ class OneHot(SelectionFunction):
                                     "array of probabilities that sum to 1".
                                     format(MODE, self.__class__.__name__, Function.__name__, PROB, prob_dist))
 
-    def _gen_llvm_function_body(self, ctx, builder, _1, state, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, _, state, arg_in, arg_out):
         idx_ptr = builder.alloca(ctx.int32_ty)
         builder.store(ctx.int32_ty(0), idx_ptr)
 
         if self.mode in {PROB, PROB_INDICATOR}:
             rng_f = ctx.get_llvm_function("__pnl_builtin_mt_rand_double")
             dice_ptr = builder.alloca(ctx.float_ty)
-            mt_state = builder.gep(state, [ctx.int32_ty(0), ctx.int32_ty(0)])
-            builder.call(rng_f, [mt_state, dice_ptr])
+            mt_state_ptr = ctx.get_state_ptr(self, builder, state, "random_state")
+            builder.call(rng_f, [mt_state_ptr, dice_ptr])
             dice = builder.load(dice_ptr)
             sum_ptr = builder.alloca(ctx.float_ty)
             builder.store(ctx.float_ty(-0.0), sum_ptr)

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -1112,16 +1112,14 @@ class AdaptiveIntegrator(IntegratorFunction):  # -------------------------------
         builder.store(res, vo_ptr)
         builder.store(res, prev_ptr)
 
-    def _gen_llvm_function_body(self, ctx, builder, params, context, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out):
         # Get rid of 2d array.
-        # When part of a Mechanism the input, and output are 2d arrays.
+        # When part of a Mechanism, the input and output are 2d arrays.
         arg_in = ctx.unwrap_2d_array(builder, arg_in)
         arg_out = ctx.unwrap_2d_array(builder, arg_out)
 
-        kwargs = {"ctx": ctx, "vi": arg_in, "vo": arg_out, "params": params, "state": context}
-        inner = functools.partial(self.__gen_llvm_integrate, **kwargs)
         with pnlvm.helpers.array_ptr_loop(builder, arg_in, "integrate") as args:
-            inner(*args)
+            self.__gen_llvm_integrate(*args, ctx, arg_in, arg_out, params, state)
 
         return builder
 

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -1073,9 +1073,9 @@ class AdaptiveIntegrator(IntegratorFunction):  # -------------------------------
             raise FunctionError(rate_value_msg.format(rate, self.name))
 
     def __gen_llvm_integrate(self, builder, index, ctx, vi, vo, params, state):
-        rate_p, builder = ctx.get_param_ptr(self, builder, params, RATE)
-        offset_p, builder = ctx.get_param_ptr(self, builder, params, OFFSET)
-        noise_p, builder = ctx.get_param_ptr(self, builder, params, NOISE)
+        rate_p = ctx.get_param_ptr(self, builder, params, RATE)
+        offset_p = ctx.get_param_ptr(self, builder, params, OFFSET)
+        noise_p = ctx.get_param_ptr(self, builder, params, NOISE)
 
         offset = pnlvm.helpers.load_extract_scalar_array_one(builder, offset_p)
 
@@ -4093,7 +4093,7 @@ class FitzHughNagumoIntegrator(IntegratorFunction):  # -------------------------
         # Load parameters
         param_vals = {}
         for p in self._get_param_ids():
-            param_ptr, builder = ctx.get_param_ptr(self, builder, params, p)
+            param_ptr = ctx.get_param_ptr(self, builder, params, p)
             param_vals[p] = pnlvm.helpers.load_extract_scalar_array_one(
                                             builder, param_ptr)
 

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -635,8 +635,9 @@ class DND(MemoryFunction):  # --------------------------------------------------
         # Check retrieval probability
         retr_ptr = builder.alloca(pnlvm.ir.IntType(1))
         builder.store(retr_ptr.type.pointee(1), retr_ptr)
-        retr_prob_ptr, builder = ctx.get_param_ptr(self, builder, params, RETRIEVAL_PROB)
-        # Prob can be [x] if we are aprt of mechanism
+        retr_prob_ptr = ctx.get_param_ptr(self, builder, params, RETRIEVAL_PROB)
+
+        # Prob can be [x] if we are part of a mechanism
         retr_prob = pnlvm.helpers.load_extract_scalar_array_one(builder, retr_prob_ptr)
         retr_rand = builder.fcmp_ordered('<', retr_prob, retr_prob.type(1.0))
 
@@ -699,9 +700,9 @@ class DND(MemoryFunction):  # --------------------------------------------------
         # Check storage probability
         store_ptr = builder.alloca(pnlvm.ir.IntType(1))
         builder.store(store_ptr.type.pointee(1), store_ptr)
-        store_prob_ptr, builder = ctx.get_param_ptr(self, builder, params, STORAGE_PROB)
+        store_prob_ptr = ctx.get_param_ptr(self, builder, params, STORAGE_PROB)
 
-        # Prob can be [x] if we are aprt of mechanism
+        # Prob can be [x] if we are part of a mechanism
         store_prob = pnlvm.helpers.load_extract_scalar_array_one(builder, store_prob_ptr)
         store_rand = builder.fcmp_ordered('<', store_prob, store_prob.type(1.0))
 

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -305,8 +305,8 @@ class Linear(TransferFunction):  # ---------------------------------------------
     def _gen_llvm_transfer(self, builder, index, ctx, vi, vo, params, context):
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
-        slope_ptr, builder = ctx.get_param_ptr(self, builder, params, SLOPE)
-        intercept_ptr, builder = ctx.get_param_ptr(self, builder, params, INTERCEPT)
+        slope_ptr = ctx.get_param_ptr(self, builder, params, SLOPE)
+        intercept_ptr = ctx.get_param_ptr(self, builder, params, INTERCEPT)
 
         slope = pnlvm.helpers.load_extract_scalar_array_one(builder, slope_ptr)
         intercept = pnlvm.helpers.load_extract_scalar_array_one(builder, intercept_ptr)
@@ -559,10 +559,10 @@ class Exponential(TransferFunction):  # ----------------------------------------
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
 
-        rate_ptr, builder = ctx.get_param_ptr(self, builder, params, RATE)
-        bias_ptr, builder = ctx.get_param_ptr(self, builder, params, BIAS)
-        scale_ptr, builder = ctx.get_param_ptr(self, builder, params, SCALE)
-        offset_ptr, builder = ctx.get_param_ptr(self, builder, params, OFFSET)
+        rate_ptr = ctx.get_param_ptr(self, builder, params, RATE)
+        bias_ptr = ctx.get_param_ptr(self, builder, params, BIAS)
+        scale_ptr = ctx.get_param_ptr(self, builder, params, SCALE)
+        offset_ptr = ctx.get_param_ptr(self, builder, params, OFFSET)
 
         rate = pnlvm.helpers.load_extract_scalar_array_one(builder, rate_ptr)
         bias = pnlvm.helpers.load_extract_scalar_array_one(builder, bias_ptr)
@@ -831,11 +831,11 @@ class Logistic(TransferFunction):  # -------------------------------------------
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
 
-        gain_ptr, builder = ctx.get_param_ptr(self, builder, params, GAIN)
-        bias_ptr, builder = ctx.get_param_ptr(self, builder, params, BIAS)
-        x_0_ptr, builder = ctx.get_param_ptr(self, builder, params, X_0)
-        scale_ptr, builder = ctx.get_param_ptr(self, builder, params, SCALE)
-        offset_ptr, builder = ctx.get_param_ptr(self, builder, params, OFFSET)
+        gain_ptr = ctx.get_param_ptr(self, builder, params, GAIN)
+        bias_ptr = ctx.get_param_ptr(self, builder, params, BIAS)
+        x_0_ptr = ctx.get_param_ptr(self, builder, params, X_0)
+        scale_ptr = ctx.get_param_ptr(self, builder, params, SCALE)
+        offset_ptr = ctx.get_param_ptr(self, builder, params, OFFSET)
 
         gain = pnlvm.helpers.load_extract_scalar_array_one(builder, gain_ptr)
         bias = pnlvm.helpers.load_extract_scalar_array_one(builder, bias_ptr)
@@ -1132,10 +1132,10 @@ class Tanh(TransferFunction):  # -----------------------------------------------
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
 
-        gain_ptr, builder = ctx.get_param_ptr(self, builder, params, GAIN)
-        bias_ptr, builder = ctx.get_param_ptr(self, builder, params, BIAS)
-        x_0_ptr, builder = ctx.get_param_ptr(self, builder, params, X_0)
-        offset_ptr, builder = ctx.get_param_ptr(self, builder, params, OFFSET)
+        gain_ptr = ctx.get_param_ptr(self, builder, params, GAIN)
+        bias_ptr = ctx.get_param_ptr(self, builder, params, BIAS)
+        x_0_ptr = ctx.get_param_ptr(self, builder, params, X_0)
+        offset_ptr = ctx.get_param_ptr(self, builder, params, OFFSET)
 
         gain = pnlvm.helpers.load_extract_scalar_array_one(builder, gain_ptr)
         bias = pnlvm.helpers.load_extract_scalar_array_one(builder, bias_ptr)
@@ -1395,9 +1395,9 @@ class ReLU(TransferFunction):  # -----------------------------------------------
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
 
-        gain_ptr, builder = ctx.get_param_ptr(self, builder, params, GAIN)
-        bias_ptr, builder = ctx.get_param_ptr(self, builder, params, BIAS)
-        leak_ptr, builder = ctx.get_param_ptr(self, builder, params, LEAK)
+        gain_ptr = ctx.get_param_ptr(self, builder, params, GAIN)
+        bias_ptr = ctx.get_param_ptr(self, builder, params, BIAS)
+        leak_ptr = ctx.get_param_ptr(self, builder, params, LEAK)
 
         gain = pnlvm.helpers.load_extract_scalar_array_one(builder, gain_ptr)
         bias = pnlvm.helpers.load_extract_scalar_array_one(builder, bias_ptr)
@@ -1607,10 +1607,10 @@ class Gaussian(TransferFunction):  # -------------------------------------------
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
 
-        standard_deviation_ptr, builder = ctx.get_param_ptr(self, builder, params, STANDARD_DEVIATION)
-        bias_ptr, builder = ctx.get_param_ptr(self, builder, params, BIAS)
-        scale_ptr, builder = ctx.get_param_ptr(self, builder, params, SCALE)
-        offset_ptr, builder = ctx.get_param_ptr(self, builder, params, OFFSET)
+        standard_deviation_ptr = ctx.get_param_ptr(self, builder, params, STANDARD_DEVIATION)
+        bias_ptr = ctx.get_param_ptr(self, builder, params, BIAS)
+        scale_ptr = ctx.get_param_ptr(self, builder, params, SCALE)
+        offset_ptr = ctx.get_param_ptr(self, builder, params, OFFSET)
 
         standard_deviation = pnlvm.helpers.load_extract_scalar_array_one(builder, standard_deviation_ptr)
         bias = pnlvm.helpers.load_extract_scalar_array_one(builder, bias_ptr)
@@ -1896,10 +1896,10 @@ class GaussianDistort(TransferFunction):  #-------------------------------------
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
 
-        variance_ptr, builder = ctx.get_param_ptr(self, builder, params, VARIANCE)
-        bias_ptr, builder = ctx.get_param_ptr(self, builder, params, BIAS)
-        scale_ptr, builder = ctx.get_param_ptr(self, builder, params, SCALE)
-        offset_ptr, builder = ctx.get_param_ptr(self, builder, params, OFFSET)
+        variance_ptr = ctx.get_param_ptr(self, builder, params, VARIANCE)
+        bias_ptr = ctx.get_param_ptr(self, builder, params, BIAS)
+        scale_ptr = ctx.get_param_ptr(self, builder, params, SCALE)
+        offset_ptr = ctx.get_param_ptr(self, builder, params, OFFSET)
 
         variance = pnlvm.helpers.load_extract_scalar_array_one(builder, variance_ptr)
         bias = pnlvm.helpers.load_extract_scalar_array_one(builder, bias_ptr)
@@ -2238,7 +2238,7 @@ class SoftMax(TransferFunction):
         max_ind_ptr = builder.alloca(ctx.int32_ty)
         builder.store(max_ind_ptr.type.pointee(-1), max_ind_ptr)
 
-        gain_ptr, builder = ctx.get_param_ptr(self, builder, params, GAIN)
+        gain_ptr = ctx.get_param_ptr(self, builder, params, GAIN)
         gain = pnlvm.helpers.load_extract_scalar_array_one(builder, gain_ptr)
 
         with pnlvm.helpers.array_ptr_loop(builder, arg_in, "exp_sum_max") as args:
@@ -2857,7 +2857,7 @@ class LinearMatrix(TransferFunction):  # ---------------------------------------
         # Restrict to 1d arrays
         assert self.defaults.variable.ndim == 1
 
-        matrix, builder = ctx.get_param_ptr(self, builder, params, MATRIX)
+        matrix = ctx.get_param_ptr(self, builder, params, MATRIX)
 
         # Convert array pointer to pointer to the fist element
         matrix = builder.gep(matrix, [ctx.int32_ty(0), ctx.int32_ty(0)])

--- a/psyneulink/core/components/states/parameterstate.py
+++ b/psyneulink/core/components/states/parameterstate.py
@@ -895,7 +895,7 @@ class ParameterState(State_Base):
                 assert False, "Unsupported modulation parameter: {}".format(afferent.sender.modulation)
 
             if name is not None:
-                f_mod_param_ptr, builder = ctx.get_param_ptr(self.function, builder, f_params, name)
+                f_mod_param_ptr = ctx.get_param_ptr(self.function, builder, f_params, name)
                 builder.store(f_mod, f_mod_param_ptr)
 
 

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -3333,8 +3333,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             # present and active
             can_exec = not self.enable_controller or execution_phase == ContextFlags.SIMULATION
             try:
-                if str(bin_execute).endswith('Exec') and can_exec:
-                    if bin_execute.startswith('LLVM'):
+                # Try running in Exec mode first
+                if (bin_execute is True or str(bin_execute).endswith('Exec')) and can_exec:
+                    if bin_execute is True or bin_execute.startswith('LLVM'):
                         _comp_ex = pnlvm.CompExecution(self, [execution_id])
                         _comp_ex.execute(inputs)
                         return _comp_ex.extract_node_output(self.output_CIM)
@@ -3344,6 +3345,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                         __execution.cuda_execute(inputs)
                         return __execution.extract_node_output(self.output_CIM)
 
+                # Exec failed for some reason, we can still try node level bin_execute
                 # Filter out mechanisms. Nested compositions are not executed in this mode
                 mechanisms = [n for n in self._all_nodes if isinstance(n, Mechanism)]
                 # Generate all mechanism wrappers
@@ -3355,7 +3357,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
                 bin_execute = True
             except Exception as e:
-                if bin_execute[:4] == 'LLVM':
+                if bin_execute.endswith('Exec'):
                     raise e
 
                 string = "Failed to compile wrapper for `{}' in `{}': {}".format(m.name, self.name, str(e))
@@ -3755,26 +3757,34 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         can_run = (not self.enable_controller or
                    (execution_context is not None and
                     execution_context.execution_phase == ContextFlags.SIMULATION))
-        if str(bin_execute).endswith('Run') and can_run:
-            if bin_execute.startswith('LLVM'):
-                _comp_ex = pnlvm.CompExecution(self, [execution_id])
-                results += _comp_ex.run(inputs, num_trials, num_inputs_sets)
-            elif bin_execute.startswith('PTX'):
-                self.__ptx_initialize(execution_id)
-                EX = self._compilation_data.ptx_execution.get(execution_id)
-                results += EX.cuda_run(inputs, num_trials, num_inputs_sets)
+        if (bin_execute is True or str(bin_execute).endswith('Run')) and can_run:
+            try:
+                if bin_execute is True or bin_execute.startswith('LLVM'):
+                    _comp_ex = pnlvm.CompExecution(self, [execution_id])
+                    results += _comp_ex.run(inputs, num_trials, num_inputs_sets)
+                elif bin_execute.startswith('PTX'):
+                    self.__ptx_initialize(execution_id)
+                    EX = self._compilation_data.ptx_execution.get(execution_id)
+                    results += EX.cuda_run(inputs, num_trials, num_inputs_sets)
 
-            full_results = self.parameters.results.get(execution_id)
-            if full_results is None:
-                full_results = results
-            else:
-                full_results.extend(results)
+                full_results = self.parameters.results.get(execution_id)
+                if full_results is None:
+                    full_results = results
+                else:
+                    full_results.extend(results)
 
-            self.parameters.results.set(full_results, execution_id)
-            # KAM added the [-1] index after changing Composition run()
-            # behavior to return only last trial of run (11/7/18)
-            self.most_recent_execution_context = execution_id
-            return full_results[-1]
+                self.parameters.results.set(full_results, execution_id)
+                # KAM added the [-1] index after changing Composition run()
+                # behavior to return only last trial of run (11/7/18)
+                self.most_recent_execution_context = execution_id
+                return full_results[-1]
+
+            except Exception as e:
+                if str(bin_execute).endswith('Run'):
+                    raise e
+
+                print("WARNING: Failed to Run execution `{}': {}".format(
+                      self.name, str(e)))
 
         # --- RESET FOR NEXT TRIAL ---
         # by looping over the length of the list of inputs - each input represents a TRIAL

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -147,7 +147,7 @@ class LLVMBuilderContext:
         if hasattr(component, '_get_output_struct_type'):
             return component._get_output_struct_type(self)
 
-        default_val = component._instance_defaults.value
+        default_val = component.defaults.value
         return self.convert_python_struct_to_llvm_ir(default_val)
 
     def get_param_struct_type(self, component):

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -135,12 +135,7 @@ class LLVMBuilderContext:
         if hasattr(component, '_get_input_struct_type'):
             return component._get_input_struct_type(self)
 
-        # KDM 12/28/18: <_instance_defaults_note> left _instance_defaults in place so that this code could use it.
-        # Ideally this would be simply .defaults. After going through the special handler above, component becomes a
-        # super() object, which seems to return the .defaults attr of the class associated with the super() object,
-        # whereas _instance_defaults retuns the .defaults attr of the instance associated. I don't know whether
-        # is a design or a convenience measure for workarounds, so I left this in place.
-        default_var = component._instance_defaults.variable
+        default_var = component.defaults.variable
         return self.convert_python_struct_to_llvm_ir(default_var)
 
     def get_output_struct_type(self, component):

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -172,6 +172,10 @@ class LLVMBuilderContext:
         idx = self.int32_ty(component._get_param_ids().index(param_name))
         return builder.gep(params_ptr, [self.int32_ty(0), idx])
 
+    def get_state_ptr(self, component, builder, state_ptr, state_name):
+        idx = self.int32_ty(component.stateful_attributes.index(state_name))
+        return builder.gep(state_ptr, [self.int32_ty(0), idx])
+
     def unwrap_2d_array(self, builder, element):
         if isinstance(element.type.pointee, ir.ArrayType) and isinstance(element.type.pointee.element, ir.ArrayType):
             assert element.type.pointee.count == 1

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -170,8 +170,7 @@ class LLVMBuilderContext:
 
     def get_param_ptr(self, component, builder, params_ptr, param_name):
         idx = self.int32_ty(component._get_param_ids().index(param_name))
-        ptr = builder.gep(params_ptr, [self.int32_ty(0), idx])
-        return ptr, builder
+        return builder.gep(params_ptr, [self.int32_ty(0), idx])
 
     def unwrap_2d_array(self, builder, element):
         if isinstance(element.type.pointee, ir.ArrayType) and isinstance(element.type.pointee.element, ir.ArrayType):


### PR DESCRIPTION
Get rid of _instance_defaults.
Try all granularities of compiled execution when `bin_execute=True`.
Add and use get_state_ptr helper function.
Stop using functools in Integrator function.