### PR TITLE
test, autodiff: Mark batching tests as 'pytorch'

### DIFF
--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -2333,6 +2333,7 @@ class TestNested:
 
         parentComposition.run(inputs=no_training_input)
 
+@pytest.mark.pytorch
 class TestBatching:
     def test_call_before_minibatch(self):
         # SET UP MECHANISMS FOR COMPOSITION


### PR DESCRIPTION
Fixes failures with no pytorch installed.
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>