### PR TITLE
appveyor: Update pytorch package to version 1.0.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,10 +20,10 @@ environment:
     EXTRA_ARGS: -m llvm
   - PYTHON: Python36
     ARCH: -x64
-    PYTORCH: cp36-cp36m
+    PYTORCH: 1.0.1-cp36-cp36m
   - PYTHON: Python37
     ARCH: -x64
-    PYTORCH: cp37-cp37m
+    PYTORCH: 1.0.1-cp37-cp37m
 
 install:
   - appveyor-retry choco upgrade graphviz.portable -y
@@ -35,8 +35,9 @@ install:
   - pip install --user -U certifi "numpy<1.16"
   - pip install --user git+https://github.com/benureau/leabra.git@master
 
-  # pytorch does not distribute packages over pypi. Install it directly.
-  - if not "%PYTORCH%" == "" pip install --user http://download.pytorch.org/whl/cpu/torch-0.4.1-%PYTORCH%-win_amd64.whl
+  # pytorch does not distribute windows packages over pypi.
+  # Install it directly.
+  - if not "%PYTORCH%" == "" pip install --user http://download.pytorch.org/whl/cpu/torch-%PYTORCH%-win_amd64.whl
 
   # Remove pytorch from requirements if none is available
   - if "%PYTORCH%" == "" (findstr /V torch < dev_requirements.txt > tmp_req && move /Y tmp_req dev_requirements.txt)


### PR DESCRIPTION
1.1.0 fails to import.
https://github.com/pytorch/pytorch/issues/21363
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>