### PR TITLE
Parameter: add and set spec attribute

### DIFF
--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -615,7 +615,9 @@ class Parameter(types.SimpleNamespace):
 
     # for user convenience - these attributes will be hidden from the repr
     # display if the function is True based on the value of the attribute
-    _hidden_if_unset_attrs = {'aliases', 'getter', 'setter', 'constructor_argument'}
+    _hidden_if_unset_attrs = {
+        'aliases', 'getter', 'setter', 'constructor_argument', 'spec'
+    }
     _hidden_if_false_attrs = {'read_only', 'modulable', 'fallback_default', 'retain_old_simulation_data'}
     _hidden_when = {
         **{k: lambda self, val: val is None for k in _hidden_if_unset_attrs},
@@ -653,6 +655,7 @@ class Parameter(types.SimpleNamespace):
         fallback_default=False,
         retain_old_simulation_data=False,
         constructor_argument=None,
+        spec=None,
         _owner=None,
         _inherited=False,
         _user_specified=False,
@@ -692,6 +695,7 @@ class Parameter(types.SimpleNamespace):
             fallback_default=fallback_default,
             retain_old_simulation_data=retain_old_simulation_data,
             constructor_argument=constructor_argument,
+            spec=spec,
             _inherited=_inherited,
             _user_specified=_user_specified,
         )

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -1298,19 +1298,41 @@ class ParametersBase(ParametersTemplate):
 
             self._register_parameter(attr)
 
-    def _get_prefixed_method(self, parse=False, validate=False, parameter_name=None):
+    def _get_prefixed_method(
+        self,
+        parse=False,
+        validate=False,
+        modulable=False,
+        parameter_name=None
+    ):
         """
-            Returns the method named **prefix**\\ **parameter_name**, used to simplify
-            pluggable methods for parsing and validation of `Parameter`\\ s
+            Returns the parsing or validation method for the Parameter named
+            **parameter_name** or for any modulable Parameter
         """
+
+        if (
+            parse and validate
+            or (not parse and not validate)
+        ):
+            raise ValueError('Exactly one of parse or validate must be True')
+
         if parse:
             prefix = self._parsing_method_prefix
         elif validate:
             prefix = self._validation_method_prefix
-        else:
-            return None
 
-        return getattr(self, '{0}{1}'.format(prefix, parameter_name))
+        if (
+            modulable and parameter_name is not None
+            or not modulable and parameter_name is None
+        ):
+            raise ValueError('modulable must be True or parameter_name must be specified, but not both.')
+
+        if modulable:
+            suffix = 'modulable'
+        elif parameter_name is not None:
+            suffix = parameter_name
+
+        return getattr(self, '{0}{1}'.format(prefix, suffix))
 
     def _validate(self, attr, value):
         try:


### PR DESCRIPTION
The `spec` attribute on `Parameter` is the actual object or value that was passed in to a Component constructor, when that value was automatically parsed. This occurs for example for tuple specifications of input_ports or modulable parameters, and is used to save the original specification for future reference