### PR TITLE
Refactor Parameter type validation

### DIFF
--- a/docs/source/Parameters.rst
+++ b/docs/source/Parameters.rst
@@ -3,4 +3,4 @@ Parameters
 
 .. automodule:: psyneulink.core.globals.parameters
    :members:
-   :exclude-members: get_validator_by_type_only, get_validator_by_function
+   :exclude-members: get_validator_by_function

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -63,7 +63,7 @@ from psyneulink.core.globals.keywords import \
     RANDOM_CONNECTIVITY_MATRIX, RATE, RECEIVER, RELU_FUNCTION, SCALE, SLOPE, SOFTMAX_FUNCTION, STANDARD_DEVIATION, SUM,\
     TRANSFER_FUNCTION_TYPE, TRANSFER_WITH_COSTS_FUNCTION, VARIANCE, VARIABLE, X_0, PREFERENCE_SET_NAME
 from psyneulink.core.globals.parameters import \
-    Parameter, ParameterError, get_validator_by_type_only, get_validator_by_function
+    Parameter, ParameterError, get_validator_by_function
 from psyneulink.core.globals.utilities import parameter_spec, get_global_seed
 from psyneulink.core.globals.context import Context, ContextFlags
 from psyneulink.core.globals.preferences.basepreferenceset import \
@@ -3785,8 +3785,10 @@ class TransferWithCosts(TransferFunction):
                                            getter=_transfer_fct_add_param_getter,
                                            setter=_transfer_fct_add_param_setter)
 
-        enabled_cost_functions = CostFunctions.DEFAULTS
-        _validate_cost_functions = get_validator_by_type_only([CostFunctions, list])
+        enabled_cost_functions = Parameter(
+            CostFunctions.DEFAULTS,
+            valid_types=(CostFunctions, list)
+        )
 
         # Create versions of cost functions' modulation params for TransferWithCosts
 

--- a/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
@@ -345,7 +345,7 @@ from psyneulink.core.globals.keywords import \
     OUTPUT_PORT, OUTPUT_PORTS, OUTPUT_PORT_PARAMS, \
     PARAMETER_PORT, PARAMETER_PORTS, \
     PROJECTION_TYPE, RECEIVER, SUM
-from psyneulink.core.globals.parameters import Parameter, get_validator_by_function, get_validator_by_type_only
+from psyneulink.core.globals.parameters import Parameter, get_validator_by_function
 from psyneulink.core.globals.sampleiterator import is_sample_spec
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
@@ -690,7 +690,12 @@ class ControlSignal(ModulatorySignal):
         )
         allocation_samples = Parameter(None, modulable=True)
 
-        cost_options = Parameter(CostFunctions.DEFAULTS, getter=_cost_options_getter, setter=_cost_options_setter)
+        cost_options = Parameter(
+            CostFunctions.DEFAULTS,
+            getter=_cost_options_getter,
+            setter=_cost_options_setter,
+            valid_types=(CostFunctions, list)
+        )
         intensity_cost = Parameter(None, read_only=True, getter=_intensity_cost_getter)
         adjustment_cost = Parameter(0, read_only=True, getter=_adjustment_cost_getter)
         duration_cost = Parameter(0, read_only=True, getter=_duration_cost_getter)
@@ -721,7 +726,6 @@ class ControlSignal(ModulatorySignal):
             getter=_combine_costs_function_getter
         )
         modulation = None
-        _validate_cost_options = get_validator_by_type_only([CostFunctions, list])
         _validate_intensity_cost_function = get_validator_by_function(is_function_type)
         _validate_adjustment_cost_function = get_validator_by_function(is_function_type)
         _validate_duration_cost_function = get_validator_by_function(is_function_type)

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -251,7 +251,7 @@ from psyneulink.core.globals.log import LogCondition, LogEntry, LogError
 from psyneulink.core.globals.utilities import call_with_pruned_args, copy_iterable_with_shared, get_alias_property_getter, get_alias_property_setter, get_deepcopy_with_shared, unproxy_weakproxy
 
 __all__ = [
-    'Defaults', 'get_validator_by_function', 'get_validator_by_type_only', 'Parameter', 'ParameterAlias', 'ParameterError',
+    'Defaults', 'get_validator_by_function', 'Parameter', 'ParameterAlias', 'ParameterError',
     'ParametersBase', 'parse_context',
 ]
 
@@ -260,24 +260,6 @@ logger = logging.getLogger(__name__)
 
 class ParameterError(Exception):
     pass
-
-
-def get_validator_by_type_only(valid_types):
-    """
-        :return: A validation method for use with Parameters classes that rejects any assignment that is not one of the **valid_types**
-        :rtype: types.FunctionType
-    """
-    if not isinstance(valid_types, collections.abc.Iterable):
-        valid_types = [valid_types]
-
-    def validator(self, value):
-        for t in valid_types:
-            if isinstance(value, t):
-                return None
-        else:
-            return 'valid types: {0}'.format(valid_types)
-
-    return validator
 
 
 def get_validator_by_function(function):


### PR DESCRIPTION
Previously, to do simple type checking for Parameter values, you needed to use the generic function validation pattern. 

Now, simply add a tuple of types as the `valid_types` argument to a Parameter.