### PR TITLE
Travis docstrings avy

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1247,7 +1247,7 @@ class Component(object, metaclass=ComponentsMeta):
     # be removed later), I’m keeping _handle_size in Component.py. I’ll move the bulk of the function to Mechanism
     # through an override, when Composition is done. For now, only State.py overwrites _handle_size().
     def _handle_size(self, size, variable):
-        """ If variable is None, _handle_size tries to infer variable based on the **size** argument to the
+        """If variable is None, _handle_size tries to infer variable based on the **size** argument to the
             __init__() function. This method is overwritten in subclasses like Mechanism and State.
             If self is a Mechanism, it converts variable to a 2D array, (for a Mechanism, variable[i] represents
             the input from the i-th input state). If self is a State, variable is a 1D array and size is a length-1 1D

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -3042,7 +3042,8 @@ class Component(object, metaclass=ComponentsMeta):
     @property
     def current_execution_count(self):
         """Maintains a simple count of executions over the life of the Component,
-        Incremented in the Component's execute method by call to self._increment_execution_count"""
+        Incremented in the Component's execute method by call to self._increment_execution_count
+        """
         try:
             return self._current_execution_count
         except:

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -704,7 +704,8 @@ class Function_Base(Function):
 
     def _validate_parameter_spec(self, param, param_name, numeric_only=True):
         """Validates function param
-        Replace direct call to parameter_spec in tc, which seems to not get called by Function __init__()'s"""
+        Replace direct call to parameter_spec in tc, which seems to not get called by Function __init__()'s
+        """
         if not parameter_spec(param, numeric_only):
             owner_name = 'of ' + self.owner_name if self.owner else ""
             raise FunctionError("{} is not a valid specification for the {} argument of {}{}".

--- a/psyneulink/core/components/functions/learningfunctions.py
+++ b/psyneulink/core/components/functions/learningfunctions.py
@@ -476,7 +476,8 @@ class BayesGLM(LearningFunction):
     def initialize_priors(self):
         """Set the prior parameters (`mu_prior <BayesGLM.mu_prior>`, `Lamba_prior <BayesGLM.Lambda_prior>`,
         `gamma_shape_prior <BayesGLM.gamma_shape_prior>`, and `gamma_size_prior <BayesGLM.gamma_size_prior>`)
-        to their initial (_0) values, and assign current (_n) values to the priors"""
+        to their initial (_0) values, and assign current (_n) values to the priors
+        """
 
         variable = np.array(self.defaults.variable)
         variable = self.defaults.variable
@@ -605,7 +606,8 @@ class BayesGLM(LearningFunction):
     def sample_weights(self, gamma_shape_n, gamma_size_n, mu_n, Lambda_n):
         """Draw a sample of prediction weights from the distributions parameterized by `mu_n <BayesGLM.mu_n>`,
         `Lambda_n <BayesGLM.Lambda_n>`, `gamma_shape_n <BayesGLM.gamma_shape_n>`, and `gamma_size_n
-        <BayesGLM.gamma_size_n>`."""
+        <BayesGLM.gamma_size_n>`.
+        """
         phi = np.random.gamma(gamma_shape_n / 2, gamma_size_n / 2)
         return np.random.multivariate_normal(mu_n.reshape(-1,), phi * np.linalg.inv(Lambda_n))
 
@@ -709,7 +711,8 @@ class Kohonen(LearningFunction):  # --------------------------------------------
         `Mechanism <Mechanism>` to which the Function belongs.
 
     prefs : PreferenceSet or specification dict : default Function.classPreferences
-        the `PreferenceSet` for the Function (see `prefs <Function_Base.prefs>` for details).    """
+        the `PreferenceSet` for the Function (see `prefs <Function_Base.prefs>` for details).
+    """
 
     componentName = KOHONEN_FUNCTION
 
@@ -988,7 +991,8 @@ class Hebbian(LearningFunction):  # --------------------------------------------
         `Mechanism <Mechanism>` to which the Function belongs.
 
     prefs : PreferenceSet or specification dict : default Function.classPreferences
-        the `PreferenceSet` for the Function (see `prefs <Function_Base.prefs>` for details).    """
+        the `PreferenceSet` for the Function (see `prefs <Function_Base.prefs>` for details).
+    """
 
     componentName = HEBBIAN_FUNCTION
 
@@ -1225,7 +1229,8 @@ class ContrastiveHebbian(LearningFunction):  # ---------------------------------
         `Mechanism <Mechanism>` to which the Function belongs.
 
     prefs : PreferenceSet or specification dict : default Function.classPreferences
-        the `PreferenceSet` for the Function (see `prefs <Function_Base.prefs>` for details).    """
+        the `PreferenceSet` for the Function (see `prefs <Function_Base.prefs>` for details).
+    """
 
     componentName = CONTRASTIVE_HEBBIAN_FUNCTION
 
@@ -1491,7 +1496,8 @@ class Reinforcement(LearningFunction):  # --------------------------------------
         `Mechanism <Mechanism>` to which the Function belongs.
 
     prefs : PreferenceSet or specification dict : default Function.classPreferences
-        the `PreferenceSet` for the Function (see `prefs <Function_Base.prefs>` for details).    """
+        the `PreferenceSet` for the Function (see `prefs <Function_Base.prefs>` for details).
+    """
 
     componentName = RL_FUNCTION
 

--- a/psyneulink/core/components/functions/objectivefunctions.py
+++ b/psyneulink/core/components/functions/objectivefunctions.py
@@ -730,7 +730,8 @@ class Distance(ObjectiveFunction):
         `component <Component>` to which to assign the Function.
 
     prefs : PreferenceSet or specification dict : default Function.classPreferences
-        specifies the `PreferenceSet` for the Function (see `prefs <Function_Base.prefs>` for details).    """
+        specifies the `PreferenceSet` for the Function (see `prefs <Function_Base.prefs>` for details).
+    """
 
     componentName = DISTANCE_FUNCTION
 

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -1788,7 +1788,6 @@ class DualAdaptiveIntegrator(IntegratorFunction):  # ---------------------------
         return value + offset
 
     def reinitialize(self, short=None, long=None, execution_context=NotImplemented):
-
         """
         Effectively begins accumulation over again at the specified utilities.
 

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -328,7 +328,8 @@ class IntegratorFunction(StatefulFunction):  # ---------------------------------
 
     def _EWMA_filter(self, previous_value, rate, variable):
         """Return `exponentially weighted moving average (EWMA)
-        <https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average>`_ of a variable"""
+        <https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average>`_ of a variable.
+        """
         return (1 - rate) * previous_value + rate * variable
 
     def _logistic(self, variable, gain, bias):

--- a/psyneulink/core/components/mechanisms/adaptive/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/control/optimizationcontrolmechanism.py
@@ -842,7 +842,7 @@ class OptimizationControlMechanism(ControlMechanism):
             self._initialize_composition_function_approximator()
 
     def _update_input_states(self, execution_id=None, runtime_params=None, context=None):
-        """ Update value for each InputState in self.input_states:
+        """Update value for each InputState in self.input_states:
 
         Call execute method for all (MappingProjection) Projections in InputState.path_afferents
         Aggregate results (using InputState execute method)

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3000,7 +3000,8 @@ class Mechanism_Base(Mechanism):
 
         def mech_cell():
             """Return html with name of Mechanism, possibly with function and/or value
-            Inclusion of roles, function and/or value is determined by arguments of call to show_structure()"""
+            Inclusion of roles, function and/or value is determined by arguments of call to show_structure()
+            """
             header = ''
             if show_headers:
                 header = mech_header

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3061,7 +3061,6 @@ class Mechanism_Base(Mechanism):
         @tc.typecheck
         def state_table(state_list:ContentAddressableList,
                         state_type:tc.enum(InputState, ParameterState, OutputState)):
-
             """Return html with table for each state in state_list, including functions and/or values as specified
 
             Each table has a header cell and and inner table with cells for each state in the list

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2462,7 +2462,7 @@ class Mechanism_Base(Mechanism):
         self.parameters.previous_value._set(self.parameters.value._get(execution_id), execution_id)
 
     def _update_input_states(self, execution_id=None, runtime_params=None, context=None):
-        """ Update value for each InputState in self.input_states:
+        """Update value for each InputState in self.input_states:
 
         Call execute method for all (MappingProjection) Projections in InputState.path_afferents
         Aggregate results (using InputState execute method)

--- a/psyneulink/core/components/mechanisms/processing/integratormechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/integratormechanism.py
@@ -244,7 +244,8 @@ class IntegratorMechanism(ProcessingMechanism_Base):
     def _handle_default_variable(self, default_variable=None, size=None, input_states=None, function=None, params=None):
         """If any parameters with len>1 have been specified for the Mechanism's function, and Mechanism's
         default_variable has not been specified, reshape Mechanism's variable to match function's,
-        but make sure function's has the same outer dimensionality as the Mechanism's"""
+        but make sure function's has the same outer dimensionality as the Mechanism's
+        """
 
         # Get variable for Mechanism
         user_specified = False

--- a/psyneulink/core/components/process.py
+++ b/psyneulink/core/components/process.py
@@ -2294,10 +2294,9 @@ class Process(Process_Base):
 
     def _execute_learning(self, execution_id=None, target=None, context=None):
 
-        """ Update each LearningProjection for mechanisms in _mechs of process
+        """Update each LearningProjection for mechanisms in _mechs of process
 
         # Begin with Projection(s) to last Mechanism in _mechs, and work backwards
-
         """
 
         # FIRST, assign targets

--- a/psyneulink/core/components/process.py
+++ b/psyneulink/core/components/process.py
@@ -2293,7 +2293,6 @@ class Process(Process_Base):
         # return self.output
 
     def _execute_learning(self, execution_id=None, target=None, context=None):
-
         """Update each LearningProjection for mechanisms in _mechs of process
 
         # Begin with Projection(s) to last Mechanism in _mechs, and work backwards

--- a/psyneulink/core/components/projections/modulatory/controlprojection.py
+++ b/psyneulink/core/components/projections/modulatory/controlprojection.py
@@ -355,7 +355,6 @@ class ControlProjection(ModulatoryProjection_Base):
                                                 **kwargs)
 
     def _instantiate_sender(self, sender, params=None, context=None):
-
         """Check if DefaultController is being assigned and if so configure it for the requested ControlProjection
 
         If self.sender is a Mechanism, re-assign to <Mechanism>.outputState

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -1165,7 +1165,6 @@ def _parse_projection_spec(projection_spec,
                            state_type = None,  # Used only for default assignment
                            # socket=None,
                            **kwargs):
-
     """Return either Projection object or Projection specification dict for projection_spec
 
     All keys in kwargs must be from PROJECTION_ARGS
@@ -1729,7 +1728,6 @@ def _validate_connection_request(
         projection_spec:_is_projection_spec,     # projection specification
         projection_socket:str,                   # socket of Projection to be connected to target state
         connectee_state:tc.optional(type)=None): # State for which connection is being sought
-
     """Validate that a Projection specification is compatible with the State to which a connection is specified
 
     Carries out undirected validation (i.e., without knowing whether the connectee is the sender or receiver).

--- a/psyneulink/core/components/states/outputstate.py
+++ b/psyneulink/core/components/states/outputstate.py
@@ -1697,7 +1697,7 @@ class StandardOutputStates():
     #     return [item[INDEX] for item in self.data]
 
 def _parse_output_state_function(owner, output_state_name, function, params_dict_as_variable=False):
-    """ Parse specification of function as Function, Function class, Function.function, function_type or method_type.
+    """Parse specification of function as Function, Function class, Function.function, function_type or method_type.
 
     If params_dict_as_variable is True, and function is a Function, check whether it allows params_dict as variable;
     if it is and does, leave as is,

--- a/psyneulink/core/components/states/state.py
+++ b/psyneulink/core/components/states/state.py
@@ -2584,7 +2584,6 @@ def _parse_state_spec(state_type=None,
                       prefs=None,
                       context=None,
                       **state_spec):
-
     """Parse State specification and return either State object or State specification dictionary
 
     If state_spec is or resolves to a State object, returns State object.

--- a/psyneulink/core/components/states/state.py
+++ b/psyneulink/core/components/states/state.py
@@ -1173,7 +1173,8 @@ class State_Base(State):
 
     def _handle_size(self, size, variable):
         """Overwrites the parent method in Component.py, because the variable of a State
-            is generally 1D, rather than 2D as in the case of Mechanisms"""
+            is generally 1D, rather than 2D as in the case of Mechanisms
+        """
         if size is not NotImplemented:
 
             def checkAndCastInt(x):

--- a/psyneulink/core/components/system.py
+++ b/psyneulink/core/components/system.py
@@ -516,7 +516,8 @@ kwSystemInputState = 'SystemInputState'
 
 class MonitoredOutputStatesOption(AutoNumber):
     """Specifies OutputStates to be monitored by a `ControlMechanism <ControlMechanism>`
-    (see `ObjectiveMechanism_Monitor` for a more complete description of their meanings."""
+    (see `ObjectiveMechanism_Monitor` for a more complete description of their meanings.
+    """
     ONLY_SPECIFIED_OUTPUT_STATES = ()
     """Only monitor explicitly specified Outputstates."""
     PRIMARY_OUTPUT_STATES = ()

--- a/psyneulink/core/components/system.py
+++ b/psyneulink/core/components/system.py
@@ -4057,7 +4057,7 @@ class System(System_Base):
         def _assign_processing_components(G, sg, rcvr,
                                           processes:tc.optional(list)=None,
                                           subgraphs:tc.optional(dict)=None):
-            """Assign nodes to graph, or subgraph for rcvr in any of the specified **processes** """
+            """Assign nodes to graph, or subgraph for rcvr in any of the specified **processes**."""
 
             from psyneulink.library.components.mechanisms.processing.objective.comparatormechanism import ComparatorMechanism
 
@@ -4540,7 +4540,7 @@ class System(System_Base):
             return True
 
         def _assign_control_components(G, sg, show_prediction_mechanisms):
-            """Assign control nodes and edges to graph, or subgraph for rcvr in any of the specified **processes** """
+            """Assign control nodes and edges to graph, or subgraph for rcvr in any of the specified **processes**."""
 
             controller = self.controller
             if controller in active_items:

--- a/psyneulink/core/components/system.py
+++ b/psyneulink/core/components/system.py
@@ -3096,7 +3096,6 @@ class System(System_Base):
             base_execution_id=None,
             animate=False,
             context=None):
-
         """Run a sequence of executions
 
         Call execute method for each execution in a sequence specified by inputs.  See :doc:`Run` for details of

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -3401,7 +3401,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             self.required_node_roles.remove(node_role_pair)
 
     def _create_CIM_states(self, context=None):
-
         """
             - remove the default InputState and OutputState from the CIMs if this is the first time that real
               InputStates and OutputStates are being added to the CIMs
@@ -5742,7 +5741,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             execution_id=None,
             base_execution_id=None,
             context=None):
-
         """Pass inputs to Composition, then execute sets of nodes that are eligible to run until termination
         conditions are met.  See `Run` for details of formatting input specifications. See `Run` for details of
         formatting input specifications. Use **animate** to generate a gif of the execution sequence.

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -4586,7 +4586,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                    color=proj_color, penwidth=proj_width)
 
         def _assign_controller_components(g):
-            """Assign control nodes and edges to graph """
+            """Assign control nodes and edges to graph"""
 
             controller = self.controller
             if controller is None:

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -3096,7 +3096,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         """Assigns NodeRole.ORIGIN to all nodes in the first entry of the consideration queue and NodeRole.TERMINAL to
             all nodes in the last entry of the consideration queue. The ObjectiveMechanism of a controller
             may not be NodeRole.TERMINAL, so if the ObjectiveMechanism is the only node in the last entry of the
-            consideration queue, then the second-to-last entry is NodeRole.TERMINAL instead. """
+            consideration queue, then the second-to-last entry is NodeRole.TERMINAL instead.
+        """
         for node in q[0]:
             self._add_node_role(node, NodeRole.ORIGIN)
 
@@ -3116,7 +3117,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         :return
 
-        A list of tuples in format (node, composition) containing all nodes of all nested compositions."""
+        A list of tuples in format (node, composition) containing all nodes of all nested compositions.
+        """
         if nested_nodes is NotImplemented:
             nested_nodes=[]
         if root_composition is NotImplemented:
@@ -3141,7 +3143,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         :return
 
-        A list of nested compositions."""
+        A list of nested compositions.
+        """
         if nested_compositions is NotImplemented:
             nested_compositions=[]
         if visited_compositions is NotImplemented:
@@ -3883,7 +3886,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         def mech_string(mech):
             """Return string with name of mechanism possibly with function and/or value
-            Inclusion of role, function and/or value is determined by arguments of call to show_structure """
+            Inclusion of role, function and/or value is determined by arguments of call to show_structure
+            """
             if show_headers:
                 mech_header = mechanism_header
             else:
@@ -6638,7 +6642,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
            `controller <Composition.controller>` in order to return the
            `net_outcome <ControlMechanism.net_outcome>` of the Composition, according to its
            `controller <Composition.controller>` under that control_allocation. All values are
-           reset to pre-simulation values at the end of the simulation. """
+           reset to pre-simulation values at the end of the simulation.
+        """
         # Apply candidate control to signal(s) for the upcoming simulation and determine its cost
         total_cost = self._get_total_cost_of_control_allocation(control_allocation, execution_id, runtime_params, context)
 

--- a/psyneulink/core/compositions/compositionfunctionapproximator.py
+++ b/psyneulink/core/compositions/compositionfunctionapproximator.py
@@ -90,7 +90,8 @@ class CompositionFunctionApproximator(Composition):
 
     def adapt(self, feature_values, control_allocation, net_outcome, execution_id=None, context=None):
         """Adjust parameters of `function <FunctionAppproximator.function>` to improve prediction of `target
-        <FunctionAppproximator.target>` from `input <FunctionAppproximator.input>`."""
+        <FunctionAppproximator.target>` from `input <FunctionAppproximator.input>`.
+        """
         raise CompositionFunctionApproximatorError("Subclass of {} ({}) must implement {} method.".
                                                    format(CompositionFunctionApproximator.__name__,
                                                           self.__class__.__name__, repr('adapt')))

--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -452,7 +452,7 @@ class Context():
 
     @initialization_status.setter
     def initialization_status(self, flag):
-        """Check that a flag is one and only one status flag """
+        """Check that a flag is one and only one status flag"""
         flag &= ContextFlags.INITIALIZATION_MASK
         if flag in INITIALIZATION_STATUS_FLAGS:
             self.flags &= ContextFlags.UNINITIALIZED
@@ -478,7 +478,7 @@ class Context():
 
     @execution_phase.setter
     def execution_phase(self, flag):
-        """Check that a flag is one and only one execution_phase flag """
+        """Check that a flag is one and only one execution_phase flag"""
         if flag in EXECUTION_PHASE_FLAGS:
             # self.flags |= flag
             self.flags &= ContextFlags.IDLE
@@ -501,7 +501,7 @@ class Context():
 
     @source.setter
     def source(self, flag):
-        """Check that a flag is one and only one source flag """
+        """Check that a flag is one and only one source flag"""
         if flag in SOURCE_FLAGS:
             self.flags &= ContextFlags.NONE
             self.flags |= flag

--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -569,7 +569,6 @@ def _get_context(context:tc.any(ContextFlags, str)):
 
 
 def _get_time(component, context_flags, execution_id=None):
-
     """Get time from Scheduler of System in which Component is being executed.
 
     Returns tuple with (run, trial, time_step) if being executed during Processing or Learning

--- a/psyneulink/core/globals/preferences/componentpreferenceset.py
+++ b/psyneulink/core/globals/preferences/componentpreferenceset.py
@@ -116,7 +116,6 @@ def is_pref_set(pref):
 class ComponentPreferenceSet(PreferenceSet):
     # DOCUMENT: FOR EACH pref TO BE ACCESSIBLE DIRECTLY AS AN ATTRIBUTE OF AN OBJECT,
     #           MUST IMPLEMENT IT AS PROPERTY (WITH GETTER AND SETTER METHODS) IN FUNCTION MODULE
-
     """Implement and manage PreferenceSets for Component class hierarchy
 
     Description:

--- a/psyneulink/library/components/mechanisms/adaptive/control/evc/evcauxiliary.py
+++ b/psyneulink/library/components/mechanisms/adaptive/control/evc/evcauxiliary.py
@@ -942,7 +942,7 @@ class PredictionMechanism(IntegratorMechanism):
                 prefs=prefs)
 
     def _execute(self, variable=None, execution_id=None, runtime_params=None, context=None):
-        """Update predicted value on "real" but not simulation runs """
+        """Update predicted value on "real" but not simulation runs"""
 
         if self.parameters.context._get(execution_id).execution_phase == ContextFlags.SIMULATION:
             # Just return current value for simulation runs

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -401,7 +401,8 @@ VECTOR='VECTOR'
 
 def decision_variable_to_array(x):
     """Generate "one-hot" 1d array designating selected action from DDM's scalar decision variable
-    (used to generate value of OutputState for action_selection Mechanism"""
+    (used to generate value of OutputState for action_selection Mechanism
+    """
     if x >= 0:
         return [x,0]
     else:

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -362,7 +362,6 @@ class ContrastiveHebbianError(Exception):
 
 # This is a convenience class that provides list of standard_output_state names in IDE
 class CONTRASTIVE_HEBBIAN_OUTPUT():
-
     """
         .. _ContrastiveHebbianMechanism_Standard_OutputStates:
 

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -1135,7 +1135,6 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
                  name=None,
                  prefs: is_pref_set=None,
                  **kwargs):
-
         """Instantiate ContrastiveHebbianMechanism
         """
 

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1123,7 +1123,7 @@ class RecurrentTransferMechanism(TransferMechanism):
         # FIX: validate learning_function and learning_rate here (use Hebbian as template for learning_rate
 
     def _instantiate_attributes_before_function(self, function=None, context=None):
-        """ using the `matrix` argument the user passed in (which is now stored in function_params), instantiate
+        """using the `matrix` argument the user passed in (which is now stored in function_params), instantiate
         ParameterStates for auto and hetero if they haven't already been instantiated. This is useful if auto and
         hetero were None in the initialization call.
         :param function:

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -239,7 +239,6 @@ class RecurrentTransferError(Exception):
 
 # This is a convenience class that provides list of standard_output_state names in IDE
 class RECURRENT_OUTPUT():
-
     """
         .. _RecurrentTransferMechanism_Standard_OutputStates:
 

--- a/psyneulink/library/compositions/gymforagercfa.py
+++ b/psyneulink/library/compositions/gymforagercfa.py
@@ -126,7 +126,8 @@ class GymForagerCFA(CompositionFunctionApproximator):
 
     def adapt(self, feature_values, control_allocation, net_outcome, execution_id=None):
         """Update `regression_weights <RegressorCFA.regression_weights>` so as to improve prediction of
-        **net_outcome** from **feature_values** and **control_allocation**."""
+        **net_outcome** from **feature_values** and **control_allocation**.
+        """
         prediction_vector = self.parameters.prediction_vector._get(execution_id)
         previous_state = self.parameters.previous_state._get(execution_id)
 

--- a/psyneulink/library/compositions/regressioncfa.py
+++ b/psyneulink/library/compositions/regressioncfa.py
@@ -283,7 +283,8 @@ class RegressionCFA(CompositionFunctionApproximator):
 
     def adapt(self, feature_values, control_allocation, net_outcome, execution_id=None):
         """Update `regression_weights <RegressorCFA.regression_weights>` so as to improve prediction of
-        **net_outcome** from **feature_values** and **control_allocation**."""
+        **net_outcome** from **feature_values** and **control_allocation**.
+        """
         prediction_vector = self.parameters.prediction_vector._get(execution_id)
         previous_state = self.parameters.previous_state._get(execution_id)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ pytest_plugins = ['pytest_profiling', 'helpers_namespace', 'benchmark']
 
 xfail_strict = True
 
-docstyle_add_ignore = D100 D101 D102 D103 D104 D105 D106 D107 D200 D201 D202 D204 D205 D207 D208 D211 D301 D400 D401 D402 D403 D412 D413 D414
+docstyle_add_ignore = D100 D101 D102 D103 D104 D105 D106 D107 D200 D201 D202 D204 D205 D207 D208 D301 D400 D401 D402 D403 D412 D413 D414
 docstyle_exclude = __init__.py
 
 [coverage:run]

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ pytest_plugins = ['pytest_profiling', 'helpers_namespace', 'benchmark']
 
 xfail_strict = True
 
-docstyle_add_ignore = D100 D101 D102 D103 D104 D105 D106 D107 D200 D201 D202 D204 D205 D207 D208 D301 D400 D401 D402 D403 D412 D413 D414
+docstyle_add_ignore = D100 D101 D102 D103 D104 D105 D106 D107 D200 D202 D204 D205 D207 D208 D301 D400 D401 D402 D403 D412 D413 D414
 docstyle_exclude = __init__.py
 
 [coverage:run]

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ pytest_plugins = ['pytest_profiling', 'helpers_namespace', 'benchmark']
 
 xfail_strict = True
 
-docstyle_add_ignore = D100 D101 D102 D103 D104 D105 D106 D107 D200 D201 D202 D204 D205 D207 D208 D210 D211 D301 D400 D401 D402 D403 D412 D413 D414
+docstyle_add_ignore = D100 D101 D102 D103 D104 D105 D106 D107 D200 D201 D202 D204 D205 D207 D208 D211 D301 D400 D401 D402 D403 D412 D413 D414
 docstyle_exclude = __init__.py
 
 [coverage:run]

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ pytest_plugins = ['pytest_profiling', 'helpers_namespace', 'benchmark']
 
 xfail_strict = True
 
-docstyle_add_ignore = D100 D101 D102 D103 D104 D105 D106 D107 D200 D201 D202 D204 D205 D207 D208 D209 D210 D211 D301 D400 D401 D402 D403 D412 D413 D414
+docstyle_add_ignore = D100 D101 D102 D103 D104 D105 D106 D107 D200 D201 D202 D204 D205 D207 D208 D210 D211 D301 D400 D401 D402 D403 D412 D413 D414
 docstyle_exclude = __init__.py
 
 [coverage:run]


### PR DESCRIPTION
Fix and enable few docstring style guidelines. These were followed in most places and needed only a few changes;
D201	No blank lines allowed before function docstring
D209	Multi-line docstring closing quotes should be on a separate line
D210	No whitespaces allowed surrounding docstring text
D211	No blank lines allowed before class docstring