### PR TITLE
travis: Drop apt cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ env: PYTHONWARNINGS="ignore::DeprecationWarning"
 # Cache installed python packages
 cache:
   pip
-  apt
 
 addons:
   apt:


### PR DESCRIPTION
There is no such thing, and it disabled all caching.
https://github.com/travis-ci/travis-ci/issues/5876
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>