### PR TITLE
Revert "{dev,tutorial}_requirements: Restrict nbformat to 4.x"

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,6 @@
 ipykernel
 ipython
 jupyter
-nbformat<5
 psyneulink-sphinx-theme
 pytest
 pytest-benchmark

--- a/tutorial_requirements.txt
+++ b/tutorial_requirements.txt
@@ -2,4 +2,3 @@ graphviz
 ipython
 jupyter
 matplotlib
-nbformat<5


### PR DESCRIPTION
This reverts commit 012c8d5130141a4db41d173d7f9ef1073f7a5bda.
Backwards compatibility was fixed in 5.0.1

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>