### PR TITLE
tests/user_seed: Use sys.executable instead of 'python'

### DIFF
--- a/tests/misc/test_user_seed.py
+++ b/tests/misc/test_user_seed.py
@@ -1,6 +1,7 @@
 import subprocess
+import sys
 
 def test_user_seed():
-    seed1 = subprocess.check_output(("python", "-c" ,"from psyneulink.core.globals.utilities import get_global_seed; print(get_global_seed())"))
-    seed2 = subprocess.check_output(("python", "-c" ,"from psyneulink.core.globals.utilities import get_global_seed; print(get_global_seed())"))
+    seed1 = subprocess.check_output((sys.executable, "-c" ,"from psyneulink.core.globals.utilities import get_global_seed; print(get_global_seed())"))
+    seed2 = subprocess.check_output((sys.executable, "-c" ,"from psyneulink.core.globals.utilities import get_global_seed; print(get_global_seed())"))
     assert seed1 != seed2


### PR DESCRIPTION
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>