### PR TITLE
Fix Buffer function not being properly stateful

### DIFF
--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -245,7 +245,7 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
 
     def _initialize_previous_value(self, initializer, execution_context=None):
         initializer = initializer or []
-        previous_value = deque(initializer, maxlen=self.history)
+        previous_value = deque(initializer, maxlen=self.parameters.history.get(execution_context))
 
         self.parameters.previous_value.set(previous_value, execution_context, override=True)
 
@@ -287,7 +287,7 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
 
         if reinitialization_value is None or reinitialization_value == []:
             self.get_previous_value(execution_context).clear()
-            value = deque([], maxlen=self.history)
+            value = deque([], maxlen=self.parameters.history.get(execution_context))
 
         else:
             value = self._initialize_previous_value(reinitialization_value, execution_context=execution_context)
@@ -338,7 +338,7 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
             if any(np.atleast_1d(noise) != 0.0):
                 previous_value = previous_value + noise
 
-        previous_value = deque(previous_value, maxlen=self.history)
+        previous_value = deque(previous_value, maxlen=self.parameters.history._get(execution_id))
 
         previous_value.append(variable)
 

--- a/psyneulink/core/components/mechanisms/adaptive/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/control/optimizationcontrolmechanism.py
@@ -1290,6 +1290,7 @@ class OptimizationControlMechanism(ControlMechanism):
             super()._dependent_components,
             [self.objective_mechanism],
             [self.agent_rep] if isinstance(self.agent_rep, CompositionFunctionApproximator) else [],
+            [self.feature_function] if isinstance(self.feature_function, Function_Base) else [],
             [self.search_function] if isinstance(self.search_function, Function_Base) else [],
             [self.search_termination_function] if isinstance(self.search_termination_function, Function_Base) else [],
         ))


### PR DESCRIPTION
Uses of "self.history" within the Buffer function are not correct, because history is a Parameter. This causes the Buffer's actual deque buffer to grow without limit, causing progressive slowdown in the StabilityFlexibility model.

This was only evidenced by commit a26b30ab7, which correctly set .most_recent_execution_id on Functions; before, the incorrect non-stateful version was coincidentally working.