### PR TITLE
travis: Use Ubuntu's native python instead of travis'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,53 +5,38 @@ branches:
     - /devel-.*/
     - /travis.*/
 
-language: python
+language: shell
 
-python:
-    - 3.6
-    - 3.7
-
-os: linux
-dist: xenial
+os:
+  - linux
+  - osx
+dist: bionic
 
 env:
+  matrix:
+    - PYTHON=3.6.8
+    - PYTHON=3.7.4
   global:
     - PYTHONWARNINGS="ignore::DeprecationWarning"
+    - PIP_PROGRESS_BAR="off"
 
 # Cache downloaded(built) python packages
+# and homebrew downloads
 cache:
-  pip
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/Library/Caches/Homebrew
+    - $HOME/Library/Caches/pip
 
 addons:
   apt:
     packages:
       - graphviz
-
-matrix:
-  include:
-  - os: osx
-    python: 3.6
-    language: minimal
-    env: PYTHON=3.6.8
-    # Cache pip and homebrew downloads
-    cache:
-        directories:
-          - $HOME/Library/Caches/Homebrew
-          - $HOME/Library/Caches/pip
-
-  - os: osx
-    python: 3.7
-    language: minimal
-    env: PYTHON=3.7.4
-    # Cache pip and homebrew downloads
-    cache:
-        directories:
-          - $HOME/Library/Caches/Homebrew
-          - $HOME/Library/Caches/pip
+      - python3-pip
 
 before_install:
   - |
-    # OSX Python is not directly supported on travis
+    # Hombrew doesn't provide older python versions.
     # Install it manually from python.org
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then
       # homebrew plugin is not working correctly
@@ -70,20 +55,23 @@ before_install:
       echo "Deploying new python venv"
       python3 -m pip  install virtualenv
       python3 -m venv $HOME/venv
-      source $HOME/venv/bin/activate
-
-      # Upgrade pip
-      pip install -U pip
+    elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      sudo apt-get install -y python${PYTHON%.*}-dev python${PYTHON%.*}-venv
+      python${PYTHON%.*} -m venv $HOME/venv
+      # Provide fake xdg-open
+      echo "#!/bin/sh" > $HOME/venv/bin/xdg-open
+      chmod +x $HOME/venv/bin/xdg-open
     fi
+  - source $HOME/venv/bin/activate
+
+  # Upgrade pip
+  - pip install -U pip
   - python --version
   - pip --version
 
 install:
   - pip install coveralls
   - pip install git+https://github.com/benureau/leabra.git@master
-  # Travis bundles pytest 4.3.1 in Linux Xenial, new pytest-xdist
-  # requires pytest>=4.4.0, and the dependencies are broken
-  - pip install -U pytest
   - pip install -e .[dev]
 
 


### PR DESCRIPTION
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>