### PR TITLE
Remove context Parameter

### DIFF
--- a/psyneulink/core/components/functions/combinationfunctions.py
+++ b/psyneulink/core/components/functions/combinationfunctions.py
@@ -809,7 +809,7 @@ class Reduce(CombinationFunction):  # ------------------------------------------
         if WEIGHTS in target_set and target_set[WEIGHTS] is not None:
             self._validate_parameter_spec(target_set[WEIGHTS], WEIGHTS, numeric_only=True)
             target_set[WEIGHTS] = np.atleast_1d(target_set[WEIGHTS])
-            if self.context.execution_phase & (ContextFlags.EXECUTING | ContextFlags.LEARNING):
+            if context.execution_phase & (ContextFlags.EXECUTING | ContextFlags.LEARNING):
                 if len(target_set[WEIGHTS]) != len(self.defaults.variable):
                     raise FunctionError("Number of weights ({0}) is not equal to number of elements in variable ({1})".
                                         format(len(target_set[WEIGHTS]), len(self.defaults.variable)))
@@ -817,7 +817,7 @@ class Reduce(CombinationFunction):  # ------------------------------------------
         if EXPONENTS in target_set and target_set[EXPONENTS] is not None:
             self._validate_parameter_spec(target_set[EXPONENTS], EXPONENTS, numeric_only=True)
             target_set[EXPONENTS] = np.atleast_1d(target_set[EXPONENTS])
-            if self.context.execution_phase & (ContextFlags.EXECUTING | ContextFlags.LEARNING):
+            if context.execution_phase & (ContextFlags.EXECUTING | ContextFlags.LEARNING):
                 if len(target_set[EXPONENTS]) != len(self.defaults.variable):
                     raise FunctionError("Number of exponents ({0}) does not equal number of elements in variable ({1})".
                                         format(len(target_set[EXPONENTS]), len(self.defaults.variable)))
@@ -1207,14 +1207,14 @@ class LinearCombination(
 
         if WEIGHTS in target_set and target_set[WEIGHTS] is not None:
             self._validate_parameter_spec(target_set[WEIGHTS], WEIGHTS, numeric_only=True)
-            if self.context.execution_phase & (ContextFlags.EXECUTING | ContextFlags.LEARNING):
+            if context.execution_phase & (ContextFlags.EXECUTING | ContextFlags.LEARNING):
                 if np.array(target_set[WEIGHTS]).shape != self.defaults.variable.shape:
                     raise FunctionError("Number of weights ({0}) is not equal to number of items in variable ({1})".
                                         format(len(target_set[WEIGHTS]), len(self.defaults.variable)))
 
         if EXPONENTS in target_set and target_set[EXPONENTS] is not None:
             self._validate_parameter_spec(target_set[EXPONENTS], EXPONENTS, numeric_only=True)
-            if self.context.execution_phase & (ContextFlags.PROCESSING | ContextFlags.LEARNING):
+            if context.execution_phase & (ContextFlags.PROCESSING | ContextFlags.LEARNING):
                 if np.array(target_set[EXPONENTS]).shape != self.defaults.variable.shape:
                     raise FunctionError("Number of exponents ({0}) does not equal number of items in variable ({1})".
                                         format(len(target_set[EXPONENTS]), len(self.defaults.variable)))
@@ -1230,7 +1230,7 @@ class LinearCombination(
                                     format(SCALE, self.name, scale))
             scale_is_a_scalar = isinstance(scale, numbers.Number) or (len(scale) == 1) and isinstance(scale[0],
                                                                                                       numbers.Number)
-            if self.context.execution_phase & (ContextFlags.PROCESSING | ContextFlags.LEARNING):
+            if context.execution_phase & (ContextFlags.PROCESSING | ContextFlags.LEARNING):
                 if not scale_is_a_scalar:
                     err_msg = "Scale is using Hadamard modulation but its shape and/or size (scale shape: {}, size:{})" \
                               " do not match the variable being modulated (variable shape: {}, size: {})". \
@@ -1253,7 +1253,7 @@ class LinearCombination(
                                     format(OFFSET, self.name, offset))
             offset_is_a_scalar = isinstance(offset, numbers.Number) or (len(offset) == 1) and isinstance(offset[0],
                                                                                                          numbers.Number)
-            if self.context.execution_phase & (ContextFlags.PROCESSING | ContextFlags.LEARNING):
+            if context.execution_phase & (ContextFlags.PROCESSING | ContextFlags.LEARNING):
                 if not offset_is_a_scalar:
                     err_msg = "Offset is using Hadamard modulation but its shape and/or size (offset shape: {}, size:{})" \
                               " do not match the variable being modulated (variable shape: {}, size: {})". \
@@ -1791,14 +1791,14 @@ class CombineMeans(CombinationFunction):  # ------------------------------------
 
         if WEIGHTS in target_set and target_set[WEIGHTS] is not None:
             target_set[WEIGHTS] = np.atleast_2d(target_set[WEIGHTS]).reshape(-1, 1)
-            if self.context.execution_phase & (ContextFlags.PROCESSING | ContextFlags.LEARNING):
+            if context.execution_phase & (ContextFlags.PROCESSING | ContextFlags.LEARNING):
                 if len(target_set[WEIGHTS]) != len(self.defaults.variable):
                     raise FunctionError("Number of weights ({0}) is not equal to number of items in variable ({1})".
                                         format(len(target_set[WEIGHTS]), len(self.defaults.variable.shape)))
 
         if EXPONENTS in target_set and target_set[EXPONENTS] is not None:
             target_set[EXPONENTS] = np.atleast_2d(target_set[EXPONENTS]).reshape(-1, 1)
-            if self.context.execution_phase & (ContextFlags.PROCESSING | ContextFlags.LEARNING):
+            if context.execution_phase & (ContextFlags.PROCESSING | ContextFlags.LEARNING):
                 if len(target_set[EXPONENTS]) != len(self.defaults.variable):
                     raise FunctionError("Number of exponents ({0}) does not equal number of items in variable ({1})".
                                         format(len(target_set[EXPONENTS]), len(self.defaults.variable.shape)))
@@ -1812,7 +1812,7 @@ class CombineMeans(CombinationFunction):  # ------------------------------------
             else:
                 raise FunctionError("{} param of {} ({}) must be a scalar or an np.ndarray".
                                     format(SCALE, self.name, scale))
-            if self.context.execution_phase & (ContextFlags.PROCESSING | ContextFlags.LEARNING):
+            if context.execution_phase & (ContextFlags.PROCESSING | ContextFlags.LEARNING):
                 if (isinstance(scale, np.ndarray) and
                         (scale.size != self.defaults.variable.size or
                                  scale.shape != self.defaults.variable.shape)):
@@ -1831,7 +1831,7 @@ class CombineMeans(CombinationFunction):  # ------------------------------------
             else:
                 raise FunctionError("{} param of {} ({}) must be a scalar or an np.ndarray".
                                     format(OFFSET, self.name, offset))
-            if self.context.execution_phase & (ContextFlags.PROCESSING | ContextFlags.LEARNING):
+            if context.execution_phase & (ContextFlags.PROCESSING | ContextFlags.LEARNING):
                 if (isinstance(offset, np.ndarray) and
                         (offset.size != self.defaults.variable.size or
                                  offset.shape != self.defaults.variable.shape)):
@@ -2083,7 +2083,7 @@ class PredictionErrorDeltaFunction(CombinationFunction):
         if WEIGHTS in target_set and target_set[WEIGHTS] is not None:
             self._validate_parameter_spec(target_set[WEIGHTS], WEIGHTS, numeric_only=True)
             target_set[WEIGHTS] = np.atleast_2d(target_set[WEIGHTS]).reshape(-1, 1)
-            if self.context.execution_phase & (ContextFlags.EXECUTING):
+            if context.execution_phase & (ContextFlags.EXECUTING):
                 if len(target_set[WEIGHTS]) != len(
                         self.defaults.variable):
                     raise FunctionError("Number of weights {} is not equal to "

--- a/psyneulink/core/components/functions/combinationfunctions.py
+++ b/psyneulink/core/components/functions/combinationfunctions.py
@@ -81,10 +81,10 @@ class CombinationFunction(Function_Base):
 
     # IMPLEMENTATION NOTE: THESE SHOULD SHOULD BE REPLACED WITH ABC WHEN IMPLEMENTED
     def __init__(self, default_variable,
-                 params,
-                 owner,
-                 prefs,
-                 context):
+                 params=None,
+                 owner=None,
+                 prefs=None,
+                 context=None):
 
         if not hasattr(self, MULTIPLICATIVE_PARAM):
             raise FunctionError("PROGRAM ERROR: {} must implement a {} attribute".
@@ -236,7 +236,7 @@ class Concatenate(CombinationFunction):  # -------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _validate_variable(self, variable, context=None):
         """Insure that list or array is 1d and that all elements are numeric
@@ -462,7 +462,7 @@ class Rearrange(CombinationFunction):  # ---------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _handle_default_variable(self, default_variable=None, size=None, input_states=None, function=None, params=None):
         if default_variable is not None:
@@ -776,7 +776,7 @@ class Reduce(CombinationFunction):  # ------------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _validate_variable(self, variable, context=None):
         """Insure that list or array is 1d and that all elements are numeric
@@ -1155,7 +1155,7 @@ class LinearCombination(
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _validate_variable(self, variable, context=None):
         """Insure that all items of list or np.ndarray in variable are of the same length
@@ -1757,7 +1757,7 @@ class CombineMeans(CombinationFunction):  # ------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
         if self.weights is not None:
             self.weights = np.atleast_2d(self.weights).reshape(-1, 1)
@@ -2013,7 +2013,7 @@ class PredictionErrorDeltaFunction(CombinationFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
         self.gamma = gamma
 

--- a/psyneulink/core/components/functions/combinationfunctions.py
+++ b/psyneulink/core/components/functions/combinationfunctions.py
@@ -871,7 +871,7 @@ class Reduce(CombinationFunction):  # ------------------------------------------
             # Avoid divide by zero warning:
             #    make sure there are no zeros for an element that is assigned a negative exponent
             # Allow during initialization because 0s are common in default_variable argument
-            if self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZING:
+            if self.is_initializing:
                 with np.errstate(divide='raise'):
                     try:
                         variable = variable ** exponents
@@ -1299,7 +1299,7 @@ class LinearCombination(
         """
         weights = self.get_current_function_param(WEIGHTS, execution_id)
         exponents = self.get_current_function_param(EXPONENTS, execution_id)
-        # if self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZED:
+        # if self.initialization_status == ContextFlags.INITIALIZED:
         #     if weights is not None and weights.shape != variable.shape:
         #         weights = weights.reshape(variable.shape)
         #     if exponents is not None and exponents.shape != variable.shape:
@@ -1330,7 +1330,7 @@ class LinearCombination(
             # Avoid divide by zero warning:
             #    make sure there are no zeros for an element that is assigned a negative exponent
             # Allow during initialization because 0s are common in default_variable argument
-            if self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZING:
+            if self.is_initializing:
                 with np.errstate(divide='raise'):
                     try:
                         variable = variable ** exponents
@@ -1904,7 +1904,7 @@ class CombineMeans(CombinationFunction):  # ------------------------------------
         if exponents is not None:
             # Avoid divide by zero warning:
             #    make sure there are no zeros for an element that is assigned a negative exponent
-            if (self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZING and
+            if (self.is_initializing and
                     any(not any(i) and j < 0 for i, j in zip(variable, exponents))):
                 means = np.ones_like(means)
             else:

--- a/psyneulink/core/components/functions/distributionfunctions.py
+++ b/psyneulink/core/components/functions/distributionfunctions.py
@@ -158,7 +158,7 @@ class NormalDist(DistributionFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _validate_params(self, request_set, target_set=None, context=None):
         super()._validate_params(request_set=request_set, target_set=target_set, context=context)
@@ -312,7 +312,7 @@ class UniformToNormalDist(DistributionFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
 
     def _function(self,
@@ -427,7 +427,7 @@ class ExponentialDist(DistributionFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
 
     def _function(self,
@@ -545,7 +545,7 @@ class UniformDist(DistributionFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
 
     def _function(self,
@@ -671,7 +671,7 @@ class GammaDist(DistributionFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
 
     def _function(self,
@@ -796,7 +796,7 @@ class WaldDist(DistributionFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
 
     def _function(self,
@@ -1029,7 +1029,7 @@ class DriftDiffusionAnalytical(DistributionFunction):  # -----------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     @property
     def output_type(self):

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -648,7 +648,7 @@ class Function_Base(Function):
         if context != ContextFlags.CONSTRUCTOR:
             raise FunctionError("Direct call to abstract class Function() is not allowed; use a Function subclass")
 
-        if self.context.initialization_status == ContextFlags.DEFERRED_INIT:
+        if self.initialization_status == ContextFlags.DEFERRED_INIT:
             self._assign_deferred_init_name(name, context)
             self.init_args[NAME] = name
             return

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -146,7 +146,7 @@ from random import randint
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.component import function_type, method_type
 from psyneulink.core.components.shellclasses import Function, Mechanism
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import \
     ARGUMENT_THERAPY_FUNCTION, EXAMPLE_FUNCTION_TYPE, FUNCTION, FUNCTION_OUTPUT_TYPE, FUNCTION_OUTPUT_TYPE_CONVERSION,\
     MODULATORY_PROJECTION, NAME, PARAMETER_STATE_PARAMS, kwComponentCategory, kwPreferenceSetName
@@ -671,6 +671,7 @@ class Function_Base(Function):
     def __call__(self, *args, **kwargs):
         return self.function(*args, **kwargs)
 
+    @handle_external_context()
     def function(self,
                  variable=None,
                  execution_id=None,
@@ -689,7 +690,7 @@ class Function_Base(Function):
                                params=params,
                                context=context,
                                **kwargs)
-        self.most_recent_execution_id=execution_id
+        self.most_recent_context.execution_id=execution_id
         self.parameters.value._set(value, execution_context=execution_id)
         return value
 

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -133,6 +133,7 @@ Class Reference
 
 """
 
+import abc
 import numbers
 import numpy as np
 import typecheck as tc
@@ -450,7 +451,6 @@ def get_param_value_for_function(owner, function):
 #         return convert_output_type(result)
 #     return wrapper
 
-
 class Function_Base(Function):
     """
     Function_Base(           \
@@ -623,6 +623,7 @@ class Function_Base(Function):
         FUNCTION_OUTPUT_TYPE: None  # Default is to not convert
     })
 
+    @abc.abstractmethod
     def __init__(self,
                  default_variable,
                  params,
@@ -644,9 +645,6 @@ class Function_Base(Function):
         :param name: (string) - optional, overrides assignment of default (componentName of subclass)
         :return:
         """
-
-        if context != ContextFlags.CONSTRUCTOR:
-            raise FunctionError("Direct call to abstract class Function() is not allowed; use a Function subclass")
 
         if self.initialization_status == ContextFlags.DEFERRED_INIT:
             self._assign_deferred_init_name(name, context)
@@ -694,6 +692,16 @@ class Function_Base(Function):
         self.most_recent_execution_id=execution_id
         self.parameters.value._set(value, execution_context=execution_id)
         return value
+
+    @abc.abstractmethod
+    def _function(
+        self,
+        variable=None,
+        execution_id=None,
+        params=None,
+        context=None
+    ):
+        pass
 
     def _parse_arg_generic(self, arg_val):
         if isinstance(arg_val, list):

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -1044,7 +1044,7 @@ class ArgumentTherapy(Function_Base):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _validate_variable(self, variable, context=None):
         """Validates variable and returns validated value

--- a/psyneulink/core/components/functions/interfacefunctions.py
+++ b/psyneulink/core/components/functions/interfacefunctions.py
@@ -34,18 +34,6 @@ class InterfaceFunction(Function_Base):
     """
     componentType = TRANSFER_FUNCTION_TYPE
 
-    def __init__(self,
-                 default_variable,
-                 params,
-                 owner,
-                 prefs,
-                 context):
-        super().__init__(default_variable=default_variable,
-                         params=params,
-                         owner=owner,
-                         prefs=prefs,
-                         context=context)
-
 
 class InterfaceStateMap(InterfaceFunction):
     """
@@ -129,7 +117,7 @@ class InterfaceStateMap(InterfaceFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
         # self.functionOutputType = None
 

--- a/psyneulink/core/components/functions/learningfunctions.py
+++ b/psyneulink/core/components/functions/learningfunctions.py
@@ -35,7 +35,7 @@ from psyneulink.core.globals.keywords import \
     CONTRASTIVE_HEBBIAN_FUNCTION, DEFAULT_VARIABLE, TDLEARNING_FUNCTION, LEARNING_FUNCTION_TYPE, LEARNING_RATE, \
     KOHONEN_FUNCTION, GAUSSIAN, LINEAR, EXPONENTIAL, HEBBIAN_FUNCTION, RL_FUNCTION, BACKPROPAGATION_FUNCTION, MATRIX
 from psyneulink.core.globals.parameters import Parameter
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.utilities import is_numeric, scalar_distance
 from psyneulink.core.globals.preferences.componentpreferenceset import is_pref_set
 
@@ -509,7 +509,8 @@ class BayesGLM(LearningFunction):
         self.gamma_shape_n = self.gamma_shape_0
         self.gamma_size_n = self.gamma_size_0
 
-    def reinitialize(self, *args):
+    @handle_external_context()
+    def reinitialize(self, *args, context=None):
         # If variable passed during execution does not match default assigned during initialization,
         #    reassign default and re-initialize priors
         if DEFAULT_VARIABLE in args[0]:

--- a/psyneulink/core/components/functions/learningfunctions.py
+++ b/psyneulink/core/components/functions/learningfunctions.py
@@ -449,7 +449,7 @@ class BayesGLM(LearningFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _handle_default_variable(self, default_variable=None, size=None):
 
@@ -769,7 +769,7 @@ class Kohonen(LearningFunction):  # --------------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
 
     def _validate_variable(self, variable, context=None):
@@ -1037,7 +1037,7 @@ class Hebbian(LearningFunction):  # --------------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
 
     def _validate_variable(self, variable, context=None):
@@ -1271,7 +1271,7 @@ class ContrastiveHebbian(LearningFunction):  # ---------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
 
     def _validate_variable(self, variable, context=None):
@@ -1559,7 +1559,7 @@ class Reinforcement(LearningFunction):  # --------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     @property
     def output_type(self):
@@ -1916,7 +1916,7 @@ class BackPropagation(LearningFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     @property
     def output_type(self):

--- a/psyneulink/core/components/functions/learningfunctions.py
+++ b/psyneulink/core/components/functions/learningfunctions.py
@@ -548,7 +548,7 @@ class BayesGLM(LearningFunction):
 
         """
 
-        if self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZING:
+        if self.is_initializing:
             self.initialize_priors()
 
         # # MODIFIED 10/26/18 OLD:
@@ -1583,7 +1583,7 @@ class Reinforcement(LearningFunction):  # --------------------------------------
                                  format(self.name, variable[LEARNING_ERROR_OUTPUT]))
 
         # Allow initialization with zero but not during a run (i.e., when called from check_args())
-        if self.context.initialization_status != ContextFlags.INITIALIZING:
+        if not self.is_initializing:
             if np.count_nonzero(variable[LEARNING_ACTIVATION_OUTPUT]) != 1:
                 raise ComponentError(
                     "Second item ({}) of variable for {} must be an array with only one non-zero value "
@@ -2073,7 +2073,7 @@ class BackPropagation(LearningFunction):
         # During init, function is called directly from Component (i.e., not from LearningMechanism execute() method),
         #     so need "placemarker" error_matrix for validation
         if error_matrix is None:
-            if self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZING:
+            if self.is_initializing:
                 error_matrix = np.zeros(
                     (len(variable[LEARNING_ACTIVATION_OUTPUT]), len(variable[LEARNING_ERROR_OUTPUT]))
                 )

--- a/psyneulink/core/components/functions/objectivefunctions.py
+++ b/psyneulink/core/components/functions/objectivefunctions.py
@@ -1168,7 +1168,7 @@ class Distance(ObjectiveFunction):
         # Cross-entropy of v1 and v2
         elif self.metric is CROSS_ENTROPY:
             # FIX: VALIDATE THAT ALL ELEMENTS OF V1 AND V2 ARE 0 TO 1
-            if self.parameters.context._get(execution_id).initialization_status != ContextFlags.INITIALIZING:
+            if not self.is_initializing:
                 v1 = np.where(v1 == 0, EPSILON, v1)
                 v2 = np.where(v2 == 0, EPSILON, v2)
             # MODIFIED CW 3/20/18: avoid divide by zero error by plugging in two zeros

--- a/psyneulink/core/components/functions/objectivefunctions.py
+++ b/psyneulink/core/components/functions/objectivefunctions.py
@@ -236,7 +236,7 @@ class Stability(ObjectiveFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
         # MODIFIED 6/12/19 NEW: [JDC]
         self._default_variable_flexibility = DefaultsFlexibility.FLEXIBLE
@@ -788,7 +788,7 @@ class Distance(ObjectiveFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _validate_params(self, request_set, target_set=None, variable=None, context=None):
         """Validate that variable had two items of equal length

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -32,7 +32,7 @@ from numbers import Number
 from typing import Iterator
 
 from psyneulink.core.components.functions.function import Function_Base, is_function_type
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.defaults import MPI_IMPLEMENTATION
 from psyneulink.core.globals.keywords import \
     DEFAULT_VARIABLE, GRADIENT_OPTIMIZATION_FUNCTION, GRID_SEARCH_FUNCTION, GAUSSIAN_PROCESS_FUNCTION, \
@@ -424,7 +424,8 @@ class OptimizationFunction(Function_Base):
                                                        repr(SEARCH_TERMINATION_FUNCTION),
                                                        self.__class__.__name__))
 
-    def reinitialize(self, *args, execution_id=NotImplemented):
+    @handle_external_context()
+    def reinitialize(self, *args, execution_id=NotImplemented, context=None):
         """Reinitialize parameters of the OptimizationFunction
 
         Parameters to be reinitialized should be specified in a parameter specification dictionary, in which they key
@@ -437,7 +438,7 @@ class OptimizationFunction(Function_Base):
             * `search_termination_function <OptimizationFunction.search_termination_function>`
         """
         if execution_id is NotImplemented:
-            execution_id = self.most_recent_execution_id
+            execution_id = self.most_recent_context.execution_id
         self._validate_params(request_set=args[0])
 
         if DEFAULT_VARIABLE in args[0]:
@@ -525,7 +526,7 @@ class OptimizationFunction(Function_Base):
             # Get next sample of sample
             new_sample = call_with_pruned_args(self.search_function, current_sample, iteration, execution_id=execution_id)
             # Compute new value based on new sample
-            new_value = call_with_pruned_args(self.objective_function, new_sample, execution_id=execution_id)
+            new_value = call_with_pruned_args(self.objective_function, new_sample, execution_id=execution_id, context=context)
             self._report_value(new_value)
             iteration += 1
             max_iterations = self.parameters.max_iterations._get(execution_id)
@@ -916,7 +917,8 @@ class GradientOptimization(OptimizationFunction):
                     raise OptimizationFunctionError(f"All items in {repr(SEARCH_SPACE)} arg for {self.name}{owner_str} "
                                                     f"must be or resolve a 2-item list or tuple; this doesn't: {s}.")
 
-    def reinitialize(self, *args):
+    @handle_external_context()
+    def reinitialize(self, *args, context=None):
         super().reinitialize(*args)
 
         # Differentiate objective_function using autograd.grad()
@@ -1317,12 +1319,12 @@ class GridSearch(OptimizationFunction):
             #                                            self.__class__.__name__,
             #                                            ))
 
-
-    def reinitialize(self, *args, execution_id=NotImplemented):
+    @handle_external_context()
+    def reinitialize(self, *args, execution_id=NotImplemented, context=None):
         """Assign size of `search_space <GridSearch.search_space>"""
         if execution_id is NotImplemented:
-            execution_id = self.most_recent_execution_id
-        super(GridSearch, self).reinitialize(*args, execution_id=execution_id)
+            execution_id = self.most_recent_context.execution_id
+        super(GridSearch, self).reinitialize(*args, execution_id=execution_id, context=context)
         sample_iterators = args[0]['search_space']
         owner_str = ''
         if self.owner:

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -892,7 +892,7 @@ class GradientOptimization(OptimizationFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _validate_params(self, request_set, target_set=None, context=None):
 
@@ -1291,7 +1291,7 @@ class GridSearch(OptimizationFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
         self.stateful_attributes = ["random_state"]
 
@@ -1940,7 +1940,7 @@ class GaussianProcess(OptimizationFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _validate_params(self, request_set, target_set=None, context=None):
         super()._validate_params(request_set=request_set, target_set=target_set,context=context)

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -483,7 +483,7 @@ class OptimizationFunction(Function_Base):
             for all the samples in the order they were evaluated; otherwise it is empty.
         """
 
-        if self._unspecified_args and self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZED:
+        if self._unspecified_args and self.initialization_status == ContextFlags.INITIALIZED:
             warnings.warn("The following arg(s) were not specified for {}: {} -- using default(s)".
                           format(self.name, ', '.join(self._unspecified_args)))
             self._unspecified_args = []
@@ -1733,7 +1733,7 @@ class GridSearch(OptimizationFunction):
         """Get next sample from grid.
         This is assigned as the `search_function <OptimizationFunction.search_function>` of the `OptimizationFunction`.
         """
-        initialization_status = self.parameters.context._get(execution_id).initialization_status
+        initialization_status = self.initialization_status
         if initialization_status == ContextFlags.INITIALIZING:
             return [signal.start for signal in self.search_space]
         try:

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -1613,7 +1613,6 @@ class GridSearch(OptimizationFunction):
                 stop = len(self.search_space)
 
             # # TEST PRINT
-            # print("\nContext: {}".format(self.context.flags_string))
             # print("search_space length: {}".format(len(self.search_space)))
             # print("Rank: {}\tSize: {}\tChunk size: {}".format(rank, size, chunk_size))
             # print("START: {0}\tEND: {1}\tPROCESSED: {2}".format(start,stop,stop-start))

--- a/psyneulink/core/components/functions/selectionfunctions.py
+++ b/psyneulink/core/components/functions/selectionfunctions.py
@@ -300,7 +300,7 @@ class OneHot(SelectionFunction):
                 raise FunctionError("If {} for {} {} is set to {}, the 2nd item of its variable ({}) must be an "
                                     "array of elements each of which is in the (0,1) interval".
                                     format(MODE, self.__class__.__name__, Function.__name__, PROB, prob_dist))
-            if self.context.initialization_status == ContextFlags.INITIALIZING:
+            if self.is_initializing:
                 return
             if not np.sum(prob_dist)==1:
                 raise FunctionError("If {} for {} {} is set to {}, the 2nd item of its variable ({}) must be an "

--- a/psyneulink/core/components/functions/selectionfunctions.py
+++ b/psyneulink/core/components/functions/selectionfunctions.py
@@ -68,10 +68,10 @@ class SelectionFunction(Function_Base):
 
     # IMPLEMENTATION NOTE: THESE SHOULD SHOULD BE REPLACED WITH ABC WHEN IMPLEMENTED
     def __init__(self, default_variable,
-                 params,
-                 owner,
-                 prefs,
-                 context):
+                 params=None,
+                 owner=None,
+                 prefs=None,
+                 context=None):
 
         if not hasattr(self, MULTIPLICATIVE_PARAM):
             raise FunctionError("PROGRAM ERROR: {} must implement a {} attribute".
@@ -278,7 +278,7 @@ class OneHot(SelectionFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
         if reset_default_variable_flexibility:
             self._default_variable_flexibility = DefaultsFlexibility.FLEXIBLE

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -555,7 +555,7 @@ class AccumulatorIntegrator(IntegratorFunction):  # ----------------------------
             params=params,
             owner=owner,
             prefs=prefs,
-            context=ContextFlags.CONSTRUCTOR)
+            )
 
         self.has_initializers = True
 
@@ -831,7 +831,7 @@ class SimpleIntegrator(IntegratorFunction):  # ---------------------------------
             params=params,
             owner=owner,
             prefs=prefs,
-            context=ContextFlags.CONSTRUCTOR)
+            )
 
         self.has_initializers = True
 
@@ -1055,7 +1055,7 @@ class AdaptiveIntegrator(IntegratorFunction):  # -------------------------------
             params=params,
             owner=owner,
             prefs=prefs,
-            context=ContextFlags.CONSTRUCTOR)
+            )
 
         self.has_initializers = True
 
@@ -1620,7 +1620,7 @@ class DualAdaptiveIntegrator(IntegratorFunction):  # ---------------------------
             params=params,
             owner=owner,
             prefs=prefs,
-            context=ContextFlags.CONSTRUCTOR)
+            )
 
         self.has_initializers = True
 
@@ -2093,7 +2093,7 @@ class InteractiveActivationIntegrator(IntegratorFunction):  # ------------------
             params=params,
             owner=owner,
             prefs=prefs,
-            context=ContextFlags.CONSTRUCTOR)
+            )
 
         self.has_initializers = True
 
@@ -2466,7 +2466,7 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
             params=params,
             owner=owner,
             prefs=prefs,
-            context=ContextFlags.CONSTRUCTOR)
+            )
 
         self.has_initializers = True
 
@@ -2819,7 +2819,7 @@ class OrnsteinUhlenbeckIntegrator(IntegratorFunction):  # ----------------------
             params=params,
             owner=owner,
             prefs=prefs,
-            context=ContextFlags.CONSTRUCTOR)
+            )
 
         self.previous_time = self.starting_point
         self.has_initializers = True
@@ -3087,7 +3087,7 @@ class LeakyCompetingIntegrator(IntegratorFunction):  # -------------------------
             params=params,
             owner=owner,
             prefs=prefs,
-            context=ContextFlags.CONSTRUCTOR)
+            )
 
         self.has_initializers = True
 
@@ -3768,7 +3768,7 @@ class FitzHughNagumoIntegrator(IntegratorFunction):  # -------------------------
             params=params,
             owner=owner,
             prefs=prefs,
-            context=ContextFlags.CONSTRUCTOR)
+            )
 
     @property
     def output_type(self):

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -48,7 +48,7 @@ from psyneulink.core.globals.keywords import \
     INTEGRATOR_FUNCTION, INTEGRATOR_FUNCTION_TYPE
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.utilities import parameter_spec, all_within_range, iscompatible
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.preferences.componentpreferenceset import is_pref_set
 
 
@@ -1787,7 +1787,8 @@ class DualAdaptiveIntegrator(IntegratorFunction):  # ---------------------------
 
         return value + offset
 
-    def reinitialize(self, short=None, long=None, execution_context=NotImplemented):
+    @handle_external_context()
+    def reinitialize(self, short=None, long=None, execution_context=NotImplemented, context=None):
         """
         Effectively begins accumulation over again at the specified utilities.
 
@@ -1804,7 +1805,7 @@ class DualAdaptiveIntegrator(IntegratorFunction):  # ---------------------------
         <DualAdaptiveIntegrator.initial_long_term_avg>` are used.
         """
         if execution_context is NotImplemented:
-            execution_context = self.most_recent_execution_id
+            execution_context = self.most_recent_context.execution_id
 
         if short is None:
             short = self.get_current_function_param("initial_short_term_avg", execution_context)

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -239,7 +239,7 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
             params=params,
             owner=owner,
             prefs=prefs,
-            context=ContextFlags.CONSTRUCTOR)
+            )
 
         self.has_initializers = True
 
@@ -738,7 +738,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
             params=params,
             owner=owner,
             prefs=prefs,
-            context=ContextFlags.CONSTRUCTOR)
+            )
 
         if self.previous_value.size != 0:
             self.parameters.key_size._set(len(self.previous_value[KEYS][0]))

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -40,7 +40,7 @@ from psyneulink.core.globals.keywords import \
     BUFFER_FUNCTION, MEMORY_FUNCTION, COSINE, ContentAddressableMemory_FUNCTION, \
     MIN_INDICATOR, NOISE, OVERWRITE, RATE, RANDOM, OLDEST, NEWEST
 from psyneulink.core.globals.utilities import all_within_range, parameter_spec, get_global_seed
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.componentpreferenceset import is_pref_set
 
@@ -255,7 +255,8 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
 
         self.has_initializers = True
 
-    def reinitialize(self, *args, execution_context=NotImplemented):
+    @handle_external_context()
+    def reinitialize(self, *args, execution_context=NotImplemented, context=None):
         """
 
         Clears the `previous_value <Buffer.previous_value>` deque.
@@ -268,7 +269,7 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
 
         """
         if execution_context is NotImplemented:
-            execution_context = self.most_recent_execution_id
+            execution_context = self.most_recent_context.execution_id
 
         # no arguments were passed in -- use current values of initializer attributes
         if len(args) == 0 or args is None:
@@ -1044,7 +1045,8 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         if isinstance(self.selection_function, type):
             self.selection_function = self.selection_function()
 
-    def reinitialize(self, *args, execution_context=NotImplemented):
+    @handle_external_context()
+    def reinitialize(self, *args, execution_context=NotImplemented, context=None):
         """
         reinitialize(<new_dictionary> default={})
 
@@ -1059,7 +1061,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         `previous_value <ContentAddressableMemory.previous_value>`.
         """
         if execution_context is NotImplemented:
-            execution_context = self.most_recent_execution_id
+            execution_context = self.most_recent_context.execution_id
 
         # no arguments were passed in -- use current values of initializer attributes
         if len(args) == 0 or args is None:

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -326,7 +326,7 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
 
         # If this is an initialization run, leave deque empty (don't want to count it as an execution step);
         # Just return current input (for validation).
-        if self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZING:
+        if self.is_initializing:
             return variable
 
         previous_value = np.array(self.get_previous_value(execution_id))
@@ -557,7 +557,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         If a duplicate key is identified during retrieval (e.g., **duplicate_keys** is changed from True to
         False), a warning is issued and zeros are returned.  If *OVERWRITE*, then retrieval of a cue with an identical
         key causes the value at that entry to be overwritten with the new value.
-        
+
     equidistant_keys_select:  RANDOM | OLDEST | NEWEST
         deterimines which entry is retrieved when duplicate keys are identified or are indistinguishable by the
         `distance_function <ContentAddressableMemory.distance_function>`.
@@ -1129,7 +1129,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
 
         # If this is an initialization run, leave memory empty (don't want to count it as an execution step),
         # and return current value (variable[1]) for validation.
-        if self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZING:
+        if self.is_initializing:
             return variable
 
         # Set key_size and val_size if this is the first entry

--- a/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
+++ b/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
@@ -31,7 +31,7 @@ from psyneulink.core.globals.keywords import INITIALIZER, STATEFUL_FUNCTION_TYPE
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.utilities import parameter_spec, iscompatible
 from psyneulink.core.globals.preferences.componentpreferenceset import is_pref_set
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 
 __all__ = ['StatefulFunction']
 
@@ -406,7 +406,7 @@ class StatefulFunction(Function_Base): #  --------------------------------------
                 "Noise parameter ({}) for {} must be a float, function, or array/list of these."
                     .format(noise, self.name))
 
-    def _try_execute_param(self, param, var):
+    def _try_execute_param(self, param, var, context=None):
 
         # FIX: [JDC 12/18/18 - HACK TO DEAL WITH ENFORCEMENT OF 2D BELOW]
         param_shape = np.array(param).shape
@@ -476,7 +476,8 @@ class StatefulFunction(Function_Base): #  --------------------------------------
 
         return val
 
-    def reinitialize(self, *args, execution_context=NotImplemented):
+    @handle_external_context()
+    def reinitialize(self, *args, execution_context=NotImplemented, context=None):
         """
             Resets `value <StatefulFunction.previous_value>`  and `previous_value <StatefulFunction.previous_value>`
             to the specified value(s).
@@ -503,7 +504,7 @@ class StatefulFunction(Function_Base): #  --------------------------------------
         """
 
         if execution_context is NotImplemented:
-            execution_context = self.most_recent_execution_id
+            execution_context = self.most_recent_context.execution_id
 
         reinitialization_values = []
 

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -102,10 +102,10 @@ class TransferFunction(Function_Base):
 
     # IMPLEMENTATION NOTE: THESE SHOULD SHOULD BE REPLACED WITH ABC WHEN IMPLEMENTED
     def __init__(self, default_variable,
-                 params,
-                 owner,
-                 prefs,
-                 context):
+                 params=None,
+                 owner=None,
+                 prefs=None,
+                 context=None):
 
         if not hasattr(self, BOUNDS):
             raise FunctionError("PROGRAM ERROR: {} must implement a {} attribute".
@@ -243,7 +243,7 @@ class Identity(TransferFunction):  # -------------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
         # self.functionOutputType = None
 
@@ -444,7 +444,7 @@ class Linear(TransferFunction):  # ---------------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _gen_llvm_transfer(self, builder, index, ctx, vi, vo, params, state):
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
@@ -701,7 +701,7 @@ class Exponential(TransferFunction):  # ----------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _gen_llvm_transfer(self, builder, index, ctx, vi, vo, params, state):
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
@@ -971,7 +971,7 @@ class Logistic(TransferFunction):  # -------------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _gen_llvm_transfer(self, builder, index, ctx, vi, vo, params, state):
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
@@ -1270,7 +1270,7 @@ class Tanh(TransferFunction):  # -----------------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _gen_llvm_transfer(self, builder, index, ctx, vi, vo, params, state):
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
@@ -1496,7 +1496,7 @@ class ReLU(TransferFunction):  # -----------------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _function(self,
                  variable=None,
@@ -1739,7 +1739,7 @@ class Gaussian(TransferFunction):  # -------------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _gen_llvm_transfer(self, builder, index, ctx, vi, vo, params, state):
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
@@ -2025,7 +2025,7 @@ class GaussianDistort(TransferFunction):  #-------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _gen_llvm_transfer(self, builder, index, ctx, vi, vo, params, state):
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
@@ -2305,7 +2305,7 @@ class SoftMax(TransferFunction):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _validate_variable(self, variable, context=None):
         if variable is None:
@@ -2693,7 +2693,7 @@ class LinearMatrix(TransferFunction):  # ---------------------------------------
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
         self.matrix = self.instantiate_matrix(self.paramsCurrent[MATRIX])
 

--- a/psyneulink/core/components/functions/userdefinedfunction.py
+++ b/psyneulink/core/components/functions/userdefinedfunction.py
@@ -480,7 +480,7 @@ class UserDefinedFunction(Function_Base):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _instantiate_attributes_before_function(self, function=None, context=None):
         super()._instantiate_attributes_before_function(function=function, context=context)

--- a/psyneulink/core/components/mechanisms/adaptive/adaptivemechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/adaptivemechanism.py
@@ -160,7 +160,7 @@ class AdaptiveMechanism_Base(Mechanism_Base):
                  params,
                  name,
                  prefs,
-                 context,
+                 context=None,
                  function=None,
                  **kwargs
                  ):

--- a/psyneulink/core/components/mechanisms/adaptive/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/control/controlmechanism.py
@@ -537,7 +537,7 @@ from psyneulink.core.components.shellclasses import Composition_Base, System_Bas
 from psyneulink.core.components.states.modulatorysignals.controlsignal import ControlSignal
 from psyneulink.core.components.states.outputstate import OutputState
 from psyneulink.core.components.states.parameterstate import ParameterState
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.defaults import defaultControlAllocation
 from psyneulink.core.globals.keywords import CONTROL, CONTROL_PROJECTION, CONTROL_SIGNAL, CONTROL_SIGNALS, \
@@ -947,8 +947,9 @@ class ControlMechanism(ModulatoryMechanism):
         return super()._instantiate_modulatory_signal(modulatory_signal=control_signal, context=context)
 
     # FIX: TBI FOR COMPOSITION
+    @handle_external_context()
     @tc.typecheck
-    def assign_as_controller(self, system:System_Base, context=ContextFlags.COMMAND_LINE):
+    def assign_as_controller(self, system:System_Base, context=None):
         """Assign ControlMechanism as `controller <System.controller>` for a `System`.
 
         **system** must be a System for which the ControlMechanism should be assigned as the `controller
@@ -981,7 +982,7 @@ class ControlMechanism(ModulatoryMechanism):
         COMMENT
         """
 
-        if context == ContextFlags.COMMAND_LINE:
+        if context.source == ContextFlags.COMMAND_LINE:
             system.controller = self
             return
 
@@ -1015,7 +1016,7 @@ class ControlMechanism(ModulatoryMechanism):
         # Add all other monitored_output_states to the ControlMechanism's monitored_output_states attribute
         #    and to its ObjectiveMechanisms monitored_output_states attribute
         if monitored_output_states:
-            self.add_to_monitor(monitored_output_states)
+            self.add_to_monitor(monitored_output_states, context=context)
 
         # The system does NOT already have a controller,
         #    so assign it ControlSignals for any parameters in the System specified for control
@@ -1058,7 +1059,7 @@ class ControlMechanism(ModulatoryMechanism):
         # Flag ObjectiveMechanism as associated with a ControlMechanism that is a controller for the System
         self._objective_mechanism.for_controller = True
 
-        if context != ContextFlags.PROPERTY:
+        if context.source != ContextFlags.PROPERTY:
             system._controller = self
 
         self._activate_projections_for_compositions(system)

--- a/psyneulink/core/components/mechanisms/adaptive/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/control/controlmechanism.py
@@ -936,7 +936,7 @@ class ControlMechanism(ModulatoryMechanism):
                                                params=params,
                                                name=name,
                                                prefs=prefs,
-                                               context=ContextFlags.CONSTRUCTOR,
+
                                                **kwargs)
 
     def _instantiate_output_states(self, context=None):

--- a/psyneulink/core/components/mechanisms/adaptive/control/defaultcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/control/defaultcontrolmechanism.py
@@ -122,7 +122,7 @@ class DefaultControlMechanism(ControlMechanism):
                 params=params,
                 name=name,
                 prefs=prefs,
-                context=ContextFlags.CONSTRUCTOR,
+
                 **kwargs)
 
     def _instantiate_input_states(self, context=None):

--- a/psyneulink/core/components/mechanisms/adaptive/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/control/optimizationcontrolmechanism.py
@@ -935,7 +935,7 @@ class OptimizationControlMechanism(ControlMechanism):
         if not self.agent_rep.parameters.retain_old_simulation_data._get():
             self.agent_rep._delete_contexts(sim_execution_id, check_simulation_storage=True)
 
-    def evaluation_function(self, control_allocation, execution_id=None):
+    def evaluation_function(self, control_allocation, execution_id=None, context=None):
         """Compute `net_outcome <ControlMechanism.net_outcome>` for current set of `feature_values
         <OptimizationControlMechanism.feature_values>` and a specified `control_allocation
         <ControlMechanism.control_allocation>`.
@@ -960,14 +960,20 @@ class OptimizationControlMechanism(ControlMechanism):
             else:
                 new_execution_id = execution_id
 
+            old_composition = context.composition
+            context.composition = self.agent_rep
+
             result = self.agent_rep.evaluate(self.parameters.feature_values._get(execution_id),
                                              control_allocation,
                                              self.parameters.num_estimates._get(execution_id),
                                              base_execution_id=execution_id,
                                              execution_id=new_execution_id,
-                                             context=self.function.parameters.context._get(execution_id),
+                                             context=context,
                                              execution_mode=self.parameters.comp_execution_mode._get(execution_id)
             )
+            context.composition = old_composition
+            context.execution_id = execution_id
+
             if self.defaults.search_statefulness:
                 self._tear_down_simulation(new_execution_id)
         # agent_rep is a CompositionFunctionApproximator (since runs_simuluations = False)
@@ -976,7 +982,7 @@ class OptimizationControlMechanism(ControlMechanism):
                                              control_allocation,
                                              self.parameters.num_estimates._get(execution_id),
                                              execution_id=execution_id,
-                                             context=self.function.parameters.context._get(execution_id)
+                                             context=context
             )
 
         return result

--- a/psyneulink/core/components/mechanisms/adaptive/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/control/optimizationcontrolmechanism.py
@@ -864,7 +864,7 @@ class OptimizationControlMechanism(ControlMechanism):
     def _execute(self, variable=None, execution_id=None, runtime_params=None, context=None):
         """Find control_allocation that optimizes result of `agent_rep.evaluate`  ."""
 
-        if (self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZING):
+        if self.is_initializing:
             return [defaultControlAllocation]
 
         # # FIX: THESE NEED TO BE FOR THE PREVIOUS TRIAL;  ARE THEY FOR FUNCTION_APPROXIMATOR?

--- a/psyneulink/core/components/mechanisms/adaptive/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/control/optimizationcontrolmechanism.py
@@ -1210,7 +1210,7 @@ class OptimizationControlMechanism(ControlMechanism):
         value = [np.atleast_1d(a) for a in control_allocation]
         self.parameters.value._set(value, execution_id)
         self._update_output_states(execution_id=execution_id, runtime_params=runtime_params,
-                                   context=ContextFlags.COMPOSITION)
+                                   context=context)
 
     # @property
     # def feature_values(self):
@@ -1232,7 +1232,7 @@ class OptimizationControlMechanism(ControlMechanism):
 
         if features:
             features = self._parse_feature_specs(features=features,
-                                                 context=ContextFlags.COMMAND_LINE)
+                                                 context=Context(source=ContextFlags.COMMAND_LINE))
         self.add_states(InputState, features)
 
     @tc.typecheck

--- a/psyneulink/core/components/mechanisms/adaptive/gating/gatingmechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/gating/gatingmechanism.py
@@ -480,7 +480,7 @@ class GatingMechanism(ModulatoryMechanism):
         if GATING_PROJECTIONS in self.paramsCurrent:
             if self.paramsCurrent[GATING_PROJECTIONS]:
                 for key, projection in self.paramsCurrent[GATING_PROJECTIONS].items():
-                    self._instantiate_gating_projection(projection, context=ContextFlags.METHOD)
+                    self._instantiate_gating_projection(projection, context=context)
 
     def _assign_as_gating_mechanism(self, context=None):
 

--- a/psyneulink/core/components/mechanisms/adaptive/gating/gatingmechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/gating/gatingmechanism.py
@@ -447,7 +447,7 @@ class GatingMechanism(ModulatoryMechanism):
                          params=params,
                          name=name,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR,
+
                          **kwargs)
 
     def _instantiate_output_states(self, context=None):

--- a/psyneulink/core/components/mechanisms/adaptive/gating/gatingmechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/gating/gatingmechanism.py
@@ -492,7 +492,7 @@ class GatingMechanism(ModulatoryMechanism):
             for state in mech._input_states + mech._output_states:
                 for projection in state.mod_afferents:
                     # If projection was deferred for init, initialize it now and instantiate for self
-                    if (projection.context.initialization_status == ContextFlags.DEFERRED_INIT
+                    if (projection.initialization_status == ContextFlags.DEFERRED_INIT
                         and projection.init_args['sender'] is None):
                         # FIX 5/23/17: MODIFY THIS WHEN (param, GatingProjection) tuple
                         # FIX:         IS REPLACED WITH (param, GatingSignal) tuple

--- a/psyneulink/core/components/mechanisms/adaptive/learning/learningauxiliary.py
+++ b/psyneulink/core/components/mechanisms/adaptive/learning/learningauxiliary.py
@@ -149,7 +149,7 @@ from psyneulink.core.components.shellclasses import Function
 from psyneulink.core.components.states.inputstate import InputState
 from psyneulink.core.components.states.outputstate import OutputState
 from psyneulink.core.components.states.parameterstate import ParameterState
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import Context, ContextFlags
 from psyneulink.core.globals.keywords import \
     BACKPROPAGATION_FUNCTION, COMPARATOR_MECHANISM, HEBBIAN_FUNCTION, IDENTITY_MATRIX, LEARNING, LEARNING_MECHANISM, \
     MATRIX, MONITOR_FOR_LEARNING, NAME, OUTCOME, PREDICTION_ERROR_MECHANISM, PROJECTIONS, RL_FUNCTION, SAMPLE, \
@@ -220,7 +220,7 @@ def _instantiate_learning_components(learning_projection, context=None):
 
     # Call should generally be from LearningProjection._instantiate_sender,
     #    but may be used more generally in the future
-    if context != ContextFlags.METHOD:
+    if context.source != ContextFlags.METHOD:
         raise LearningAuxiliaryError("PROGRAM ERROR".format("_instantiate_learning_components only supports "
                                                              "calls from a LearningProjection._instantiate_sender()"))
 
@@ -782,8 +782,8 @@ def _assign_error_signal_projections(processing_mech:Mechanism,
                 #                              name=ERROR_SIGNAL))
                 aff_lm.add_states(InputState(projections=eff_lm.output_states[ERROR_SIGNAL],
                                              name=ERROR_SIGNAL,
-                                             context=ContextFlags.METHOD),
-                                  context=ContextFlags.METHOD)
+                                             context=Context(source=ContextFlags.METHOD)),
+                                  context=Context(source=ContextFlags.METHOD))
 
         for projection in aff_lm.projections:
             projection._activate_for_compositions(system)

--- a/psyneulink/core/components/mechanisms/adaptive/learning/learningmechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/learning/learningmechanism.py
@@ -521,7 +521,7 @@ from psyneulink.core.components.mechanisms.processing.objectivemechanism import 
 from psyneulink.core.components.shellclasses import Mechanism
 from psyneulink.core.components.states.modulatorysignals.learningsignal import LearningSignal
 from psyneulink.core.components.states.parameterstate import ParameterState
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import \
     AFTER, ASSERT, CONTEXT, CONTROL_PROJECTIONS, ENABLED, INPUT_STATES, \
     LEARNED_PARAM, LEARNING, LEARNING_MECHANISM, LEARNING_PROJECTION, LEARNING_SIGNAL, LEARNING_SIGNALS, \
@@ -1254,11 +1254,9 @@ class LearningMechanism(AdaptiveMechanism_Base):
         #    since it is used by the execute method
         self._error_signal_input_states = self.error_signal_input_states
 
+    @handle_external_context()
     def add_states(self, error_sources, context=None):
         """Add error_source and error_matrix for each InputState added"""
-
-        if context is None:
-            context = ContextFlags.COMMAND_LINE
 
         states = super().add_states(states=error_sources)
         instantiated_input_states = []

--- a/psyneulink/core/components/mechanisms/adaptive/learning/learningmechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/learning/learningmechanism.py
@@ -1022,7 +1022,7 @@ class LearningMechanism(AdaptiveMechanism_Base):
         # delete self.init_args[ERROR_SOURCES]
 
         # # Flag for deferred initialization
-        # self.parameters.context._get(execution_id).initialization_status = ContextFlags.DEFERRED_INIT
+        # self.initialization_status = ContextFlags.DEFERRED_INIT
         # self.initialization_status = ContextFlags.DEFERRED_INIT
 
         self._learning_rate = learning_rate
@@ -1355,14 +1355,14 @@ class LearningMechanism(AdaptiveMechanism_Base):
             summed_error_signal += error_signal
 
         if (self.reportOutputPref and
-                self.parameters.context._get(execution_id).initialization_status != ContextFlags.INITIALIZING):
+                self.initialization_status != ContextFlags.INITIALIZING):
             print("\n{} weight change matrix: \n{}\n".format(self.name, summed_learning_signal))
 
         # Durning initialization return zeros so that the first "real" trial for Backprop does not start
         # with the error computed during initialization
         if (self.in_composition and
                 isinstance(self.function, BackPropagation) and
-                self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZING):
+                self.initialization_status == ContextFlags.INITIALIZING):
             return [0*summed_learning_signal, 0*summed_error_signal]
 
         return [summed_learning_signal, summed_error_signal]

--- a/psyneulink/core/components/mechanisms/adaptive/learning/learningmechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/learning/learningmechanism.py
@@ -995,9 +995,6 @@ class LearningMechanism(AdaptiveMechanism_Base):
                  prefs:is_pref_set=None,
                  **kwargs
                  ):
-
-        context = kwargs.pop(CONTEXT, ContextFlags.CONSTRUCTOR)
-
         # IMPLEMENTATION NOTE:
         #    assign to private attribute as self.error_sources is used as a property
         #    private attribute is used for validation and in _instantiate_attribute_before_function;
@@ -1034,7 +1031,6 @@ class LearningMechanism(AdaptiveMechanism_Base):
                          params=params,
                          name=name,
                          prefs=prefs,
-                         context=context,
                          **kwargs)
 
     def _check_type_and_timing(self):

--- a/psyneulink/core/components/mechanisms/adaptive/modulatorymechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/modulatorymechanism.py
@@ -418,7 +418,7 @@ from psyneulink.core.components.states.modulatorysignals.gatingsignal import Gat
 from psyneulink.core.components.states.inputstate import InputState
 from psyneulink.core.components.states.outputstate import OutputState
 from psyneulink.core.components.states.parameterstate import ParameterState
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.defaults import defaultControlAllocation, defaultGatingAllocation
 from psyneulink.core.globals.keywords import AUTO_ASSIGN_MATRIX, CONTEXT, \
     CONTROL, CONTROL_PROJECTIONS, CONTROL_SIGNALS, EID_SIMULATION, GATING_SIGNALS, INIT_EXECUTE_METHOD_ONLY, \
@@ -1465,7 +1465,8 @@ class ModulatoryMechanism(AdaptiveMechanism_Base):
 
     # FIX: TBI FOR COMPOSITION
     @tc.typecheck
-    def assign_as_controller(self, system:System_Base, context=ContextFlags.COMMAND_LINE):
+    @handle_external_context()
+    def assign_as_controller(self, system:System_Base, context=None):
         """Assign ModulatoryMechanism as `controller <System.controller>` for a `System`.
 
         **system** must be a System for which the ModulatoryMechanism should be assigned as the `controller
@@ -1498,7 +1499,7 @@ class ModulatoryMechanism(AdaptiveMechanism_Base):
         COMMENT
         """
 
-        if context == ContextFlags.COMMAND_LINE:
+        if context.source == ContextFlags.COMMAND_LINE:
             system.controller = self
             return
 
@@ -1576,7 +1577,7 @@ class ModulatoryMechanism(AdaptiveMechanism_Base):
         # Flag ObjectiveMechanism as associated with a ModulatoryMechanism that is a controller for the System
         self._objective_mechanism.for_controller = True
 
-        if context != ContextFlags.PROPERTY:
+        if context.source != ContextFlags.PROPERTY:
             system._controller = self
 
         self._activate_projections_for_compositions(system)
@@ -1615,7 +1616,7 @@ class ModulatoryMechanism(AdaptiveMechanism_Base):
         self.parameters.value._set(value, execution_id)
         self._update_output_states(execution_id=execution_id,
                                    runtime_params=runtime_params,
-                                   context=ContextFlags.COMPOSITION)
+                                   context=context)
 
     @property
     def monitored_output_states(self):

--- a/psyneulink/core/components/mechanisms/adaptive/modulatorymechanism.py
+++ b/psyneulink/core/components/mechanisms/adaptive/modulatorymechanism.py
@@ -535,7 +535,7 @@ class DefaultAllocationFunction(Function_Base):
         super().__init__(default_variable=default_variable,
                          params=params,
                          owner=owner,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _function(self,
                  variable=None,
@@ -985,9 +985,6 @@ class ModulatoryMechanism(AdaptiveMechanism_Base):
                  prefs:is_pref_set=None,
                  **kwargs
                  ):
-
-        context = kwargs.pop(CONTEXT, ContextFlags.CONSTRUCTOR)
-
         function = function or DefaultAllocationFunction
         modulatory_signals = modulatory_signals or []
         if not isinstance(modulatory_signals, list):
@@ -1015,7 +1012,6 @@ class ModulatoryMechanism(AdaptiveMechanism_Base):
                                                   name=name,
                                                   function=function,
                                                   prefs=prefs,
-                                                  context=context,
                                                   **kwargs)
 
         if system is not None:

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -931,6 +931,7 @@ Class Reference
 
 """
 
+import abc
 import inspect
 import itertools
 import logging
@@ -1413,6 +1414,7 @@ class Mechanism_Base(Mechanism):
     # def __new__(cls, name=NotImplemented, params=NotImplemented, context=None):
 
     @tc.typecheck
+    @abc.abstractmethod
     def __init__(self,
                  default_variable=None,
                  size=None,
@@ -1437,11 +1439,6 @@ class Mechanism_Base(Mechanism):
         * registers Mechanism with MechanismRegistry
 
         """
-
-        # Forbid direct call to base class constructor
-        if context is None or (context !=ContextFlags.CONSTRUCTOR and
-                               not self.initialization_status == ContextFlags.VALIDATING):
-            raise MechanismError("Direct call to abstract class Mechanism() is not allowed; use a subclass")
 
         # IMPLEMENT **kwargs (PER State)
 

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -1817,11 +1817,6 @@ class Mechanism_Base(Mechanism):
             except AttributeError as e:
                 if DEFER_VARIABLE_SPEC_TO_MECH_MSG in e.args[0]:
                     pass
-        # INPUT_STATES is not specified and call is from constructor (i.e., not assign_params):
-        elif context & ContextFlags.CONSTRUCTOR:
-            # - set to None, so it is set to default (self.defaults.variable) in instantiate_inputState
-            # - warning (if in VERBOSE mode) will be issued in instantiate_inputState, where default value is known
-            params[INPUT_STATES] = None
 
         # VALIDATE FUNCTION_PARAMS
         try:
@@ -1898,14 +1893,6 @@ class Mechanism_Base(Mechanism):
                                      self.execute.__self__.name))
                 i += 1
             params[OUTPUT_STATES] = param_value
-
-        # OUTPUT_STATES is not specified and call is from construct (i.e., not assign_params)
-        elif context & ContextFlags.CONSTRUCTOR:
-            # - set to None, so that it is set to default (self.value) in instantiate_output_state
-            # - warning (if in VERBOSE mode) will be issued in instantiate_inputState, where default value is known
-            # - number of OutputStates is validated against length of owner Mechanism's execute method output (EMO)
-            #     in instantiate_output_state, where an OutputState is assigned to each item (value) of the EMO
-            params[OUTPUT_STATES] = None
 
         def validate_labels_dict(lablel_dict, type):
             for label, value in labels_dict.items():

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2237,9 +2237,6 @@ class Mechanism_Base(Mechanism):
             <Mechanism_OutputStates>` after either one `TIME_STEP` or a `TRIAL`.
 
         """
-        # initialize context for this execution_id if not done already
-        if self.parameters.context._get(execution_id) is None:
-            self._assign_context_values(execution_id)
 
         if self.initialization_status == ContextFlags.INITIALIZED:
             context.string = "{} EXECUTING {}: {}".format(context.source.name,self.name,

--- a/psyneulink/core/components/mechanisms/processing/compositioninterfacemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/compositioninterfacemechanism.py
@@ -168,4 +168,4 @@ class CompositionInterfaceMechanism(ProcessingMechanism_Base):
                                                             params=params,
                                                             name=name,
                                                             prefs=prefs,
-                                                            context=ContextFlags.CONSTRUCTOR)
+                                                            )

--- a/psyneulink/core/components/mechanisms/processing/defaultprocessingmechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/defaultprocessingmechanism.py
@@ -92,5 +92,5 @@ class DefaultProcessingMechanism_Base(Mechanism_Base):
                                                               params=params,
                                                               name=name,
                                                               prefs=prefs,
-                                                              context=ContextFlags.CONSTRUCTOR,
+
                                                               **kwargs)

--- a/psyneulink/core/components/mechanisms/processing/integratormechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/integratormechanism.py
@@ -233,7 +233,7 @@ class IntegratorMechanism(ProcessingMechanism_Base):
                                                   params=params,
                                                   name=name,
                                                   prefs=prefs,
-                                                  context=ContextFlags.CONSTRUCTOR,
+
                                                   **kwargs)
 
         # IMPLEMENT: INITIALIZE LOG ENTRIES, NOW THAT ALL PARTS OF THE MECHANISM HAVE BEEN INSTANTIATED

--- a/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
@@ -782,9 +782,11 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
             else:
                 reference_value.append(projection_tuple.state.value)
 
+        context.source = ContextFlags.METHOD
         input_states = self._instantiate_input_states(monitor_specs=monitor_specs,
                                                       reference_value=reference_value,
-                                                      context = ContextFlags.METHOD)
+                                                      context=context
+                                                      )
 
         output_states = [[projection.sender for projection in state.path_afferents] for state in input_states]
 

--- a/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
@@ -620,9 +620,6 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
             warnings.warn(f'Use of {repr(MONITORED_OUTPUT_STATES)} as arg of {self.__class__.__name__} is deprecated;  '
                           f'use {repr(MONITOR)} instead')
             monitor = kwargs.pop(MONITORED_OUTPUT_STATES)
-
-        context = kwargs.pop(CONTEXT, ContextFlags.CONSTRUCTOR)
-
         monitor = monitor or None # deal with possibility of empty list
         input_states = monitor
         if output_states is None or output_states is OUTCOME:
@@ -650,7 +647,6 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
                          params=params,
                          name=name,
                          prefs=prefs,
-                         context=context,
                          **kwargs)
 
         # This is used to specify whether the ObjectiveMechanism is associated with a ControlMechanism that is

--- a/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
@@ -987,7 +987,7 @@ def _parse_monitor_specs(monitor_specs):
 #                                                          projection_spec,
 #                                                          receiver.path_afferents[0].function_params[MATRIX]))
 #                 receiver.path_afferents[0].init_args[SENDER] = sender
-#                 receiver.path_afferents[0]._deferred_init()
+#                 receiver.path_afferents[0]._deferred_init(context=context)
 #             else:
 #                 projection_spec = MappingProjection(sender=sender,
 #                                                     receiver=receiver,

--- a/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
@@ -685,7 +685,7 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
         """
 
         # If call is for initialization
-        if self.context.initialization_status == ContextFlags.INITIALIZING:
+        if self.initialization_status == ContextFlags.INITIALIZING:
             # Use self.input_states (containing specs from **input_states** arg of constructor)
             #    or pass off instantiation of default InputState(s) to super
             input_states = self.input_states or None
@@ -974,7 +974,7 @@ def _parse_monitor_specs(monitor_specs):
 #         if isinstance(sender, OutputState):
 #             # Projection has been specified for receiver and initialization begun, so call deferred_init()
 #             if receiver.path_afferents:
-#                 if not receiver.path_afferents[0].context.initialization_status == ContextFlags.DEFERRED_INIT:
+#                 if not receiver.path_afferents[0].initialization_status == ContextFlags.DEFERRED_INIT:
 #                     raise ObjectiveMechanismError("PROGRAM ERROR: {} of {} already has an afferent projection "
 #                                                   "implemented and initialized ({})".
 #                                                   format(receiver.name, owner.name, receiver.path_afferents[0].name))

--- a/psyneulink/core/components/mechanisms/processing/processingmechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/processingmechanism.py
@@ -289,9 +289,6 @@ class ProcessingMechanism(ProcessingMechanism_Base):
                  name=None,
                  prefs:is_pref_set=None,
                  **kwargs):
-
-        context = kwargs.pop(CONTEXT, ContextFlags.CONSTRUCTOR)
-
         # Assign args to params and functionParams dicts
         params = self._assign_args_to_param_dicts(function=function,
                                                   input_states=input_states,
@@ -306,5 +303,4 @@ class ProcessingMechanism(ProcessingMechanism_Base):
                                                   params=params,
                                                   name=name,
                                                   prefs=prefs,
-                                                  context=context,
                                                   **kwargs)

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -981,7 +981,7 @@ class TransferMechanism(ProcessingMechanism_Base):
                 params=params,
                 name=name,
                 prefs=prefs,
-                context=ContextFlags.CONSTRUCTOR,
+
                 **kwargs
         )
 

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1283,10 +1283,10 @@ class TransferMechanism(ProcessingMechanism_Base):
                                     f"size ({variable.shape[-1]}) of the innermost dimension (axis 0) of its "
                                     f"{repr(VARIABLE)} (i.e., the length of its items .")
             self.integrator_function.parameters.variable.default_value = variable
-            function_context_buffer = self.integrator_function.context.initialization_status
-            self.integrator_function.context.initialization_status = ContextFlags.INITIALIZING
+            function_context_buffer = self.integrator_function.initialization_status
+            self.integrator_function.initialization_status = ContextFlags.INITIALIZING
             self.integrator_function.parameters.value.default_value = self.integrator_function(variable)
-            self.integrator_function.context.initialization_status = function_context_buffer
+            self.integrator_function.initialization_status = function_context_buffer
         # MODIFIED 6/24/19 END
 
         self.has_integrated = True
@@ -1313,7 +1313,7 @@ class TransferMechanism(ProcessingMechanism_Base):
 
         integration_rate = self.get_current_mechanism_param(INTEGRATION_RATE, execution_id)
 
-        if self.parameters.context.get(execution_id).initialization_status == ContextFlags.INITIALIZING:
+        if self.initialization_status == ContextFlags.INITIALIZING:
             self._instantiate_integrator_function(variable=function_variable,
                                                   noise=noise,
                                                   initializer=initial_value,
@@ -1552,7 +1552,7 @@ class TransferMechanism(ProcessingMechanism_Base):
         if (
             self.convergence_criterion is not None
             and self.parameters.previous_value._get(execution_id) is not None
-            and self.parameters.context._get(execution_id).initialization_status != ContextFlags.INITIALIZING
+            and self.initialization_status != ContextFlags.INITIALIZING
         ):
             if self.delta(value, execution_id) <= self.convergence_criterion:
                 return True

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1504,7 +1504,7 @@ class TransferMechanism(ProcessingMechanism_Base):
             self.parameters.previous_value._set(value, execution_id)
 
     def _parse_function_variable(self, variable, execution_id=None, context=None):
-        if context is ContextFlags.INSTANTIATE:
+        if context.source is ContextFlags.INSTANTIATE:
 
             return super(TransferMechanism, self)._parse_function_variable(variable=variable, execution_id=execution_id, context=context)
 

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1558,11 +1558,11 @@ class TransferMechanism(ProcessingMechanism_Base):
         ):
             if self.delta(value, execution_id) <= self.convergence_criterion:
                 return True
-            elif self.get_current_execution_time(execution_id).pass_ >= self.max_passes:
+            elif self.get_current_execution_time(context).pass_ >= self.max_passes:
                 raise TransferError("Maximum number of executions ({}) has occurred before reaching "
                                     "convergence_criterion ({}) for {} in trial {} of run {}".
                                     format(self.max_passes, self.convergence_criterion, self.name,
-                                           self.get_current_execution_time(execution_id).trial, self.get_current_execution_time(execution_id).run))
+                                           self.get_current_execution_time(context).trial, self.get_current_execution_time(context).run))
             else:
                 return False
         # Otherwise just return True

--- a/psyneulink/core/components/process.py
+++ b/psyneulink/core/components/process.py
@@ -893,7 +893,7 @@ class Process(Process_Base):
                           context=context)
 
         if not context:
-            self.context.initialization_status = ContextFlags.INITIALIZING
+            self.initialization_status = ContextFlags.INITIALIZING
             self.context.string = INITIALIZING + self.name + kwSeparator + PROCESS_INIT
         # If input was not provided, generate defaults to match format of ORIGIN mechanisms for process
         if default_variable is None and len(pathway) > 0:
@@ -1485,7 +1485,7 @@ class Process(Process_Base):
 
                     # If initialization of MappingProjection has been deferred,
                     #    check sender and receiver, assign them if they have not been assigned, and initialize it
-                    if item.context.initialization_status == ContextFlags.DEFERRED_INIT:
+                    if item.initialization_status == ContextFlags.DEFERRED_INIT:
                         # Check sender arg
                         try:
                             sender_arg = item.init_args[SENDER]
@@ -2243,7 +2243,7 @@ class Process(Process_Base):
         self._initialize_from_context(execution_id, base_execution_id, override=False)
 
         # Report output if reporting preference is on and this is not an initialization run
-        report_output = self.prefs.reportOutputPref and self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZED
+        report_output = self.prefs.reportOutputPref and self.initialization_status == ContextFlags.INITIALIZED
 
         # FIX: CONSOLIDATE/REARRANGE _assign_input_values, _check_args, AND ASSIGNMENT OF input TO variable
         # FIX: (SO THAT assign_input_value DOESN'T HAVE TO RETURN input

--- a/psyneulink/core/components/projections/modulatory/controlprojection.py
+++ b/psyneulink/core/components/projections/modulatory/controlprojection.py
@@ -337,10 +337,10 @@ class ControlProjection(ModulatoryProjection_Base):
                                                   params=params)
 
         # If receiver has not been assigned, defer init to State.instantiate_projection_to_state()
-        if (sender is None or sender.context.initialization_status == ContextFlags.DEFERRED_INIT or
+        if (sender is None or sender.initialization_status == ContextFlags.DEFERRED_INIT or
                 inspect.isclass(receiver) or receiver is None or
-                    receiver.context.initialization_status == ContextFlags.DEFERRED_INIT):
-            self.context.initialization_status = ContextFlags.DEFERRED_INIT
+                    receiver.initialization_status == ContextFlags.DEFERRED_INIT):
+            self.initialization_status = ContextFlags.DEFERRED_INIT
 
         # Validate sender (as variable) and params, and assign to variable and paramInstanceDefaults
         # Note: pass name of mechanism (to override assignment of componentName in super.__init__)

--- a/psyneulink/core/components/projections/modulatory/controlprojection.py
+++ b/psyneulink/core/components/projections/modulatory/controlprojection.py
@@ -328,9 +328,6 @@ class ControlProjection(ModulatoryProjection_Base):
                  name=None,
                  prefs:is_pref_set=None,
                  **kwargs):
-
-        context = kwargs.pop(CONTEXT, ContextFlags.CONSTRUCTOR)
-
         # Assign args to params and functionParams dicts
         params = self._assign_args_to_param_dicts(function=function,
                                                   control_signal_params=control_signal_params,
@@ -353,7 +350,6 @@ class ControlProjection(ModulatoryProjection_Base):
                                                 params=params,
                                                 name=name,
                                                 prefs=prefs,
-                                                context=context,
                                                 **kwargs)
 
     def _instantiate_sender(self, sender, params=None, context=None):

--- a/psyneulink/core/components/projections/modulatory/gatingprojection.py
+++ b/psyneulink/core/components/projections/modulatory/gatingprojection.py
@@ -326,7 +326,7 @@ class GatingProjection(ModulatoryProjection_Base):
         # If receiver has not been assigned, defer init to State.instantiate_projection_to_state()
         if sender is None or receiver is None:
             # Flag for deferred initialization
-            self.context.initialization_status = ContextFlags.DEFERRED_INIT
+            self.initialization_status = ContextFlags.DEFERRED_INIT
 
         # Validate sender (as variable) and params, and assign to variable and paramInstanceDefaults
         # Note: pass name of mechanism (to override assignment of componentName in super.__init__)
@@ -370,7 +370,7 @@ class GatingProjection(ModulatoryProjection_Base):
 
         super()._validate_params(request_set=request_set, target_set=target_set, context=context)
 
-        if self.context.initialization_status == ContextFlags.INITIALIZING:
+        if self.initialization_status == ContextFlags.INITIALIZING:
             from psyneulink.core.components.states.inputstate import InputState
             from psyneulink.core.components.states.outputstate import OutputState
             if not isinstance(self.receiver, (InputState, OutputState, Mechanism)):

--- a/psyneulink/core/components/projections/modulatory/gatingprojection.py
+++ b/psyneulink/core/components/projections/modulatory/gatingprojection.py
@@ -315,9 +315,6 @@ class GatingProjection(ModulatoryProjection_Base):
                  prefs:is_pref_set=None,
                  **kwargs
                  ):
-
-        context = kwargs.pop(CONTEXT, ContextFlags.CONSTRUCTOR)
-
         # Assign args to params and functionParams dicts
         params = self._assign_args_to_param_dicts(function=function,
                                                   gating_signal_params=gating_signal_params,
@@ -338,7 +335,6 @@ class GatingProjection(ModulatoryProjection_Base):
                          params=params,
                          name=name,
                          prefs=prefs,
-                         context=context,
                          **kwargs)
 
     def _instantiate_sender(self, sender, params=None, context=None):

--- a/psyneulink/core/components/projections/modulatory/learningprojection.py
+++ b/psyneulink/core/components/projections/modulatory/learningprojection.py
@@ -183,7 +183,7 @@ from psyneulink.core.components.shellclasses import ShellClass
 from psyneulink.core.components.states.modulatorysignals.learningsignal import LearningSignal
 from psyneulink.core.components.states.outputstate import OutputState
 from psyneulink.core.components.states.parameterstate import ParameterState
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import Context, ContextFlags
 from psyneulink.core.globals.keywords import \
     CONTEXT, FUNCTION, FUNCTION_PARAMS, INTERCEPT, LEARNING, LEARNING_PROJECTION, LEARNING_SIGNAL, \
     MATRIX, PARAMETER_STATE, PARAMETER_STATES, PROJECTION_SENDER, SLOPE, ONLINE, AFTER
@@ -613,8 +613,10 @@ class LearningProjection(ModulatoryProjection_Base):
         if not isinstance(self.sender, (OutputState, LearningMechanism)):
             from psyneulink.core.components.mechanisms.adaptive.learning.learningauxiliary \
                 import _instantiate_learning_components
+            context.source = ContextFlags.METHOD
             _instantiate_learning_components(learning_projection=self,
-                                             context=ContextFlags.METHOD)
+                                             # TODO: do we need this argument?
+                                             context=context)
 
         if isinstance(self.sender, OutputState) and not isinstance(self.sender.owner, LearningMechanism):
             raise LearningProjectionError("Sender specified for LearningProjection {} ({}) is not a LearningMechanism".

--- a/psyneulink/core/components/projections/modulatory/learningprojection.py
+++ b/psyneulink/core/components/projections/modulatory/learningprojection.py
@@ -539,7 +539,7 @@ class LearningProjection(ModulatoryProjection_Base):
         # If receiver has not been assigned, defer init to State.instantiate_projection_to_state()
         if sender is None or receiver is None:
             # Flag for deferred initialization
-            self.context.initialization_status = ContextFlags.DEFERRED_INIT
+            self.initialization_status = ContextFlags.DEFERRED_INIT
 
         super().__init__(sender=sender,
                          receiver=receiver,
@@ -562,7 +562,7 @@ class LearningProjection(ModulatoryProjection_Base):
 
         super()._validate_params(request_set=request_set, target_set=target_set, context=context)
 
-        if self.context.initialization_status == ContextFlags.INITIALIZING:
+        if self.initialization_status == ContextFlags.INITIALIZING:
             # VALIDATE SENDER
             sender = self.sender
             if isinstance(sender, LearningMechanism):
@@ -699,8 +699,8 @@ class LearningProjection(ModulatoryProjection_Base):
         runtime_params = runtime_params or {}
 
         # Pass during initialization (since has not yet been fully initialized
-        if self.parameters.context._get(execution_id).initialization_status == ContextFlags.DEFERRED_INIT:
-            return self.parameters.context._get(execution_id).initialization_status
+        if self.initialization_status == ContextFlags.DEFERRED_INIT:
+            return self.initialization_status
 
         if variable is not None:
             learning_signal = variable
@@ -745,7 +745,7 @@ class LearningProjection(ModulatoryProjection_Base):
         if learning_rate is not None:
             value *= learning_rate
 
-        if self.parameters.context._get(execution_id).initialization_status != ContextFlags.INITIALIZING and self.reportOutputPref:
+        if self.initialization_status != ContextFlags.INITIALIZING and self.reportOutputPref:
             print("\n{} weight change matrix: \n{}\n".format(self.name, np.diag(value)))
 
         return value

--- a/psyneulink/core/components/projections/modulatory/learningprojection.py
+++ b/psyneulink/core/components/projections/modulatory/learningprojection.py
@@ -522,9 +522,6 @@ class LearningProjection(ModulatoryProjection_Base):
         #     error function and learning function specifications from the specification of a LearningProjection (used
         #     to implement learning for a MappingProjection, e.g., in a tuple) to the LearningMechanism responsible
         #     for implementing the function; and for specifying the default LearningProjection for a Process.
-
-        context = kwargs.pop(CONTEXT, ContextFlags.CONSTRUCTOR)
-
         # Assign args to params and functionParams dicts
         params = self._assign_args_to_param_dicts(error_function=error_function,
                                                   learning_function=learning_function,
@@ -548,7 +545,6 @@ class LearningProjection(ModulatoryProjection_Base):
                          params=params,
                          name=name,
                          prefs=prefs,
-                         context=context,
                          **kwargs)
 
     def _validate_params(self, request_set, target_set=None, context=None):

--- a/psyneulink/core/components/projections/modulatory/modulatoryprojection.py
+++ b/psyneulink/core/components/projections/modulatory/modulatoryprojection.py
@@ -202,34 +202,6 @@ class ModulatoryProjection_Base(Projection_Base):
     """
     componentCategory = MODULATORY_PROJECTION
 
-    def __init__(self,
-                 receiver,
-                 sender=None,
-                 weight=None,
-                 exponent=None,
-                 function=None,
-                 params=None,
-                 name=None,
-                 prefs=None,
-                 context=None,
-                 **kwargs):
-
-        if context != ContextFlags.CONSTRUCTOR:
-            raise ModulatoryProjectionError(f"Direct call to abstract class {self.__name__} is not allowed; "
-                                            f"use projection() or one of the following subclasses: "
-                                            f"ControlProjection, GatingProjection, or LearingProjection.")
-
-        super().__init__(receiver=receiver,
-                         sender=sender,
-                         params=params,
-                         weight=weight,
-                         exponent=exponent,
-                         function=function,
-                         name=name,
-                         prefs=prefs,
-                         context=context,
-                         **kwargs)
-
     def _assign_default_projection_name(self, state=None, sender_name=None, receiver_name=None):
 
         template = "{} for {}[{}]"

--- a/psyneulink/core/components/projections/modulatory/modulatoryprojection.py
+++ b/psyneulink/core/components/projections/modulatory/modulatoryprojection.py
@@ -234,21 +234,20 @@ class ModulatoryProjection_Base(Projection_Base):
 
         template = "{} for {}[{}]"
 
-        if self.context.initialization_status &  (ContextFlags.INITIALIZED | ContextFlags.INITIALIZING):
+        if self.initialization_status &  (ContextFlags.INITIALIZED | ContextFlags.INITIALIZING):
             # If the name is not a default name for the class, return
             if not self.className + '-' in self.name:
                 return self.name
             self.name = template.format(self.className, self.receiver.owner.name, self.receiver.name)
 
-        elif self.context.initialization_status == ContextFlags.DEFERRED_INIT:
+        elif self.initialization_status == ContextFlags.DEFERRED_INIT:
             projection_name = template.format(self.className, state.owner.name, state.name)
             # self.init_args[NAME] = self.init_args[NAME] or projection_name
             self.name = self.init_args[NAME] or projection_name
 
         else:
             raise ModulatoryProjectionError("PROGRAM ERROR: {} has unrecognized initialization_status ({})".
-                                            format(self, ContextFlags._get_context_string(self.context.flags,
-                                                                                          INITIALIZATION_STATUS)))
+                                            format(self, self.initialization_status))
 
     def _delete_projection(projection):
         """Delete Projection and its entry in receiver and sender lists"""

--- a/psyneulink/core/components/projections/pathway/mappingprojection.py
+++ b/psyneulink/core/components/projections/pathway/mappingprojection.py
@@ -528,9 +528,6 @@ class MappingProjection(PathwayProjection_Base):
                  name=None,
                  prefs:is_pref_set=None,
                  **kwargs):
-
-        context = kwargs.pop(CONTEXT, ContextFlags.CONSTRUCTOR)
-
         # Assign args to params and functionParams dicts
         # Assign matrix to function_params for use as matrix param of MappingProjection.function
         # (7/12/17 CW) this is a PATCH to allow the user to set matrix as an np.matrix... I still don't know why
@@ -557,7 +554,6 @@ class MappingProjection(PathwayProjection_Base):
                          params=params,
                          name=name,
                          prefs=prefs,
-                         context=context,
                          **kwargs)
 
         try:

--- a/psyneulink/core/components/projections/pathway/mappingprojection.py
+++ b/psyneulink/core/components/projections/pathway/mappingprojection.py
@@ -546,7 +546,7 @@ class MappingProjection(PathwayProjection_Base):
 
         # If sender or receiver has not been assigned, defer init to State.instantiate_projection_to_state()
         if sender is None or receiver is None:
-            self.context.initialization_status = ContextFlags.DEFERRED_INIT
+            self.initialization_status = ContextFlags.DEFERRED_INIT
 
         # Validate sender (as variable) and params, and assign to variable and paramInstanceDefaults
         super().__init__(sender=sender,

--- a/psyneulink/core/components/projections/pathway/mappingprojection.py
+++ b/psyneulink/core/components/projections/pathway/mappingprojection.py
@@ -580,7 +580,8 @@ class MappingProjection(PathwayProjection_Base):
                 default_variable=matrix,
                 initializer=matrix,
                 # rate=initial_rate
-            )
+            ),
+            context=context
         )
         self._parameter_states[MATRIX]._instantiate_value(context)
 

--- a/psyneulink/core/components/projections/pathway/mappingprojection.py
+++ b/psyneulink/core/components/projections/pathway/mappingprojection.py
@@ -686,10 +686,6 @@ class MappingProjection(PathwayProjection_Base):
 
     def _execute(self, variable=None, execution_id=None, runtime_params=None, context=None):
 
-        self.parameters.context._get(execution_id).execution_phase = \
-            self.receiver.owner.parameters.context._get(execution_id).execution_phase
-        self.parameters.context._get(execution_id).string = context
-
         self._update_parameter_states(execution_id=execution_id, runtime_params=runtime_params, context=context)
 
         value = super()._execute(

--- a/psyneulink/core/components/projections/pathway/pathwayprojection.py
+++ b/psyneulink/core/components/projections/pathway/pathwayprojection.py
@@ -103,7 +103,7 @@ class PathwayProjection_Base(Projection_Base):
         name_template = "{}[{}]"
         projection_name_template = "{} from {} to {}"
 
-        if self.context.initialization_status == ContextFlags.DEFERRED_INIT:
+        if self.initialization_status == ContextFlags.DEFERRED_INIT:
             if self.init_args[SENDER]:
                 sender = self.init_args[SENDER]
                 if isinstance(sender, type):
@@ -122,7 +122,7 @@ class PathwayProjection_Base(Projection_Base):
         elif not self.className + '-' in self.name:
             return self.name
 
-        elif self.context.initialization_status == ContextFlags.INITIALIZED:
+        elif self.initialization_status == ContextFlags.INITIALIZED:
             if self.sender.owner:
                 sender_name = name_template.format(self.sender.owner.name, self.sender.name)
             if self.receiver.owner:
@@ -130,10 +130,11 @@ class PathwayProjection_Base(Projection_Base):
             self.name = projection_name_template.format(self.className, sender_name, receiver_name)
 
         else:
-            raise PathwayProjectionError("PROGRAM ERROR: {} has unrecognized initialization_status ({})".
-                                            format(self,
-                                                   ContextFlags._get_context_string(
-                                                           self.context.flags, INITIALIZATION_STATUS)))
+            raise PathwayProjectionError(
+                "PROGRAM ERROR: {} has unrecognized initialization_status ({})".format(
+                    self, self.initialization_status
+                )
+            )
 
     def _delete_projection(projection):
         """Delete Projection and its entry in receiver and sender lists"""

--- a/psyneulink/core/components/projections/pathway/pathwayprojection.py
+++ b/psyneulink/core/components/projections/pathway/pathwayprojection.py
@@ -68,33 +68,6 @@ class PathwayProjection_Base(Projection_Base):
 
     componentCategory = PATHWAY_PROJECTION
 
-    def __init__(self,
-                 receiver,
-                 sender=None,
-                 weight=None,
-                 exponent=None,
-                 function=None,
-                 params=None,
-                 name=None,
-                 prefs=None,
-                 context=None,
-                 **kwargs):
-
-        if context != ContextFlags.CONSTRUCTOR:
-            raise PathwayProjectionError(f"Direct call to abstract class {self.__name__} is not allowed; "
-                                         f"use projection() or a subclasses.")
-
-        super().__init__(receiver=receiver,
-                         sender=sender,
-                         weight=weight,
-                         exponent=exponent,
-                         function=function,
-                         params=params,
-                         name=name,
-                         prefs=prefs,
-                         context=context,
-                         **kwargs)
-
     def _assign_default_projection_name(self, state=None, sender_name=None, receiver_name=None):
 
         from psyneulink.core.components.mechanisms.mechanism import Mechanism

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -940,10 +940,10 @@ class Projection_Base(Projection):
             # params['matrix'] to state.value, calls setattr(state.owner, 'matrix', state.value), which sets the
             # 'matrix' parameter state's variable to ALSO be equal to state.value! If this is unintended, please change.
             value = state.parameters.value._get(execution_id)
-            getattr(self.parameters, state_name)._set(value, execution_id)
+            getattr(self.parameters, state_name)._set(value, execution_id, context)
             # manual setting of previous value to matrix value (happens in above param['matrix'] setting
             if state_name == MATRIX:
-                state.function.parameters.previous_value._set(value, execution_id)
+                state.function.parameters.previous_value._set(value, execution_id, context)
 
     def add_to(self, receiver, state, context=None):
         _add_projection_to(receiver=receiver, state=state, projection_spec=self, context=context)

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -952,16 +952,12 @@ class Projection_Base(Projection):
         if variable is None:
             variable = self.sender.parameters.value._get(execution_id)
 
-        self.parameters.context._get(execution_id).execution_phase = ContextFlags.PROCESSING
-        self.parameters.context._get(execution_id).string = context
-
         value = super()._execute(
             variable=variable,
             execution_id=execution_id,
             runtime_params=runtime_params,
             context=context
         )
-        self.parameters.context._get(execution_id).execution_phase = ContextFlags.IDLE
         return value
 
     def _activate_for_compositions(self, composition):

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -697,7 +697,7 @@ class Projection_Base(Projection):
                                                   exponent=exponent,
                                                   params=params)
 
-        if self.context.initialization_status == ContextFlags.DEFERRED_INIT:
+        if self.initialization_status == ContextFlags.DEFERRED_INIT:
             self._assign_deferred_init_name(name, context)
             self.init_args = locals().copy()
             self.init_args[NAME] = name
@@ -987,7 +987,7 @@ class Projection_Base(Projection):
     @property
     def socket_assignments(self):
 
-        if self.context.initialization_status == ContextFlags.DEFERRED_INIT:
+        if self.initialization_status == ContextFlags.DEFERRED_INIT:
             sender = self.init_args[SENDER]
             receiver = self.init_args[RECEIVER]
         else:
@@ -1192,7 +1192,7 @@ def _parse_projection_spec(projection_spec,
                                   "between Projection and ProjectionTuple")
         projection._weight = proj_spec_dict[WEIGHT] or projection.weight
         projection._exponent = proj_spec_dict[EXPONENT] or projection.exponent
-        if projection.context.initialization_status == ContextFlags.DEFERRED_INIT:
+        if projection.initialization_status == ContextFlags.DEFERRED_INIT:
             projection.init_args[NAME] = proj_spec_dict[NAME] or projection.init_args[NAME]
         else:
             projection.name = proj_spec_dict[NAME] or projection.name
@@ -1778,7 +1778,7 @@ def _validate_connection_request(
     if isinstance(projection_spec, Projection):
 
         # It is in deferred_init status
-        if projection_spec.context.initialization_status == ContextFlags.DEFERRED_INIT:
+        if projection_spec.initialization_status == ContextFlags.DEFERRED_INIT:
 
             # Try to get the State to which the Projection will be connected when fully initialized
             #     as confirmation that it is the correct type for state_type
@@ -1899,7 +1899,7 @@ def _validate_receiver(sender_mech:Mechanism,
     """
     spec_type = " in the {} arg ".format(spec_type) or ""
 
-    if projection.context.initialization_status == ContextFlags.DEFERRED_INIT:
+    if projection.initialization_status == ContextFlags.DEFERRED_INIT:
         # receiver = projection.init_args['receiver'].owner
         state = projection.init_args['receiver']
         receiver = state.owner

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -385,6 +385,7 @@ COMMENT
 .. _Projection_Class_Reference:
 
 """
+import abc
 import inspect
 import itertools
 import warnings
@@ -627,6 +628,7 @@ class Projection_Base(Projection):
     requiredParamClassDefaultTypes = Component.requiredParamClassDefaultTypes.copy()
     requiredParamClassDefaultTypes.update({PROJECTION_SENDER: [str, Mechanism, State]}) # Default sender type
 
+    @abc.abstractmethod
     def __init__(self,
                  receiver,
                  sender=None,
@@ -687,11 +689,6 @@ class Projection_Base(Projection):
         """
         from psyneulink.core.components.states.parameterstate import ParameterState
         from psyneulink.core.components.states.state import State_Base
-
-        if context != ContextFlags.CONSTRUCTOR:
-            raise ProjectionError("Direct call to abstract class Projection() is not allowed; "
-                                 "use projection() or one of the following subclasses: {0}".
-                                 format(", ".join("{!s}".format(key) for (key) in ProjectionRegistry.keys())))
 
         params = self._assign_args_to_param_dicts(weight=weight,
                                                   exponent=exponent,

--- a/psyneulink/core/components/states/inputstate.py
+++ b/psyneulink/core/components/states/inputstate.py
@@ -487,7 +487,7 @@ from psyneulink.core.components.functions.combinationfunctions import Combinatio
 from psyneulink.core.components.functions.statefulfunctions.memoryfunctions import Buffer
 from psyneulink.core.components.states.outputstate import OutputState
 from psyneulink.core.components.states.state import StateError, State_Base, _instantiate_state_list, state_type_keywords
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import Context, ContextFlags
 from psyneulink.core.globals.keywords import \
     COMBINE, COMMAND_LINE, CONTEXT, EXPONENT, FUNCTION, GATING_SIGNAL, INPUT_STATE, INPUT_STATES, INPUT_STATE_PARAMS, \
     LEARNING_SIGNAL, MAPPING_PROJECTION, MATRIX, MECHANISM, NAME, OPERATION, OUTPUT_STATE, OUTPUT_STATES, OWNER,\
@@ -799,7 +799,7 @@ class InputState(State_Base):
 
         context = kwargs.pop(CONTEXT, None)
         if context is None:
-            context = ContextFlags.COMMAND_LINE
+            context = Context(source=ContextFlags.COMMAND_LINE, string=COMMAND_LINE)
             self.context.source = ContextFlags.COMMAND_LINE
             self.context.string = COMMAND_LINE
 
@@ -1393,7 +1393,7 @@ def _instantiate_input_states(owner, input_states=None, reference_value=None, co
                                          context=context)
 
     # Call from Mechanism.add_states, so add to rather than assign input_states (i.e., don't replace)
-    if context & (ContextFlags.METHOD | ContextFlags.COMMAND_LINE):
+    if context.source & (ContextFlags.METHOD | ContextFlags.COMMAND_LINE):
         owner.input_states.extend(state_list)
     else:
         owner._input_states = state_list

--- a/psyneulink/core/components/states/inputstate.py
+++ b/psyneulink/core/components/states/inputstate.py
@@ -487,7 +487,7 @@ from psyneulink.core.components.functions.combinationfunctions import Combinatio
 from psyneulink.core.components.functions.statefulfunctions.memoryfunctions import Buffer
 from psyneulink.core.components.states.outputstate import OutputState
 from psyneulink.core.components.states.state import StateError, State_Base, _instantiate_state_list, state_type_keywords
-from psyneulink.core.globals.context import Context, ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import \
     COMBINE, COMMAND_LINE, CONTEXT, EXPONENT, FUNCTION, GATING_SIGNAL, INPUT_STATE, INPUT_STATES, INPUT_STATE_PARAMS, \
     LEARNING_SIGNAL, MAPPING_PROJECTION, MATRIX, MECHANISM, NAME, OPERATION, OUTPUT_STATE, OUTPUT_STATES, OWNER,\
@@ -780,6 +780,7 @@ class InputState(State_Base):
                                })
     #endregion
 
+    @handle_external_context()
     @tc.typecheck
     def __init__(self,
                  owner=None,
@@ -795,13 +796,8 @@ class InputState(State_Base):
                  params=None,
                  name=None,
                  prefs:is_pref_set=None,
+                 context=None,
                  **kwargs):
-
-        context = kwargs.pop(CONTEXT, None)
-        if context is None:
-            context = Context(source=ContextFlags.COMMAND_LINE, string=COMMAND_LINE)
-            self.context.source = ContextFlags.COMMAND_LINE
-            self.context.string = COMMAND_LINE
 
         if variable is None and size is None and projections is not None:
             variable = self._assign_variable_from_projection(variable, size, projections)
@@ -1120,8 +1116,6 @@ class InputState(State_Base):
                         try:
                             sender_dim = np.array(projection_spec.state.value).ndim
                         except AttributeError as e:
-                            # KDM 10/23/18: if DEFERRED_INIT is set, it will be set on the non-stateful .context
-                            # attr so these should be ok
                             if (isinstance(projection_spec.state, type) or
                                      projection_spec.state.initialization_status == ContextFlags.DEFERRED_INIT):
                                 continue

--- a/psyneulink/core/components/states/inputstate.py
+++ b/psyneulink/core/components/states/inputstate.py
@@ -984,7 +984,7 @@ class InputState(State_Base):
             pass
         return variable
 
-    def _get_fallback_variable(self, execution_id=None):
+    def _get_fallback_variable(self, execution_id=None, context=None):
         """
             Call self.function with self._path_proj_values
 
@@ -992,12 +992,10 @@ class InputState(State_Base):
             return None so that it is ignored in execute method (i.e., not combined with base_value)
         """
         # Check for Projections that are active in the Composition being run
-        current_active_composition = self.parameters.context._get(execution_id).composition
-
         path_proj_values = [
             proj.parameters.value._get(execution_id)
             for proj in self.path_afferents
-            if self.afferents_info[proj].is_active_in_composition(current_active_composition)
+            if self.afferents_info[proj].is_active_in_composition(context.composition)
         ]
 
         if len(path_proj_values) > 0:

--- a/psyneulink/core/components/states/inputstate.py
+++ b/psyneulink/core/components/states/inputstate.py
@@ -802,9 +802,6 @@ class InputState(State_Base):
             context = ContextFlags.COMMAND_LINE
             self.context.source = ContextFlags.COMMAND_LINE
             self.context.string = COMMAND_LINE
-        else:
-            context = ContextFlags.CONSTRUCTOR
-            self.context.source = ContextFlags.CONSTRUCTOR
 
         if variable is None and size is None and projections is not None:
             variable = self._assign_variable_from_projection(variable, size, projections)

--- a/psyneulink/core/components/states/inputstate.py
+++ b/psyneulink/core/components/states/inputstate.py
@@ -834,7 +834,7 @@ class InputState(State_Base):
             self.init_args['projections'] = projections
 
             # Flag for deferred initialization
-            self.context.initialization_status = ContextFlags.DEFERRED_INIT
+            self.initialization_status = ContextFlags.DEFERRED_INIT
             return
 
         self.reference_value = reference_value
@@ -1128,7 +1128,7 @@ class InputState(State_Base):
                             # KDM 10/23/18: if DEFERRED_INIT is set, it will be set on the non-stateful .context
                             # attr so these should be ok
                             if (isinstance(projection_spec.state, type) or
-                                     projection_spec.state.context.initialization_status==ContextFlags.DEFERRED_INIT):
+                                     projection_spec.state.initialization_status == ContextFlags.DEFERRED_INIT):
                                 continue
                             else:
                                 raise StateError("PROGRAM ERROR: indeterminate value for {} "
@@ -1145,7 +1145,7 @@ class InputState(State_Base):
                             else:
                                 matrix = None
                         elif isinstance(projection, Projection):
-                            if projection.context.initialization_status == ContextFlags.DEFERRED_INIT:
+                            if projection.initialization_status == ContextFlags.DEFERRED_INIT:
                                 continue
                             # possible needs to be projection.defaults.matrix?
                             matrix = projection.matrix

--- a/psyneulink/core/components/states/modulatorysignals/controlsignal.py
+++ b/psyneulink/core/components/states/modulatorysignals/controlsignal.py
@@ -730,10 +730,10 @@ class ControlSignal(ModulatorySignal):
         duration_cost = 0
         cost = None
 
-        intensity_cost_function = Exponential
-        adjustment_cost_function = Linear
-        duration_cost_function = SimpleIntegrator
-        combine_costs_function = Reduce(operation=SUM)
+        intensity_cost_function = Parameter(Exponential, stateful=False, loggable=False)
+        adjustment_cost_function = Parameter(Linear, stateful=False, loggable=False)
+        duration_cost_function = Parameter(SimpleIntegrator, stateful=False, loggable=False)
+        combine_costs_function = Parameter(Reduce(operation=SUM), stateful=False, loggable=False)
         modulation = None
 
         _validate_cost_options = get_validator_by_type_only([ControlSignalCosts, list])

--- a/psyneulink/core/components/states/modulatorysignals/controlsignal.py
+++ b/psyneulink/core/components/states/modulatorysignals/controlsignal.py
@@ -960,7 +960,7 @@ class ControlSignal(ModulatorySignal):
     def _instantiate_cost_attributes(self, context=None):
         if self.cost_options:
             # Default cost params
-            if self.context.initialization_status != ContextFlags.DEFERRED_INIT:
+            if self.initialization_status != ContextFlags.DEFERRED_INIT:
                 self.intensity_cost = self.intensity_cost_function(self.defaults.allocation)
             else:
                 self.intensity_cost = self.intensity_cost_function(self.class_defaults.allocation)
@@ -999,7 +999,7 @@ class ControlSignal(ModulatorySignal):
     def _initialize_cost_attributes(self, context=None):
         if self.cost_options:
             # Default cost params
-            if self.context.initialization_status != ContextFlags.DEFERRED_INIT:
+            if self.initialization_status != ContextFlags.DEFERRED_INIT:
                 self.intensity_cost = self.intensity_cost_function(self.defaults.allocation)
             else:
                 self.intensity_cost = self.intensity_cost_function(self.class_defaults.allocation)

--- a/psyneulink/core/components/states/modulatorysignals/modulatorysignal.py
+++ b/psyneulink/core/components/states/modulatorysignals/modulatorysignal.py
@@ -429,8 +429,8 @@ class ModulatorySignal(OutputState):
                 modulates = kwargs.pop(PROJECTIONS, modulates)
 
         # Deferred initialization
-        # if self.context.initialization_status & (ContextFlags.DEFERRED_INIT | ContextFlags.INITIALIZING):
-        if self.context.initialization_status & ContextFlags.DEFERRED_INIT:
+        # if self.initialization_status & (ContextFlags.DEFERRED_INIT | ContextFlags.INITIALIZING):
+        if self.initialization_status & ContextFlags.DEFERRED_INIT:
             # If init was deferred, it may have been because owner was not yet known (see OutputState.__init__),
             #   and so modulation hasn't had a chance to be assigned to the owner's value
             #   (i.e., if it was not specified in the constructor), so do it now;
@@ -456,7 +456,7 @@ class ModulatorySignal(OutputState):
                          prefs=prefs,
                          **kwargs)
 
-        if self.context.initialization_status == ContextFlags.INITIALIZED:
+        if self.initialization_status == ContextFlags.INITIALIZED:
             self._assign_default_state_name()
 
     def _instantiate_attributes_after_function(self, context=None):

--- a/psyneulink/core/components/states/outputstate.py
+++ b/psyneulink/core/components/states/outputstate.py
@@ -992,9 +992,6 @@ class OutputState(State_Base):
             context = ContextFlags.COMMAND_LINE
             self.context.source = ContextFlags.COMMAND_LINE
             self.context.string = COMMAND_LINE
-        else:
-            context = ContextFlags.CONSTRUCTOR
-            self.context.source = ContextFlags.CONSTRUCTOR
 
         # For backward compatibility with CALCULATE, ASSIGN and INDEX
         if 'calculate' in kwargs:

--- a/psyneulink/core/components/states/outputstate.py
+++ b/psyneulink/core/components/states/outputstate.py
@@ -1425,8 +1425,6 @@ def _instantiate_output_states(owner, output_states=None, context=None):
 
             # OutputState object
             if isinstance(output_state, OutputState):
-                # KDM 10/23/18: if DEFERRED_INIT is set, it will be set on the non-stateful .context
-                # attr so these should be ok
                 if output_state.initialization_status == ContextFlags.DEFERRED_INIT:
                     try:
                         output_state_value = OutputState._get_state_function_value(owner,

--- a/psyneulink/core/components/states/outputstate.py
+++ b/psyneulink/core/components/states/outputstate.py
@@ -594,7 +594,7 @@ from psyneulink.core.components.component import Component, ComponentError
 from psyneulink.core.components.functions.function import Function, function_type, method_type
 from psyneulink.core.components.functions.selectionfunctions import OneHot
 from psyneulink.core.components.states.state import State_Base, _instantiate_state_list, state_type_keywords
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import \
     ALL, ASSIGN, CALCULATE, COMMAND_LINE, CONTEXT, FUNCTION, GATING_SIGNAL, INDEX, INPUT_STATE, INPUT_STATES, \
     MAPPING_PROJECTION, MAX_ABS_INDICATOR, MAX_ABS_VAL, MAX_INDICATOR, MAX_VAL, MECHANISM_VALUE, NAME, \
@@ -975,6 +975,7 @@ class OutputState(State_Base):
     #endregion
 
     @tc.typecheck
+    @handle_external_context()
     def __init__(self,
                  owner=None,
                  reference_value=None,
@@ -988,10 +989,6 @@ class OutputState(State_Base):
                  **kwargs):
 
         context = kwargs.pop(CONTEXT, None)
-        if context is None:
-            context = ContextFlags.COMMAND_LINE
-            self.context.source = ContextFlags.COMMAND_LINE
-            self.context.string = COMMAND_LINE
 
         # For backward compatibility with CALCULATE, ASSIGN and INDEX
         if 'calculate' in kwargs:
@@ -1501,7 +1498,7 @@ def _instantiate_output_states(owner, output_states=None, context=None):
                                          context=context)
 
     # Call from Mechanism.add_states, so add to rather than assign output_states (i.e., don't replace)
-    if context & (ContextFlags.COMMAND_LINE | ContextFlags.METHOD):
+    if context.source & (ContextFlags.COMMAND_LINE | ContextFlags.METHOD):
         owner.output_states.extend(state_list)
     else:
         owner._output_states = state_list

--- a/psyneulink/core/components/states/outputstate.py
+++ b/psyneulink/core/components/states/outputstate.py
@@ -1024,7 +1024,7 @@ class OutputState(State_Base):
             self.init_args['projections'] = projections
 
             # Flag for deferred initialization
-            self.context.initialization_status = ContextFlags.DEFERRED_INIT
+            self.initialization_status = ContextFlags.DEFERRED_INIT
             return
 
         self.reference_value = reference_value
@@ -1433,7 +1433,7 @@ def _instantiate_output_states(owner, output_states=None, context=None):
             if isinstance(output_state, OutputState):
                 # KDM 10/23/18: if DEFERRED_INIT is set, it will be set on the non-stateful .context
                 # attr so these should be ok
-                if output_state.context.initialization_status == ContextFlags.DEFERRED_INIT:
+                if output_state.initialization_status == ContextFlags.DEFERRED_INIT:
                     try:
                         output_state_value = OutputState._get_state_function_value(owner,
                                                                                    output_state.function,

--- a/psyneulink/core/components/states/outputstate.py
+++ b/psyneulink/core/components/states/outputstate.py
@@ -1255,7 +1255,7 @@ class OutputState(State_Base):
         )
         return np.atleast_1d(value)
 
-    def _get_fallback_variable(self, execution_id=None):
+    def _get_fallback_variable(self, execution_id=None, context=None):
         # fall back to specified item(s) of owner's value
         try:
             return self.parameters.variable._get(execution_id)

--- a/psyneulink/core/components/states/parameterstate.py
+++ b/psyneulink/core/components/states/parameterstate.py
@@ -812,7 +812,7 @@ class ParameterState(State_Base):
         """Return parameter variable (since ParameterState's function never changes the form of its variable"""
         return variable
 
-    def _get_fallback_variable(self, execution_id=None):
+    def _get_fallback_variable(self, execution_id=None, context=None):
         """
         Get backingfield ("base") value of param of function of Mechanism to which the ParameterState belongs.
         """

--- a/psyneulink/core/components/states/parameterstate.py
+++ b/psyneulink/core/components/states/parameterstate.py
@@ -768,7 +768,7 @@ class ParameterState(State_Base):
                                                                      ControlProjection.__name__,
                                                                      LearningProjection.__name__,
                                                                      mod_projection, state_dict[NAME], owner.name))
-                                elif mod_projection.context.initialization_status == ContextFlags.DEFERRED_INIT:
+                                elif mod_projection.initialization_status == ContextFlags.DEFERRED_INIT:
                                     continue
                                 mod_proj_value = mod_projection.defaults.value
                             else:

--- a/psyneulink/core/components/states/parameterstate.py
+++ b/psyneulink/core/components/states/parameterstate.py
@@ -560,9 +560,7 @@ class ParameterState(State_Base):
 
         # If context is not COMPONENT or CONSTRUCTOR, raise exception
         context = kwargs.pop(CONTEXT, None)
-        if context == ContextFlags.COMPONENT:
-            context = ContextFlags.CONSTRUCTOR
-        if not context == ContextFlags.CONSTRUCTOR:
+        if context is None:
             raise ParameterStateError(f"Contructor for {self.__class__.__name__} cannot be called directly"
                                       f"(context: {context}")
 

--- a/psyneulink/core/components/states/state.py
+++ b/psyneulink/core/components/states/state.py
@@ -730,6 +730,7 @@ Class Reference
 """
 
 import abc
+import abc
 import inspect
 import itertools
 import numbers
@@ -1048,6 +1049,7 @@ class State_Base(State):
     paramClassDefaults.update({STATE_TYPE: None})
 
     @tc.typecheck
+    @abc.abstractmethod
     def __init__(self,
                  owner:tc.any(Mechanism, Projection),
                  variable=None,
@@ -1108,14 +1110,6 @@ class State_Base(State):
                 self.context.string = kargs[STATE_CONTEXT]
             except (KeyError, NameError):
                 pass
-
-        # Enforce that only called from subclass
-        if (not isinstance(context, State_Base) and
-                not (self.initialization_status == ContextFlags.INITIALIZING or
-                     context & (ContextFlags.COMMAND_LINE | ContextFlags.CONSTRUCTOR))):
-            raise StateError("Direct call to abstract class State() is not allowed; "
-                                      "use state() or one of the following subclasses: {0}".
-                                      format(", ".join("{!s}".format(key) for (key) in StateRegistry.keys())))
 
         # Enforce that subclass must implement and _execute method
         if not hasattr(self, '_execute'):

--- a/psyneulink/core/components/states/state.py
+++ b/psyneulink/core/components/states/state.py
@@ -1107,7 +1107,6 @@ class State_Base(State):
                 pass
             try:
                 context = kargs[STATE_CONTEXT]
-                self.context.string = kargs[STATE_CONTEXT]
             except (KeyError, NameError):
                 pass
 
@@ -1143,8 +1142,6 @@ class State_Base(State):
         self._mod_proj_values = {}
         for (attrib, value) in ModulationParam.__members__.items():
             self._mod_proj_values[getattr(ModulationParam,attrib)] = []
-
-        self.context.string = context.__class__.__name__
 
         # VALIDATE VARIABLE, PARAM_SPECS, AND INSTANTIATE self.function
         super(State_Base, self).__init__(default_variable=variable,
@@ -1905,15 +1902,6 @@ class State_Base(State):
         Call self.function (default: LinearCombination function) to combine their values
         Returns combined values of projections, modulated by any mod_afferents
         """
-
-        # Set context to owner's context:
-        self._assign_context_values(
-            execution_id,
-            execution_phase=self.owner.parameters.context._get(execution_id).execution_phase,
-        )
-        # self.parameters.context._get(execution_id).execution_phase = self.owner.parameters.context._get(execution_id).execution_phase
-        self.parameters.context._get(execution_id).string = self.owner.parameters.context._get(execution_id).string
-
         # SET UP ------------------------------------------------------------------------------------------------
 
         # Get State-specific param_specs
@@ -1977,7 +1965,6 @@ class State_Base(State):
             if not self.afferents_info[projection].is_active_in_composition(context.composition):
                 continue
 
-            projection._assign_context_values(execution_id, composition=self.parameters.context._get(execution_id).composition)
             # Only accept projections from a Process to which the owner Mechanism belongs
             if isinstance(sender, ProcessInputState):
                 if not sender.owner in self.owner.processes.keys():

--- a/psyneulink/core/components/states/state.py
+++ b/psyneulink/core/components/states/state.py
@@ -1167,7 +1167,7 @@ class State_Base(State):
 
         self.projections = self.path_afferents + self.mod_afferents + self.efferents
 
-        if context == ContextFlags.COMMAND_LINE:
+        if context.source == ContextFlags.COMMAND_LINE:
             owner.add_states([self])
 
     def _handle_size(self, size, variable):
@@ -1486,7 +1486,7 @@ class State_Base(State):
                 # If sender has been instantiated, try to complete initialization
                 # If not, assume it will be handled later (by Mechanism or Composition)
                 if isinstance(sender, State) and sender.initialization_status == ContextFlags.INITIALIZED:
-                    projection._deferred_init()
+                    projection._deferred_init(context=context)
 
 
             # VALIDATE (if initialized)
@@ -2520,8 +2520,7 @@ def _instantiate_state(state_type:_is_state_class,           # State's type
                 else:
                     # state.reference_value = owner.defaults.variable[0]
                     state.reference_value = state.init_args[VARIABLE]
-            state.init_args[CONTEXT]=context
-            state._deferred_init()
+            state._deferred_init(context=context)
 
         # # FIX: 10/3/17 - CHECK THE FOLLOWING BY CALLING STATE-SPECIFIC METHOD?
         # # FIX: DO THIS IN _parse_connection_specs?

--- a/psyneulink/core/components/states/state.py
+++ b/psyneulink/core/components/states/state.py
@@ -1111,7 +1111,7 @@ class State_Base(State):
 
         # Enforce that only called from subclass
         if (not isinstance(context, State_Base) and
-                not (self.context.initialization_status == ContextFlags.INITIALIZING or
+                not (self.initialization_status == ContextFlags.INITIALIZING or
                      context & (ContextFlags.COMMAND_LINE | ContextFlags.CONSTRUCTOR))):
             raise StateError("Direct call to abstract class State() is not allowed; "
                                       "use state() or one of the following subclasses: {0}".
@@ -1428,7 +1428,7 @@ class State_Base(State):
             # ASSIGN PARAMS
 
             # Deferred init
-            if projection.context.initialization_status == ContextFlags.DEFERRED_INIT:
+            if projection.initialization_status == ContextFlags.DEFERRED_INIT:
 
                 proj_sender = projection.init_args[SENDER]
                 proj_receiver = projection.init_args[RECEIVER]
@@ -1475,7 +1475,7 @@ class State_Base(State):
 
                 # Construct and assign name
                 if isinstance(sender, State):
-                    if sender.context.initialization_status == ContextFlags.DEFERRED_INIT:
+                    if sender.initialization_status == ContextFlags.DEFERRED_INIT:
                         sender_name = sender.init_args[NAME]
                     else:
                         sender_name = sender.name
@@ -1491,13 +1491,13 @@ class State_Base(State):
 
                 # If sender has been instantiated, try to complete initialization
                 # If not, assume it will be handled later (by Mechanism or Composition)
-                if isinstance(sender, State) and sender.context.initialization_status == ContextFlags.INITIALIZED:
+                if isinstance(sender, State) and sender.initialization_status == ContextFlags.INITIALIZED:
                     projection._deferred_init()
 
 
             # VALIDATE (if initialized)
 
-            if projection.context.initialization_status == ContextFlags.INITIALIZED:
+            if projection.initialization_status == ContextFlags.INITIALIZED:
 
                 # FIX: 10/3/17 - VERIFY THE FOLLOWING:
                 # IMPLEMENTATION NOTE:
@@ -1728,7 +1728,7 @@ class State_Base(State):
                 projection = projection_spec
                 projection_type = projection.__class__
 
-                if projection.context.initialization_status == ContextFlags.DEFERRED_INIT:
+                if projection.initialization_status == ContextFlags.DEFERRED_INIT:
                     projection.init_args[RECEIVER] = projection.init_args[RECEIVER] or receiver
                     proj_recvr = projection.init_args[RECEIVER]
                 else:
@@ -1775,13 +1775,13 @@ class State_Base(State):
             # ASSIGN REMAINING PARAMS
 
             # Deferred init
-            if projection.context.initialization_status == ContextFlags.DEFERRED_INIT:
+            if projection.initialization_status == ContextFlags.DEFERRED_INIT:
 
                 projection.init_args[SENDER] = self
 
                 # Construct and assign name
                 if isinstance(receiver, State):
-                    if receiver.context.initialization_status == ContextFlags.DEFERRED_INIT:
+                    if receiver.initialization_status == ContextFlags.DEFERRED_INIT:
                         receiver_name = receiver.init_args[NAME]
                     else:
                         receiver_name = receiver.name
@@ -1807,15 +1807,15 @@ class State_Base(State):
 
                 # If receiver has been instantiated, try to complete initialization
                 # If not, assume it will be handled later (by Mechanism or Composition)
-                if isinstance(receiver, State) and receiver.context.initialization_status == ContextFlags.INITIALIZED:
+                if isinstance(receiver, State) and receiver.initialization_status == ContextFlags.INITIALIZED:
                     projection._deferred_init()
 
             # VALIDATE (if initialized or being initialized (INITIALIZA))
 
-            if projection.context.initialization_status & (ContextFlags.INITIALIZED | ContextFlags.INITIALIZING):
+            if projection.initialization_status & (ContextFlags.INITIALIZED | ContextFlags.INITIALIZING):
 
                 # If still being initialized, then assign sender and receiver as necessary
-                if projection.context.initialization_status == ContextFlags.INITIALIZING:
+                if projection.initialization_status == ContextFlags.INITIALIZING:
                     if not isinstance(projection.sender, State):
                         projection.sender = self
 
@@ -2047,7 +2047,7 @@ class State_Base(State):
 
             # If this is initialization run and projection initialization has been deferred, pass
             try:
-                if projection.parameters.context._get(execution_id).initialization_status == ContextFlags.DEFERRED_INIT:
+                if projection.initialization_status == ContextFlags.DEFERRED_INIT:
                     continue
             except AttributeError:
                 pass
@@ -2509,7 +2509,7 @@ def _instantiate_state(state_type:_is_state_class,           # State's type
 
         # State initialization was deferred (owner or reference_value was missing), so
         #    assign owner, variable, and/or reference_value if they were not already specified
-        if state.context.initialization_status == ContextFlags.DEFERRED_INIT:
+        if state.initialization_status == ContextFlags.DEFERRED_INIT:
             if not state.init_args[OWNER]:
                 state.init_args[OWNER] = owner
             # If variable was not specified by user or State's constructor:
@@ -2822,7 +2822,7 @@ def _parse_state_spec(state_type=None,
         #    so assume it is a reference to the State itself that is being (or has been) instantiated
         elif isinstance(state_specification, state_type):
             # Make sure that the specified State belongs to the Mechanism passed in the owner arg
-            if state_specification.context.initialization_status == ContextFlags.DEFERRED_INIT:
+            if state_specification.initialization_status == ContextFlags.DEFERRED_INIT:
                 state_owner = state_specification.init_args[OWNER]
             else:
                 state_owner = state_specification.owner
@@ -2869,8 +2869,8 @@ def _parse_state_spec(state_type=None,
 
         # Projection has been instantiated
         if isinstance(projection_spec, Projection):
-            if projection_spec.context.initialization_status == ContextFlags.INITIALIZED:
-            # if projection_spec.context.initialization_status != ContextFlags.DEFERRED_INIT:
+            if projection_spec.initialization_status == ContextFlags.INITIALIZED:
+            # if projection_spec.initialization_status != ContextFlags.DEFERRED_INIT:
                 projection_value = projection_spec.value
             # If deferred_init, need to get sender and matrix to determine value
             else:

--- a/psyneulink/core/components/system.py
+++ b/psyneulink/core/components/system.py
@@ -911,7 +911,7 @@ class System(System_Base):
 
         # Required to defer assignment of self.controller by setter
         #     until the rest of the System has been instantiated
-        self.context.initialization_status = ContextFlags.INITIALIZING
+        self.initialization_status = ContextFlags.INITIALIZING
 
         processes = processes or []
         if not isinstance(processes, list):
@@ -958,7 +958,7 @@ class System(System_Base):
 
         if not context:
             context = ContextFlags.COMPOSITION
-            self.context.initialization_status = ContextFlags.INITIALIZING
+            self.initialization_status = ContextFlags.INITIALIZING
             self.context.string = INITIALIZING + self.name + kwSeparator + SYSTEM_INIT
 
         self.default_execution_id = self.name
@@ -970,7 +970,7 @@ class System(System_Base):
                          prefs=prefs,
                          context=context)
 
-        self.context.initialization_status = ContextFlags.INITIALIZED
+        self.initialization_status = ContextFlags.INITIALIZED
         self.reinitialize_mechanisms_when = reinitialize_mechanisms_when
 
         # Assign controller
@@ -2581,7 +2581,7 @@ class System(System_Base):
             for parameter_state in mech._parameter_states:
                 for projection in parameter_state.mod_afferents:
                     # If Projection was deferred for init, instantiate its ControlSignal and then initialize it
-                    if projection.context.initialization_status == ContextFlags.DEFERRED_INIT:
+                    if projection.initialization_status == ContextFlags.DEFERRED_INIT:
                         proj_control_signal_specs = projection.control_signal_params or {}
                         proj_control_signal_specs.update({PROJECTIONS: [projection]})
                         control_signal_specs.append(proj_control_signal_specs)
@@ -2728,7 +2728,7 @@ class System(System_Base):
 
         if input is None:
             if (self.prefs.verbosePref and not (self.parameters.context._get(execution_id).source == ContextFlags.COMMAND_LINE or
-                                                self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZING)):
+                                                self.initialization_status == ContextFlags.INITIALIZING)):
                 print("- No input provided;  default will be used: {0}")
             input = np.zeros_like(self.defaults.variable)
             for i in range(num_origin_mechs):
@@ -2850,7 +2850,7 @@ class System(System_Base):
                     print("{0}: {1} executed".format(self.name, self.controller.name))
 
             except AttributeError as error_msg:
-                if self.parameters.context._get(execution_id).initialization_status != ContextFlags.INITIALIZING:
+                if self.initialization_status != ContextFlags.INITIALIZING:
                     error_msg.args += ("PROGRAM ERROR: Problem executing controller ({}) for {}".format(self.controller.name, self.name),)
                     raise
 
@@ -5055,7 +5055,7 @@ class SystemInputState(OutputState):
             self.name = owner.name + "_" + SYSTEM_TARGET_INPUT_STATE
         else:
             self.name = owner.name + "_" + name
-        self.context.initialization_status = ContextFlags.INITIALIZING
+        self.initialization_status = ContextFlags.INITIALIZING
         self.context.string = context
         self.prefs = prefs
         self.log = Log(owner=self)

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -1707,6 +1707,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         self.log = CompositionLog(owner=self)
         self._terminal_backprop_sequences = {}
 
+        self.initialization_status = ContextFlags.INITIALIZED
+
     def __repr__(self):
         return '({0} {1})'.format(type(self).__name__, self.name)
 
@@ -2658,7 +2660,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             self._parse_receiver_spec(projection, receiver, sender, learning_projection)
 
         # If Deferred init
-        if projection.context.initialization_status == ContextFlags.DEFERRED_INIT:
+        if projection.initialization_status == ContextFlags.DEFERRED_INIT:
             # If sender or receiver are State specs, use those;  otherwise, use graph node (Mechanism or Composition)
             if not isinstance(sender, OutputState):
                 sender = sender_mechanism
@@ -4265,7 +4267,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             self._animate = buffer_animate_state
 
         # Store simulation results on "base" composition
-        if context.initialization_status != ContextFlags.INITIALIZING:
+        if self.initialization_status != ContextFlags.INITIALIZING:
             try:
                 self.parameters.simulation_results._get(base_execution_id).append(
                     self.get_output_values(execution_id))
@@ -6471,7 +6473,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             # FIX: SHOULD SET CONTEXT AS CONTROL HERE AND RESET AT END (AS DONE FOR animation BELOW)
             execution_phase = self.parameters.context._get(execution_id).execution_phase
             if (
-                    execution_phase != ContextFlags.INITIALIZING
+                    self.initialization_status != ContextFlags.INITIALIZING
                     and execution_phase != ContextFlags.SIMULATION
             ):
                 if self.controller and not bin_execute:

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -659,7 +659,7 @@ If you receive an error like below, while checking for a context value for examp
 
 ::
 
-    self.parameters.context._get(execution_id).execution_phase == ContextStatus.PROCESSING
+    self.parameters.context._get(execution_id).execution_phase == ContextFlags.PROCESSING
     AttributeError: 'NoneType' object has no attribute 'execution_phase'
 
 this means that there was no context value found for execution_id, and can be indicative that execution_id

--- a/psyneulink/core/compositions/pathwaycomposition.py
+++ b/psyneulink/core/compositions/pathwaycomposition.py
@@ -90,6 +90,7 @@ class PathwayComposition(Composition):
         runtime_params=None,
         skip_initialization=False,
         bin_execute=False,
+        context=None,
     ):
 
         if isinstance(inputs, list):
@@ -104,6 +105,7 @@ class PathwayComposition(Composition):
                                                          clamp_input=clamp_input,
                                                          runtime_params=runtime_params,
                                                          skip_initialization=skip_initialization,
-                                                         bin_execute=bin_execute
+                                                         bin_execute=bin_execute,
+                                                         context=context,
         )
         return output

--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -443,7 +443,7 @@ class Context():
 
     def update_execution_time(self):
         if self.execution & ContextFlags.EXECUTING:
-            self.execution_time = _get_time(self.owner, self.context.flags)
+            self.execution_time = _get_time(self.owner, self.most_recent_context.flags)
         else:
             raise ContextError("PROGRAM ERROR: attempt to call update_execution_time for {} "
                                "when 'EXECUTING' was not in its context".format(self.owner.name))
@@ -551,7 +551,6 @@ def _get_time(component, context, execution_id=None):
                        format(component.__class__.__name__,
                               Mechanism.__name__, State.__name__, Projection.__name__))
 
-    # FIX: Modify to use component.owner.context.composition once that is implemented
     # Get System in which it is being (or was last) executed (if any):
 
     system = context.composition

--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -68,19 +68,9 @@ COMMENT:
 
         Among other things, this is used to determine the source of call of a constructor (until someone
             proposes/implements a better method!).  This is used in several ways, for example:
-            a) to insure that any call to a _Base class is from a subclass constructor
-              rather than by the user from the command line (which is not allowed).
-            b) to determine whether an InputState or OutputState is being added as part of the construction process
+            a) to determine whether an InputState or OutputState is being added as part of the construction process
               (e.g., for LearningMechanism) or by the user from the command line (see Mechanism.add_states)
 
-        Application (a) above is implemented as follows:
-            * user-accessible subclasses do not implement a context argument in their constructors
-            * subclasses just below the _Base class call super().__init__() with context=ContextFlags.CONSTRUCTOR
-            * all lower sub-subclasses call super without context arg
-            * the constructor for all _Base classes checks that context==ContextFlags.CONSTRUCTOR
-              and assign self.context.source = context
-            * the constructor for all _Base classes do NOT pass a context arg to super (i.e., shellclasses or Component)
-              since Component.__init__() assigns context arg as CONSTRUCTOR for all of its calls
 COMMENT
 
 .. _Context_Class_Reference:

--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -489,7 +489,7 @@ class Context():
 
 
 @tc.typecheck
-def _get_context(context:tc.any(ContextFlags, str)):
+def _get_context(context:tc.any(ContextFlags, Context, str)):
     """Set flags based on a string of ContextFlags keywords
     If context is already a ContextFlags mask, return that
     Otherwise, return mask with flags set corresponding to keywords in context
@@ -497,6 +497,8 @@ def _get_context(context:tc.any(ContextFlags, str)):
     # FIX: 3/23/18 UPDATE WITH NEW FLAGS
     if isinstance(context, ContextFlags):
         return context
+    if isinstance(context, Context):
+        context = context.string
     context_flag = ContextFlags.UNSET
     if VALIDATE in context:
         context_flag |= ContextFlags.VALIDATING

--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -13,8 +13,8 @@
 
 Overview
 --------
-The Context class is used for the `context <Component.context>` attribute of all `Components <Component>`.  It is
-set when a Component is first instantiated, and updated under various operating conditions.  Its primary
+The Context class is used to pass information about execution and state.  It is generally
+created at runtime, and updated under various operating conditions. Its primary
 attribute is `flags <Context.flags>` - a binary vector, the individual flags of which are specified using the
 `ContextFlags` enum.  The `flags <Context.flags>` attribute is divided functionally into the two fields:
 
@@ -22,8 +22,9 @@ attribute is `flags <Context.flags>` - a binary vector, the individual flags of 
 
   * `source <Context.source>` - source of a call to a method belonging to or operating on the Component.
 
-Each field can be addressed using the corresponding property of the class, and in general only one of the flags
-in a field is set (although see individual property documentation for exceptions).
+Each field can be addressed using the corresponding property of the class; only one source
+flag may be set, but in some cases multiple execution_phase flags may be set
+(although see individual property documentation for exceptions).
 
 Context and Logging
 -------------------
@@ -37,8 +38,9 @@ are a subset of (and are aliased to) the flags in `ContextFlags`.
 Additional Attributes
 ---------------------
 
-In addition to `flags <Context.flags>`, Context has four other attributes that record information relevant to the
-operating state of the Component:
+In addition to `flags <Context.flags>`, `execution_phase <Context.execution_phase>`, and
+`source <Context.source>`, Context has four other attributes that record information
+relevant to the operating state of the Component:
 
     `owner <Context.owner>`
       the Component to which the Context belongs (assigned to its `context <Component.context>` attribute;

--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -263,35 +263,6 @@ SOURCE_FLAGS = {ContextFlags.CONSTRUCTOR,
                 ContextFlags.COMPONENT,
                 ContextFlags.COMPOSITION}
 
-# For backward compatibility
-class ContextStatus(enum.IntFlag):
-    """Used to identify the status of a `Component` when its value or one of its attributes is being accessed.
-    Also used to specify the context in which a value of the Component or its attribute is `logged <Log_Conditions>`.
-    """
-    OFF = 0
-    # """No recording."""
-    INITIALIZATION = ContextFlags.INITIALIZING
-    """Set during execution of the Component's constructor."""
-    VALIDATION =  ContextFlags.VALIDATING
-    """Set during validation of the value of a Component or its attribute."""
-    EXECUTION =  ContextFlags.EXECUTING
-    """Set during any execution of the Component."""
-    PROCESSING = ContextFlags.PROCESSING
-    """Set during the `processing phase <System_Execution_Processing>` of execution of a Composition."""
-    LEARNING = ContextFlags.LEARNING
-    """Set during the `learning phase <System_Execution_Learning>` of execution of a Composition."""
-    CONTROL = ContextFlags.CONTROL
-    """Set during the `control phase System_Execution_Control>` of execution of a Composition."""
-    SIMULATION = ContextFlags.SIMULATION
-    # Set during simulation by Composition.controller
-    COMMAND_LINE = ContextFlags.COMMAND_LINE
-    # Component accessed by user
-    CONSTRUCTOR = ContextFlags.CONSTRUCTOR
-    # Component being constructor (used in call to super.__init__)
-    ALL_ASSIGNMENTS = \
-        INITIALIZATION | VALIDATION | EXECUTION | PROCESSING | LEARNING | CONTROL
-    """Specifies all contexts."""
-
 
 class Context():
     """Used to indicate the state of initialization and phase of execution of a Component, as well as the source of

--- a/psyneulink/core/globals/environment.py
+++ b/psyneulink/core/globals/environment.py
@@ -102,7 +102,7 @@ If you receive an error like below, while checking for a context value for examp
 
 ::
 
-    self.parameters.context._get(execution_id).execution_phase == ContextStatus.PROCESSING
+    self.parameters.context._get(execution_id).execution_phase == ContextFlags.PROCESSING
     AttributeError: 'NoneType' object has no attribute 'execution_phase'
 
 this means that there was no context value found for execution_id, and can be indicative that execution_id

--- a/psyneulink/core/globals/environment.py
+++ b/psyneulink/core/globals/environment.py
@@ -865,7 +865,7 @@ def run(obj,
 
     # INITIALIZATION
     if initialize:
-        obj.initialize(execution_context=execution_id)
+        obj.initialize(execution_context=execution_id, context=context)
 
     # SET UP TIMING
     if object_type == MECHANISM:
@@ -892,7 +892,7 @@ def run(obj,
             for mechanism in obj.mechanisms:
                 if hasattr(mechanism, "reinitialize_when") and mechanism.parameters.has_initializers._get(execution_id):
                     if mechanism.reinitialize_when.is_satisfied(scheduler=obj.scheduler_processing, execution_context=execution_id):
-                        mechanism.reinitialize(None, execution_context=execution_id)
+                        mechanism.reinitialize(None, execution_context=execution_id, context=context)
 
             input_num = execution%num_inputs_sets
 
@@ -916,7 +916,9 @@ def run(obj,
                         obj.target = execution_targets
                         obj.current_targets = execution_targets
 
-            if context.source == ContextFlags.COMMAND_LINE or not obj.parameters.context._get(execution_id).execution_phase == ContextFlags.SIMULATION:
+            if context.source == ContextFlags.COMMAND_LINE or ContextFlags.SIMULATION not in context.execution_phase:
+                context.execution_phase = ContextFlags.PROCESSING
+                context.composition = obj
                 obj._assign_context_values(execution_id, execution_phase=ContextFlags.PROCESSING, composition=obj, propagate=True)
                 obj.parameters.context._get(execution_id).string = RUN + ": EXECUTING " + object_type.upper() + " " + obj.name
 
@@ -933,7 +935,7 @@ def run(obj,
             if call_after_time_step:
                 call_with_pruned_args(call_after_time_step, execution_context=execution_id)
 
-        if obj.parameters.context._get(execution_id).execution_phase != ContextFlags.SIMULATION:
+        if ContextFlags.SIMULATION not in context.execution_phase:
             if isinstance(result, Iterable):
                 result_copy = result.copy()
             else:

--- a/psyneulink/core/globals/environment.py
+++ b/psyneulink/core/globals/environment.py
@@ -864,7 +864,7 @@ def run(obj,
 
     # Class-specific validation:
     if not obj.parameters.context._get(execution_id).flags:
-        obj.parameters.context._get(execution_id).initialization_status = ContextFlags.VALIDATING
+        obj.initialization_status = ContextFlags.VALIDATING
         obj.parameters.context._get(execution_id).string = RUN + "validating " + obj.name
 
     # INITIALIZATION

--- a/psyneulink/core/globals/environment.py
+++ b/psyneulink/core/globals/environment.py
@@ -96,20 +96,6 @@ or Mechanism.input_states, as these are added in the proper classes' _dependent_
     under **new_execution_id**
     - a good example of a "nonstandard" override is `OptimizationControlMechanism._dependent_components`
 
-Debugging Tips
-^^^^^^^^^^^^^^
-If you receive an error like below, while checking for a context value for example,
-
-::
-
-    self.parameters.context._get(execution_id).execution_phase == ContextFlags.PROCESSING
-    AttributeError: 'NoneType' object has no attribute 'execution_phase'
-
-this means that there was no context value found for execution_id, and can be indicative that execution_id
-was not initialized to the values of another execution context, which normally happens during execution.
-See `Execution Contexts initialization <Run_Execution_Contexts_Init>`.
-
-
 .. _Run_Timing:
 
 *Timing*
@@ -919,8 +905,6 @@ def run(obj,
             if context.source == ContextFlags.COMMAND_LINE or ContextFlags.SIMULATION not in context.execution_phase:
                 context.execution_phase = ContextFlags.PROCESSING
                 context.composition = obj
-                obj._assign_context_values(execution_id, execution_phase=ContextFlags.PROCESSING, composition=obj, propagate=True)
-                obj.parameters.context._get(execution_id).string = RUN + ": EXECUTING " + object_type.upper() + " " + obj.name
 
             result = obj.execute(
                 input=execution_inputs,

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -973,6 +973,13 @@ class Parameter(types.SimpleNamespace):
             context_str = ContextFlags._get_context_string(context.flags)
             log_condition_satisfied = self.log_condition & context.flags
 
+        if (
+            not log_condition_satisfied
+            and self.log_condition & LogCondition.INITIALIZATION
+            and self._owner._owner.initialization_status is ContextFlags.INITIALIZING
+        ):
+            log_condition_satisfied = True
+
         if log_condition_satisfied:
             if execution_id not in self.log:
                 self.log[execution_id] = collections.deque([])

--- a/psyneulink/core/globals/preferences/componentpreferenceset.py
+++ b/psyneulink/core/globals/preferences/componentpreferenceset.py
@@ -298,13 +298,13 @@ class ComponentPreferenceSet(PreferenceSet):
                                                     level=owner_class.classPreferenceLevel,
                                                     prefs=ComponentDefaultPrefDicts[owner_class.classPreferenceLevel],
                                                     name=name,
-                                                    context=ContextFlags.CONSTRUCTOR)
+                                                    )
         # Instantiate PreferenceSet
         super().__init__(owner=owner,
                          level=owner_class.classPreferenceLevel,
                          prefs=prefs,
                          name=name,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
         self._level = level
 
     @property

--- a/psyneulink/core/globals/preferences/preferenceset.py
+++ b/psyneulink/core/globals/preferences/preferenceset.py
@@ -8,6 +8,7 @@
 #
 # **********************************************  PreferenceSet **********************************************************
 #
+import abc
 import inspect
 
 from collections import namedtuple
@@ -46,6 +47,7 @@ class PreferenceSetError(Exception):
          return repr(self.error_value)
 
 
+@abc.abstractmethod
 class PreferenceSet(object):
     """Abstract class for PreferenceSets that stores preferences and provides access to level-specific settings
 
@@ -184,12 +186,6 @@ class PreferenceSet(object):
         """
 
         # VALIDATE ATTRIBUTES AND ARGS
-        # PreferenceSet is an abstract class, and so should only be initialized from the constructor of a subclass
-        if context != ContextFlags.CONSTRUCTOR:
-            raise PreferenceSetError("Direct call to abstract class PreferenceSet() is not allowed; "
-                                     "use one of the following subclasses: {0}".
-                                     format(", ".join("{!s}".format(key) for (key) in PreferenceSetRegistry.keys())))
-
         # Make sure subclass implements a baseClass class attribute and that owner is a subclass or instance of it
         try:
             base_class_NOT_A_CLASS = not inspect.isclass(self.baseClass)

--- a/psyneulink/core/globals/socket.py
+++ b/psyneulink/core/globals/socket.py
@@ -9,7 +9,7 @@ class ConnectionInfo(types.SimpleNamespace):
         Stores info about a *connection*, or the joining of a Projection to a State
 
         **compositions** : the `Composition`\\ s which the connection is associated with
-        **active_context** : the `ContextStatus` under which the connection is active
+        **active_context** : the `ContextFlags` under which the connection is active
     """
 
     ALL = True

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -109,7 +109,8 @@ from psyneulink.core.globals.keywords import DISTANCE_METRICS, EXPONENTIAL, GAUS
 __all__ = [
     'append_type_to_name', 'AutoNumber', 'ContentAddressableList', 'convert_to_list', 'convert_to_np_array',
     'convert_all_elements_to_np_array', 'NodeRole', 'get_class_attributes', 'flatten_list',
-    'get_modulationOperation_name', 'get_value_from_array', 'is_component', 'is_distance_metric', 'is_matrix',
+    'get_modulationOperation_name', 'get_value_from_array', 'is_component',
+    'is_distance_metric', 'is_matrix',
     'insert_list', 'is_matrix_spec', 'all_within_range', 'is_iterable',
     'is_modulation_operation', 'is_numeric', 'is_numeric_or_none', 'is_same_function_spec', 'is_unit_interval',
     'is_value_spec', 'iscompatible', 'kwCompatibilityLength', 'kwCompatibilityNumeric', 'kwCompatibilityType',
@@ -1662,4 +1663,3 @@ def unproxy_weakproxy(proxy):
             True
     """
     return proxy.__repr__.__self__
-

--- a/psyneulink/library/components/mechanisms/adaptive/control/agt/lccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/adaptive/control/agt/lccontrolmechanism.py
@@ -285,7 +285,7 @@ from psyneulink.core.components.mechanisms.processing.objectivemechanism import 
 from psyneulink.core.components.projections.modulatory.controlprojection import ControlProjection
 from psyneulink.core.components.shellclasses import Mechanism, System_Base
 from psyneulink.core.components.states.outputstate import OutputState
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import Context, ContextFlags
 from psyneulink.core.globals.keywords import ALL, CONTROL, CONTROL_PROJECTIONS, CONTROL_SIGNALS, FUNCTION, INIT_EXECUTE_METHOD_ONLY, PROJECTIONS
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.componentpreferenceset import is_pref_set
@@ -917,7 +917,7 @@ class LCControlMechanism(ControlMechanism):
         super()._add_system(system, role)
         if isinstance(self.modulated_mechanisms, str) and self.modulated_mechanisms is ALL:
             # Call with ContextFlags.COMPONENT so that OutputStates are replaced rather than added
-            self._instantiate_output_states(context=ContextFlags.COMPONENT)
+            self._instantiate_output_states(context=Context(source=ContextFlags.COMPONENT))
 
     @tc.typecheck
     def add_modulated_mechanisms(self, mechanisms:list):

--- a/psyneulink/library/components/mechanisms/adaptive/control/evc/evcauxiliary.py
+++ b/psyneulink/library/components/mechanisms/adaptive/control/evc/evcauxiliary.py
@@ -23,7 +23,7 @@ from psyneulink.core.components.functions.statefulfunctions.integratorfunctions 
 from psyneulink.core.components.functions.statefulfunctions.memoryfunctions import Buffer
 from psyneulink.core.components.functions.transferfunctions import Linear
 from psyneulink.core.components.mechanisms.processing.integratormechanism import IntegratorMechanism
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.defaults import MPI_IMPLEMENTATION, defaultControlAllocation
 from psyneulink.core.globals.keywords import COMBINE_OUTCOME_AND_COST_FUNCTION, COST_FUNCTION, EVC_SIMULATION, FUNCTION, FUNCTION_PARAMS, NOISE, PREDICTION_MECHANISM, RATE, \
     kwPreferenceSetName, kwProgressBarChar
@@ -875,6 +875,7 @@ class PredictionMechanism(IntegratorMechanism):
         rate = Parameter(1.0, modulable=True)
 
     @tc.typecheck
+    @handle_external_context(source=None)
     def __init__(self,
                  default_variable=None,
                  size=None,
@@ -893,9 +894,9 @@ class PredictionMechanism(IntegratorMechanism):
                  prefs:is_pref_set=None,
                  context=None):
 
-        if not context in {ContextFlags.COMPONENT, ContextFlags.COMPOSITION, ContextFlags.COMMAND_LINE}:
+        if not context.source in {ContextFlags.COMPONENT, ContextFlags.COMPOSITION, ContextFlags.COMMAND_LINE}:
             warnings.warn("PredictionMechanism should not be constructed on its own.  If you insist,"
-                          "set context=ContextFlags.COMMAND_LINE, but proceed at your peril!")
+                          "set context=Context(source=ContextFlags.COMMAND_LINE), but proceed at your peril!")
             return
 
         if params and FUNCTION in params:

--- a/psyneulink/library/components/mechanisms/adaptive/control/evc/evcauxiliary.py
+++ b/psyneulink/library/components/mechanisms/adaptive/control/evc/evcauxiliary.py
@@ -148,7 +148,7 @@ class ValueFunction(EVCAuxiliaryFunction):
     def __init__(self, function=None):
         function = function or self.function
         super().__init__(function=function,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _function(
         self,
@@ -301,7 +301,7 @@ class ControlSignalGridSearch(EVCAuxiliaryFunction):
         function = function or self.function
         super().__init__(function=function,
                          owner=owner,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _function(
         self,

--- a/psyneulink/library/components/mechanisms/adaptive/control/evc/evcauxiliary.py
+++ b/psyneulink/library/components/mechanisms/adaptive/control/evc/evcauxiliary.py
@@ -201,7 +201,7 @@ class ValueFunction(EVCAuxiliaryFunction):
 
         """
 
-        if self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZING:
+        if self.is_initializing:
             return (np.array([0]), np.array([0]), np.array([0]))
 
         # remove this in favor of attribute or parameter?
@@ -333,8 +333,7 @@ class ControlSignalGridSearch(EVCAuxiliaryFunction):
 
         """
 
-        if (self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZING or
-                self.owner.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZING):
+        if self.is_initializing:
             return [defaultControlAllocation]
 
         # Get value of, or set default for standard args

--- a/psyneulink/library/components/mechanisms/adaptive/control/evc/evcauxiliary.py
+++ b/psyneulink/library/components/mechanisms/adaptive/control/evc/evcauxiliary.py
@@ -346,12 +346,6 @@ class ControlSignalGridSearch(EVCAuxiliaryFunction):
         EVC_values = []
         EVC_policies = []
 
-        # Reset context so that System knows this is a simulation (to avoid infinitely recursive loop)
-        # FIX 3/30/18 - IS controller CORRECT FOR THIS, OR SHOULD IT BE System (controller.system)??
-        controller.parameters.context._get(execution_id).execution_phase = ContextFlags.SIMULATION
-        controller.parameters.context._get(execution_id).string = "{0} EXECUTING {1} of {2}".format(controller.name,
-                                                                      EVC_SIMULATION,
-                                                                      controller.system.name)
         context.execution_phase = ContextFlags.SIMULATION
         # Get allocation_samples for all ControlSignals
         num_control_signals = len(controller.control_signals)

--- a/psyneulink/library/components/mechanisms/adaptive/control/evc/evccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/adaptive/control/evc/evccontrolmechanism.py
@@ -1265,6 +1265,7 @@ class EVCControlMechanism(ControlMechanism):
 
         # Run simulation
         self.system.parameters.context._get(execution_id).execution_phase = ContextFlags.SIMULATION
+        context.execution_phase = ContextFlags.SIMULATION
         self.system.run(
             inputs=inputs,
             execution_id=execution_id,
@@ -1272,6 +1273,7 @@ class EVCControlMechanism(ControlMechanism):
             animate=False,
             context=context
         )
+        context.execution_phase = ContextFlags.CONTROL
         self.system.parameters.context._get(execution_id).execution_phase = ContextFlags.CONTROL
 
         # Restore System attributes

--- a/psyneulink/library/components/mechanisms/adaptive/control/evc/evccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/adaptive/control/evc/evccontrolmechanism.py
@@ -391,7 +391,7 @@ from psyneulink.core.components.shellclasses import Function, System_Base
 from psyneulink.core.components.states.modulatorysignals.controlsignal import COST_OPTIONS, ControlSignal, ControlSignalCosts
 from psyneulink.core.components.states.outputstate import OutputState
 from psyneulink.core.components.states.parameterstate import ParameterState
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import CONTROL, CONTROLLER, COST_FUNCTION, EVC_MECHANISM, INIT_FUNCTION_METHOD_ONLY, PARAMETER_STATES, PARAMS, PREDICTION_MECHANISM, PREDICTION_MECHANISMS, SUM
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.componentpreferenceset import is_pref_set
@@ -1121,8 +1121,9 @@ class EVCControlMechanism(ControlMechanism):
             control_signal._instantiate_cost_attributes()
         return control_signal
 
+    @handle_external_context()
     @tc.typecheck
-    def assign_as_controller(self, system:System_Base, context=ContextFlags.COMMAND_LINE):
+    def assign_as_controller(self, system:System_Base, context=None):
         self._instantiate_prediction_mechanisms(system=system, context=context)
         super().assign_as_controller(system=system, context=context)
 
@@ -1144,7 +1145,7 @@ class EVCControlMechanism(ControlMechanism):
         Return an control_allocation
         """
 
-        if context != ContextFlags.PROPERTY:
+        if context.source != ContextFlags.PROPERTY:
             self._update_predicted_input(execution_id=execution_id)
         # self.system._cache_state()
 

--- a/psyneulink/library/components/mechanisms/adaptive/control/evc/evccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/adaptive/control/evc/evccontrolmechanism.py
@@ -1264,7 +1264,6 @@ class EVCControlMechanism(ControlMechanism):
         animate_buffer = self.system._animate
 
         # Run simulation
-        self.system.parameters.context._get(execution_id).execution_phase = ContextFlags.SIMULATION
         context.execution_phase = ContextFlags.SIMULATION
         self.system.run(
             inputs=inputs,
@@ -1274,7 +1273,6 @@ class EVCControlMechanism(ControlMechanism):
             context=context
         )
         context.execution_phase = ContextFlags.CONTROL
-        self.system.parameters.context._get(execution_id).execution_phase = ContextFlags.CONTROL
 
         # Restore System attributes
         self.system._animate = animate_buffer

--- a/psyneulink/library/components/mechanisms/adaptive/learning/autoassociativelearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/adaptive/learning/autoassociativelearningmechanism.py
@@ -344,7 +344,7 @@ class AutoAssociativeLearningMechanism(LearningMechanism):
         # self.init_args['name'] = name
 
         # # Flag for deferred initialization
-        # self.context.initialization_status = ContextFlags.DEFERRED_INIT
+        # self.initialization_status = ContextFlags.DEFERRED_INIT
         # self.initialization_status = ContextFlags.DEFERRED_INIT
 
         # self._learning_rate = learning_rate
@@ -417,11 +417,11 @@ class AutoAssociativeLearningMechanism(LearningMechanism):
             context=context
         )
 
-        if self.parameters.context._get(execution_id).initialization_status != ContextFlags.INITIALIZING and self.reportOutputPref:
+        if self.initialization_status != ContextFlags.INITIALIZING and self.reportOutputPref:
             print("\n{} weight change matrix: \n{}\n".format(self.name, self.parameters.learning_signal._get(execution_id)))
 
         # # TEST PRINT
-        # if not self.context.initialization_status == ContextFlags.INITIALIZING:
+        # if not self.initialization_status == ContextFlags.INITIALIZING:
         #     if self.context.composition:
         #         time = self.context.composition.scheduler_processing.clock.simple_time
         #     else:

--- a/psyneulink/library/components/mechanisms/adaptive/learning/autoassociativelearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/adaptive/learning/autoassociativelearningmechanism.py
@@ -451,7 +451,9 @@ class AutoAssociativeLearningMechanism(LearningMechanism):
         from psyneulink.core.components.process import Process
         if self.parameters.learning_enabled._get(execution_id) and self.parameters.context._get(execution_id).composition and not isinstance(self.parameters.context._get(execution_id).composition, Process):
             learned_projection = self.activity_source.recurrent_projection
-            learned_projection.execute(execution_id=execution_id, context=ContextFlags.LEARNING)
+            context.execution_phase = ContextFlags.LEARNING
+            learned_projection.execute(execution_id=execution_id, context=context)
+            context.execution_phase = ContextFlags.IDLE
             learned_projection.parameters.context._get(execution_id).execution_phase = ContextFlags.IDLE
 
     @property

--- a/psyneulink/library/components/mechanisms/adaptive/learning/autoassociativelearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/adaptive/learning/autoassociativelearningmechanism.py
@@ -362,7 +362,7 @@ class AutoAssociativeLearningMechanism(LearningMechanism):
 
     def _parse_function_variable(self, variable, execution_id=None, context=None):
         return variable
-    
+
     def _instantiate_attributes_after_function(self, context=None):
         super(AutoAssociativeLearningMechanism, self)._instantiate_attributes_after_function(context=context)
         # KAM 2/27/19 added the line below to set the learning rate of the hebbian learning function to the learning
@@ -420,19 +420,6 @@ class AutoAssociativeLearningMechanism(LearningMechanism):
         if self.initialization_status != ContextFlags.INITIALIZING and self.reportOutputPref:
             print("\n{} weight change matrix: \n{}\n".format(self.name, self.parameters.learning_signal._get(execution_id)))
 
-        # # TEST PRINT
-        # if not self.initialization_status == ContextFlags.INITIALIZING:
-        #     if self.context.composition:
-        #         time = self.context.composition.scheduler_processing.clock.simple_time
-        #     else:
-        #         time = self.current_execution_time
-        #     print("\nEXECUTED AutoAssociative LearningMechanism [CONTEXT: {}]\nTRIAL:  {}  TIME-STEP: {}".
-        #         format(self.context.flags_string,
-        #                time.trial,
-        #                # self.pass_,
-        #                time.time_step))
-        #     print("{} weight change matrix: \n{}\n".format(self.name, self.learning_signal))
-
         value = np.array([learning_signal])
 
         self.parameters.value._set(value, execution_id)
@@ -455,7 +442,6 @@ class AutoAssociativeLearningMechanism(LearningMechanism):
             context.execution_phase = ContextFlags.LEARNING
             learned_projection.execute(execution_id=execution_id, context=context)
             context.execution_phase = old_exec_phase
-            learned_projection.parameters.context._get(execution_id).execution_phase = ContextFlags.IDLE
 
     @property
     def activity_source(self):

--- a/psyneulink/library/components/mechanisms/adaptive/learning/autoassociativelearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/adaptive/learning/autoassociativelearningmechanism.py
@@ -449,11 +449,12 @@ class AutoAssociativeLearningMechanism(LearningMechanism):
         super()._update_output_states(execution_id, runtime_params, context)
 
         from psyneulink.core.components.process import Process
-        if self.parameters.learning_enabled._get(execution_id) and self.parameters.context._get(execution_id).composition and not isinstance(self.parameters.context._get(execution_id).composition, Process):
+        if self.parameters.learning_enabled._get(execution_id) and context.composition and not isinstance(context.composition, Process):
             learned_projection = self.activity_source.recurrent_projection
+            old_exec_phase = context.execution_phase
             context.execution_phase = ContextFlags.LEARNING
             learned_projection.execute(execution_id=execution_id, context=context)
-            context.execution_phase = ContextFlags.IDLE
+            context.execution_phase = old_exec_phase
             learned_projection.parameters.context._get(execution_id).execution_phase = ContextFlags.IDLE
 
     @property

--- a/psyneulink/library/components/mechanisms/adaptive/learning/kohonenlearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/adaptive/learning/kohonenlearningmechanism.py
@@ -441,7 +441,9 @@ class KohonenLearningMechanism(LearningMechanism):
         super()._update_output_states(execution_id, runtime_params, context)
 
         if self.parameters.context._get(execution_id).composition is not None:
-            self.learned_projection.execute(execution_id=execution_id, context=ContextFlags.LEARNING)
+            context.execution_phase = ContextFlags.LEARNING
+            self.learned_projection.execute(execution_id=execution_id, context=context)
+            context.execution_phase = ContextFlags.IDLE
             self.learned_projection.parameters.context._get(execution_id).execution_phase = ContextFlags.IDLE
 
     @property

--- a/psyneulink/library/components/mechanisms/adaptive/learning/kohonenlearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/adaptive/learning/kohonenlearningmechanism.py
@@ -383,7 +383,7 @@ class KohonenLearningMechanism(LearningMechanism):
                          params=params,
                          name=name,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _validate_variable(self, variable, context=None):
         """Validate that variable has only one item: activation_input.

--- a/psyneulink/library/components/mechanisms/adaptive/learning/kohonenlearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/adaptive/learning/kohonenlearningmechanism.py
@@ -444,7 +444,6 @@ class KohonenLearningMechanism(LearningMechanism):
             context.add_flag(ContextFlags.LEARNING)
             self.learned_projection.execute(execution_id=execution_id, context=context)
             context.remove_flag(ContextFlags.LEARNING)
-            self.learned_projection.parameters.context._get(execution_id).execution_phase = ContextFlags.IDLE
 
     @property
     def learned_projection(self):

--- a/psyneulink/library/components/mechanisms/adaptive/learning/kohonenlearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/adaptive/learning/kohonenlearningmechanism.py
@@ -440,10 +440,10 @@ class KohonenLearningMechanism(LearningMechanism):
 
         super()._update_output_states(execution_id, runtime_params, context)
 
-        if self.parameters.context._get(execution_id).composition is not None:
-            context.execution_phase = ContextFlags.LEARNING
+        if context.composition is not None:
+            context.add_flag(ContextFlags.LEARNING)
             self.learned_projection.execute(execution_id=execution_id, context=context)
-            context.execution_phase = ContextFlags.IDLE
+            context.remove_flag(ContextFlags.LEARNING)
             self.learned_projection.parameters.context._get(execution_id).execution_phase = ContextFlags.IDLE
 
     @property

--- a/psyneulink/library/components/mechanisms/adaptive/learning/kohonenlearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/adaptive/learning/kohonenlearningmechanism.py
@@ -370,7 +370,7 @@ class KohonenLearningMechanism(LearningMechanism):
         # self.init_args['name'] = name
 
         # # Flag for deferred initialization
-        # self.context.initialization_status = ContextFlags.DEFERRED_INIT
+        # self.initialization_status = ContextFlags.DEFERRED_INIT
         # self.initialization_status = ContextFlags.DEFERRED_INIT
 
         # self._learning_rate = learning_rate
@@ -426,7 +426,7 @@ class KohonenLearningMechanism(LearningMechanism):
             context=context
         )
 
-        if self.context.initialization_status != ContextFlags.INITIALIZING and self.reportOutputPref:
+        if self.initialization_status != ContextFlags.INITIALIZING and self.reportOutputPref:
             print("\n{} weight change matrix: \n{}\n".format(self.name, learning_signal))
 
         return [learning_signal]

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -363,7 +363,7 @@ from psyneulink.core.components.mechanisms.mechanism import Mechanism_Base
 from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism
 from psyneulink.core.components.states.modulatorysignals.controlsignal import ControlSignal
 from psyneulink.core.components.states.outputstate import SEQUENTIAL, StandardOutputStates
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import ALLOCATION_SAMPLES, FUNCTION, FUNCTION_PARAMS, INPUT_STATE_VARIABLES, NAME, OUTPUT_STATES, OWNER_VALUE, VARIABLE, kwPreferenceSetName
 from psyneulink.core.globals.parameters import Parameter, parse_execution_context
 from psyneulink.core.globals.preferences.componentpreferenceset import is_pref_set, kpReportOutputPref
@@ -1164,20 +1164,21 @@ class DDM(ProcessingMechanism):
                 return_value[self.DECISION_VARIABLE_INDEX] = threshold
             return return_value
 
-    def reinitialize(self, *args, execution_context=NotImplemented):
+    @handle_external_context()
+    def reinitialize(self, *args, execution_context=NotImplemented, context=None):
         from psyneulink.core.components.functions.statefulfunctions.integratorfunctions import IntegratorFunction
 
         if execution_context is NotImplemented:
-            execution_id = self.most_recent_execution_id
+            execution_id = self.most_recent_context.execution_id
         else:
             execution_id = parse_execution_context(execution_context)
 
         # (1) reinitialize function, (2) update mechanism value, (3) update output states
         if isinstance(self.function, IntegratorFunction):
-            new_values = self.function.reinitialize(*args, execution_context=execution_id)
-            self.parameters.value._set(np.array(new_values), execution_id)
+            new_values = self.function.reinitialize(*args, execution_context=execution_id, context=context)
+            self.parameters.value._set(np.array(new_values), execution_id, context=context)
             self._update_output_states(execution_id=execution_id,
-                                       context="REINITIALIZING")
+                                       context=context)
 
     def is_finished(self, execution_context=None):
         # find the single numeric entry in previous_value

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1124,7 +1124,7 @@ class DDM(ProcessingMechanism):
 
             result = super()._execute(variable, execution_id=execution_id, context=context)
 
-            if self.parameters.context._get(execution_id).initialization_status != ContextFlags.INITIALIZING:
+            if self.initialization_status != ContextFlags.INITIALIZING:
                 logger.info('{0} {1} is at {2}'.format(type(self).__name__, self.name, result))
 
             return np.array([result[0], [result[1]]])

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -196,9 +196,6 @@ class EpisodicMemoryMechanism(ProcessingMechanism_Base):
                  name=None,
                  prefs:is_pref_set=None,
                  **kwargs):
-
-        context = kwargs.pop(CONTEXT, ContextFlags.CONSTRUCTOR)
-
         # Template for memory_store entries
         default_variable = [np.zeros(content_size)]
 
@@ -219,7 +216,6 @@ class EpisodicMemoryMechanism(ProcessingMechanism_Base):
                          params=params,
                          name=name,
                          prefs=prefs,
-                         context=context,
                          **kwargs
                          )
 

--- a/psyneulink/library/components/mechanisms/processing/leabramechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/leabramechanism.py
@@ -248,7 +248,7 @@ class LeabraFunction(Function_Base):
                          params=params,
                          owner=owner,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _validate_variable(self, variable, context=None):
         if not isinstance(variable, (list, np.ndarray, numbers.Number)):
@@ -602,7 +602,7 @@ class LeabraMechanism(ProcessingMechanism_Base):
                          params=params,
                          name=name,
                          prefs=prefs,
-                         context=ContextFlags.CONSTRUCTOR)
+                         )
 
     def _execute(
         self,

--- a/psyneulink/library/components/mechanisms/processing/leabramechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/leabramechanism.py
@@ -282,7 +282,7 @@ class LeabraFunction(Function_Base):
                  context=None):
         network = self.parameters.network._get(execution_id)
         # HACK: otherwise the INITIALIZING function executions impact the state of the leabra network
-        if self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZING:
+        if self.is_initializing:
             output_size = len(network.layers[-1].units)
             return np.zeros(output_size)
 

--- a/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
@@ -399,7 +399,7 @@ class ComparatorMechanism(ObjectiveMechanism):
                          params=params,
                          name=name,
                          prefs=prefs,
-                         # context=ContextFlags.CONSTRUCTOR,
+
                          **kwargs
                          )
 

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -1289,7 +1289,7 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
                  runtime_params=None,
                  context=None):
 
-        if self.parameters.context._get(execution_id).initialization_status == ContextFlags.INITIALIZING:
+        if self.initialization_status == ContextFlags.INITIALIZING:
             # Set minus_phase activity, plus_phase, current_activity and initial_value
             #    all  to zeros with size of Mechanism's array
             # Should be OK to use attributes here because initialization should only occur during None context

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -1348,7 +1348,7 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
                 self.parameters.current_termination_criterion._get(execution_id),
                 execution_id
             )
-            self.parameters.phase_terminated._set(self.is_converged(np.atleast_2d(current_activity), execution_id), execution_id)
+            self.parameters.phase_terminated._set(self.is_converged(np.atleast_2d(current_activity), execution_id, context), execution_id)
         elif current_termination_condition is COUNT:
             self.parameters.phase_terminated._set(
                 (self.parameters.phase_execution_count._get(execution_id) == self.parameters.current_termination_criterion._get(execution_id)),
@@ -1383,7 +1383,7 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
                 #    both the integrator_function's previous_value
                 #    and the Mechanism's current activity (which is returned as its input)
                 if not self.continuous:
-                    self.reinitialize(self.initial_value, execution_context=execution_id)
+                    self.reinitialize(self.initial_value, execution_context=execution_id, context=context)
                     self.parameters.current_activity._set(self.parameters.initial_value._get(execution_id), execution_id)
                 self.parameters.current_termination_criterion._set(self.plus_phase_termination_criterion, execution_id)
                 self.parameters.current_termination_condition._set(self.plus_phase_termination_condition, execution_id)

--- a/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
@@ -71,7 +71,7 @@ from psyneulink.core.components.mechanisms.processing.transfermechanism import T
 from psyneulink.core.components.process import Process
 from psyneulink.core.components.projections.modulatory.learningprojection import LearningProjection
 from psyneulink.core.components.projections.pathway.mappingprojection import MappingProjection
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import DEFAULT_MATRIX, FUNCTION, GAUSSIAN, IDENTITY_MATRIX, INITIALIZING, KOHONEN_MECHANISM, LEARNED_PROJECTION, LEARNING_SIGNAL, MATRIX, MAX_INDICATOR, NAME, OWNER_VALUE, OWNER_VARIABLE, RESULT, VARIABLE
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.componentpreferenceset import is_pref_set
@@ -485,6 +485,7 @@ class KohonenMechanism(TransferMechanism):
             self.configure_learning(context=context)
 
     # IMPLEMENTATION NOTE: THIS SHOULD BE MOVED TO COMPOSITION WHEN THAT IS IMPLEMENTED
+    @handle_external_context()
     def configure_learning(self,
                            learning_function:tc.optional(tc.any(is_function_type))=None,
                            learning_rate:tc.optional(tc.any(numbers.Number, list, np.ndarray, np.matrix))=None,
@@ -535,7 +536,6 @@ class KohonenMechanism(TransferMechanism):
 
         self.matrix = self.learned_projection.parameter_states[MATRIX]
 
-        context = context or ContextFlags.COMMAND_LINE
         self.context.source = self.context.source or ContextFlags.COMMAND_LINE
 
         self.learning_mechanism = self._instantiate_learning_mechanism(learning_function=self.learning_function,

--- a/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
@@ -536,8 +536,6 @@ class KohonenMechanism(TransferMechanism):
 
         self.matrix = self.learned_projection.parameter_states[MATRIX]
 
-        self.context.source = self.context.source or ContextFlags.COMMAND_LINE
-
         self.learning_mechanism = self._instantiate_learning_mechanism(learning_function=self.learning_function,
                                                                        learning_rate=self.learning_rate,
                                                                        learned_projection=self.learned_projection,

--- a/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
@@ -648,7 +648,7 @@ class LCAMechanism(RecurrentTransferMechanism):
         time_step_size = self.get_current_mechanism_param("time_step_size", execution_id)
 
         # if not self.integrator_function:
-        if self.parameters.context.get(execution_id).initialization_status == ContextFlags.INITIALIZING:
+        if self.initialization_status == ContextFlags.INITIALIZING:
             self.integrator_function = LeakyCompetingIntegrator(
                 function_variable,
                 initializer=initial_value,

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1536,9 +1536,10 @@ class RecurrentTransferMechanism(TransferMechanism):
 
         return super()._get_variable_from_input(input, execution_id)
 
-    def reinitialize(self, *args, execution_context=NotImplemented):
+    @handle_external_context()
+    def reinitialize(self, *args, execution_context=NotImplemented, context=None):
         if self.parameters.integrator_mode.get(execution_context):
-            super().reinitialize(*args, execution_context=execution_context)
+            super().reinitialize(*args, execution_context=execution_context, context=context)
         self.parameters.previous_value.set(None, execution_context, override=True)
 
     @property

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1497,8 +1497,6 @@ class RecurrentTransferMechanism(TransferMechanism):
             elif self.learning_condition is UPDATE:
                 self.learning_condition = None
 
-        self.context.source = self.context.source or ContextFlags.COMMAND_LINE
-
         self.learning_mechanism = self._instantiate_learning_mechanism(activity_vector=self._learning_signal_source,
                                                                        learning_function=self.learning_function,
                                                                        learning_rate=self.learning_rate,

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1512,7 +1512,7 @@ class RecurrentTransferMechanism(TransferMechanism):
 
     def _execute(self, variable=None, execution_id=None, runtime_params=None, context=None):
 
-        # if self.context.initialization_status != ContextFlags.INITIALIZING:
+        # if not self.is_initializing
         #     self.parameters.previous_value._set(self.value)
         # self._output = super()._execute(variable=variable, execution_id=execution_id, runtime_params=runtime_params, context=context)
         # return self._output

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -200,7 +200,7 @@ from psyneulink.core.components.states.inputstate import InputState
 from psyneulink.core.components.states.outputstate import PRIMARY, StandardOutputStates
 from psyneulink.core.components.states.parameterstate import ParameterState
 from psyneulink.core.components.states.state import _instantiate_state
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import AUTO, ENERGY, ENTROPY, HETERO, HOLLOW_MATRIX, INPUT_STATE, MATRIX, MAX_ABS_DIFF, NAME, OUTPUT_MEAN, OUTPUT_MEDIAN, OUTPUT_STD_DEV, OUTPUT_VARIANCE, PARAMS_CURRENT, RECURRENT_TRANSFER_MECHANISM, RESULT
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.componentpreferenceset import is_pref_set
@@ -1025,7 +1025,7 @@ class RecurrentTransferMechanism(TransferMechanism):
             self.recurrent_size
         except AttributeError:
             self.recurrent_size = len(variable[0])
-        super()._instantiate_defaults(variable,request_set,assign_missing,target_set,default_set,context)
+        super()._instantiate_defaults(variable,request_set,assign_missing,target_set,default_set, context=context)
 
     def _validate_params(self, request_set, target_set=None, context=None):
         """Validate shape and size of auto, hetero, matrix.
@@ -1460,6 +1460,7 @@ class RecurrentTransferMechanism(TransferMechanism):
         self.aux_components.append((lproj, True))
         return learning_mechanism
 
+    @handle_external_context()
     def configure_learning(self,
                            learning_function:tc.optional(tc.any(is_function_type))=None,
                            learning_rate:tc.optional(tc.any(numbers.Number, list, np.ndarray, np.matrix))=None,
@@ -1496,7 +1497,6 @@ class RecurrentTransferMechanism(TransferMechanism):
             elif self.learning_condition is UPDATE:
                 self.learning_condition = None
 
-        context = context or ContextFlags.COMMAND_LINE
         self.context.source = self.context.source or ContextFlags.COMMAND_LINE
 
         self.learning_mechanism = self._instantiate_learning_mechanism(activity_vector=self._learning_signal_source,

--- a/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
+++ b/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
@@ -327,12 +327,6 @@ class AutoAssociativeProjection(MappingProjection):
                          prefs=prefs,
                          **kwargs)
 
-    def _update_parameter_states(self, execution_id=None, runtime_params=None, context=None):
-
-        if context.execution_phase == ContextFlags.LEARNING:
-            self.parameters.context._get(execution_id).execution_phase = ContextFlags.LEARNING
-        super()._update_parameter_states(execution_id, runtime_params, context)
-
     # COMMENTED OUT BY KAM 1/9/2018 -- this method is not currently used; should be moved to Recurrent Transfer Mech
     #     if it is used in the future
 

--- a/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
+++ b/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
@@ -329,7 +329,7 @@ class AutoAssociativeProjection(MappingProjection):
 
     def _update_parameter_states(self, execution_id=None, runtime_params=None, context=None):
 
-        if context==ContextFlags.LEARNING:
+        if context.execution_phase == ContextFlags.LEARNING:
             self.parameters.context._get(execution_id).execution_phase = ContextFlags.LEARNING
         super()._update_parameter_states(execution_id, runtime_params, context)
 

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -828,7 +828,6 @@ class AutodiffComposition(Composition):
         execution_id = self._assign_execution_ids(execution_id, context)
         context.composition = self
         context.source = ContextFlags.COMPOSITION
-        self._assign_context_values(execution_id=execution_id, composition=self, propagate=True)
 
         if scheduler_processing is None:
             scheduler_processing = self.scheduler_processing
@@ -852,14 +851,8 @@ class AutodiffComposition(Composition):
 
             output = self.autodiff_training(autodiff_inputs, autodiff_targets, autodiff_epochs, execution_id, context, do_logging, scheduler_processing)
             self.parameters.pytorch_representation._get(execution_id).copy_weights_to_psyneulink(execution_id)
-            ctx = self.output_CIM.parameters.context._get(execution_id)
 
-            # new_ctx = copy.deepcopy(ctx)
-            # new_ctx.execution_phase = ContextFlags.PROCESSING
-            # self.output_CIM.parameters.context._set(new_ctx, execution_id=execution_id)
-            if ctx is not None:  # HACK: CW 12/18/18 for some reason context isn't set correctly
-                ctx.execution_phase = ContextFlags.PROCESSING
-                context.add_flag(ContextFlags.PROCESSING)
+            context.add_flag(ContextFlags.PROCESSING)
             # note that output[-1] might not be the truly most recent value
             # HACK CW 2/5/19: the line below is a hack. In general, the output_CIM of an AutodiffComposition
             # is not having its parameters populated correctly, and this should be fixed in the long run.
@@ -909,7 +902,6 @@ class AutodiffComposition(Composition):
         # TBI: Handle trials, timesteps, etc
         execution_id = self._assign_execution_ids(execution_id, context)
         context.composition = self
-        self._assign_context_values(execution_id=execution_id, composition=self, propagate=True)
 
         if scheduler_processing is None:
             scheduler_processing = self.scheduler_processing

--- a/tests/components/test_general.py
+++ b/tests/components/test_general.py
@@ -1,0 +1,21 @@
+import psyneulink as pnl
+import pytest
+
+from psyneulink.core.components.projections.modulatory.modulatoryprojection import ModulatoryProjection_Base
+from psyneulink.core.components.projections.pathway.pathwayprojection import PathwayProjection_Base
+
+
+@pytest.mark.parametrize(
+    'class_type',
+    [
+        pnl.Mechanism_Base,
+        pnl.Function_Base,
+        pnl.State_Base,
+        ModulatoryProjection_Base,
+        PathwayProjection_Base,
+    ]
+)
+def test_abstract_classes(class_type):
+    with pytest.raises(TypeError) as err:
+        class_type()
+    assert 'abstract class' in str(err.value)

--- a/tests/mechanisms/test_recurrent_transfer_mechanism.py
+++ b/tests/mechanisms/test_recurrent_transfer_mechanism.py
@@ -699,8 +699,10 @@ class TestRecurrentTransferMechanismInProcess:
         assert np.allclose(proj.matrix, [[2, 2, 2, 2], [2, 2, 2, 2], [2, 2, 2, 2], [2, 2, 2, 2]])
         # p.run(inputs={T1: [[1, 2, 3, 4]]})
         T1.execute([[1, 2, 3, 4]])
-        proj.execute(context="EXECUTING testing projection")
-        assert np.allclose(proj.matrix, np.array([[2, 2, 2, 2], [2, 2, 2, 2], [2, 2, 2, 2], [2, 2, 2, 2]]))
+        proj.execute()
+        # removed this assert, because before the changes of most_recent_execution_id -> most_recent_execution_context
+        # proj.matrix referred to the 'Process-0' execution_id, even though it was last executed with None
+        # assert np.allclose(proj.matrix, np.array([[2, 2, 2, 2], [2, 2, 2, 2], [2, 2, 2, 2], [2, 2, 2, 2]]))
 
     def test_recurrent_mech_process_matrix_change(self):
         R = RecurrentTransferMechanism(


### PR DESCRIPTION
- Replace all logic depending on the context parameter to depend on a Context object passed through functions
- Add handle_external_context decorator to generate Context objects for outward-facing functions
- Move initialization_status from Context to Component, because it should only change nonstatefully
- Replace most_recent_execution_id with most_recent_context , a Context object that also has an execution_id attribute