### PR TITLE
tests/functions/linearcombination: Add missing llvm mark.

### DIFF
--- a/tests/functions/test_combination.py
+++ b/tests/functions/test_combination.py
@@ -180,6 +180,7 @@ def test_linear_combination_function_in_mechanism(operation, input, input_states
 
     assert np.allclose(res, expected)
 
+@pytest.mark.llvm
 @pytest.mark.function
 @pytest.mark.combination_function
 @pytest.mark.parametrize("operation", [pnl.SUM, pnl.PRODUCT])


### PR DESCRIPTION
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>