### PR TITLE
Condense calls to and overrides of _handle_default_variable

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1009,6 +1009,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         else:
             default_variable = v
             self.defaults.variable = default_variable
+            self.parameters.variable._user_specified = True
 
         self.parameters.has_initializers._set(False, context)
 

--- a/psyneulink/core/components/functions/combinationfunctions.py
+++ b/psyneulink/core/components/functions/combinationfunctions.py
@@ -417,11 +417,6 @@ class Rearrange(CombinationFunction):  # ---------------------------------------
             prefs=prefs,
         )
 
-    def _handle_default_variable(self, default_variable=None, size=None, input_ports=None, function=None, params=None):
-        if default_variable is not None:
-            self.parameters.variable._user_specified = True
-        return default_variable
-
     def _validate_variable(self, variable, context=None):
         """Insure that all elements are numeric and that list or array is at least 2d
         """

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -238,12 +238,6 @@ class IntegratorFunction(StatefulFunction):  # ---------------------------------
 
         self.has_initializers = True
 
-    # MODIFIED 6/21/19 NEW: [JDC]
-    def _handle_default_variable(self, default_variable=None, size=None):
-        if default_variable is not None:
-            self.parameters.variable._user_specified = True
-        return super()._handle_default_variable(default_variable, size)
-
     # FIX CONSIDER MOVING THIS TO THE LEVEL OF Function_Base OR EVEN Component
     def _validate_params(self, request_set, target_set=None, context=None):
         """Check inner dimension (length) of all parameters used for the function

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -1548,8 +1548,6 @@ class Mechanism_Base(Mechanism):
                           registry=self._portRegistry,
                           context=context)
 
-        default_variable = self._handle_default_variable(default_variable, size, input_ports, function, params)
-
         super(Mechanism_Base, self).__init__(
             default_variable=default_variable,
             size=size,


### PR DESCRIPTION
- Mechanisms called _handle_default_variable in Mechanism.__init__, and then again in Component.__init__. This is replaced by a single call in Component.__init__
- All default Parameter values are available for _handle_default_variable in a subclass
- Correctly set `parameters.variable._user_specified` universally, so previous overrides doing this are unnecessary