### PR TITLE
travis: Bump python 3.7 version to 3.7.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ dist: bionic
 
 env:
   matrix:
-    - PYTHON=3.7.4
+    - PYTHON=3.7.5
     - PYTHON=3.6.8
   global:
     - PYTHONWARNINGS="ignore::DeprecationWarning"


### PR DESCRIPTION
Released 10/15/2019.
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>