### PR TITLE
Use standard renaming for ModulatorySignals corresponding to an efferent

### DIFF
--- a/psyneulink/core/components/ports/modulatorysignals/modulatorysignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/modulatorysignal.py
@@ -406,6 +406,8 @@ Class Reference
 ---------------
 """
 
+import itertools
+
 from psyneulink.core.components.component import component_keywords
 from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.components.ports.port import Port_Base
@@ -646,11 +648,14 @@ class ModulatorySignal(OutputPort):
         #    or the ModulatorySignal has no projections (which are used to name it)
         #    then return
         if (
-            not (
-                self.name is self.__class__.__name__
-                or self.__class__.__name__ + '-' in self.name
+            (
+                not (
+                    self.name is self.__class__.__name__
+                    or self.__class__.__name__ + '-' in self.name
+                )
+                or len(self.efferents) == 0
             )
-            or len(self.efferents) == 0
+            and self.name not in [p.receiver.name for p in self.efferents]
         ):
             return self.name
 

--- a/psyneulink/core/components/ports/modulatorysignals/modulatorysignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/modulatorysignal.py
@@ -645,9 +645,13 @@ class ModulatorySignal(OutputPort):
         # If the name is not a default name for the class,
         #    or the ModulatorySignal has no projections (which are used to name it)
         #    then return
-        if (not (self.name is self.__class__.__name__
-                 or self.__class__.__name__ + '-' in self.name) or
-                    len(self.efferents)==0):
+        if (
+            not (
+                self.name is self.__class__.__name__
+                or self.__class__.__name__ + '-' in self.name
+            )
+            or len(self.efferents) == 0
+        ):
             return self.name
 
         # Construct default name


### PR DESCRIPTION
Previously, if a ModulatorySignal was named the same as one of its receiver's efferents, it would be considered not a default name and not assigned using the normal naming pattern