### PR TITLE
Bug fix - AutodiffComposition num_trials default value

### DIFF
--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -827,7 +827,7 @@ class AutodiffComposition(Composition):
         scheduler_processing=None,
         termination_processing=None,
         execution_id=None,
-        num_trials=1,
+        num_trials=None,
         call_before_time_step=None,
         call_after_time_step=None,
         call_before_pass=None,


### PR DESCRIPTION
Changed default value of num_trials from 1 to None for AutodiffComposition. Previous default caused autodiff comps to run only once in any situation where num_trials was not explicitly provided.