### PR TITLE
test fix for test_integrator_mechanism

### DIFF
--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -1128,7 +1128,7 @@ class TestIntegratorNoise:
 
         val = float(I.execute(10))
 
-        np.testing.assert_allclose(val, -0.977277879876411)
+        np.testing.assert_allclose(val, 0.1648065410516709, atol=3.0, rtol=0.0)
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism


### PR DESCRIPTION
Hi,

The test `TestIntegratorNoise::test_integrator_accumulator_noise_fn` in `test_integrator_mechanism.py` fails intermittently when the seed is not set. I observed that the developers had to update the expected value in the assertion with a new value over several occasions in the past even with the seed set. 

I ran the tests about 60 times with different seeds and observed the range of values for `val`. It looks something like this:
![image](https://user-images.githubusercontent.com/43548542/72942741-dab5d000-3d39-11ea-9a2e-8fc8e55e3dfc.png)

The mean of `val` is about ` 0.1648065410516709` and it ranges from `-2.4416497795147944` to `3.0591995142489194`.

I think a better way to set this assertion might be to account for this range of values using a broader check in the assertion. This would avoid the trouble of changing the expected values in the future.

Please let me know if this looks reasonable or if you have other suggestions on how to deal with this scenario.

