### PR TITLE
utilities: Use time since epoch to initialize the random seed

### DIFF
--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -1493,10 +1493,11 @@ def flatten_list(l):
     return [item for sublist in l for item in sublist]
 
 
-_seed = int(time.monotonic())
+_seed = np.int32((time.time() * 1000) % 2**31)
 def get_global_seed(offset=1):
     global _seed
     _seed += offset
+    _seed %= 2**31
     return _seed - offset
 
 

--- a/tests/misc/test_user_seed.py
+++ b/tests/misc/test_user_seed.py
@@ -1,0 +1,6 @@
+import subprocess
+
+def test_user_seed():
+    seed1 = subprocess.check_output(("python", "-c" ,"from psyneulink.core.globals.utilities import get_global_seed; print(get_global_seed())"))
+    seed2 = subprocess.check_output(("python", "-c" ,"from psyneulink.core.globals.utilities import get_global_seed; print(get_global_seed())"))
+    assert seed1 != seed2


### PR DESCRIPTION
Convert to ms before casting to integer.
Fixes random seed initialization on macos.

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>