### PR TITLE
treewide: Import collection ABCs from collection.abc module

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -407,7 +407,8 @@ import types
 import warnings
 
 from abc import ABCMeta
-from collections import Iterable, OrderedDict, UserDict
+from collections.abc import Iterable
+from collections import OrderedDict, UserDict
 from enum import Enum, IntEnum
 
 import numpy as np
@@ -2613,7 +2614,7 @@ class Component(object, metaclass=ComponentsMeta):
 
                 elif target_set is not None:
                     # Copy any iterables so that deletions can be made to assignments belonging to the instance
-                    from collections import Iterable
+                    from collections.abc import Iterable
                     if not isinstance(param_value, Iterable) or isinstance(param_value, str):
                         target_set[param_name] = param_value
                     else:

--- a/psyneulink/core/components/mechanisms/adaptive/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/control/optimizationcontrolmechanism.py
@@ -389,8 +389,8 @@ import numbers
 import numpy as np
 import typecheck as tc
 
-from collections import Iterable, namedtuple
-from typing import NamedTuple
+from collections.abc import Iterable
+from collections import namedtuple
 
 from psyneulink.core.components.functions.function import \
     Function_Base, ModulationParam, _is_modulation_param, is_function_type

--- a/psyneulink/core/components/mechanisms/processing/compositioninterfacemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/compositioninterfacemechanism.py
@@ -48,7 +48,7 @@ Class Reference
 
 import typecheck as tc
 
-from collections import Iterable
+from collections.abc import Iterable
 
 from psyneulink.core.components.functions.transferfunctions import Identity
 from psyneulink.core.components.mechanisms.mechanism import Mechanism

--- a/psyneulink/core/components/mechanisms/processing/integratormechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/integratormechanism.py
@@ -67,7 +67,7 @@ Class Reference
 ---------------
 
 """
-from collections import Iterable
+from collections.abc import Iterable
 
 import typecheck as tc
 

--- a/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
@@ -334,7 +334,8 @@ Class Reference
 import itertools
 import warnings
 
-from collections import Iterable, namedtuple
+from collections.abc import Iterable
+from collections import namedtuple
 
 import typecheck as tc
 

--- a/psyneulink/core/components/mechanisms/processing/processingmechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/processingmechanism.py
@@ -89,7 +89,7 @@ belongs is run. A ProcessingMechanism always executes before any `AdaptiveMechan
 
 """
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import typecheck as tc
 

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -348,7 +348,7 @@ import itertools
 import numbers
 import warnings
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import typecheck as tc

--- a/psyneulink/core/components/states/state.py
+++ b/psyneulink/core/components/states/state.py
@@ -734,7 +734,7 @@ import itertools
 import numbers
 import warnings
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import typecheck as tc

--- a/psyneulink/core/components/system.py
+++ b/psyneulink/core/components/system.py
@@ -433,7 +433,8 @@ import re
 import warnings
 
 from PIL import Image
-from collections import Iterable, OrderedDict, namedtuple
+from collections.abc import Iterable
+from collections import OrderedDict, namedtuple
 from os import path, remove
 from shutil import rmtree
 

--- a/psyneulink/core/globals/environment.py
+++ b/psyneulink/core/globals/environment.py
@@ -627,7 +627,7 @@ import datetime
 import types
 import warnings
 
-from collections import Iterable
+from collections.abc import Iterable
 from numbers import Number
 
 import numpy as np

--- a/psyneulink/core/globals/log.py
+++ b/psyneulink/core/globals/log.py
@@ -504,7 +504,7 @@ def _time_string(time):
 
 #region Custom Entries Dict
 # Modified from: http://stackoverflow.com/questions/7760916/correct-useage-of-getter-setter-for-dictionary-values
-from collections import MutableMapping
+from collections.abc import MutableMapping
 class EntriesDict(MutableMapping,dict):
     """Maintains a Dict of Log entries; assignment of a LogEntry to an entry appends it to the list for that entry.
 

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -265,7 +265,7 @@ def get_validator_by_type_only(valid_types):
         :return: A validation method for use with Parameters classes that rejects any assignment that is not one of the **valid_types**
         :rtype: types.FunctionType
     """
-    if not isinstance(valid_types, collections.Iterable):
+    if not isinstance(valid_types, collections.abc.Iterable):
         valid_types = [valid_types]
 
     def validator(self, value):

--- a/psyneulink/core/globals/sampleiterator.py
+++ b/psyneulink/core/globals/sampleiterator.py
@@ -18,7 +18,7 @@
 import numpy as np
 
 import typecheck as tc
-from collections import Iterator
+from collections.abc import Iterator
 from inspect import isclass
 from decimal import Decimal, getcontext
 from numbers import Number

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -325,7 +325,7 @@ def is_iterable(x):
     if isinstance(x, np.ndarray) and x.ndim == 0:
         return False
     else:
-        return isinstance(x, collections.Iterable)
+        return isinstance(x, collections.abc.Iterable)
 
 
 kwCompatibilityType = "type"
@@ -629,7 +629,7 @@ def get_args(frame):
     return dict((key, value) for key, value in values.items() if key in args)
 
 
-from collections import Mapping
+from collections.abc import Mapping
 def recursive_update(d, u, non_destructive=False):
     """Recursively update entries of dictionary d with dictionary u
     From: https://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth
@@ -1391,7 +1391,7 @@ def convert_all_elements_to_np_array(arr, cast_from=None, cast_to=None):
     if cast_from is not None and isinstance(arr, cast_from):
         return np.asarray(arr, dtype=cast_to)
 
-    if not isinstance(arr, collections.Iterable) or isinstance(arr, str):
+    if not isinstance(arr, collections.abc.Iterable) or isinstance(arr, str):
         return np.array(arr)
 
     if isinstance(arr, np.matrix):

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -346,7 +346,7 @@ Class Reference
 import logging
 import random
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import typecheck as tc

--- a/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
@@ -126,7 +126,7 @@ Class Reference
 
 """
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import typecheck as tc

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -300,7 +300,7 @@ Class Reference
 
 """
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import typecheck as tc

--- a/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
@@ -55,7 +55,7 @@ import logging
 import numbers
 import warnings
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import typecheck as tc

--- a/psyneulink/library/components/mechanisms/processing/transfer/kwtamechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kwtamechanism.py
@@ -170,7 +170,7 @@ import logging
 import numbers
 import warnings
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import typecheck as tc

--- a/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
@@ -134,7 +134,7 @@ Class Reference
 
 import warnings
 
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import typecheck as tc

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -177,7 +177,7 @@ import numpy as np
 import typecheck as tc
 import warnings
 
-from collections import Iterable
+from collections.abc import Iterable
 from types import MethodType
 
 from psyneulink.core import llvm as pnlvm

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -241,7 +241,7 @@ from psyneulink.core.scheduling.scheduler import Scheduler
 import numpy as np
 import copy
 
-from collections import Iterable
+from collections.abc import Iterable
 from toposort import toposort
 
 import logging


### PR DESCRIPTION
Direct import will stop working in python 3.8:
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>