### PR TITLE
Feat/composition/generator as input

### DIFF
--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -1703,7 +1703,6 @@ class GridSearch(OptimizationFunction):
                 variable=variable,
                 context=context,
                 params=params,
-
             )
 
             optimal_value_count = 1

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -1114,6 +1114,8 @@ import numpy as np
 import typecheck as tc
 
 from PIL import Image
+from copy import deepcopy, copy
+from inspect import isgenerator, isgeneratorfunction
 
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.component import Component, ComponentsMeta
@@ -1618,6 +1620,10 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         if True, all Parameter values generated during simulations will be saved for later inspection;
         if False, simulation values will be deleted unless otherwise specified by individual Parameters
 
+    input_specification : None or dict or list or generator or function
+        stores the `inputs` for executions of the Composition when it is executed using its `run <Composition.run>`
+        method.
+
     name : str
         the name of the Composition; if it is not specified in the **name** argument of the constructor, a default
         is assigned by CompositionRegistry (see `Naming` for conventions used for default and duplicate names).
@@ -1661,6 +1667,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         results = Parameter([], loggable=False, pnl_internal=True)
         simulation_results = Parameter([], loggable=False, pnl_internal=True)
         retain_old_simulation_data = Parameter(False, stateful=False, loggable=False)
+        input_specification = Parameter(None, stateful=False, loggable=False, pnl_internal=True)
 
     class _CompilationData(ParametersBase):
         ptx_execution = None
@@ -4582,18 +4589,49 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             context=None,
             execution_mode=False,
             return_results=False,
+            block_simulate=False
     ):
         """Runs a simulation of the `Composition`, with the specified control_allocation, excluding its
            `controller <Composition.controller>` in order to return the
            `net_outcome <ControlMechanism.net_outcome>` of the Composition, according to its
            `controller <Composition.controller>` under that control_allocation. All values are
            reset to pre-simulation values at the end of the simulation.
+
+           If `block_simulate` is set to True, the `controller <Composition.controller>` will attempt to use the
+           entire input set provided to the `run <Composition.run>` method of the `Composition` as input for the
+           simulated call to `run <Composition.run>`. If it is not, the `controller <Composition.controller>` will
+           use the inputs slated for its next or previous execution, depending on whether the `controller_mode` of the
+           `Composition` is set to `before` or `after`, respectively.
+
+           .. note::
+                Block simulation can not be used if the Composition's stimuli were specified as a generator. If
+                `block_simulate` is set to True and the input type for the Composition was a generator,
+                block simulation will be disabled for the current execution of `evaluate <Composition.evaluate>`.
         """
         # Apply candidate control to signal(s) for the upcoming simulation and determine its cost
         total_cost = self._get_total_cost_of_control_allocation(control_allocation, context, runtime_params)
 
         # Build input dictionary for simulation
-        inputs = self._build_predicted_inputs_dict(predicted_input)
+        input_spec = self.parameters.input_specification.get(context)
+        if input_spec and block_simulate and not isgenerator(input_spec):
+            if isgeneratorfunction(input_spec):
+                inputs = input_spec()
+            elif isinstance(input_spec, dict):
+                inputs = input_spec
+        else:
+            inputs = self._build_predicted_inputs_dict(predicted_input)
+
+        if hasattr(self, '_input_spec') and block_simulate and isgenerator(input_spec):
+            warnings.warn(f"The evaluate method of {self.name} is attempting to use block simulation, but the "
+                          f"supplied input spec is a generator. Generators can not be used as inputs for block "
+                          f"simulation. This evaluation will not use block simulation.")
+
+        # HACK: _animate attribute is set in execute method, but Evaluate can be called on a Composition that has not
+        # yet called the execute method, so we need to do a check here too.
+        # -DTS
+        if not hasattr(self, '_animate'):
+            # These are meant to be assigned in run method;  needed here for direct call to execute method
+            self._animate = False
 
         # Run Composition in "SIMULATION" context
         if self._animate is not False and self._animate_simulations is not False:
@@ -6337,6 +6375,12 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         for node in reinitialize_values:
             node.reinitialize(*reinitialize_values[node], context=context)
 
+        if ContextFlags.SIMULATION not in context.execution_phase:
+            try:
+                self.parameters.input_specification._set(copy(inputs), context)
+            except:
+                self.parameters.input_specification._set(inputs, context)
+
         # MODIFIED 8/27/19 OLD:
         # try:
         #     if ContextFlags.SIMULATION not in context.execution_phase:
@@ -6382,7 +6426,11 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         input_nodes = self.get_nodes_by_role(NodeRole.INPUT)
 
-        # if there is only one INPUT Node, allow inputs to be specified in a list
+        # if inputs is a generator function, we should instantiate it now so that it will be properly handled
+        # below
+        if isgeneratorfunction(inputs):
+            inputs = inputs()
+
         # if there is only one INPUT Node, allow inputs to be specified in a list
         if isinstance(inputs, (list, np.ndarray)):
             if len(input_nodes) == 1:
@@ -6498,7 +6546,15 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                     return trial_output
             elif hasattr(inputs, '__next__'):
                 try:
-                    execution_stimuli = inputs.__next__()
+                    next_inputs = inputs.__next__()
+                    next_inputs, num_inputs_sets, autodiff_stimuli = self._adjust_stimulus_dict(next_inputs,
+                                                                                                bin_execute=bin_execute)
+                    execution_stimuli = {}
+                    for node in next_inputs:
+                        if len(next_inputs[node]) == 1:
+                            execution_stimuli[node] = next_inputs[node][0]
+                            continue
+                        execution_stimuli[node] = next_inputs[node][stimulus_index]
                 except StopIteration:
                     break
             else:
@@ -6566,6 +6622,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
             if call_after_trial:
                 call_with_pruned_args(call_after_trial, context=context)
+
+        # Reset input spec for next trial
+        self.parameters.input_specification._set(None, context)
 
         scheduler.get_clock(context)._increment_time(TimeScale.RUN)
 

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -4717,6 +4717,106 @@ class TestInputSpecifications:
               num_trials=1)
         assert c.parameters.results.get(c) == [[np.array([0.])]]
 
+    @pytest.mark.parametrize(
+            "with_outer_controller,with_inner_controller",
+            [(True, True), (True, False), (False, True), (False, False)]
+    )
+    def test_input_type_equivalence(self, with_outer_controller, with_inner_controller):
+        # instantiate mechanisms and inner comp
+        ia = pnl.TransferMechanism(name='ia')
+        ib = pnl.TransferMechanism(name='ib')
+        icomp = pnl.Composition(name='icomp', controller_mode=pnl.BEFORE)
+
+        # set up structure of inner comp
+        icomp.add_node(ia, required_roles=pnl.NodeRole.INPUT)
+        icomp.add_node(ib, required_roles=pnl.NodeRole.OUTPUT)
+        icomp.add_projection(pnl.MappingProjection(), sender=ia, receiver=ib)
+
+        # add controller to inner comp
+        if with_inner_controller:
+            icomp.add_controller(
+                    pnl.OptimizationControlMechanism(
+                            agent_rep=icomp,
+                            features=[ia.input_port],
+                            name="iController",
+                            objective_mechanism=pnl.ObjectiveMechanism(
+                                    monitor=ib.output_port,
+                                    function=pnl.SimpleIntegrator,
+                                    name="oController Objective Mechanism"
+                            ),
+                            function=pnl.GridSearch(direction=pnl.MAXIMIZE),
+                            control_signals=[pnl.ControlSignal(projections=[(pnl.SLOPE, ia)],
+                                                               variable=1.0,
+                                                               intensity_cost_function=pnl.Linear(slope=0.0),
+                                                               allocation_samples=pnl.SampleSpec(start=1.0,
+                                                                                                 stop=10.0,
+                                                                                                 num=2))])
+            )
+
+        # instantiate outer comp
+        ocomp = pnl.Composition(name='ocomp', controller_mode=pnl.BEFORE)
+
+        # setup structure of outer comp
+        ocomp.add_node(icomp)
+
+        # add controller to outer comp
+        if with_outer_controller:
+            ocomp.add_controller(
+                    pnl.OptimizationControlMechanism(
+                            agent_rep=ocomp,
+                            features=[ia.input_port],
+                            name="oController",
+                            objective_mechanism=pnl.ObjectiveMechanism(
+                                    monitor=ib.output_port,
+                                    function=pnl.SimpleIntegrator,
+                                    name="oController Objective Mechanism"
+                            ),
+                            function=pnl.GridSearch(direction=pnl.MAXIMIZE),
+                            control_signals=[pnl.ControlSignal(projections=[(pnl.SLOPE, ia)],
+                                                               variable=1.0,
+                                                               intensity_cost_function=pnl.Linear(slope=0.0),
+                                                               allocation_samples=pnl.SampleSpec(start=1.0,
+                                                                                                 stop=10.0,
+                                                                                                 num=2))])
+            )
+
+        # set up input using three different formats:
+        #  1) generator function
+        #  2) instance of generator function
+        #  3) inputs dict
+        inputs_dict = {
+            icomp:
+                {
+                    ia: [[-2], [1]]
+                }
+        }
+
+        def inputs_generator_function():
+            for i in range(2):
+                yield {
+                    icomp:
+                        {
+                            ia: inputs_dict[icomp][ia][i]
+                        }
+                }
+
+        inputs_generator_instance = inputs_generator_function()
+
+        # run Composition with all three input types and assert that results are as expected.
+        ocomp.run(inputs=inputs_generator_function)
+        ocomp.run(inputs=inputs_generator_instance)
+        ocomp.run(inputs=inputs_dict)
+
+        # assert results are as expected
+        if not with_inner_controller and not with_outer_controller:
+            assert ocomp.results[0:2] == ocomp.results[2:4] == ocomp.results[4:6] == [[-2], [1]]
+        elif with_inner_controller and not with_outer_controller or \
+                with_outer_controller and not with_inner_controller:
+            assert ocomp.results[0:2] == ocomp.results[2:4] == ocomp.results[4:6] == [[-2], [10]]
+        else:
+            assert ocomp.results[0:2] == ocomp.results[2:4] == ocomp.results[4:6] == [[-2], [100]]
+
+
 class TestProperties:
     @pytest.mark.composition
     @pytest.mark.parametrize("mode", ['Python', True,


### PR DESCRIPTION
- Fixed bug causing shadow projections to be assigned incorrectly when a nested composition was an input node of its parent composition

- Added block simulate argument to evaluate method, allowing for full input sets to be passed to simulated calls to run instead of just a single trial's worth of stimuli