### PR TITLE
travis: Run pytest directly instead of as python module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ install:
 
 
 script:
-  - python -m pytest -n auto --strict-markers -p no:logging $PYTEST_COV
+  - pytest -n auto --strict-markers -p no:logging $PYTEST_COV
 
 after_script:
   - if [ "x$COVERALLS_REPO_TOKEN" != "x" ]; then coveralls; fi


### PR DESCRIPTION
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>