### PR TITLE
Fix compiled printf

### DIFF
--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -272,7 +272,7 @@ class LLVMBuilderContext:
         self.inject_printf(builder, prefix, override_debug=override_debug)
 
         with pnlvm.helpers.array_ptr_loop(builder, array, "print_array_loop") as (b1, i):
-            self.inject_printf(b1, "%f ", b1.load(b1.gep(array, [self.int32_ty(0), i])), override_debug=override_debug)
+            self.inject_printf(b1, "%lf ", b1.load(b1.gep(array, [self.int32_ty(0), i])), override_debug=override_debug)
 
         self.inject_printf(builder, suffix, override_debug=override_debug)
 

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -49,7 +49,7 @@ def module_count():
 
 
 _BUILTIN_PREFIX = "__pnl_builtin_"
-_builtin_intrinsics = frozenset(('pow', 'log', 'exp', 'printf'))
+_builtin_intrinsics = frozenset(('pow', 'log', 'exp'))
 
 
 class LLVMBuilderContext:

--- a/psyneulink/core/llvm/builtins.py
+++ b/psyneulink/core/llvm/builtins.py
@@ -398,9 +398,6 @@ def setup_pnl_intrinsics(ctx):
     ir.Function(ctx.module, single_intr_ty, name=_BUILTIN_PREFIX + "log")
     ir.Function(ctx.module, double_intr_ty, name=_BUILTIN_PREFIX + "pow")
 
-    # Printf declaration
-    printf_ty = ir.FunctionType(ir.IntType(32), [ir.IntType(8).as_pointer()], var_arg=True)
-    ir.Function(ctx.module, printf_ty, name=_BUILTIN_PREFIX + "printf")
 
 
 def _generate_intrinsic_wrapper(module, name, ret, args):
@@ -414,33 +411,6 @@ def _generate_intrinsic_wrapper(module, name, ret, args):
     builder.debug_metadata = LLVMBuilderContext.get_debug_location(function, None)
     builder.ret(builder.call(intrinsic, function.args))
 
-
-def _generate_cpu_printf_wrapper(module):
-    #FIXME: Does not seem to handle varargs correctly (varargs aren't passed to function.args)
-    printf_ty = ir.FunctionType(ir.IntType(32), [ir.IntType(8).as_pointer()], var_arg=True)
-    function = ir.Function(module, printf_ty, name=_BUILTIN_PREFIX + "printf")
-    function.attributes.add('alwaysinline')
-    block = function.append_basic_block(name="entry")
-    builder = ir.IRBuilder(block)
-    builder.debug_metadata = LLVMBuilderContext.get_debug_location(function, None)
-
-    try:
-        import llvmlite.binding as llvm
-        libc = ctypes.util.find_library("c")
-        llvm.load_library_permanently(libc)
-        # Address will be none if the symbol is not found
-        printf_address = llvm.address_of_symbol("printf")
-    except:
-        printf_address = None
-
-    if printf_address is not None:
-        # Direct pointer constants don't work
-        printf = builder.inttoptr(pnlvm.ir.IntType(64)(printf_address), printf_ty.as_pointer())
-        builder.ret(builder.call(printf, function.args))
-    else:
-        builder.ret(ir.IntType(32)(-1))
-
-
 def _generate_cpu_builtins_module(_float_ty):
     """Generate function wrappers for log, exp, and pow intrinsics."""
     module = ir.Module(name="cpu_builtins")
@@ -448,7 +418,6 @@ def _generate_cpu_builtins_module(_float_ty):
         _generate_intrinsic_wrapper(module, intrinsic, _float_ty, [_float_ty])
 
     _generate_intrinsic_wrapper(module, "pow", _float_ty, [_float_ty, _float_ty])
-    _generate_cpu_printf_wrapper(module)
     return module
 
 

--- a/psyneulink/core/llvm/builtins.py
+++ b/psyneulink/core/llvm/builtins.py
@@ -416,6 +416,7 @@ def _generate_intrinsic_wrapper(module, name, ret, args):
 
 
 def _generate_cpu_printf_wrapper(module):
+    #FIXME: Does not seem to handle varargs correctly (varargs aren't passed to function.args)
     printf_ty = ir.FunctionType(ir.IntType(32), [ir.IntType(8).as_pointer()], var_arg=True)
     function = ir.Function(module, printf_ty, name=_BUILTIN_PREFIX + "printf")
     function.attributes.add('alwaysinline')

--- a/psyneulink/library/compositions/pytorchmodelcreator.py
+++ b/psyneulink/library/compositions/pytorchmodelcreator.py
@@ -490,7 +490,7 @@ class PytorchModelCreator(torch.nn.Module):
                 a.attributes.add('noalias')
 
         context, params, model_input, model_output, optim_struct, training_set, trial_num = llvm_func.args
-        ctx.inject_printf(builder,"TRIAL NUM: %d\n", trial_num)
+        ctx.inject_printf(builder, "TRIAL NUM: %d\n", trial_num)
         # setup useful mappings
         input_nodes = composition.get_nodes_by_role(NodeRole.INPUT)
         output_nodes = composition.get_nodes_by_role(NodeRole.OUTPUT)

--- a/tests/llvm/test_helpers.py
+++ b/tests/llvm/test_helpers.py
@@ -192,33 +192,31 @@ def test_helper_all_close(mode):
     assert np.array_equal(res, ref)
 
 @pytest.mark.llvm
-@pytest.mark.parametrize("ctype,ir_argtype,format_spec,values_to_check", [
-    (ctypes.c_int32, pnlvm.ir.IntType(32), "%u", range(0,100)),
-    (ctypes.c_int64, pnlvm.ir.IntType(64), "%ld", [int(-4E10), int(-3E10), int(-2E10)]),
-    (ctypes.c_float, pnlvm.ir.FloatType(), "%f", range(0,10)),
+@pytest.mark.parametrize("ir_argtype,format_spec,values_to_check", [
+    (pnlvm.ir.IntType(32), "%u", range(0,100)),
+    (pnlvm.ir.IntType(64), "%ld", [int(-4E10), int(-3E10), int(-2E10)]),
+    (pnlvm.ir.DoubleType(), "%lf", [x*.5 for x in range(0,10)]),
     ])
 @pytest.mark.skipif(sys.platform == 'win32', reason="Loading C library is complicated on windows")
-def test_helper_printf(capfd, ctype, ir_argtype, format_spec, values_to_check):
-    format_str = f"Hello {(format_spec+' ')*len(values_to_check)}" +"\n"
+def test_helper_printf(capfd, ir_argtype, format_spec, values_to_check):
+    format_str = f"Hello {(format_spec+' ')*len(values_to_check)} \n"
     with pnlvm.LLVMBuilderContext() as ctx:
-        func_ty = ir.FunctionType(ir.VoidType(), [ir_argtype] *len(values_to_check))
-
-        custom_name = ctx.get_unique_name("hello")
+        func_ty = ir.FunctionType(ir.VoidType(), [])
+        ir_values_to_check = [ir_argtype(i) for i in values_to_check]
+        custom_name = ctx.get_unique_name("test_printf")
         function = ir.Function(ctx.module, func_ty, name=custom_name)
         block = function.append_basic_block(name="entry")
         builder = ir.IRBuilder(block)
 
-        ctx.inject_printf(builder, format_str, *function.args, override_debug=True)
+        ctx.inject_printf(builder, format_str, *ir_values_to_check, override_debug=True)
         builder.ret_void()
 
     bin_f = pnlvm.LLVMBinaryFunction.get(custom_name)
 
 
     # Printf is buffered in libc.
-    res = [ctype(i) for i in values_to_check]
-    bin_f(*res)
+    bin_f()
     libc = ctypes.util.find_library("c")
     libc = ctypes.CDLL(libc)
-    # fflush(NULL) flushes all open streams.
     libc.fflush(0)
     assert capfd.readouterr().out == format_str % tuple(values_to_check)

--- a/tests/llvm/test_helpers.py
+++ b/tests/llvm/test_helpers.py
@@ -9,11 +9,11 @@ from psyneulink.core import llvm as pnlvm
 from llvmlite import ir
 
 
-DIM_X=1000
-TST_MIN=1.0
-TST_MAX=3.0
+DIM_X = 1000
+TST_MIN = 1.0
+TST_MAX = 3.0
 
-vector = np.random.rand(DIM_X)
+VECTOR = np.random.rand(DIM_X)
 
 @pytest.mark.llvm
 @pytest.mark.parametrize('mode', ['CPU',
@@ -21,7 +21,7 @@ vector = np.random.rand(DIM_X)
 def test_helper_fclamp(mode):
 
     with pnlvm.LLVMBuilderContext() as ctx:
-        local_vec = copy.deepcopy(vector)
+        local_vec = copy.deepcopy(VECTOR)
         double_ptr_ty = ctx.float_ty.as_pointer()
         func_ty = ir.FunctionType(ir.VoidType(), (double_ptr_ty, ctx.int32_ty,
                                                   double_ptr_ty))
@@ -45,7 +45,7 @@ def test_helper_fclamp(mode):
 
         builder.ret_void()
 
-    ref = np.clip(vector, TST_MIN, TST_MAX)
+    ref = np.clip(VECTOR, TST_MIN, TST_MAX)
     bounds = np.asfarray([TST_MIN, TST_MAX])
     bin_f = pnlvm.LLVMBinaryFunction.get(custom_name)
     if mode == 'CPU':
@@ -66,7 +66,7 @@ def test_helper_fclamp(mode):
 def test_helper_fclamp_const(mode):
 
     with pnlvm.LLVMBuilderContext() as ctx:
-        local_vec = copy.deepcopy(vector)
+        local_vec = copy.deepcopy(VECTOR)
         double_ptr_ty = ctx.float_ty.as_pointer()
         func_ty = ir.FunctionType(ir.VoidType(), (double_ptr_ty, ctx.int32_ty))
 
@@ -86,7 +86,7 @@ def test_helper_fclamp_const(mode):
 
         builder.ret_void()
 
-    ref = np.clip(vector, TST_MIN, TST_MAX)
+    ref = np.clip(VECTOR, TST_MIN, TST_MAX)
     bin_f = pnlvm.LLVMBinaryFunction.get(custom_name)
     if mode == 'CPU':
         ct_ty = pnlvm._convert_llvm_ir_to_ctype(double_ptr_ty)
@@ -129,7 +129,7 @@ def test_helper_is_close(mode):
 
         builder.ret_void()
         
-    vec1 = copy.deepcopy(vector)
+    vec1 = copy.deepcopy(VECTOR)
     tmp = np.random.rand(DIM_X)
     tmp[0::2] = vec1[0::2]
     vec2 = np.asfarray(tmp)
@@ -172,8 +172,8 @@ def test_helper_all_close(mode):
         builder.store(res, out)
         builder.ret_void()
 
-    vec1 = copy.deepcopy(vector)
-    vec2 = copy.deepcopy(vector)
+    vec1 = copy.deepcopy(VECTOR)
+    vec2 = copy.deepcopy(VECTOR)
 
     ref = np.allclose(vec1, vec2)
     bin_f = pnlvm.LLVMBinaryFunction.get(custom_name)
@@ -193,9 +193,9 @@ def test_helper_all_close(mode):
 
 @pytest.mark.llvm
 @pytest.mark.parametrize("ir_argtype,format_spec,values_to_check", [
-    (pnlvm.ir.IntType(32), "%u", range(0,100)),
+    (pnlvm.ir.IntType(32), "%u", range(0, 100)),
     (pnlvm.ir.IntType(64), "%ld", [int(-4E10), int(-3E10), int(-2E10)]),
-    (pnlvm.ir.DoubleType(), "%lf", [x*.5 for x in range(0,10)]),
+    (pnlvm.ir.DoubleType(), "%lf", [x *.5 for x in range(0, 10)]),
     ])
 @pytest.mark.skipif(sys.platform == 'win32', reason="Loading C library is complicated on windows")
 def test_helper_printf(capfd, ir_argtype, format_spec, values_to_check):

--- a/tests/llvm/test_helpers.py
+++ b/tests/llvm/test_helpers.py
@@ -1,4 +1,3 @@
-from ctypes import util
 import ctypes
 import copy
 import numpy as np


### PR DESCRIPTION
@jvesely 
This pull fixes compiled printf by reverting it to the original version, and also adds extra test cases to better check for correctness.

There is a bug with the live version in which varargs are not correctly passed to the builtin printf wrapper