### PR TITLE
Fix/state/ parse state spec

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1016,24 +1016,7 @@ class Component(object, metaclass=ComponentsMeta):
                                     format(self.__class__.__bases__[0].__name__))
 
         # ASSIGN PREFS
-
-        # If a PreferenceSet was provided, assign to instance
-        # If a PreferenceSet was provided, assign to instance
         _assign_prefs(self, prefs, BasePreferenceSet)
-
-        # # MODIFIED 9/30/19 OLD:
-        # if isinstance(prefs, PreferenceSet):
-        #     self.prefs = prefs
-        #     # FIX:  CHECK LEVEL HERE??  OR DOES IT NOT MATTER, AS OWNER WILL BE ASSIGNED DYNAMICALLY??
-        # # Otherwise, if prefs is a specification dict instantiate it, or if it is None assign defaults
-        # else:
-        #     self.prefs = BasePreferenceSet(owner=self, prefs=prefs, context=context)
-        # try:
-        #     # assign log conditions from preferences
-        #     self.parameters.value.log_condition = self.prefs._log_pref.setting
-        # except AttributeError:
-        #     pass
-        # MODIFIED 9/30/19 END
 
         # ASSIGN LOG
         from psyneulink.core.globals.log import Log

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -1466,7 +1466,7 @@ class ControlMechanism(ModulatoryMechanism_Base):
                             f"of {self.name} ({control_signal.owner_value_index})is not an int."
 
     def _instantiate_control_signal(self,  control_signal, context=None):
-        """Parse and instantiate ControlSignal (or subclass relveant to ControlMechanism subclass)
+        """Parse and instantiate ControlSignal (or subclass relevant to ControlMechanism subclass)
 
         Temporarily assign variable to default allocation value to avoid chicken-and-egg problem:
            value, output_states and control_signals haven't been expanded yet to accomodate the new
@@ -1511,6 +1511,24 @@ class ControlMechanism(ModulatoryMechanism_Base):
         from psyneulink.core.components.projections.projection import ProjectionError
 
         allocation_parameter_default = self.parameters.control_allocation.default_value
+
+        # FIX: 10/2/19 -- MOVE THIS TO _instantiate_state, AND POSSIBLY EVEN _parse_state_spec
+        # # MODIFIED 10/2/19 NEW: [JDC]
+        # # FIX: 10/2/19 - CHECK IF control_signal_spec IS A DICT AND, IF SO, IT HAS A PROJECTIONS SPEC AND, IF SO
+        # #                GET ITS SENDER AND IF THAT IS IN DEFERRED INIT, USE THAT;
+        # #                THIS HAPPENS IF A ControlSignal IS USED TO SPECIFY CONTROL OF A PARAMETER
+        # #                AND IT IS USED TO SPECIFY ITS OWN PARAMETERS (E.G., allocation_samples OR THE LIKE)
+        # if isinstance(control_signal_spec, dict) and PROJECTIONS in control_signal_spec:
+        #     assert len(control_signal_spec[PROJECTIONS])==1, f"More than one Projection found in control_signal_spec"
+        #     # control_signal = control_signal_spec[PROJECTIONS][0]._deferred_init(context=context)
+        #     # return control_signal
+        #     control_signal = control_signal_spec[PROJECTIONS][0].sender
+        #     control_signal._deferred_init(context=context)
+        #     return control_signal
+        #     # return control_signal
+
+        # MODIFIED 10/2/19 END
+
         control_signal = _instantiate_state(state_type=ControlSignal,
                                                owner=self,
                                                variable=self.default_allocation           # User specified value

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -1512,23 +1512,6 @@ class ControlMechanism(ModulatoryMechanism_Base):
 
         allocation_parameter_default = self.parameters.control_allocation.default_value
 
-        # FIX: 10/2/19 -- MOVE THIS TO _instantiate_state, AND POSSIBLY EVEN _parse_state_spec
-        # # MODIFIED 10/2/19 NEW: [JDC]
-        # # FIX: 10/2/19 - CHECK IF control_signal_spec IS A DICT AND, IF SO, IT HAS A PROJECTIONS SPEC AND, IF SO
-        # #                GET ITS SENDER AND IF THAT IS IN DEFERRED INIT, USE THAT;
-        # #                THIS HAPPENS IF A ControlSignal IS USED TO SPECIFY CONTROL OF A PARAMETER
-        # #                AND IT IS USED TO SPECIFY ITS OWN PARAMETERS (E.G., allocation_samples OR THE LIKE)
-        # if isinstance(control_signal_spec, dict) and PROJECTIONS in control_signal_spec:
-        #     assert len(control_signal_spec[PROJECTIONS])==1, f"More than one Projection found in control_signal_spec"
-        #     # control_signal = control_signal_spec[PROJECTIONS][0]._deferred_init(context=context)
-        #     # return control_signal
-        #     control_signal = control_signal_spec[PROJECTIONS][0].sender
-        #     control_signal._deferred_init(context=context)
-        #     return control_signal
-        #     # return control_signal
-
-        # MODIFIED 10/2/19 END
-
         control_signal = _instantiate_state(state_type=ControlSignal,
                                                owner=self,
                                                variable=self.default_allocation           # User specified value

--- a/psyneulink/core/components/mechanisms/modulatory/modulatorymechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/modulatorymechanism.py
@@ -22,26 +22,22 @@ this need not be the case.
 .. _ModulatoryMechanism_Types:
 
 
-# FIX 9/27/19
-There are three types of ModulatoryMechanism:
+There are two primary types of ModulatoryMechanism:
 
-* `ModulatoryMechanism`
-    takes an evaluative signal (generally received from an `ObjectiveMechanism`) and generates an
-    `modulatory_allocation <ModulatoryMechanism.modulatory_allocation>`, each item of which is assigned to one of its
-    `ModulatorySignals <ModulatorySignal>`;  each of those generates a `modulatory_signal
-    <ModulatorySignal.modulatory_signal>` that is used by its `ModulatoryProjection(s) <ModulatoryProjection>` to
-    modulate the parameter of a `function <State_Base.function>` (and thereby the `value <State_Base.value>`) of a
-    `State`.  A ModulatoryMechanism can be assigned any combination of `ControlSignals <ControlSignal>` and
-    `GatingSignals <GatingSignal>`.
-..
 * `ControlMechanism`
-    a subclsass of `ModulatoryMechanism` that adds support for `costs <ControlMechanism.costs>`;  it takes an
-    evaluative signal (generally received from an `ObjectiveMechanism`) and generates a `control_allocation
+    modulates the `value <State_Base.value>` of a `State` of a `Mechanism`.  Takes an evaluative signal (generally
+    received from an `ObjectiveMechanism`) and generates a `control_allocation
     <ControlMechanism.control_allocation>`, each item of which is assigned to one of its `ControlSignals
     <ControlSignal>`;  each of those generates a `control_signal <ControlSignal.control_signal>` that is used by its
     `ControlProjection(s) <ControlProjection>` to modulate the parameter of a `function <State_Base.function>` (and
-    thereby the `value <State_Base.value>`) of a `State`.  A ControlMechanism can be assigned only the `ControlSignal`
-    class of `ModulatorySignal`, but can be also be assigned other generic `OutputStates <OutputState>`.
+    thereby the `value <State_Base.value>`) of a `State`.  ControlSignals have `costs <ControlSignal_Costs>`,
+    and a ControlMechanism has a `costs <ControlMechanism.costs>` and a `net_outcome <ControlMechanism.net_outcome>`
+    that is computed based on the `costs <ControlSignal.costs>` of its ControlSignals. A ControlMechanism can be
+    assigned only the `ControlSignal` class of `ModulatorySignal`, but can be also be assigned other generic
+    `OutputStates <OutputState>` that appear after its ControlSignals in its `output_states
+    <ControlMechanism.output_states>` attribute.
+
+COMMENT:
 ..
 * `GatingMechanism`
     a subclsass of `ModulatoryMechanism` that is specialized for modulating the input to or ouput from a `Mechanism`;
@@ -52,26 +48,24 @@ There are three types of ModulatoryMechanism:
     <State_Base.function>` (and thereby the `value <State_Base.value>`) of an `InputState` or `OutputState`.
     A GatingMechanism can be assigned only the `GatingSignal` class of `ModulatorySignal`, but can be also be assigned
     other generic `OutputStates <OutputState>`.
-.
+COMMENT.
 ..
 * `LearningMechanism`
-    takes an error signal (received from an `ObjectiveMechanism` or another `LearningMechanism`) and generates a
-    `learning_signal <LearningMechanism.learning_signal>` that is provided to its `LearningSignal(s)
-    <LearningSignal>`, and used by their `LearningProjections <LearningProjection>` to modulate the `matrix
-    <MappingProjection.matrix>` parameter of a `MappingProjection`. A LearningMechanism can be assigned only
-    `LearningSignals <LearningSignal>` as its `OuputStates <OutputState>`.
+    modulates the `matrix <MappingProjection.matrix>` parameter of a `MappingProjection`.  Takes an error signal
+    (received from an `ObjectiveMechanism` or another `LearningMechanism`) and generates a `learning_signal
+    <LearningMechanism.learning_signal>` that is provided to its `LearningSignal(s) <LearningSignal>`, and used by
+    their `LearningProjections <LearningProjection>` to modulate the `matrix <MappingProjection.matrix>` parameter
+    of a `MappingProjection`. A LearningMechanism can be assigned only the `LearningSignal` class of `ModulatorySignal`
+    as its `OuputStates <OutputState>`, but can be also be assigned other generic `OutputStates <OutputState>`,
+    that appear after its LearningSignals in its `output_states <LearningMechanism.output_states>` attribute.
 
 See `ModulatorySignal <ModulatorySignal_Naming>` for conventions used for the names of Modulatory components.
 
-A single `ModulatoryMechanism` can be assigned more than one ModulatorySignal of the appropriate
-
-which, each of which can
-be assigned
-different `allocations <ModulatorySignal.allocation>` (for ControlSignals and GatingSignals) or `learning_signals
-<LearningMechanism.learning_signal>` (for LearningSignals).  A single ModulatorySignal can also be assigned multiple
-ModulatoryProjections; however, as described  under `_ModulatorySignal_Projections`, they will all be assigned the
-same `variable <ModulatoryProjection_Base.variable>`.
-
+A single `ModulatoryMechanism` can be assigned more than one ModulatorySignal of the appropriate type, each of which
+can be assigned different `control_allocations <ControlSignal.control_allocation>` (for ControlSignals) or
+`learning_signals <LearningMechanism.learning_signal>` (for LearningSignals).  A single ModulatorySignal can also be
+assigned multiple ModulatoryProjections; however, as described  in `ModulatorySignal_Projections`, they will all
+be assigned the same `variable <ModulatoryProjection_Base.variable>`.
 
 COMMENT:
 ModulatoryMechanisms are always executed after all `ProcessingMechanisms <ProcessingMechanism>` in the `Process` or

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -1607,10 +1607,7 @@ def _parse_connection_specs(connectee_state_type,
                 # FIX: 11/28/17 HACK TO DEAL WITH GatingSignal Projection to OutputState
                 # FIX: 5/11/19: CORRECTED TO HANDLE ControlMechanism SPECIFIED FOR GATING
                 if ((_is_gating_spec(first_item) or _is_control_spec(first_item))
-                    and (isinstance(last_item, OutputState) or last_item == OutputState
-                        # # FIX: 9/27/19:  ADDED TO DEAL WITH ControlMechanism SPECIFIED FOR GATING OF INPUTSTATE
-                        #  or isinstance(last_item, InputState) or last_item == InputState
-                        )
+                    and (isinstance(last_item, OutputState) or last_item == OutputState)
                 ):
                     projection_socket = SENDER
                     state_types = [OutputState]
@@ -1665,7 +1662,6 @@ def _parse_connection_specs(connectee_state_type,
             if _is_projection_spec(projection_spec) or _is_modulatory_spec(projection_spec) or projection_spec is None:
 
                 # FIX: 11/21/17 THIS IS A HACK TO DEAL WITH GatingSignal Projection TO InputState or OutputState
-                # FIX: 9/27/19 AUGMENT TO INCLUDE ControlSignal Projection??
                 from psyneulink.core.components.states.inputstate import InputState
                 from psyneulink.core.components.states.outputstate import OutputState
                 from psyneulink.core.components.states.modulatorysignals.gatingsignal import GatingSignal
@@ -1687,14 +1683,8 @@ def _parse_connection_specs(connectee_state_type,
                 ):
                     projection_spec = state
 
-                # # MODIFIED 9/27/19 OLD:
-                # elif _is_gating_spec(first_item):
-                # # MODIFIED 9/27/19 NEW: [JDC]
-                # elif _is_gating_spec(first_item) or _is_control_spec((first_item)):
-                # MODIFIED 9/27/19 NEWER: [JDC] XYZ
                 elif (_is_gating_spec(first_item) or _is_control_spec((first_item))
                       and not isinstance(last_item, (GatingProjection, ControlProjection))):
-                # MODIFIED 9/27/19 END
                     projection_spec = first_item
                 projection_spec = _parse_projection_spec(projection_spec,
                                                          owner=owner,

--- a/psyneulink/core/components/states/state.py
+++ b/psyneulink/core/components/states/state.py
@@ -2547,7 +2547,6 @@ def _instantiate_state(state_type:_is_state_class,           # State's type
         # Its value is assigned to the VARIABLE entry (including if it was originally just a value)
         reference_value = reference_value_dict[VARIABLE]
 
-    # MODIFIED 10/3/19 OLD:
     parsed_state_spec = _parse_state_spec(state_type=state_type,
                                           owner=owner,
                                           reference_value=reference_value,
@@ -2890,43 +2889,7 @@ def _parse_state_spec(state_type=None,
                 state_specification = mech
                 projection = state_type
 
-        # # MODIFIED 9/27/19 OLD:
-        # # Specication is a State with which connectee can connect, so assume it is a Projection specification
-        # if state_specification.__class__.__name__ in state_type.connectsWith + state_type.modulators:
-        #     projection = state_type
-        #
-        # # Specification is a State that is same as connectee's type (state_type),
-        # #    so assume it is a reference to the State itself that is being (or has been) instantiated
-        # elif isinstance(state_specification, state_type):
-        #     # Make sure that the specified State belongs to the Mechanism passed in the owner arg
-        #     if state_specification.initialization_status == ContextFlags.DEFERRED_INIT:
-        #         state_owner = state_specification.init_args[OWNER]
-        #     else:
-        #         state_owner = state_specification.owner
-        #     if owner is not None and state_owner is not None and state_owner is not owner:
-        #         try:
-        #             new_state_specification = state_type._parse_self_state_type_spec(state_type,
-        #                                                                              owner,
-        #                                                                              state_specification,
-        #                                                                              context)
-        #             state_specification = _parse_state_spec(state_type=state_type,
-        #                                                     owner=owner,
-        #                                                     state_spec=new_state_specification)
-        #             assert True
-        #         except AttributeError:
-        #             raise StateError("Attempt to assign a {} ({}) to {} that belongs to another {} ({})".
-        #                              format(State.__name__, state_specification.name, owner.name,
-        #                                     Mechanism.__name__, state_owner.name))
-        #     return state_specification
-
-        # MODIFIED 9/27/19 NEW: [JDC]
-        # Specification is a State that is same as connectee's type (state_type),
-        #    so assume it is a reference to the State itself that is being (or has been) instantiated
-        # # MODIFIED 9/27/19 OLD:
-        # if isinstance(state_specification, state_type):
-        # MODIFIED 9/27/19 NEWER: [JDC]
         if state_specification.__class__ == state_type:
-        # MODIFIED 9/27/19 END
             # Make sure that the specified State belongs to the Mechanism passed in the owner arg
             if state_specification.initialization_status == ContextFlags.DEFERRED_INIT:
                 state_owner = state_specification.init_args[OWNER]
@@ -2951,7 +2914,6 @@ def _parse_state_spec(state_type=None,
         # Specication is a State with which connectee can connect, so assume it is a Projection specification
         elif state_specification.__class__.__name__ in state_type.connectsWith + state_type.modulators:
             projection = state_type
-        # MODIFIED 9/27/19 END
 
         # Re-process with Projection specified
         state_dict = _parse_state_spec(state_type=state_type,

--- a/psyneulink/core/components/states/state.py
+++ b/psyneulink/core/components/states/state.py
@@ -2487,17 +2487,6 @@ def _instantiate_state_list(owner,
         for proj in state.path_afferents:
             owner.aux_components.append(proj)
 
-        # # Get name of state, and use as index to assign to states ContentAddressableList
-        # default_name = state._assign_default_state_name()
-        # if default_name:
-        #      state_name = default_name
-        # elif state.initialization_status is ContextFlags.DEFERRED_INIT
-        #     state_name = state.init_args[NAME]
-        # else:
-        #     state_name = state.name
-        #
-        # states[state_name] = state
-
         states[state.name] = state
 
     return states
@@ -2568,29 +2557,6 @@ def _instantiate_state(state_type:_is_state_class,           # State's type
                                           prefs=prefs,
                                           context=context,
                                           **state_spec)
-    # # MODIFIED 10/3/19 NEW: [JDC]
-    # # Check if state_spec is
-    # if (isinstance(state_spec, dict)
-    #         and 'state_spec' in state_spec
-    #         and isinstance(state_spec['state_spec'], dict)
-    #         and PROJECTIONS in state_spec['state_spec']
-    #         and state_spec['state_spec'][PROJECTIONS]
-    #         and isinstance(state_spec['state_spec'][PROJECTIONS][0], Projection)
-    #         and isinstance(state_spec['state_spec'][PROJECTIONS][0].sender, state_type)):
-    #     parsed_state_spec = state_spec['state_spec'][PROJECTIONS][0].sender
-    #     parsed_state_spec.init_args[PARAMS][PROJECTIONS]=state_spec['state_spec'][PROJECTIONS][0]
-    #
-    # else:
-    #     parsed_state_spec = _parse_state_spec(state_type=state_type,
-    #                                           owner=owner,
-    #                                           reference_value=reference_value,
-    #                                           name=name,
-    #                                           variable=variable,
-    #                                           params=params,
-    #                                           prefs=prefs,
-    #                                           context=context,
-    #                                           **state_spec)
-    # MODIFIED 10/3/19 END
 
     # STATE SPECIFICATION IS A State OBJECT ***************************************
     # Validate and return
@@ -2817,12 +2783,8 @@ def _parse_state_spec(state_type=None,
             # If the State specification is a Projection that has a sender already assigned,
             #    then return that State with the Projection assigned to it
             #    (this occurs, for example, if an instantiated ControlSignal is used to specify a parameter
-            if (PROJECTIONS in state_spec[STATE_SPEC_ARG]
-                    and state_spec[STATE_SPEC_ARG][PROJECTIONS]
-                    and isinstance(state_spec[STATE_SPEC_ARG][PROJECTIONS], list)
-                    and isinstance(state_spec[STATE_SPEC_ARG][PROJECTIONS][0], Projection)
-                    and isinstance(state_spec[STATE_SPEC_ARG][PROJECTIONS][0].sender, state_type)
-            ):
+            try:
+                assert len(state_spec[STATE_SPEC_ARG][PROJECTIONS])==1
                 projection = state_spec[STATE_SPEC_ARG][PROJECTIONS][0]
                 state = projection.sender
                 if state.initialization_status == ContextFlags.DEFERRED_INIT:
@@ -2830,6 +2792,8 @@ def _parse_state_spec(state_type=None,
                 else:
                     state._instantiate_projections_to_state(projections=projection, context=context)
                 return state
+            except:
+                pass
 
             # Use the value of any standard args specified in the State specification dictionary
             #    to replace those explicitly specified in the call to _instantiate_state (i.e., passed in standard_args)

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -2786,8 +2786,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         else:
             existing_projections = self._check_for_existing_projections(projection, sender=sender, receiver=receiver)
 
-        # FIX: 9/30/19 - THIS SEEMS TO BE DONE FOR ALL PROJECTIONS, NOT JUST AUTOASSOCIATIVE ONES;
-        #                FILTERS OUT AUTOASSOCIATIVE?
         # KAM HACK 2/13/19 to get hebbian learning working for PSY/NEU 330
         # Add autoassociative learning mechanism + related projections to composition as processing components
         if (sender_mechanism != self.input_CIM
@@ -2806,8 +2804,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             except CompositionError as c:
                 raise CompositionError(f"{c.args[0]} to {self.name}.")
 
-        # FIX: 9/30/19 - THIS SEEMS TO BE NEEDED FOR ALL PROJECTIONS, NOT JUST AUTOASSOCIATIVE ONES
-        #                FILTERS OUT AUTOASSOCIATIVE?
         # KAM HACK 2/13/19 to get hebbian learning working for PSY/NEU 330
         # Add autoassociative learning mechanism + related projections to composition as processing components
         if not existing_projections:

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -3999,7 +3999,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                                                                         learned_projection,
                                                                                         learning_rate,
                                                                                         learning_update)
-
             learning_mechanisms.append(learning_mechanism)
             learned_projections.append(learned_projection)
 
@@ -4009,9 +4008,15 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 projections = self._add_error_projection_to_dependent_learning_mechs(lm)
                 self.add_projections(projections)
 
-        # Suppress no efferent connections warning for error_signal OutputState of last LearningMechanism in sequence
+        # Suppress "no efferent connections" warning for:
+        #    - error_signal OutputState of last LearningMechanism in sequence
+        #    - comparator
         learning_mechanisms[-1].output_states[ERROR_SIGNAL].parameters.require_projection_in_composition.set(False,
                                                                                                              override=True)
+        if comparator:
+            for s in comparator.output_states:
+                s.parameters.require_projection_in_composition.set(False,
+                                                                   override=True)
 
         learning_related_components = {LEARNING_MECHANISM: learning_mechanisms,
                                        COMPARATOR_MECHANISM: comparator,
@@ -4053,6 +4058,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                                                WEIGHT: -1},
                                                        function=error_function,
                                                        output_states=[OUTCOME, MSE])
+            # for s in comparator_mechanism.output_states:
+            #     s.require_projection_in_composition = False
 
         learning_function = BackPropagation(default_variable=[input_source.output_states[0].value,
                                                               output_source.output_states[0].value,

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -4058,8 +4058,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                                                WEIGHT: -1},
                                                        function=error_function,
                                                        output_states=[OUTCOME, MSE])
-            # for s in comparator_mechanism.output_states:
-            #     s.require_projection_in_composition = False
 
         learning_function = BackPropagation(default_variable=[input_source.output_states[0].value,
                                                               output_source.output_states[0].value,

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1059,12 +1059,6 @@ class DDM(ProcessingMechanism):
                 raise DDMError("PROGRAM ERROR: unrecognized specification for {} of {} ({})".
                                format(THRESHOLD, self.name, threshold))
 
-    def _instantiate_attributes_before_function(self, function=None, context=None):
-        """Delete params not in use, call super.instantiate_execute_method
-        """
-
-        super()._instantiate_attributes_before_function(function=function, context=context)
-
     def _instantiate_plotting_functions(self, context=None):
         if "DriftDiffusionIntegrator" in str(self.function):
             self.get_axes_function = DriftDiffusionIntegrator(rate=self.function_params['rate'],

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -523,10 +523,6 @@ class AutodiffComposition(Composition):
 
         self.min_delta = min_delta
 
-        # CW 11/1/18: maybe we should make scheduler a property, like in Composition
-        # # MODIFIED 10/2/19 OLD:
-        # self.scheduler = None
-        # MODIFIED 10/2/19 NEW: [JDC]
         if not disable_cuda and torch.cuda.is_available():
             if cuda_index is None:
                 self.device = torch.device('cuda')

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -47,10 +47,13 @@ class TestControlSpecification:
         # ControlProjection specified on Mechanism should initially be in deferred_init,
         #    but then initialized and added to controller when the Mechanism is added.
         ddm = pnl.DDM(function=pnl.DriftDiffusionAnalytical(
+                                # drift_rate=(1.0,
+                                #             pnl.ControlProjection(
+                                #                   function=pnl.Linear,
+                                #                   control_signal_params={ALLOCATION_SAMPLES: np.arange(0.1, 1.01, 0.3)}))))
                                 drift_rate=(1.0,
-                                            pnl.ControlProjection(
-                                                  function=pnl.Linear,
-                                                  control_signal_params={ALLOCATION_SAMPLES: np.arange(0.1, 1.01, 0.3)}))))
+                                            pnl.ControlSignal(allocation_samples=np.arange(0.1, 1.01, 0.3),
+                                                              intensity_cost_function=pnl.Linear))))
         ctl_mech = pnl.ControlMechanism()
         comp = pnl.Composition(controller=ctl_mech)
         comp.add_node(ddm)


### PR DESCRIPTION
• State
  - fixed bug in which State specification using Projection that
    has a sender failed to use sender as the State
• Composition
  - _create_backpropagation_learning_pathway:
    suppress "no efferents" warning for ComparatorMechanism