### PR TITLE
appveyor: Remove pytorch version restriction

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,10 +20,8 @@ environment:
     EXTRA_ARGS: -m llvm
   - PYTHON: Python36
     ARCH: -x64
-    PYTORCH: 1.0.1-cp36-cp36m
   - PYTHON: Python37
     ARCH: -x64
-    PYTORCH: 1.0.1-cp37-cp37m
 
 install:
   - if not exist graphviz-2.38.msi appveyor-retry curl https://graphviz.gitlab.io/_pages/Download/windows/graphviz-2.38.msi -o graphviz-2.38.msi
@@ -37,11 +35,8 @@ install:
   - pip install --user git+https://github.com/benureau/leabra.git@master
 
   # pytorch does not distribute windows packages over pypi.
-  # Install it directly.
-  - if not "%PYTORCH%" == "" pip install --user http://download.pytorch.org/whl/cpu/torch-%PYTORCH%-win_amd64.whl
-
-  # Remove pytorch from requirements if none is available
-  - if "%PYTORCH%" == "" (findstr /V torch < dev_requirements.txt > tmp_req && move /Y tmp_req dev_requirements.txt)
+  # Install it directly, or remove from requirements if not available (win32).
+  - if "%ARCH%" == "" (findstr /V torch < dev_requirements.txt > tmp_req && move /Y tmp_req dev_requirements.txt) else (pip install --user torch -f https://download.pytorch.org/whl/cpu/torch_stable.html)
 
   - pip install --user -e .[dev]
 


### PR DESCRIPTION
pytorch 1.2 works ok on windows with numpy <1.16.
Use ARCH env var to decide if pytorch is avialable.

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>