### PR TITLE
feature: OCM modulation of nested node parameters

### DIFF
--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -948,13 +948,14 @@ from psyneulink.core.components.functions.function import FunctionOutputType, AD
 from psyneulink.core.components.functions.transferfunctions import Linear
 from psyneulink.core.components.shellclasses import Function, Mechanism, Projection, State
 from psyneulink.core.components.states.inputstate import DEFER_VARIABLE_SPEC_TO_MECH_MSG, InputState
+from psyneulink.core.components.states.modulatorysignals.controlsignal import ControlSignal
 from psyneulink.core.components.states.modulatorysignals.modulatorysignal import _is_modulatory_spec
 from psyneulink.core.components.states.outputstate import OutputState
 from psyneulink.core.components.states.parameterstate import ParameterState
 from psyneulink.core.components.states.state import REMOVE_STATES, _parse_state_spec
 from psyneulink.core.globals.context import ContextFlags
 from psyneulink.core.globals.keywords import \
-    CURRENT_EXECUTION_COUNT, CURRENT_EXECUTION_TIME, EXECUTION_PHASE, FUNCTION, FUNCTION_PARAMS, \
+    CONTROL_SIGNAL, CURRENT_EXECUTION_COUNT, CURRENT_EXECUTION_TIME, EXECUTION_PHASE, FUNCTION, FUNCTION_PARAMS, \
     INITIALIZING, INIT_EXECUTE_METHOD_ONLY, INIT_FUNCTION_METHOD_ONLY, \
     INPUT_LABELS_DICT, INPUT_STATE, INPUT_STATES, INPUT_STATE_VARIABLES, MONITOR_FOR_CONTROL, MONITOR_FOR_LEARNING, \
     OUTPUT_LABELS_DICT, OUTPUT_STATE, OUTPUT_STATES, OWNER_VALUE, PARAMETER_STATE, PARAMETER_STATES, PREVIOUS_VALUE, \

--- a/psyneulink/core/components/mechanisms/processing/parameterinterfacemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/parameterinterfacemechanism.py
@@ -13,33 +13,33 @@
 Overview
 --------
 
-A CompositionInterfaceMechanism stores inputs from outside the Composition so that those can be delivered to the
-Composition's `INPUT <NodeRole.INPUT>` Mechanism(s).
+A ParameterInterfaceMechanism is a specialized subclass of CompositionInterfaceMechanism. The ParameterInterfaceMechanism
+stores inputs from outside the Composition so that those can be delivered to ParameterStates of its nested nodes.
 
-.. _CompositionInterfaceMechanism_Creation:
+.. _ParameterInterfaceMechanism_Creation:
 
-Creating an CompositionInterfaceMechanism
+Creating a ParameterInterfaceMechanism
 -----------------------------------------
 
-A CompositionInterfaceMechanism is created automatically when an `INPUT <NodeRole.INPUT>` Mechanism is identified in a
-Composition. When created, the CompositionInterfaceMechanism's OutputState is set directly by the Composition. This
-Mechanism should never be executed, and should never be created by a user.
+A ParameterInterfaceMechanism is created automatically when a controller is added to a Composition. When created, the
+CompositionInterfaceMechanism's OutputState is set directly by the Composition. This Mechanism should never be executed,
+and should never be created by a user.
 
-.. _CompositionInterfaceMechanism_Structure
+.. _ParameterInterfaceMechanism_Structure
 
 Structure
 ---------
 
 [TBD]
 
-.. _CompositionInterfaceMechanism_Execution
+.. _ParameterInterfaceMechanism_Execution
 
 Execution
 ---------
 
 [TBD]
 
-.. _CompositionInterfaceMechanism_Class_Reference:
+.. _ParameterInterfaceMechanism_Class_Reference:
 
 Class Reference
 ---------------
@@ -53,20 +53,20 @@ from collections.abc import Iterable
 from psyneulink.core.components.functions.transferfunctions import Identity
 from psyneulink.core.components.mechanisms.mechanism import Mechanism
 from psyneulink.core.components.mechanisms.mechanism import Mechanism_Base
-from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism_Base
+from psyneulink.core.components.mechanisms.processing.compositioninterfacemechanism import CompositionInterfaceMechanism
 from psyneulink.core.components.states.inputstate import InputState
 from psyneulink.core.components.states.outputstate import OutputState
 from psyneulink.core.globals.context import ContextFlags
-from psyneulink.core.globals.keywords import COMPOSITION_INTERFACE_MECHANISM, kwPreferenceSetName
+from psyneulink.core.globals.keywords import PARAMETER_INTERFACE_MECHANISM, kwPreferenceSetName
 from psyneulink.core.globals.preferences.componentpreferenceset import is_pref_set, kpReportOutputPref
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
 
-__all__ = ['CompositionInterfaceMechanism']
+__all__ = ['ParameterInterfaceMechanism']
 
 
-class CompositionInterfaceMechanism(ProcessingMechanism_Base):
+class ParameterInterfaceMechanism(CompositionInterfaceMechanism):
     """
-    CompositionInterfaceMechanism(                            \
+    ParameterInterfaceMechanism(                            \
     default_variable=None,                               \
     size=None,                                              \
     function=Identity() \
@@ -74,7 +74,7 @@ class CompositionInterfaceMechanism(ProcessingMechanism_Base):
     name=None,                                              \
     prefs=None)
 
-    Implements the CompositionInterfaceMechanism subclass of Mechanism.
+    Implements the ParameterInterfaceMechanism subclass of CompositionInterfaceMechanism.
 
     Arguments
     ---------
@@ -82,8 +82,8 @@ class CompositionInterfaceMechanism(ProcessingMechanism_Base):
     default_variable : number, list or np.ndarray
         the input to the Mechanism to use if none is provided in a call to its
         `execute <Mechanism_Base.execute>` or `run <Mechanism_Base.run>` methods;
-        also serves as a template to specify the length of `variable <CompositionInterfaceMechanism.variable>` for
-        `function <CompositionInterfaceMechanism.function>`, and the `primary outputState <OutputState_Primary>` of the
+        also serves as a template to specify the length of `variable <ParameterInterfaceMechanism.variable>` for
+        `function <ParameterInterfaceMechanism.function>`, and the `primary outputState <OutputState_Primary>` of the
         Mechanism.
 
     size : int, list or np.ndarray of ints
@@ -95,11 +95,11 @@ class CompositionInterfaceMechanism(ProcessingMechanism_Base):
 
     params : Optional[Dict[param keyword, param value]]
         a `parameter dictionary <ParameterState_Specifying_Parameters>` that can be used to specify the parameters for
-        the `Mechanism <Mechanism>`, parameters for its `function <CompositionInterfaceMechanism.function>`, and/or a
+        the `Mechanism <Mechanism>`, parameters for its `function <ParameterInterfaceMechanism.function>`, and/or a
         custom function and its parameters.  Values specified for parameters in the dictionary override any assigned
         to those parameters in arguments of the constructor.
 
-    name : str : default CompositionInterfaceMechanism-<index>
+    name : str : default ParameterInterfaceMechanism-<index>
         a string used for the name of the Mechanism.
         If not is specified, a default is assigned by `MechanismRegistry`
         (see :doc:`Registry <LINK>` for conventions used in naming, including for default and duplicate names).
@@ -114,7 +114,7 @@ class CompositionInterfaceMechanism(ProcessingMechanism_Base):
     variable : value: default
         the input to Mechanism's ``function``.
 
-    name : str : default CompositionInterfaceMechanism-<index>
+    name : str : default ParameterInterfaceMechanism-<index>
         the name of the Mechanism.
         Specified in the **name** argument of the constructor for the Mechanism;
         if not is specified, a default is assigned by `MechanismRegistry`
@@ -127,13 +127,12 @@ class CompositionInterfaceMechanism(ProcessingMechanism_Base):
         (see :doc:`PreferenceSet <LINK>` for details).
 
     """
-
-    componentType = COMPOSITION_INTERFACE_MECHANISM
+    componentType = PARAMETER_INTERFACE_MECHANISM
 
     classPreferenceLevel = PreferenceLevel.TYPE
     # These will override those specified in TypeDefaultPreferences
     classPreferences = {
-        kwPreferenceSetName: 'CompositionInterfaceMechanismCustomClassPreferences',
+        kwPreferenceSetName: 'ParameterInterfaceMechanismCustomClassPreferences',
         kpReportOutputPref: PreferenceEntry(False, PreferenceLevel.INSTANCE)}
 
     paramClassDefaults = Mechanism_Base.paramClassDefaults.copy()
@@ -149,23 +148,12 @@ class CompositionInterfaceMechanism(ProcessingMechanism_Base):
                  composition=None,
                  params=None,
                  name=None,
-                 prefs:is_pref_set=None):
-
-        if default_variable is None and size is None:
-            default_variable = self.class_defaults.variable
-        self.composition = composition
-        self.connected_to_composition = False
-
-        # Assign args to params and functionParams dicts
-        params = self._assign_args_to_param_dicts(function=function,
-                                                  input_states=input_states,
-                                                  params=params)
-
-        super(CompositionInterfaceMechanism, self).__init__(default_variable=default_variable,
-                                                            size=size,
-                                                            input_states=input_states,
-                                                            function=function,
-                                                            params=params,
-                                                            name=name,
-                                                            prefs=prefs,
-                                                            context=ContextFlags.CONSTRUCTOR)
+                 prefs: is_pref_set = None):
+        super(ParameterInterfaceMechanism, self).__init__(default_variable=default_variable,
+                                                        size=size,
+                                                        input_states=input_states,
+                                                        function=function,
+                                                        params=params,
+                                                        name=name,
+                                                        prefs=prefs,
+                                                        context=ContextFlags.CONSTRUCTOR)

--- a/psyneulink/core/components/projections/modulatory/controlprojection.py
+++ b/psyneulink/core/components/projections/modulatory/controlprojection.py
@@ -104,6 +104,7 @@ import typecheck as tc
 from psyneulink.core.components.component import parameter_keywords
 from psyneulink.core.components.functions.transferfunctions import Linear
 from psyneulink.core.components.mechanisms.adaptive.control.controlmechanism import ControlMechanism
+from psyneulink.core.components.mechanisms.processing.parameterinterfacemechanism import ParameterInterfaceMechanism
 from psyneulink.core.components.projections.modulatory.modulatoryprojection import ModulatoryProjection_Base
 from psyneulink.core.components.projections.projection import ProjectionError, Projection_Base, projection_keywords
 from psyneulink.core.components.shellclasses import Mechanism, Process_Base
@@ -384,7 +385,7 @@ class ControlProjection(ModulatoryProjection_Base):
         # If sender is specified as a Mechanism, validate that it is a ControlMechanism
         if isinstance(sender, Mechanism):
             # If sender is a ControlMechanism, call it to instantiate its ControlSignal projection
-            if not isinstance(sender, ControlMechanism):
+            if not isinstance(sender, (ControlMechanism, ParameterInterfaceMechanism)):
                 raise ControlProjectionError(
                     "Mechanism specified as sender for {} ({}) must be a "
                     "ControlMechanism (but it is a {})".format(

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -3147,7 +3147,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         if visited_compositions is NotImplemented:
             visited_compositions = [self]
         for node in self.nodes:
-            if node.componentType == 'Composition':
+            if node.componentType == 'Composition' and \
+                    node not in visited_compositions:
                 nested_compositions.append(node)
                 visited_compositions.append(node)
                 node._get_nested_compositions(nested_compositions,

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -94,6 +94,54 @@ In the following script comp_0, comp_1 and comp_2 are identical, but constructed
     >>> comp_1_output = comp_1.run(inputs=input_dict)
     >>> comp_2_output = comp_2.run(inputs=input_dict)
 
+*Nested Compositions*
+=====================
+
+A Composition can be used as a node of another Composition. To do this, simply call `add_node <Composition.add_node>`
+from the parent composition using the child Composition as an argument. You can then project to and from the nested
+composition just as you would any other node.
+
+    *Create outer Composition:*
+
+    >>> outer_A = pnl.ProcessingMechanism(name='outer_A')
+    >>> outer_B = pnl.ProcessingMechanism(name='outer_B')
+    >>> outer_comp = pnl.Composition(name='outer_comp')
+    >>> outer_comp.add_nodes([outer_A, outer_B])
+
+    *Create and configure inner Composition:*
+
+    >>> inner_A = pnl.ProcessingMechanism(name='inner_A')
+    >>> inner_B = pnl.ProcessingMechanism(name='inner_B')
+    >>> inner_comp = pnl.Composition(name='inner_comp')
+    >>> inner_comp.add_linear_processing_pathway([inner_A, inner_B])
+
+    *Nest inner Composition within outer Composition using `add_node <Composition.add_node>`:*
+
+    >>> outer_comp.add_node(inner_comp)
+
+    *Create Projections:*
+
+    >>> outer_comp.add_projection(pnl.MappingProjection(), sender=outer_A, receiver=inner_comp)
+    >>> outer_comp.add_projection(pnl.MappingProjection(), sender=inner_comp, receiver=outer_B)
+    >>> input_dict = {outer_A: [[[1.0]]]}
+
+    *Run Composition:*
+
+    >>> outer_comp.run(inputs=input_dict)
+
+    *Using `add_linear_processing_pathway <Composition.add_linear_processing_pathway>` with nested compositions for brevity:*
+
+    >>> outer_A = pnl.ProcessingMechanism(name='outer_A')
+    >>> outer_B = pnl.ProcessingMechanism(name='outer_B')
+    >>> outer_comp = pnl.Composition(name='outer_comp')
+    >>> inner_A = pnl.ProcessingMechanism(name='inner_A')
+    >>> inner_B = pnl.ProcessingMechanism(name='inner_B')
+    >>> inner_comp = pnl.Composition(name='inner_comp')
+    >>> inner_comp.add_linear_processing_pathway([inner_A, inner_B])
+    >>> outer_comp.add_linear_processing_pathway([outer_A, inner_comp, outer_B])
+    >>> input_dict = {outer_A: [[[1.0]]]}
+    >>> outer_comp.run(inputs=input_dict)
+
 .. _Running_a_Composition:
 
 Running a Composition
@@ -700,6 +748,7 @@ from psyneulink.core.components.shellclasses import Mechanism, Projection
 from psyneulink.core.components.states.inputstate import InputState
 from psyneulink.core.components.states.parameterstate import ParameterState
 from psyneulink.core.components.states.outputstate import OutputState
+from psyneulink.core.components.states.modulatorysignals.controlsignal import ControlSignal
 from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism
 from psyneulink.core.globals.registry import remove_instance_from_registry
 from psyneulink.core.globals.context import ContextFlags
@@ -1223,8 +1272,11 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                                        composition=self)
         self.output_CIM = CompositionInterfaceMechanism(name=self.name + " Output_CIM",
                                                         composition=self)
+        self.parameter_CIM = CompositionInterfaceMechanism(name=self.name + " Parameter_CIM",
+                                                        composition=self)
         self.input_CIM_states = {}
         self.output_CIM_states = {}
+        self.parameter_CIM_states = {}
 
         self.shadows = {}
 
@@ -1334,11 +1386,16 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         if node not in self.shadows:
             self.shadows[node] = []
 
+        nested_nodes = dict(self._get_nested_nodes())
         # If this node is shadowing another node, then add it to that node's entry in the Composition's "shadows" dict
+        # If the node it's shadowing is a nested node, add it to the entry for the composition it's nested in.
         for input_state in node.input_states:
             if hasattr(input_state, "shadow_inputs") and input_state.shadow_inputs is not None:
-                if node not in self.shadows[input_state.shadow_inputs.owner]:
-                    self.shadows[input_state.shadow_inputs.owner].append(node)
+                owner = input_state.shadow_inputs.owner
+                if owner in nested_nodes:
+                    owner = nested_nodes[owner]
+                if node not in self.shadows[owner]:
+                    self.shadows[owner].append(node)
 
     def add_node(self, node, required_roles=None):
         """
@@ -1426,7 +1483,26 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
             # Add all projections to the composition
             for proj_spec in projections:
-                self.add_projection(projection=proj_spec[0], feedback=proj_spec[1])
+                # The proj_spec assumes a direct connection between sender and receiver, and is therefore invalid if
+                # either are nested (i.e. projections between them need to be routed through a CIM). In these cases,
+                # we instantiate a new projection between sender and receiver instead of using the original spec.
+                # If the sender or receiver is an AutoAssociativeProjection, then the owner will be another projection
+                # instead of a mechanism, so we need to use owner_mech instead.
+                sender_node = proj_spec[0].sender.owner
+                if isinstance(sender_node, AutoAssociativeProjection):
+                    sender_node = proj_spec[0].sender.owner.owner_mech
+                receiver_node = proj_spec[0].receiver.owner
+                if isinstance(receiver_node, AutoAssociativeProjection):
+                    receiver_node = proj_spec[0].receiver.owner.owner_mech
+                if sender_node in self.nodes and \
+                        receiver_node in self.nodes:
+                    self.add_projection(projection=proj_spec[0],
+                                        feedback=proj_spec[1])
+                else:
+                    self.add_projection(sender=proj_spec[0].sender,
+                                        receiver=proj_spec[0].receiver,
+                                        feedback=proj_spec[1])
+
         if required_roles:
             if not isinstance(required_roles, list):
                 required_roles = [required_roles]
@@ -1526,18 +1602,22 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         self._update_shadows_dict(controller)
 
         # Skip first (OUTCOME) input_state
+        input_cims=[self.input_CIM] + [comp.input_CIM for comp in self._get_nested_compositions()]
         for input_state in controller.input_states[1:]:
             if hasattr(input_state, "shadow_inputs") and input_state.shadow_inputs is not None:
                 for proj in input_state.shadow_inputs.path_afferents:
                     sender = proj.sender
-                    if sender.owner != self.input_CIM:
+                    if sender.owner not in input_cims:
                         self.add_projection(projection=MappingProjection(sender=sender, receiver=input_state),
                                             sender=sender.owner,
                                             receiver=controller)
                         shadow_proj._activate_for_compositions(self)
                     else:
-                        shadow_proj = MappingProjection(sender=proj.sender, receiver=input_state)
-                        shadow_proj._activate_for_compositions(self)
+                        try:
+                            shadow_proj = MappingProjection(sender=proj.sender, receiver=input_state)
+                            shadow_proj._activate_for_compositions(self)
+                        except DuplicateProjectionError:
+                            pass
             # MODIFIED 6/11/19 NEW: [JDC]
             for proj in input_state.path_afferents:
                 proj._activate_for_compositions(self)
@@ -3027,6 +3107,53 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 for previous_node in q[-2]:
                     self._add_node_role(previous_node, NodeRole.TERMINAL)
 
+    def _get_nested_nodes(self,
+                          nested_nodes=NotImplemented,
+                          root_composition=NotImplemented,
+                          visited_compositions=NotImplemented):
+        """Recursive search that returns all nodes of all nested compositions in a tuple with the composition they are
+            embedded in.
+
+        :return
+
+        A list of tuples in format (node, composition) containing all nodes of all nested compositions."""
+        if nested_nodes is NotImplemented:
+            nested_nodes=[]
+        if root_composition is NotImplemented:
+            root_composition=self
+        if visited_compositions is NotImplemented:
+            visited_compositions = [self]
+        for node in self.nodes:
+            if node.componentType == 'Composition' and \
+                    node not in visited_compositions:
+                visited_compositions.append(node)
+                node._get_nested_nodes(nested_nodes,
+                                       root_composition,
+                                       visited_compositions)
+            elif root_composition is not self:
+                nested_nodes.append((node,self))
+        return nested_nodes
+
+    def _get_nested_compositions(self,
+                                 nested_compositions=NotImplemented,
+                                 visited_compositions=NotImplemented):
+        """Recursive search that returns all nested compositions.
+
+        :return
+
+        A list of nested compositions."""
+        if nested_compositions is NotImplemented:
+            nested_compositions=[]
+        if visited_compositions is NotImplemented:
+            visited_compositions = [self]
+        for node in self.nodes:
+            if node.componentType == 'Composition':
+                nested_compositions.append(node)
+                visited_compositions.append(node)
+                node._get_nested_compositions(nested_compositions,
+                                              visited_compositions)
+        return nested_compositions
+
     def _determine_node_roles(self):
         # Clear old roles
         self.nodes_to_roles.update({k: set() for k in self.nodes_to_roles})
@@ -3294,6 +3421,18 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             - delete all of the above for any node States which were previously, but are no longer, classified as
               INPUT/OUTPUT
 
+            - if composition has a controller, remove default InputState and OutputState of all nested compositions'
+              `parameter CIMs <Composition.parameter_CIM>` which contain nodes that will be modulated and whose default
+              states have not already been removed
+
+            - delete afferents of compositions' parameter CIMs if their sender is no longer the controller of any of
+              the composition's parent compositions
+
+            - create a corresponding InputState and ControlSignal on the `parameter_CIM <Composition.parameter_CIM>` for
+              each parameter modulated by the controller
+
+            - instantiate and activate projections from ControlSignals of controller to corresponding InputStates
+              of nested compositions' `parameter_CIMs <Composition.parameter_CIM>`
         """
 
         if not self.input_CIM.connected_to_composition:
@@ -3419,6 +3558,67 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             self.output_CIM.remove_states(self.output_CIM_states[output_state][0])
             self.output_CIM.remove_states(self.output_CIM_states[output_state][1])
             del self.output_CIM_states[output_state]
+
+        # PARAMETER CIMS
+        if self.controller:
+            controller = self.controller
+            nested_nodes = dict(self._get_nested_nodes())
+            nested_comps = self._get_nested_compositions()
+            for comp in nested_comps:
+                for state in comp.parameter_CIM.input_states:
+                    for afferent in state.all_afferents:
+                        if not comp in afferent.sender.owner.composition._get_nested_compositions():
+                            del state._afferents_info[afferent]
+                            if afferent in state.path_afferents:
+                                state.path_afferents.remove(afferent)
+                            if afferent in state.mod_afferents:
+                                state.mod_afferents.remove(afferent)
+
+            for modulatory_signal in controller.modulatory_signals:
+                for projection in modulatory_signal.projections:
+                    receiver = projection.receiver
+                    mech = receiver.owner
+                    if mech in nested_nodes:
+                        comp = nested_nodes[mech]
+                        pcim = comp.parameter_CIM
+                        pcim_states = comp.parameter_CIM_states
+                        if receiver not in pcim_states:
+                            if not pcim.connected_to_composition:
+                                pcim.input_states.remove(pcim.input_state)
+                                pcim.output_states.remove(pcim.output_state)
+                                pcim.connected_to_composition = True
+                            modulation = modulatory_signal.owner.modulation
+                            input_state = InputState(
+                                owner = pcim,
+                            )
+                            control_signal = ControlSignal(
+                                owner = pcim,
+                                modulation = modulation,
+                                variable = OWNER_VALUE,
+                                function = InterfaceStateMap(
+                                    corresponding_input_state = input_state
+                                ),
+                                modulates = receiver,
+                                name = 'PARAMETER_CIM_' + mech.name + "_" + receiver.name
+                            )
+                            for projection in control_signal.projections:
+                                projection._activate_for_compositions(comp)
+                            pcim_states[receiver] = (modulatory_signal, input_state)
+
+            for comp in nested_comps:
+                pcim = comp.parameter_CIM
+                connected_to_controller = False
+                for afferent in pcim.afferents:
+                    if afferent.sender.owner is controller:
+                        connected_to_controller = True
+                if not connected_to_controller:
+                    for efferent in controller.efferents:
+                        if efferent.receiver in pcim_states:
+                            input_projection = MappingProjection(
+                                sender = efferent.sender,
+                                receiver = pcim_states[efferent.receiver][1]
+                            )
+                            input_projection._activate_for_compositions(comp)
 
     def _assign_values_to_input_CIM(self, inputs, execution_id=None):
         """
@@ -5052,6 +5252,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         if nested:
             self.input_CIM.parameters.context._get(execution_id).execution_phase = ContextFlags.PROCESSING
             self.input_CIM.execute(execution_id=execution_id, context=ContextFlags.PROCESSING)
+            self.parameter_CIM.parameters.context._get(execution_id).execution_phase = ContextFlags.PROCESSING
+            self.parameter_CIM.execute(execution_id=execution_id, context=ContextFlags.PROCESSING)
         else:
             inputs = self._adjust_execution_stimuli(inputs)
             self._assign_values_to_input_CIM(inputs, execution_id=execution_id)
@@ -5297,9 +5499,15 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                         _comp_ex.execute_node(node)
                     else:
                         if node is not self.controller:
-                            node.execute(execution_id=execution_id,
-                                         runtime_params=execution_runtime_params,
-                                         context=ContextFlags.COMPOSITION)
+                            if nested and node in self.get_nodes_by_role(NodeRole.INPUT):
+                                for state in node.input_states:
+                                    state.update(execution_id=execution_id,
+                                                 context=ContextFlags.COMPOSITION)
+                            node.execute(
+                                execution_id=execution_id,
+                                runtime_params=execution_runtime_params,
+                                context=ContextFlags.COMPOSITION
+                            )
 
                     # Reset runtime_params for node and its function if specified
                         if execution_id in node._runtime_params_reset:
@@ -6398,11 +6606,20 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # ASSUMPTION: input_states[0] is NOT a feature and input_states[1:] are features
         # If this is not a good assumption, we need another way to look up the feature InputStates
         # of the OCM and know which InputState maps to which predicted_input value
+
+        nested_nodes = dict(self._get_nested_nodes())
         for j in range(len(self.controller.input_states) - 1):
             input_state = self.controller.input_states[j + 1]
             if hasattr(input_state, "shadow_inputs") and input_state.shadow_inputs is not None:
-                inputs[input_state.shadow_inputs.owner] = predicted_input[j]
-
+                owner = input_state.shadow_inputs.owner
+                if not owner in nested_nodes:
+                    inputs[input_state.shadow_inputs.owner] = predicted_input[j]
+                else:
+                    comp = nested_nodes[owner]
+                    if not comp in inputs:
+                        inputs[comp]=[[predicted_input[j]]]
+                    else:
+                        inputs[comp]=np.concatenate([[predicted_input[j]],inputs[comp][0]])
         return inputs
 
     def evaluate(
@@ -6609,7 +6826,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             super()._dependent_components,
             self.nodes,
             self.projections,
-            [self.input_CIM, self.output_CIM],
+            [self.input_CIM, self.output_CIM, self.parameter_CIM],
             self.input_CIM.efferents,
             self.output_CIM.afferents,
             [self.controller] if self.controller is not None else []

--- a/psyneulink/core/globals/keywords.py
+++ b/psyneulink/core/globals/keywords.py
@@ -594,6 +594,7 @@ KWTA_MECHANISM = "KWTAMechanism"
 INTEGRATOR_MECHANISM = "IntegratorMechanism"
 DDM_MECHANISM = "DDM"
 COMPOSITION_INTERFACE_MECHANISM = "CompositionInterfaceMechanism"
+PARAMETER_INTERFACE_MECHANISM = "ParameterInterfaceMechanism"
 PROCESSING_MECHANISM = "ProcessingMechanism"
 
 # Functions:

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -197,8 +197,172 @@ class TestControlMechanisms:
     #     assert np.allclose(result, [[[4.], [4.]],
     #                                 [[4.], [4.]]])
 
+    def test_multilevel_control(self):
+        oA = pnl.TransferMechanism(
+            name='OuterA',
+        )
+        oB = pnl.TransferMechanism(
+            name='OuterB',
+        )
+        iA = pnl.TransferMechanism(
+            name='InnerA',
+        )
+        iB = pnl.TransferMechanism(
+            name='InnerB',
+        )
+        iComp = pnl.Composition(name='InnerComp')
+        iComp.add_node(iA)
+        iComp.add_node(iB)
+        iComp.add_projection(pnl.MappingProjection(), iA, iB)
+        oComp = pnl.Composition(name='OuterComp')
+        oComp.add_node(oA)
+        oComp.add_node(oB)
+        oComp.add_node(iComp)
+        oComp.add_projection(pnl.MappingProjection(), oA, iComp)
+        oComp.add_projection(pnl.MappingProjection(), iB, oB)
+        oController = pnl.ControlMechanism(
+            name='Controller',
+            control_signals=[
+                pnl.ControlSignal(
+                    name='ControllerTransfer',
+                    function=pnl.Linear(slope=2),
+                    modulates=(pnl.SLOPE, iA),
+                )
+            ],
+        )
+        oComp.add_controller(oController)
+        assert oComp.controller == oController
+        iController = pnl.ControlMechanism(
+            name='Controller___',
+            control_signals=[
+                pnl.ControlSignal(
+                    name='ControllerTransfer',
+                    function=pnl.Linear(slope=4),
+                    modulates=(pnl.SLOPE, iB)
+                )
+            ],
+        )
+        iComp.add_controller(iController)
+        assert iComp.controller == iController
+        assert oComp.controller == oController
+        assert oComp.run(inputs=[5]) == [40]
 
 class TestModelBasedOptimizationControlMechanisms:
+
+    def test_nested_evc(self):
+        import psyneulink as pnl
+        import numpy as np
+        from psyneulink import PROJECTIONS, ALLOCATION_SAMPLES
+
+        outer_comp = pnl.Composition(retain_old_simulation_data=True)
+        # Mechanisms
+        Input = pnl.TransferMechanism(name='Input')
+        reward = pnl.TransferMechanism(output_states=[pnl.RESULT, pnl.OUTPUT_MEAN, pnl.OUTPUT_VARIANCE],
+                                       name='reward')
+        Decision = pnl.DDM(function=pnl.DriftDiffusionAnalytical(drift_rate=(1.0,
+                                                                             pnl.ControlProjection(function=pnl.Linear,
+                                                                                                   control_signal_params={
+                                                                                                       pnl.ALLOCATION_SAMPLES: np.arange(
+                                                                                                           0.1, 1.01,
+                                                                                                           0.3)})),
+                                                                 threshold=(1.0,
+                                                                            pnl.ControlProjection(function=pnl.Linear,
+                                                                                                  control_signal_params={
+                                                                                                      pnl.ALLOCATION_SAMPLES: np.arange(
+                                                                                                          0.1, 1.01,
+                                                                                                          0.3)})),
+                                                                 noise=0.5,
+                                                                 starting_point=0,
+                                                                 t0=0.45),
+                           output_states=[pnl.DECISION_VARIABLE,
+                                          pnl.RESPONSE_TIME,
+                                          pnl.PROBABILITY_UPPER_THRESHOLD],
+                           name='Decision')
+
+        comp = pnl.Composition(name="evc", retain_old_simulation_data=True)
+        comp.add_node(reward, required_roles=[pnl.NodeRole.OUTPUT])
+        comp.add_node(Decision, required_roles=[pnl.NodeRole.OUTPUT])
+        task_execution_pathway = [Input, pnl.IDENTITY_MATRIX, Decision]
+        comp.add_linear_processing_pathway(task_execution_pathway)
+        comp._analyze_graph()
+        outer_comp.add_node(comp)
+        outer_comp._analyze_graph()
+        outer_comp.add_controller(controller=pnl.OptimizationControlMechanism(
+            agent_rep=outer_comp,
+            features=[Input.input_state, reward.input_state],
+            feature_function=pnl.AdaptiveIntegrator(rate=0.5),
+            objective_mechanism=pnl.ObjectiveMechanism(
+                function=pnl.LinearCombination(operation=pnl.PRODUCT),
+                monitor=[reward,
+                         Decision.output_states[pnl.PROBABILITY_UPPER_THRESHOLD],
+                         (Decision.output_states[pnl.RESPONSE_TIME], -1, 1)]),
+            function=pnl.GridSearch(),
+            control_signals=[{PROJECTIONS: ("drift_rate", Decision),
+                              ALLOCATION_SAMPLES: np.arange(0.1, 1.01, 0.3)},
+                             {PROJECTIONS: ("threshold", Decision),
+                              ALLOCATION_SAMPLES: np.arange(0.1, 1.01, 0.3)}])
+        )
+
+        comp.enable_controller = True
+
+        comp._analyze_graph()
+
+        outer_comp._analyze_graph()
+        outer_comp.run(inputs=[
+            [[20], [0.5]],
+            [[20], [0.123]]
+        ])
+
+        # Note: Removed decision variable OutputState from simulation results because sign is chosen randomly
+        expected_sim_results_array = [
+            [[10.], [10.0], [0.0], [0.48999867], [0.50499983]],
+            [[10.], [10.0], [0.0], [1.08965888], [0.51998934]],
+            [[10.], [10.0], [0.0], [2.40680493], [0.53494295]],
+            [[10.], [10.0], [0.0], [4.43671978], [0.549834]],
+            [[10.], [10.0], [0.0], [0.48997868], [0.51998934]],
+            [[10.], [10.0], [0.0], [1.08459402], [0.57932425]],
+            [[10.], [10.0], [0.0], [2.36033556], [0.63645254]],
+            [[10.], [10.0], [0.0], [4.24948962], [0.68997448]],
+            [[10.], [10.0], [0.0], [0.48993479], [0.53494295]],
+            [[10.], [10.0], [0.0], [1.07378304], [0.63645254]],
+            [[10.], [10.0], [0.0], [2.26686573], [0.72710822]],
+            [[10.], [10.0], [0.0], [3.90353015], [0.80218389]],
+            [[10.], [10.0], [0.0], [0.4898672], [0.549834]],
+            [[10.], [10.0], [0.0], [1.05791834], [0.68997448]],
+            [[10.], [10.0], [0.0], [2.14222978], [0.80218389]],
+            [[10.], [10.0], [0.0], [3.49637662], [0.88079708]],
+            [[15.], [15.0], [0.0], [0.48999926], [0.50372993]],
+            [[15.], [15.0], [0.0], [1.08981011], [0.51491557]],
+            [[15.], [15.0], [0.0], [2.40822035], [0.52608629]],
+            [[15.], [15.0], [0.0], [4.44259627], [0.53723096]],
+            [[15.], [15.0], [0.0], [0.48998813], [0.51491557]],
+            [[15.], [15.0], [0.0], [1.0869779], [0.55939819]],
+            [[15.], [15.0], [0.0], [2.38198336], [0.60294711]],
+            [[15.], [15.0], [0.0], [4.33535807], [0.64492386]],
+            [[15.], [15.0], [0.0], [0.48996368], [0.52608629]],
+            [[15.], [15.0], [0.0], [1.08085171], [0.60294711]],
+            [[15.], [15.0], [0.0], [2.32712843], [0.67504223]],
+            [[15.], [15.0], [0.0], [4.1221271], [0.7396981]],
+            [[15.], [15.0], [0.0], [0.48992596], [0.53723096]],
+            [[15.], [15.0], [0.0], [1.07165729], [0.64492386]],
+            [[15.], [15.0], [0.0], [2.24934228], [0.7396981]],
+            [[15.], [15.0], [0.0], [3.84279648], [0.81637827]]
+        ]
+
+        for simulation in range(len(expected_sim_results_array)):
+            assert np.allclose(expected_sim_results_array[simulation],
+                               # Note: Skip decision variable OutputState
+                               outer_comp.simulation_results[simulation][0:3] + outer_comp.simulation_results[
+                                                                                    simulation][4:6])
+
+        expected_results_array = [
+            [[20.0], [20.0], [0.0], [1.0], [2.378055160151634], [0.9820137900379085]],
+            [[20.0], [20.0], [0.0], [0.1], [0.48999967725112503], [0.5024599801509442]]
+        ]
+
+        for trial in range(len(expected_results_array)):
+            np.testing.assert_allclose(outer_comp.results[trial], expected_results_array[trial], atol=1e-08,
+                                       err_msg='Failed on expected_output[{0}]'.format(trial))
 
     def test_evc(self):
         # Mechanisms


### PR DESCRIPTION
Created new Mechanism: ParameterInterfaceMechanism. It is a subclass of CompositionInterfaceMechanism that is granted special permissions to use ControlSignals as its OutputStates.

Compositions now instantiate with a ParameterInterfaceMechanism attribute.

Implemented feature allowing OCM of a composition to modulate parameter states of nested nodes via ParameterInterfaceMechanism. Necessary Projections, InputStates, and ControlSignals are added to compositions in _create_CIM_states().

Added _get_nested_nodes() and _get_nested_compositions() convenience methods to Composition.