### PR TITLE
requirements: Enable pytest >= 4.6

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-pytest<4.6
+pytest
 pytest-benchmark
 pytest-cov
 pytest-profiling


### PR DESCRIPTION
The issue with test enumeration was fixed in 4.6.1:
https://github.com/pytest-dev/pytest/issues/5358

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>