### PR TITLE
Fix MSE Loss function

### DIFF
--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -287,6 +287,15 @@ class LLVMBuilderContext:
 
         self.inject_printf(builder, suffix, override_debug=override_debug)
 
+    def inject_printf_float_matrix(self, builder, matrix, prefix="", suffix="\n", override_debug=False):
+        self.inject_printf(builder, prefix, override_debug=override_debug)
+        with pnlvm.helpers.array_ptr_loop(builder, matrix, "print_row_loop") as (b1, i):
+            row = b1.gep(matrix, [self.int32_ty(0), i])
+            with pnlvm.helpers.array_ptr_loop(b1, row, "print_col_loop") as (b2, j):
+                self.inject_printf(b2, "%lf ", b2.load(b2.gep(row, [self.int32_ty(0), j])), override_debug=override_debug)
+            self.inject_printf(b2, "\n",override_debug=override_debug)
+        self.inject_printf(builder, suffix, override_debug=override_debug)
+
     @contextmanager
     def _gen_composition_exec_context(self, composition, simulation=False, suffix="", extra_args=[]):
         cond_gen = ConditionGenerator(self, composition)

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -55,11 +55,6 @@ def array_ptr_loop(builder, array, id):
     stop = ir.IntType(32)(array.type.pointee.count)
     return for_loop_zero_inc(builder, stop, id)
 
-def matrix_ptr_loop(builder, matrix, id):
-    with array_ptr_loop(builder, matrix, id+"_outer") as (b1,outer_idx):
-        row = b1.load(b1.gep(matrix, [self.int32_ty(0), outer_idx]))
-        with array_ptr_loop(b1, row, id+"_inner") as (b2, inner_idx):
-            yield (b2, outer_idx, inner_idx)
 
 def fclamp(builder, val, min_val, max_val):
     min_val = min_val if isinstance(min_val, ir.Value) else val.type(min_val)

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -55,6 +55,11 @@ def array_ptr_loop(builder, array, id):
     stop = ir.IntType(32)(array.type.pointee.count)
     return for_loop_zero_inc(builder, stop, id)
 
+def matrix_ptr_loop(builder, matrix, id):
+    with array_ptr_loop(builder, matrix, id+"_outer") as (b1,outer_idx):
+        row = b1.load(b1.gep(matrix, [self.int32_ty(0), outer_idx]))
+        with array_ptr_loop(b1, row, id+"_inner") as (b2, inner_idx):
+            yield (b2, outer_idx, inner_idx)
 
 def fclamp(builder, val, min_val, max_val):
     min_val = min_val if isinstance(min_val, ir.Value) else val.type(min_val)

--- a/psyneulink/library/compositions/compiledloss.py
+++ b/psyneulink/library/compositions/compiledloss.py
@@ -54,6 +54,9 @@ class MSELoss(Loss):
             diff = b1.fmul(diff,diff)
             b1.store(b1.fadd(b1.load(sum),diff),sum)
 
+        # Average the values in sum by dimensionality
+        builder.store(builder.fdiv(builder.load(sum),builder.uitofp(dim, ctx.float_ty)), sum)
+        
         builder.ret(builder.load(sum))
 
         return builder.function
@@ -69,7 +72,13 @@ class MSELoss(Loss):
         assert len(output.type.pointee) == dim
 
         if sum_loss is False:
+            # we take mean
             self._pytorch_model._gen_inject_vec_sub(ctx, builder, value, target, output)
+            # multiply each element i by 2/n to get dC/da_i
+            scalar_mult = builder.fdiv(ctx.float_ty(2), ctx.float_ty(dim)) 
+            with pnlvm.helpers.for_loop_zero_inc(builder, ctx.int32_ty(dim), "mse_mean_mult_loop") as (b1, index):
+                element_ptr = b1.gep(output, [ctx.int32_ty(0), index])
+                b1.store(b1.fmul(b1.load(element_ptr),scalar_mult),element_ptr)
         else:
             # in this case, we add the loss
             tmp = self._pytorch_model._gen_inject_vec_sub(ctx, builder, value, target)

--- a/psyneulink/library/compositions/compiledloss.py
+++ b/psyneulink/library/compositions/compiledloss.py
@@ -75,7 +75,7 @@ class MSELoss(Loss):
             # we take mean
             self._pytorch_model._gen_inject_vec_sub(ctx, builder, value, target, output)
             # multiply each element i by 2/n to get dC/da_i
-            scalar_mult = builder.fdiv(ctx.float_ty(2), ctx.float_ty(dim)) 
+            scalar_mult = builder.fdiv(ctx.float_ty(2), ctx.float_ty(dim))
             with pnlvm.helpers.for_loop_zero_inc(builder, ctx.int32_ty(dim), "mse_mean_mult_loop") as (b1, index):
                 element_ptr = b1.gep(output, [ctx.int32_ty(0), index])
                 b1.store(b1.fmul(b1.load(element_ptr),scalar_mult),element_ptr)

--- a/psyneulink/library/compositions/pytorchmodelcreator.py
+++ b/psyneulink/library/compositions/pytorchmodelcreator.py
@@ -644,12 +644,10 @@ class PytorchModelCreator(torch.nn.Module):
 
         ctx.inject_printf(builder,"Running Autodiff Training with params:\n\tepoch count: %d \n\tnum_trials: %d \n",
                             epochs,
-                            num_trials,
-                            override_debug=True)
+                            num_trials)
 
         ctx.inject_printf(builder,"\tlearning_struct_addr: 0x%Lx \n",
-                            training_set_array,
-                            override_debug=True)
+                            training_set_array)
         input_cim_idx = composition._get_node_index(composition.input_CIM)
         model_params = builder.gep(params, [ctx.int32_ty(0), ctx.int32_ty(2)])
 

--- a/psyneulink/library/compositions/pytorchmodelcreator.py
+++ b/psyneulink/library/compositions/pytorchmodelcreator.py
@@ -424,12 +424,12 @@ class PytorchModelCreator(torch.nn.Module):
                     is_set = False
                     for j, (input_vertex, weights) in enumerate(afferents.items()):
                         source_node = input_vertex.component
-                        ctx.inject_printf(builder, f"COMPILED FORWARD {source_node} -> {component}\n")
                         source_node_idx = self._composition._get_node_index(source_node)
                         input_value = self._get_output_value_ptr(ctx, builder, arg_out, source_node_idx)
 
                         # We cast the ctype weights array to llvmlite pointer
                         weights_llvmlite, _, _ = self._gen_get_node_weight_ptr(ctx, builder, params, component, source_node)
+                        ctx.inject_printf_float_matrix(builder, weights_llvmlite, prefix=f"{source_node} -> {component}\tweight:\t")
                         # node inputs are 2d arrays in a struct
                         input_ptr = builder.gep(mech_input, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(j)])
                         self._gen_inject_vxm(ctx, builder, input_value, weights_llvmlite, input_ptr)
@@ -466,8 +466,8 @@ class PytorchModelCreator(torch.nn.Module):
                 # if biases is not None:
                 #   value = value + biases
                 if store_z_values is True:
-                    ctx.inject_printf_float_array(builder, z_values[component], prefix=f"Z VALUE FOR {component} :\t")
-                ctx.inject_printf_float_array(builder, value, prefix=f"FORWARD VALUE FOR {component} :\t")
+                    ctx.inject_printf_float_array(builder, z_values[component], prefix=f"{component}\tforward input:\t")
+                ctx.inject_printf_float_array(builder, value, prefix=f"{component}\tforward output:\t")
 
         return z_values
 
@@ -490,7 +490,6 @@ class PytorchModelCreator(torch.nn.Module):
                 a.attributes.add('noalias')
 
         context, params, model_input, model_output, optim_struct, training_set, trial_num = llvm_func.args
-        ctx.inject_printf(builder, "TRIAL NUM: %d\n", trial_num)
         # setup useful mappings
         input_nodes = composition.get_nodes_by_role(NodeRole.INPUT)
         output_nodes = composition.get_nodes_by_role(NodeRole.OUTPUT)
@@ -504,7 +503,7 @@ class PytorchModelCreator(torch.nn.Module):
             node_model_input = builder.gep(model_input, [ctx.int32_ty(0), ctx.int32_ty(i)])
             self._gen_inject_vec_copy(ctx, builder, node_input_array_ptr, node_model_input)
 
-            ctx.inject_printf_float_array(builder, node_model_input, prefix=f"\tNODE {i} INPUT: ")
+            ctx.inject_printf_float_array(builder, node_model_input, prefix=f"{node}\tinput:\t")
 
         # 2) call forward computation
         model_params = builder.gep(params, [ctx.int32_ty(0), ctx.int32_ty(2)])
@@ -512,7 +511,6 @@ class PytorchModelCreator(torch.nn.Module):
             ctx, builder, context, params, model_input, model_output, store_z_values=True)
         # 3) compute errors
 
-        ctx.inject_printf(builder, "\tCOMPUTE ERR FOR INPUT %d\n", trial_num)
 
         error_dict = {}
         backprop_queue = deque()
@@ -549,10 +547,10 @@ class PytorchModelCreator(torch.nn.Module):
 
                 tmp_loss = loss.gen_inject_lossfunc_call(ctx, builder, loss_fn, node_output, node_target)
 
-                ctx.inject_printf_float_array(builder, node_target, prefix=f"{node} target:")
-                ctx.inject_printf_float_array(builder, node_output, prefix=f"{node} value:")
+                ctx.inject_printf_float_array(builder, node_target, prefix=f"{node}\ttarget:\t")
+                ctx.inject_printf_float_array(builder, node_output, prefix=f"{node}\tvalue:\t")
 
-                ctx.inject_printf(builder,f"tmp loss for {node} :%f\n",tmp_loss)
+                ctx.inject_printf(builder,f"{node}\tloss:\t%f\n",tmp_loss)
                 builder.store(builder.fadd(builder.load(total_loss),tmp_loss),total_loss)
                 loss_derivative = loss._gen_inject_loss_differential(ctx, builder, node_output, node_target)
                 # compute δ_l = dσ/da ⊙ σ'(z)
@@ -582,8 +580,8 @@ class PytorchModelCreator(torch.nn.Module):
 
                 self._gen_inject_vec_hadamard(ctx, builder, activation_func_derivative, error_val, error_val)
 
-            ctx.inject_printf_float_array(builder, activation_func_derivative, prefix=f"dSIGMA VALUE FOR {node}:\t")
-            ctx.inject_printf_float_array(builder, error_val, prefix=f"ERROR VALUE FOR {node}:\t")
+            ctx.inject_printf_float_array(builder, activation_func_derivative, prefix=f"{node}\tdSigma:\t")
+            ctx.inject_printf_float_array(builder, error_val, prefix=f"{node}\terror:\t")
 
         # 4) compute weight gradients
         for (node, err_val) in error_dict.items():
@@ -614,7 +612,7 @@ class PytorchModelCreator(torch.nn.Module):
                                                  [ctx.int32_ty(0), weight_row, weight_column]))
                     
         builder.store(builder.fmul(ctx.float_ty(.5),builder.load(total_loss)),total_loss)
-        ctx.inject_printf(builder,"TOTAL LOSS: %f\n",builder.load(total_loss))
+        ctx.inject_printf(builder,"TOTAL LOSS:\t%f\n",builder.load(total_loss))
         builder.ret_void()
 
         return builder.function
@@ -687,7 +685,7 @@ class PytorchModelCreator(torch.nn.Module):
                 # FIXME: converting this call to direct code results in
                 # significant longer compilation times
                 b2.call(optimizer_zero_grad, [optimizer_struct])
-                ctx.inject_printf(b2, "BACKPROP %d\n", trial_num)
+                ctx.inject_printf(b2, "TRIAL %d\n", trial_num)
                 b2.call(backprop, [context, params, model_input, data,
                                    optimizer_struct, training_set_array,
                                    trial_num])

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -942,7 +942,7 @@ class TestTrainingCorrectness:
                              0.05186586, 0.05829845, 0.05179337, 0.03504668, 0.05379566,
                              0.07103772, 0.03544133, 0.03019486, 0.12605846, 0.03976812])
 
-        np.allclose(output,comparator)
+        assert np.allclose(output,comparator)
 
     def test_pytorch_equivalence_with_autodiff_training_disabled_on_proj(self):
         iSs = np.array(


### PR DESCRIPTION
When the MSE Loss function was previously changed, the compiled version still used the old one.
These changes fix that issue, and re-enable correctness tests for compiled autodiff correctness

Additionally, there are some cleanups made to compiled print statements that allow for clearer debugging