### PR TITLE
Move `compiledoptimizer.zero_grad` to a explicitly called llvm function.

### DIFF
--- a/psyneulink/library/compositions/compiledoptimizer.py
+++ b/psyneulink/library/compositions/compiledoptimizer.py
@@ -70,7 +70,6 @@ class Optimizer():
                 self._pytorch_model._get_param_struct_type(ctx).as_pointer()]
         builder = ctx.create_llvm_function(args, self, name)
         llvm_func = builder.function
-        llvm_func.attributes.add('alwaysinline')
         optim_struct, model_params = llvm_func.args
 
         delta_w_struct = builder.gep(
@@ -145,7 +144,6 @@ class AdamOptimizer(Optimizer):
                 self._pytorch_model._get_param_struct_type(ctx).as_pointer()]
         builder = ctx.create_llvm_function(args, self, name)
         llvm_func = builder.function
-        llvm_func.attributes.add('alwaysinline')
         optim_struct, model_params = llvm_func.args
 
         # setup values
@@ -315,7 +313,6 @@ class SGDOptimizer(Optimizer):
                 self._pytorch_model._get_param_struct_type(ctx).as_pointer()]
         builder = ctx.create_llvm_function(args, self, name)
         llvm_func = builder.function
-        llvm_func.attributes.add('alwaysinline')
         optim_struct, model_params = llvm_func.args
 
         zero = ctx.int32_ty(0)

--- a/psyneulink/library/compositions/pytorchmodelcreator.py
+++ b/psyneulink/library/compositions/pytorchmodelcreator.py
@@ -693,13 +693,13 @@ class PytorchModelCreator(torch.nn.Module):
         optimizer.initialize_optimizer_struct(ctx,builder,optimizer_struct)
         backprop = ctx.get_llvm_function(self._gen_llvm_training_backprop(ctx,optimizer,loss).name)
         optimizer_step = ctx.get_llvm_function(optimizer.step(ctx).name)
-
+        optimizer_zero_grad = ctx.get_llvm_function(optimizer.zero_grad(ctx).name)
         with pnlvm.helpers.for_loop_zero_inc(builder, epochs, "epoch_loop") as (b1, epoch_idx):
             ctx.inject_printf(builder, "\033[0;32mEPOCH %d\033[0m\n", epoch_idx)
             with pnlvm.helpers.for_loop_zero_inc(b1, num_inputs, "input_loop") as (b2, input_idx):
                 ctx.inject_printf(b2, "\n\033[0;31mINPUT %d\033[0m\n", input_idx)
                 ctx.inject_printf(b2, "OPTIMIZER ZERO GRAD %d\n", input_idx)
-                optimizer.zero_grad(ctx,b2,optimizer_struct)
+                b2.call(optimizer_zero_grad,[optimizer_struct,model_params])
                 ctx.inject_printf(b2, "BACKPROP %d\n", input_idx)
                 b2.call(backprop,[model_context, model_params, model_input, model_output, optimizer_struct, input_struct_ptr, target_struct_ptr, input_idx])
                 ctx.inject_printf(b2, "OPTIMIZER STEP %d\n", input_idx)


### PR DESCRIPTION
This drastically reduces compilation time, as Loop-invariant code motion optimization from the compiler was over-eager to try and optimize the line.