### PR TITLE
Component: ensure default Parameter values are not shared

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2885,7 +2885,7 @@ class Component(object, metaclass=ComponentsMeta):
             if function.owner is None and not function.is_pnl_inherent:
                 self.function = function
             else:
-                self.function = self._clone_function(function)
+                self.function = copy.deepcopy(function)
 
             # setting init status because many mechanisms change execution or validation behavior
             # during initialization
@@ -3036,13 +3036,6 @@ class Component(object, metaclass=ComponentsMeta):
                     param_state.source = self.function
         except AttributeError:
             pass
-
-    def _clone_function(self, function):
-        from psyneulink.core.components.functions.function import Function_Base, FunctionRegistry
-        fct = copy.deepcopy(function)
-        # ensure copy does not have identical name
-        register_category(fct, Function_Base, fct.name, FunctionRegistry)
-        return fct
 
     @property
     def current_execution_count(self):

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2161,7 +2161,8 @@ class Component(object, metaclass=ComponentsMeta):
         self.parameters = self.Parameters(owner=self, parent=self.class_parameters)
 
         # assign defaults based on pass in params and class defaults
-        defaults = self.class_defaults.values(show_all=True).copy()
+        defaults = copy.deepcopy(self.class_defaults.values(show_all=True))
+
         try:
             function_params = param_defaults[FUNCTION_PARAMS]
         except KeyError:

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -671,6 +671,12 @@ class Function_Base(Function):
     def __call__(self, *args, **kwargs):
         return self.function(*args, **kwargs)
 
+    def __deepcopy__(self, memo):
+        new = super().__deepcopy__(memo)
+        # ensure copy does not have identical name
+        register_category(new, Function_Base, new.name, FunctionRegistry)
+        return new
+
     @handle_external_context()
     def function(self,
                  variable=None,

--- a/tests/functions/test_memory.py
+++ b/tests/functions/test_memory.py
@@ -513,3 +513,25 @@ def test_ContentAddressableMemory_max_entries():
                        [[11,21,31],[41,51,61]],
                        [[12,22,32],[42,52,62]]]
     assert np.allclose(em.memory, expected_memory)
+
+
+@pytest.mark.parametrize(
+    'param_name',
+    [
+        'distance_function',
+        'selection_function',
+    ]
+)
+def test_ContentAddressableMemory_unique_functions(param_name):
+    a = ContentAddressableMemory()
+    b = ContentAddressableMemory()
+
+    assert (
+        getattr(a.parameters, param_name).get()
+        is not getattr(b.parameters, param_name).get()
+    )
+
+    assert (
+        getattr(a.defaults, param_name)
+        is not getattr(b.defaults, param_name)
+    )


### PR DESCRIPTION
Previously, class default values of Parameters could be inadvertently shared among instances of the class