### PR TITLE
Docs Styling

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,0 +1,12 @@
+/*
+Sets bottom-margin size for list elements in the main body of the document to 12px.
+
+Because Sphinx includes the table of contents in the main section, we then reset just the list elements
+in that section to 0px.
+ */
+.main li{
+    margin-bottom: 12px;
+}
+.toctree-wrapper li{
+    margin-bottom: 0px;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -168,7 +168,7 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
-
+html_css_files = ['css/custom.css']
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -99,7 +99,7 @@ user once the component is constructed, with the one exception of `prefs <Compon
         my_component = SomeComponent(function=SomeFunction)
 
       This will create a default instance of the specified subclass, using default values for its parameters.
-    |
+
     * **Function** - this can be either an existing `Function <Function>` object or the constructor for one, as in the
       following examples::
 

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -109,7 +109,7 @@ Projection in context:
         MappingProjections, a `matrix specification <Mapping_Matrix_Specification>` can also be used to specify the
         projection (see **value** below).
       COMMENT:
-      |
+
       * *LEARNING_PROJECTION*  (or *LEARNING*) -- this can only be used in the specification of a `MappingProjection`
         (see `tuple <Mapping_Matrix_Specification>` format).  If the `receiver <MappingProjection.receiver>` of the
         MappingProjection projects to a `LearningMechanism` or a `ComparatorMechanism` that projects to one, then a
@@ -118,7 +118,7 @@ Projection in context:
         <LearningMechanism_Creation>`, along with a LearningSignal that is assigned as the LearningProjection's `sender
         <LearningProjection.sender>`. See `LearningMechanism_Learning_Configurations` for additional details.
       COMMENT
-      |
+
       * *CONTROL_PROJECTION* (or *CONTROL*) -- this can be used when specifying a parameter using the `tuple format
         <ParameterState_Tuple_Specification>`, to create a default `ControlProjection` to the `ParameterState` for that
         parameter.  If the `Component <Component>` to which the parameter belongs is part of a `System`, then a
@@ -128,7 +128,7 @@ Projection in context:
         at which time the ControlSignal is added to the System's `controller <System.controller>` and assigned
         as its the ControlProjection's `sender <ControlProjection.sender>`.  See `ControlMechanism_Control_Signals` for
         additional details.
-      |
+
       * *GATING_PROJECTION* (or *GATING*) -- this can be used when specifying an `InputState
         <InputState_Projection_Source_Specification>` or an `OutputState <OutputState_Projections>`, to create a
         default `GatingProjection` to the `State <State>`. If the GatingProjection's `sender <GatingProjection.sender>`
@@ -160,7 +160,7 @@ Projection in context:
         (for example, a `MappingProjection` for an `InputState`, a `LearningProjection` for the `matrix
         <MappingProjection.matrix>` parameter of a `MappingProjection`, and a `ControlProjection` for any other
         type of parameter.
-      |
+
       * *PROJECTION_PARAMS*: *Dict[Projection argument, argument value]* --
         the key for each entry of the dictionary must be the name of a Projection parameter, and its value the value
         of the parameter.  It can contain any of the standard parameters for instantiating a Projection (in particular
@@ -189,13 +189,13 @@ Projection in context:
 
      * **State specification** -- specifies the `State <State_Specification>` to connect with (**not** the one being
        connected; that is determined from context)
-     |
+
      * **weight** -- must be a value specifying the `weight <Projection_Base.weight>` of the Projection;  it can be
        `None`, in which case it is ignored, but there must be a specification present;
-     |
+
      * **exponent** -- must be a value specifying the `exponent <Projection_Base.exponent>` of the Projection;  it
        can be `None`, in which case it is ignored, but there must be a specification present;
-     |
+
      * **Projection specification** -- this is optional but, if included, msut be a `Projection specification
        <Projection_Specification>`;  it can take any of the forms of a Projection specification described above for
        any Projection subclass; it can be used to provide additional specifications for the Projection, such as its

--- a/psyneulink/core/components/states/inputstate.py
+++ b/psyneulink/core/components/states/inputstate.py
@@ -205,7 +205,7 @@ should project to the InputState. Each of these is described below:
           the value must be an integer or float, and is assigned as the value of the InputState's `weight
           <InputState.weight>` attribute (see `weight and exponent <InputState_Weights_And_Exponents>`);
           this takes precedence over any specification in the **weight** argument of the InputState's constructor.
-      |
+
       * *EXPONENT*:<number>
           the value must be an integer or float, and is assigned as the value of the InputState's `exponent
           <InputState.exponent>` attribute (see `weight and exponent <InputState_Weights_And_Exponents>`);
@@ -257,10 +257,10 @@ should project to the InputState. Each of these is described below:
           `OutputState` or `ModulatorySignal`, or a list of such names, and the 2nd item must be the Mechanism to
           which they all belong.  Projections of the relevant types are created for each of the specified States
           (see `State 2-item tuple <State_2_Item_Tuple>` for additional details).
-        |
+
         * **2-item tuple:** *(<value, State specification, or list of State specs>, <Projection specification>)* --
           this is a contracted form of the 4-item tuple described below;
-        |
+
         * **4-item tuple:** *(<value, State spec, or list of State specs>, weight, exponent, Projection specification)*
           -- this allows the specification of State(s) that should project to the InputState, together with a
           specification of the InputState's `weight <InputState.weight>` and/or `exponent <InputState.exponent>`
@@ -269,23 +269,23 @@ should project to the InputState. Each of these is described below:
           (e.g., using the matrix of the Projection specification) and/or attributes of the Projection(s) to it. Each
           tuple must have at least the following first three items (in the order listed), and can include the fourth:
 
-            |
+
             * **value, State specification, or list of State specifications** -- specifies either the `variable
               <InputState.variable>` of the InputState, or one or more States that should project to it.  The State
               specification(s) can be a (State name, Mechanism) tuple (see above), and/or include Mechanisms (in which
               case their `primary OutputState <OutputStatePrimary>` is used.  All of the State specifications must be
               consistent with (that is, their `value <State_Base.value>` must be compatible with the `variable
               <Projection_Base.variable>` of) the Projection specified in the fourth item if that is included;
-            |
+
             * **weight** -- must be an integer or a float; multiplies the `value <InputState.value>` of the InputState
               before it is combined with others by the Mechanism's `function <Mechanism.function>` (see
               ObjectiveMechanism for `examples <ObjectiveMechanism_Weights_and_Exponents_Example>`);
-            |
+
             * **exponent** -- must be an integer or float; exponentiates the `value <InputState.value>` of the
               InputState before it is combined with others by the ObjectiveMechanism's `function
               <ObjectiveMechanism.function>` (see ObjectiveMechanism for `examples
               <ObjectiveMechanism_Weights_and_Exponents_Example>`);
-            |
+
             * **Projection specification** (optional) -- `specifies a Projection <Projection_Specification>` that
               must be compatible with the State specification(s) in the 1st item; if there is more than one State
               specified, and the Projection specification is used, all of the States
@@ -301,12 +301,12 @@ should project to the InputState. Each of these is described below:
       * *InputState or [InputState, ...]* -- each InputState must belong to an existing Mechanism; creates a new
         InputState for each one specified, along with Projections to it that parallel those of the one specified
         (see below).
-      |
+
       * *{SHADOW_INPUTS: <InputState or Mechanism or [<InputState or Mechanism>,...]>}* -- any InputStates specified
         must belong to an existing Mechanism;  creates a new InputState for each one specified, and for each of the
         InputStates belonging to any Mechanisms specified, along with Projections to them that parallel those of the
         one(s) specified (see below).
-      |
+
       For each InputState specified, and all of the InputStates belonging to any Mechanisms specified, a new InputState
       is created along with Projections to it that parallel those received by the corresponding InputState in the
       list.  In other words, for each InputState specified, a new one is created that receives exactly the same inputs
@@ -352,11 +352,11 @@ starting with constraints that are given the highest precedence:
 
     * **More than one Component is specified with the same :ref:`value` format** -- that format is used to determine
       the format of the InputState's `variable <InputState.variable>`.
-    |
+
     * **More than one Component is specified with different :ref:`value` formats** -- the InputState's `variable
       <InputState.variable>` is determined by item of the default `variable <Mechanism_Base.variable>` for
       the class of its owner Mechanism.
-    |
+
     * **A single Component is specified** -- its :ref:`value` is used to determine the format of the InputState's
       `variable <InputState.variable>`;  if the Component is a(n):
 
@@ -366,10 +366,10 @@ starting with constraints that are given the highest precedence:
           <InputState.variable>` and the Projection's `value <Projection_Base.value>` (since the Projection's
           `sender <Projection_Base.sender>` is unspecified, its `initialization is deferred
           <Projection_Deferred_Initialization>`.
-        |
+
         * **Existing MappingProjection** -- then its `value <Projection_Base.value>` determines the
           InputState's `variable <InputState.variable>`.
-        |
+
         * `Matrix specification <Mapping_Matrix_Specification>` -- its receiver dimensionality determines the format
           of the InputState's `variable <InputState.variable>`. For a standard 2d "weight" matrix (i.e., one that maps
           a 1d array from its `sender <Projection_Base.sender>` to a 1d array of its `receiver
@@ -378,14 +378,14 @@ starting with constraints that are given the highest precedence:
           dimensionality of the receiver (used for the InputState's `variable <InputState.variable>`) is the
           dimensionality of the matrix minus the dimensionality of the sender's `value <OutputState.value>`
           (see `matrix dimensionality <Mapping_Matrix_Dimensionality>`).
-      |
+
       * **OutputState or ProcessingMechanism** -- the `value <OutputState.value>` of the OutputState (if it is a
         Mechanism, then its `primary OutputState <OutputState_Primary>`) determines the format of the InputState's
         `variable <InputState.variable>`, and a MappingProjection is created from the OutputState to the InputState
         using an `IDENTITY_MATRIX`.  If the InputState's `variable <InputState.variable>` is constrained (as in some
         of the cases above), then a `FULL_CONNECTIVITY_MATRIX` is used which maps the shape of the OutputState's `value
         <OutputState.value>` to that of the InputState's `variable <InputState.variable>`.
-      |
+
       * **GatingProjection, GatingSignal or GatingMechanism** -- any of these can be used to specify an InputState;
         their `value` does not need to be compatible with the InputState's `variable <InputState.variable>`, however
         it does have to be compatible with the `modulatory parameter <Function_Modulatory_Params>` of the InputState's

--- a/psyneulink/core/components/states/outputstate.py
+++ b/psyneulink/core/components/states/outputstate.py
@@ -176,12 +176,12 @@ which it should project. Each of these is described below:
         as the input to the OutputState's `function <OutputState.function>` (see `OutputState_Customization`); this
         must be compatible (in the number and format of the items it specifies) with the OutputState's `function
         <OutputState.function>`.
-      |
+
       * *FUNCTION*:<`Function <Function>`, function or method> - specifies the function used to transform and/or
         combine the item(s) specified for the OutputState's `variable <OutputState.variable>` into its
         `value <OutputState.value>`;  its input must be compatible (in the number and format of elements) with the
         specification of the OutputState's `variable <OutputState.variable>` (see `OutputState_Customization`).
-      |
+
       * *PROJECTIONS* or *MECHANISMS*:<list of `Projections <Projection>` and/or `Mechanisms <Mechanism>`> - specifies
         one or more efferent `MappingProjections <MappingProjection>` from the OutputState, Mechanims that should
         receive them, and/or `ModulatoryProjections <ModulatoryProjection>` for it to receive;  this may be constrained
@@ -197,7 +197,7 @@ which it should project. Each of these is described below:
         Mechanism's `value <Mechanism_Base.value>` to be used for the OutputState's `variable <OutputState.variable>`;
         equivalent to specifying (OWNER_VALUE, <int>) for *VARIABLE* (see `OutputState_Customization`), which should be
         used for compatibility with future versions.
-      |
+
       * *ASSIGN*:<function> *[DEPRECATED in version 0.4.5]* - specifies the OutputState's `function`
         <OutputState.assign>` attribute;  *FUNCTION* should be used for compatibility with future versions.
 
@@ -261,10 +261,10 @@ which it should project. Each of these is described below:
           `InputState` or `ModulatorySignal`, or a list of such names, and the 2nd item must be the Mechanism to
           which they all belong.  Projections of the relevant types are created for each of the specified States
           (see `State 2-item tuple <State_2_Item_Tuple>` for additional details).
-        |
+
         * **2-item tuple:** *(<State, Mechanism, or list of them>, <Projection specification>)* -- this is a contracted
           form of the 3-item tuple described below
-        |
+
         * **3-item tuple:** *(<value, State spec, or list of State specs>, variable spec, Projection specification)* --
           this allows the specification of State(s) to which the OutputState should project, together with a
           specification of its `variable <OutputState.variable>` attribute, and (optionally) parameters of the
@@ -278,10 +278,10 @@ which it should project. Each of these is described below:
               case their `primary InputState <InputStatePrimary>` is used.  All of the State specifications must be
               consistent with (that is, their `value <State_Base.value>` must be compatible with the `variable
               <Projection_Base.variable>` of) the Projection specified in the fourth item if that is included.
-            |
+
             * **variable spec** -- specifies the attributes of the OutputState's `owner <OutputState.owner>` Mechanism
               used for its `variable <OutputState.variable>` (see `OutputState_Customization`).
-            |
+
             * **Projection specification** (optional) -- `specifies a Projection <Projection_Specification>` that
               must be compatible with the State specification(s) in the 1st item; if there is more than one
               State specified, and the Projection specification is used, all of the States
@@ -328,12 +328,12 @@ below, starting with constraints that are given the highest precedence:
     `specified to project to any other Components <OutputState_Projection_Destination_Specification>`, then if the
     Component is a:
 
-    |
+
     * **InputState or Mechanism** (for which its `primary InputState <InputState_Primary>` is used) -- if its
       `variable <State_Base.variable>` matches the format of the OutputState's `value <OutputState.value>`, a
       `MappingProjection` is created using an `IDENTITY_MATRIX`;  otherwise, a `FULL_CONNECTIVITY_MATRIX` is used
       that maps the OutputState's `value <OutputState.value>` to the InputState's `variable <State_Base.variable>`.
-    |
+
     * **MappingProjection** -- if its `matrix <MappingProjection.matrix>` is specified, then the `sender dimensionality
       <Mapping_Matrix_Dimensionality>` of the matrix must be the same as that of the OutputState's `value
       <OutputState.value>`; if its `receiver <MappingProjection.receiver>` is specified, but not its `matrix
@@ -341,7 +341,7 @@ below, starting with constraints that are given the highest precedence:
       receiver (as described just above);  if neither its `matrix <MappingProjection.matrix>` or its `receiver
       <MappingProjection.receiver>` are specified, then the Projection's `initialization is deferred
       <MappingProjection_Deferred_Initialization>` until its `receiver <MappingProjection.receiver>` is specified.
-    |
+
     * **GatingProjection, GatingSignal or GatingMechanism** -- any of these can be used to specify an OutputState;
       their `value` does not need to be compatible with the OutputState's `variable <InputState.variable>` or
       `value <OutputState.value>`, however it does have to be compatible with the `modulatory parameter

--- a/psyneulink/core/components/system.py
+++ b/psyneulink/core/components/system.py
@@ -83,14 +83,14 @@ arguments of the `System`, as described below.
     Mechanisms within the System. If an OutputState of a particular Mechanism is desired, and it shares its name with
     other Mechanisms in the System, then it must be referenced explicitly (see `InputState specification
     <InputState_Specification>`, and examples under `System_Control_Examples`).
-  |
+
   * **MonitoredOutputStatesOption** -- must be a value of `MonitoredOutputStatesOption`, and must appear alone or as a
     single item in the list specifying the **monitor_for_control** argument;  any other specification(s) included in
     the list will take precedence.  The MonitoredOutputStatesOption applies to all of the Mechanisms in the System
     except its `controller <System.controller>` and `LearningMechanisms <LearningMechanism>`. The
     *PRIMARY_OUTPUT_STATES* value specifies that the `primary OutputState <OutputState_Primary>` of every Mechanism be
     monitored, whereas *ALL_OUTPUT_STATES* specifies that *every* OutputState of every Mechanism be monitored.
-  |
+
   The default for the **monitor_for_control** argument is *MonitoredOutputStatesOption.PRIMARY_OUTPUT_STATES*.
   The OutputStates specified in the **monitor_for_control** argument are added to any already specified for the
   ControlMechanism's `objective_mechanism <ControlMechanism.objective_mechanism>`, and the full set is listed in

--- a/psyneulink/core/globals/log.py
+++ b/psyneulink/core/globals/log.py
@@ -89,21 +89,21 @@ the Logs of their `States <State>`.  Specifically the Logs of these Components c
 * **Mechanisms**
 
   * *value* -- the `value <Mechanism_Base.value>` of the Mechanism.
-  |
+
   * *InputStates* -- the `value <InputState.value>` of any `InputState` (listed in the Mechanism's `input_states
     <Mechanism_Base.input_states>` attribute).
-  |
+
   * *ParameterStates* -- the `value <ParameterState.value>` of `ParameterState` (listed in the Mechanism's
     `parameter_states <Mechanism_Base.parameter_states>` attribute);  this includes all of the `user configurable
     <Component_User_Params>` parameters of the Mechanism and its `function <Mechanism_Base.function>`.
-  |
+
   * *OutputStates* -- the `value <OutputState.value>` of any `OutputState` (listed in the Mechanism's `output_states
     <Mechanism_Base.output_states>` attribute).
 ..
 * **Projections**
 
   * *value* -- the `value <Projection_Base.value>` of the Projection.
-  |
+
   * *matrix* -- the value of the `matrix <MappingProjection.matrix>` parameter (for `MappingProjections
     <MappingProjection>` only).
 

--- a/psyneulink/library/components/mechanisms/adaptive/control/evc/evccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/adaptive/control/evc/evccontrolmechanism.py
@@ -241,7 +241,7 @@ greatest EVC value. The following steps are used to calculate the EVC for each `
     `objective_mechanism`, which provides the result to the EVCControlMechanism.  If `system
     <EVCControlMechanism.system>`\\.recordSimulationPref is `True`, the results of each simulation are appended to the
     `simulation_results <System.simulation_results>` attribute of `system <EVCControlMechanism.system>`.
-  |
+
   * **Evaluate the System's performance** - this is carried out by the EVCControlMechanism's `objective_mechanism
     <EVCControlMechanism.objective_mechanism>`, which is executed as part of the simulation of the System.  The
     `function <ObjectiveMechanism.function>` for a default ObjectiveMechanism is a `LinearCombination` Function that
@@ -250,15 +250,15 @@ greatest EVC value. The following steps are used to calculate the EVC for each `
     <EVCControlMechanism.objective_mechanism>`'s `monitored_output_states <ObjectiveMechanism.monitored_output_states>`
     attribute) by taking their elementwise (Hadamard) product.  However, this behavior can be customized in a variety
     of ways, as described `above <EVCControlMechanism_ObjectiveMechanism>`.
-  |
+
   * **Calculate EVC** - call the EVCControlMechanism's `value_function <EVCControlMechanism.value_function>` passing it
     the outcome (received from the `objective_mechanism`) and a list of the `costs <ControlSignal.cost>` \\s of its
     `ControlSignals <EVCControlMechanism_ControlSignals>`.  The default `value_function
     <EVCControlMechanism.value_function>` calls two additional auxiliary functions, in the following order:
-    |
+
     - `cost_function <EVCControlMechanism.cost_function>`, which sums the costs;  this can be configured to weight
       and/or exponentiate individual costs (see `cost_function <EVCControlMechanism.cost_function>` attribute);
-    |
+
     - `combine_outcome_and_cost_function <EVCControlMechanism.combine_outcome_and_cost_function>`, which subtracts the
       sum of the costs from the outcome to generate the EVC;  this too can be configured (see
       `combine_outcome_and_cost_function <EVCControlMechanism.combine_outcome_and_cost_function>`).

--- a/psyneulink/library/components/mechanisms/processing/transfer/kwtamechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kwtamechanism.py
@@ -146,13 +146,13 @@ When a KTWA is executed, it first determines its `variable <KWTAMechanism.variab
   - calculate the scope of offsets that will satisfy the constraint; how this is done is determined by the
     `average_based <KWTAMechanism.average_based>` attribute (see `above
     <KWTAMechanism_average_based>`);
-  |
+
   - select an offset from the scope based on the `ratio <KWTAMechanism.ratio>` option (see `above
     <KWTAMechanism_ratio>`);
-  |
+
   - constrain the offset to be 0 or negative if the `inhibition_only <KWTAMechanism.inhibition_only>` option
     is set (see `above <KWTAMechanism_inhibition_only>`;
-  |
+
   - apply the offset to all elements of the `variable <KWTAMechanism.variable>`.
 ..
 The modified `variable <KWTAMechanism.variable>` is then passed to the KWTAMechanism's `function


### PR DESCRIPTION
-Added custom css file to Sphinx configuration
-Added default bottom-margin of 12px for html list items in docs
-Removed manually entered linebreaks from lists in docstrings