### PR TITLE
llvm: Implement support for compiling mechanisms using "execute_until_finished"

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1175,7 +1175,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      # Invalid types
                      "input_port_variables", "results", "simulation_results",
                      "monitor_for_control", "feature_values", "simulation_ids",
-                     "input_labels_dict", "output_labels_dict"}
+                     "input_labels_dict", "output_labels_dict",
+                     "modulated_mechanisms"}
         # mechanism functions are handled separately
         if hasattr(self, 'ports'):
             blacklist.add("function")

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1141,8 +1141,9 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         # mechanism functions are handled separately
         blacklist = {"function"} if hasattr(self, 'ports') else {}
         def _is_compilation_state(p):
-            return (p.name in stateful or isinstance(p.get(), Component)) and \
-                    p.name not in blacklist
+            return p.name not in blacklist and (
+                   p.name in stateful or
+                   isinstance(p.get(), (Component, np.random.RandomState)))
 
         return filter(_is_compilation_state, self.parameters)
 

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1184,7 +1184,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 #FIXME: this should use defaults
                 val = p.get()
                 # Check if the value is string (like integration_method)
-                return not isinstance(val, (str, dict, ComponentsMeta, ContentAddressableList, type(_is_compilation_param)))
+                return not isinstance(val, (str, dict, ComponentsMeta, ContentAddressableList, type(_is_compilation_param), type(max)))
             return False
 
         return filter(_is_compilation_param, self.parameters)

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1136,7 +1136,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
     def _get_compilation_state(self):
         # FIXME: MAGIC LIST, Use stateful tag for this
         whitelist = {"previous_time", "previous_value", "previous_v",
-                     "previous_w", "random_state"}
+                     "previous_w", "random_state", "is_finished_flag",
+                     "num_executions_before_finished"}
         # mechanism functions are handled separately
         blacklist = {"function"} if hasattr(self, 'ports') else {}
         def _is_compilation_state(p):

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1134,16 +1134,15 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
     # Compilation support
     # ------------------------------------------------------------------------------------------------------------------
     def _get_compilation_state(self):
-        try:
-            stateful = set(self.stateful_attributes)
-        except AttributeError:
-            stateful = set()
+        # FIXME: MAGIC LIST, Use stateful tag for this
+        whitelist = {"previous_time", "previous_value", "previous_v",
+                     "previous_w", "random_state"}
         # mechanism functions are handled separately
         blacklist = {"function"} if hasattr(self, 'ports') else {}
         def _is_compilation_state(p):
-            return p.name not in blacklist and (
-                   p.name in stateful or
-                   isinstance(p.get(), (Component, np.random.RandomState)))
+            val = p.get()   # memoize for this function
+            return val is not None and p.name not in blacklist and \
+                   (p.name in whitelist or isinstance(val, Component))
 
         return filter(_is_compilation_state, self.parameters)
 

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1167,15 +1167,13 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         return pnlvm._tupleize(_convert(self._get_state_values(context)))
 
     def _get_compilation_params(self):
-        # Filter out known unused/invalid params
-        black_list = {'variable', 'value', 'initializer'}
-        try:
-            # Don't list stateful params, the are included in state
-            black_list.update(self.stateful_attributes)
-        except AttributeError:
-            pass
+        # FIXME: MAGIC LIST, Use stateful tag for this
+        blacklist = {"previous_time", "previous_value", "previous_v",
+                     "previous_w", "random_state", "is_finished_flag",
+                     "num_executions_before_finished", "variable",
+                     "value", "initializer"}
         def _is_compilation_param(p):
-            if p.name not in black_list and not isinstance(p, ParameterAlias):
+            if p.name not in blacklist and not isinstance(p, ParameterAlias):
                 #FIXME: this should use defaults
                 val = p.get()
                 # Check if the value is string (like integration_method)

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1159,17 +1159,18 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         lists = (_convert(s) for s in self._get_state_values(context))
         return pnlvm._tupleize(lists)
 
-    def _get_compilation_params(self, context=None):
+    def _get_compilation_params(self):
         # Filter out known unused/invalid params
         black_list = {'variable', 'value', 'initializer'}
         try:
-            # Don't list stateful params, the are included in context
+            # Don't list stateful params, the are included in state
             black_list.update(self.stateful_attributes)
         except AttributeError:
             pass
         def _is_compilation_param(p):
             if p.name not in black_list and not isinstance(p, ParameterAlias):
-                val = p.get(context)
+                #FIXME: this should use defaults
+                val = p.get()
                 # Check if the value is string (like integration_method)
                 return not isinstance(val, (str, ComponentsMeta))
             return False
@@ -1177,7 +1178,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         return filter(_is_compilation_param, self.parameters)
 
     def _get_param_ids(self, context=None):
-        return [p.name for p in self._get_compilation_params(context)]
+        return [p.name for p in self._get_compilation_params()]
 
     def _get_param_values(self, context=None):
         def _get_values(p):
@@ -1206,7 +1207,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                     param = np.asfarray(param[0]).tolist()
             return param
 
-        return tuple(map(_get_values, self._get_compilation_params(context)))
+        return tuple(map(_get_values, self._get_compilation_params()))
 
     def _get_param_initializer(self, context):
         return pnlvm._tupleize(self._get_param_values(context))

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1171,13 +1171,20 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         blacklist = {"previous_time", "previous_value", "previous_v",
                      "previous_w", "random_state", "is_finished_flag",
                      "num_executions_before_finished", "variable",
-                     "value", "initializer"}
+                     "value", "initializer",
+                     # Invalid types
+                     "input_port_variables", "results", "simulation_results",
+                     "monitor_for_control", "feature_values", "simulation_ids",
+                     "input_labels_dict", "output_labels_dict"}
+        # mechanism functions are handled separately
+        if hasattr(self, 'ports'):
+            blacklist.add("function")
         def _is_compilation_param(p):
             if p.name not in blacklist and not isinstance(p, ParameterAlias):
                 #FIXME: this should use defaults
                 val = p.get()
                 # Check if the value is string (like integration_method)
-                return not isinstance(val, (str, ComponentsMeta))
+                return not isinstance(val, (str, dict, ComponentsMeta, ContentAddressableList, type(_is_compilation_param)))
             return False
 
         return filter(_is_compilation_param, self.parameters)

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -3109,6 +3109,41 @@ class LeakyCompetingIntegrator(IntegratorFunction):  # -------------------------
 
         return self.convert_output_type(adjusted_value)
 
+    def _gen_llvm_integrate(self, builder, index, ctx, vi, vo, params, state):
+        rate = self._gen_llvm_load_param(ctx, builder, params, index, RATE)
+        noise = self._gen_llvm_load_param(ctx, builder, params, index, NOISE)
+        offset = self._gen_llvm_load_param(ctx, builder, params, index, OFFSET)
+        time_step = self._gen_llvm_load_param(ctx, builder, params, index, TIME_STEP_SIZE)
+
+        # Get the only context member -- previous value
+        prev_ptr = ctx.get_state_ptr(self, builder, state, "previous_value")
+        # Get rid of 2d array. When part of a Mechanism the input,
+        # (and output, and context) are 2d arrays.
+        prev_ptr = ctx.unwrap_2d_array(builder, prev_ptr)
+        assert len(prev_ptr.type.pointee) == len(vi.type.pointee)
+
+        prev_ptr = builder.gep(prev_ptr, [ctx.int32_ty(0), index])
+        prev_val = builder.load(prev_ptr)
+
+        in_ptr = builder.gep(vi, [ctx.int32_ty(0), index])
+        in_val = builder.load(in_ptr)
+
+        ret = builder.fmul(prev_val, rate)
+        ret = builder.fadd(ret, in_val)
+        ret = builder.fmul(ret, time_step)
+
+        sqrt_f = ctx.get_builtin("sqrt", [ctx.float_ty])
+        mod_step = builder.call(sqrt_f, [time_step])
+        mod_noise = builder.fmul(noise, mod_step)
+
+        ret = builder.fadd(ret, prev_val)
+        ret = builder.fadd(ret, mod_noise)
+        ret = builder.fadd(ret, offset)
+
+        out_ptr = builder.gep(vo, [ctx.int32_ty(0), index])
+        builder.store(ret, out_ptr)
+        builder.store(ret, prev_ptr)
+
 
 class FitzHughNagumoIntegrator(IntegratorFunction):  # ----------------------------------------------------------------------------
     """

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -3030,7 +3030,7 @@ class LeakyCompetingIntegrator(IntegratorFunction):  # -------------------------
 
         """
         rate = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM, 'leak'], function_arg=True)
-        offset = Parameter(None, modulable=True, aliases=[ADDITIVE_PARAM], function_arg=True)
+        offset = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM], function_arg=True)
         time_step_size = Parameter(0.1, modulable=True, function_arg=True)
 
     @tc.typecheck
@@ -3087,9 +3087,6 @@ class LeakyCompetingIntegrator(IntegratorFunction):  # -------------------------
         initializer = self.get_current_function_param(INITIALIZER, context)  # unnecessary?
         time_step_size = self.get_current_function_param(TIME_STEP_SIZE, context)
         offset = self.get_current_function_param(OFFSET, context)
-
-        if offset is None:
-            offset = 0.0
 
         # execute noise if it is a function
         noise = self._try_execute_param(self.get_current_function_param(NOISE, context), variable)

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2511,7 +2511,7 @@ class Mechanism_Base(Mechanism):
         return ctx.get_state_struct_type(self.function)
 
     def _get_mech_state_struct_type(self, ctx):
-        return pnlvm.ir.LiteralStructType(())
+        return ctx.get_state_struct_type(super())
 
     def _get_state_struct_type(self, ctx):
         ports_state_struct = self._get_ports_state_struct_type(ctx)
@@ -2560,7 +2560,7 @@ class Mechanism_Base(Mechanism):
         return self.function._get_state_initializer(context)
 
     def _get_mech_state_init(self, context):
-        return ()
+        return super()._get_state_initializer(context)
 
     def _get_state_initializer(self, context):
         port_state_init = self._get_ports_state_initializer(context)

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2492,7 +2492,7 @@ class Mechanism_Base(Mechanism):
         return ctx.get_param_struct_type(self.function)
 
     def _get_mech_param_struct_type(self, ctx):
-        return pnlvm.ir.LiteralStructType(())
+        return ctx.get_param_struct_type(super())
 
     def _get_param_struct_type(self, ctx):
         states_param_struct = self._get_states_param_struct_type(ctx)
@@ -2550,7 +2550,7 @@ class Mechanism_Base(Mechanism):
         return (port_param_init, function_param_init, mech_param_init)
 
     def _get_mech_params_init(self, context):
-        return ()
+        return super()._get_param_initializer(context)
 
     def _get_ports_state_initializer(self, context):
         gen = (s._get_state_initializer(context) for s in self.ports)

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2210,7 +2210,7 @@ class Port_Base(Port):
             input_types.append(ctx.get_output_struct_type(mod))
         return pnlvm.ir.LiteralStructType(input_types)
 
-    def _get_compilation_params(self, context=None):
+    def _get_compilation_params(self):
         return [self.parameters.function]
 
     def _get_compilation_state(self):

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6590,10 +6590,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
             except Exception as e:
                 if bin_execute is not True:
-                    raise e
+                    raise e from None
 
-                print("WARNING: Failed to Run execution `{}': {}".format(
-                      self.name, str(e)))
+                warnings.warn("Failed to run `{}': {}".format(self.name, str(e)))
 
         # Reset gym forager environment for the current trial
         if self.env:
@@ -6935,10 +6934,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                         return __execution.extract_node_output(self.output_CIM)
                 except Exception as e:
                     if bin_execute is not True:
-                        raise e
+                        raise e from None
 
-                    string = "Failed to execute `{}': {}".format(self.name, str(e))
-                    print("WARNING: {}".format(string))
+                    warnings.warn("Failed to execute `{}': {}".format(self.name, str(e)))
 
             # Exec failed for some reason, we can still try node level bin_execute
             try:
@@ -6958,10 +6956,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 bin_execute = True
             except Exception as e:
                 if bin_execute is not True:
-                    raise e
+                    raise e from None
 
-                string = "Failed to compile wrapper for `{}' in `{}': {}".format(m.name, self.name, str(e))
-                print("WARNING: {}".format(string))
+                warnings.warn("Failed to compile wrapper for `{}' in `{}': {}".format(m.name, self.name, str(e)))
                 bin_execute = False
 
         # Execute controller --------------------------------------------------------

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -235,10 +235,11 @@ class LLVMBuilderContext:
         return builder.gep(params_ptr, [self.int32_ty(0), idx],
                            name="ptr_param_{}_{}".format(param_name, component.name))
 
-    def get_state_ptr(self, component, builder, state_ptr, port_Name):
-        idx = self.int32_ty(component._get_state_ids().index(port_Name))
+    def get_state_ptr(self, component, builder, state_ptr, stateful_name):
+        idx = self.int32_ty(component._get_state_ids().index(stateful_name))
         return builder.gep(state_ptr, [self.int32_ty(0), idx],
-                           name="ptr_state_{}_{}".format(port_Name, component.name))
+                           name="ptr_state_{}_{}".format(stateful_name,
+                                                         component.name))
 
     def unwrap_2d_array(self, builder, element):
         if isinstance(element.type.pointee, ir.ArrayType) and isinstance(element.type.pointee.element, ir.ArrayType):

--- a/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
@@ -832,12 +832,6 @@ class LCControlMechanism(ControlMechanism):
 
         return gain_t, output_values[0], output_values[1], output_values[2]
 
-    def _get_mech_param_struct_type(self, ctx):
-        return ctx.convert_python_struct_to_llvm_ir((self.scaling_factor_gain, self.base_level_gain))
-
-    def _get_mech_params_init(self, context):
-        return (self.scaling_factor_gain, self.base_level_gain)
-
     def _gen_llvm_function_postprocess(self, builder, ctx, mf_out):
         # prepend gain type (matches output[1] type)
         gain_ty = mf_out.type.pointee.elements[1]
@@ -850,8 +844,10 @@ class LCControlMechanism(ControlMechanism):
         # Load mechanism parameters
         params, _, _, _ = builder.function.args
         mech_params = builder.gep(params, [ctx.int32_ty(0), ctx.int32_ty(2)])
-        scaling_factor_ptr = builder.gep(mech_params, [ctx.int32_ty(0), ctx.int32_ty(0)])
-        base_factor_ptr = builder.gep(mech_params, [ctx.int32_ty(0), ctx.int32_ty(1)])
+        scaling_factor_ptr = ctx.get_param_ptr(self, builder, mech_params,
+                                               "scaling_factor_gain")
+        base_factor_ptr = ctx.get_param_ptr(self, builder, mech_params,
+                                           "base_level_gain")
         scaling_factor = builder.load(scaling_factor_ptr)
         base_factor = builder.load(base_factor_ptr)
 

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1078,13 +1078,6 @@ class DDM(ProcessingMechanism):
                 return_value[self.DECISION_VARIABLE_INDEX] = threshold
             return return_value
 
-    def _get_mech_state_struct_type(self, ctx):
-        return ctx.convert_python_struct_to_llvm_ir(self.random_state)
-
-    def _get_mech_state_init(self, context):
-        random_state = self.get_current_mechanism_param("random_state", context)
-        return pnlvm._tupleize(random_state.get_state()[1:])
-
     def _gen_llvm_function_postprocess(self, builder, ctx, mf_out):
         mech_out_ty = ctx.convert_python_struct_to_llvm_ir(self.defaults.value)
         mech_out = builder.alloca(mech_out_ty)
@@ -1132,7 +1125,8 @@ class DDM(ProcessingMechanism):
                                               func_params, THRESHOLD)
             threshold = pnlvm.helpers.load_extract_scalar_array_one(builder,
                                                                     threshold_ptr)
-            random_state = builder.gep(state, [ctx.int32_ty(0), ctx.int32_ty(2)])
+            mech_state = builder.gep(state, [ctx.int32_ty(0), ctx.int32_ty(2)])
+            random_state = ctx.get_state_ptr(self, builder, mech_state, "random_state")
             random_f = ctx.import_llvm_function("__pnl_builtin_mt_rand_double")
             random_val_ptr = builder.alloca(random_f.args[1].type.pointee)
             builder.call(random_f, [random_state, random_val_ptr])

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1381,8 +1381,9 @@ class RecurrentTransferMechanism(TransferMechanism):
 
             prev_val_ptr = builder.gep(state, [ctx.int32_ty(0),
                 ctx.int32_ty(len(state.type.pointee) - 2)])
-            # FIXME: Why does this have a wrapper struct?
-            recurrent_in = builder.gep(prev_val_ptr, [ctx.int32_ty(0), ctx.int32_ty(0)])
+            # Extract the correct output port
+            recurrent_in = builder.gep(prev_val_ptr, [ctx.int32_ty(0),
+                ctx.int32_ty(self.output_ports.index(self.recurrent_projection.sender))])
             builder.call(recurrent_f, [recurrent_params, recurrent_state, recurrent_in, real_last_ptr])
 
         # Copy mod afferents. These are not impacted by the recurrent projection

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1404,7 +1404,7 @@ class RecurrentTransferMechanism(TransferMechanism):
 
         # Reset the flag and counter
         builder.store(is_finished_flag_ptr.type.pointee(0), is_finished_flag_ptr)
-        builder.store(is_finished_count_ptr.type.pointee(0), is_finished_flag_ptr)
+        builder.store(is_finished_count_ptr.type.pointee(0), is_finished_count_ptr)
 
         # Enter the loop
         loop_block = builder.append_basic_block(builder.basic_block.name + "_loop")

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1405,52 +1405,6 @@ class RecurrentTransferMechanism(TransferMechanism):
 
         return super()._gen_llvm_input_ports(ctx, builder, params, state, transfer_in)
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out):
-        mech_state = builder.gep(state, [ctx.int32_ty(0), ctx.int32_ty(2)])
-        mech_param = builder.gep(params, [ctx.int32_ty(0), ctx.int32_ty(2)])
-        is_finished_flag_ptr = ctx.get_state_ptr(self, builder, mech_state,
-                                                 "is_finished_flag")
-        is_finished_count_ptr = ctx.get_state_ptr(self, builder, mech_state,
-                                                 "num_executions_before_finished")
-        is_finished_max_ptr = ctx.get_param_ptr(self, builder, mech_param,
-                                                "max_executions_before_finished")
-
-        # Reset the flag and counter
-        builder.store(is_finished_flag_ptr.type.pointee(0), is_finished_flag_ptr)
-        builder.store(is_finished_count_ptr.type.pointee(0), is_finished_count_ptr)
-
-        # Enter the loop
-        loop_block = builder.append_basic_block(builder.basic_block.name + "_loop")
-        end_block = builder.append_basic_block(builder.basic_block.name + "_end")
-        builder.branch(loop_block)
-        builder.position_at_end(loop_block)
-
-        # Run the transfer mechanism
-        builder = super()._gen_llvm_function_body(ctx, builder, params, state, arg_in, arg_out)
-
-        is_finished_cond = self._gen_llvm_is_finished_cond(ctx, builder,
-                                                           mech_param,
-                                                           mech_state,
-                                                           arg_out)
-
-        #FIXME: Flag and count should be int instead of float
-        is_finished_count = builder.load(is_finished_count_ptr)
-        is_finished_count = builder.fadd(is_finished_count,
-                                         is_finished_count.type(1))
-        builder.store(is_finished_count, is_finished_count_ptr)
-        is_finished_max = builder.load(is_finished_max_ptr)
-        max_reached = builder.fcmp_ordered(">=", is_finished_count,
-                                           is_finished_max)
-        is_finished_cond = builder.or_(is_finished_cond, max_reached)
-        with builder.if_then(is_finished_cond):
-            builder.store(is_finished_flag_ptr.type.pointee(1), is_finished_flag_ptr)
-            builder.branch(end_block)
-
-        builder.branch(loop_block)
-        builder.position_at_end(end_block)
-
-        return builder
-
     @property
     def _dependent_components(self):
         return list(itertools.chain(

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ markers =
 	control_mechanism
 	ddm_mechanism
 	integrator_mechanism
+	lca_mechanism
 	objective_mechanism
 	recurrent_transfer_mechanism
 	transfer_mechanism

--- a/tests/functions/test_integrator.py
+++ b/tests/functions/test_integrator.py
@@ -51,6 +51,18 @@ def DriftIntFun(init, value, iterations, **kwargs):
                      2.36535325, 2.3125881 , 1.94195457, 3.4923464 , 2.73809322],
                     [3., 3., 3., 3., 3., 3., 3., 3., 3., 3.])
 
+def LeakyFun(init, value, iterations, **kwargs):
+    assert iterations == 3
+    if np.isscalar(kwargs["noise"]):
+        if "initializer" not in kwargs:
+            return [2.32811721, 2.37936209, 2.34473413, 2.32690665, 2.2895675 , 2.35801869, 2.29385877, 2.43375102, 2.45589355, 2.27718154]
+        else:
+            return [3.18435588, 2.95135395, 2.95906574, 3.32792543, 2.36639192, 2.45224771, 2.31572467, 3.3342168 , 3.29745831, 3.21808653]
+    else:
+        if "initializer" not in kwargs:
+            return [2.52718839, 2.40363898, 2.04011061, 2.33303847, 1.65066149, 2.2271978, 1.67937964, 2.59975537, 2.21006955, 1.92695773]
+        else:
+            return [3.38342706, 2.97563084, 2.65444222, 3.33405725, 1.72748591, 2.32142682, 1.70124553, 3.50022115, 3.05163432, 2.86786272]
 
 GROUP_PREFIX="IntegratorFunction "
 
@@ -67,6 +79,7 @@ GROUP_PREFIX="IntegratorFunction "
     (Functions.AdaptiveIntegrator, AdaptiveIntFun),
     (Functions.SimpleIntegrator, SimpleIntFun),
     (Functions.DriftDiffusionIntegrator, DriftIntFun),
+    (Functions.LeakyCompetingIntegrator, LeakyFun),
     ], ids=lambda x: x[0])
 @pytest.mark.parametrize("mode", [
     "Python",

--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -314,7 +314,7 @@ class TestReinitialize:
         assert np.allclose(I.value, 0.0)
         assert np.allclose(I.output_ports[0].value, 0.0)
 
-    def test_LCAMechanism_valid(self):
+    def test_LCIIntegrator_valid(self):
         I = IntegratorMechanism(
             name='IntegratorMechanism',
             function=LeakyCompetingIntegrator(),

--- a/tests/mechanisms/test_lca.py
+++ b/tests/mechanisms/test_lca.py
@@ -14,8 +14,16 @@ from psyneulink.library.components.mechanisms.processing.transfer.lcamechanism i
     LCAMechanism, MAX_VS_AVG, MAX_VS_NEXT, CONVERGENCE
 
 class TestLCA:
-    def test_LCAMechanism_length_1(self):
-
+    @pytest.mark.mechanism
+    @pytest.mark.lca_mechanism
+    @pytest.mark.benchmark(group="LCAMechanism")
+    @pytest.mark.parametrize('mode', ['Python',
+                                      pytest.param('LLVM', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                      pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
+                                      pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])])
+    def test_LCAMechanism_length_1(self, benchmark, mode):
         T = TransferMechanism(function=Linear(slope=1.0))
         L = LCAMechanism(function=Linear(slope=2.0),
                          self_excitation=3.0,
@@ -38,13 +46,7 @@ class TestLCA:
 
         #  - - - - - - - - - - - - - -  - - - - - - - - - - - -
 
-        results=[]
-        def record_execution():
-            results.append(L.parameters.value.get(C)[0][0])
-
-        C.run(inputs={T: [1.0]},
-              num_trials=3,
-              call_after_trial=record_execution)
+        C.run(inputs={T: [1.0]}, num_trials=3, bin_execute=mode)
 
         # - - - - - - - TRIAL 1 - - - - - - -
 
@@ -61,9 +63,19 @@ class TestLCA:
         # new_transfer_input = 0.265 + ( 0.5 * 0.265 + 3.0 * 0.53 + 0.0 + 1.0)*0.1 + 0.0    =    0.53725
         # f(new_transfer_input) = 0.53725 * 2.0 = 1.0745
 
-        assert np.allclose(results, [0.2, 0.53, 1.0745])
+        assert np.allclose(C.results, [[[0.2]], [[0.53]], [[1.0745]]])
+        benchmark(C.run, inputs={T: [1.0]}, num_trials=3, bin_execute=mode)
 
-    def test_LCAMechanism_length_2(self):
+    @pytest.mark.mechanism
+    @pytest.mark.lca_mechanism
+    @pytest.mark.benchmark(group="LCAMechanism")
+    @pytest.mark.parametrize('mode', ['Python',
+                                      pytest.param('LLVM', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                      pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
+                                      pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])])
+    def test_LCAMechanism_length_2(self, benchmark, mode):
         # Note: since the LCAMechanism's threshold is not specified in this test, each execution only updates
         #       the Mechanism once.
 
@@ -91,13 +103,7 @@ class TestLCA:
 
         #  - - - - - - - - - - - - - -  - - - - - - - - - - - -
 
-        results=[]
-        def record_execution():
-            results.append(L.parameters.value.get(C)[0])
-
-        C.run(inputs={T: [1.0, 2.0]},
-              num_trials=3,
-              call_after_trial=record_execution)
+        C.run(inputs={T: [1.0, 2.0]}, num_trials=3, bin_execute=mode)
 
         # - - - - - - - TRIAL 1 - - - - - - -
 
@@ -123,7 +129,8 @@ class TestLCA:
         # new_transfer_input_2 = 0.51 + ( 0.5 * 0.51 + 3.0 * 1.02 - 1.0*0.45 + 2.0)*0.1 + 0.0    =    0.9965
         # f(new_transfer_input_2) = 0.9965 * 2.0 = 1.463
 
-        assert np.allclose(results, [[0.2, 0.4], [0.45, 1.02], [0.7385, 1.993]])
+        assert np.allclose(C.results, [[[0.2, 0.4]], [[0.45, 1.02]], [[0.7385, 1.993]]])
+        benchmark(C.run, inputs={T: [1.0, 2.0]}, num_trials=3, bin_execute=mode)
 
     def test_equivalance_of_threshold_and_when_finished_condition(self):
         # Note: This tests the equivalence of results when:

--- a/tests/mechanisms/test_lca.py
+++ b/tests/mechanisms/test_lca.py
@@ -164,12 +164,22 @@ class TestLCA:
 
     # Note: In the following tests, since the LCAMechanism's threshold is specified
     #       it executes until the it reaches threshold.
-    def test_LCAMechanism_threshold(self):
+    @pytest.mark.mechanism
+    @pytest.mark.lca_mechanism
+    @pytest.mark.benchmark(group="LCAMechanism")
+    @pytest.mark.parametrize('mode', ['Python',
+                                      pytest.param('LLVM', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                      pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
+                                      pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])])
+    def test_LCAMechanism_threshold(self, benchmark, mode):
         lca = LCAMechanism(size=2, threshold=0.7)
         comp = Composition()
         comp.add_node(lca)
-        result = comp.run(inputs={lca:[1,0]})
+        result = comp.run(inputs={lca:[1,0]}, bin_execute=mode)
         assert np.allclose(result, [[0.71463572, 0.28536428]])
+        benchmark(comp.run, inputs={lca:[1,0]}, bin_execute=mode)
 
     def test_LCAMechanism_threshold_with_max_vs_next(self):
         lca = LCAMechanism(size=3, threshold=0.1, threshold_criterion=MAX_VS_NEXT)


### PR DESCRIPTION
Used by `LCAMechanism`
Add support for `LeakyCompetingIntegrator` function, used by `LCAMechanism`.
Enable compilation tests for `LCAMechanism`.
Cleanup code generation for mechanisms, reuse standard functions for generating parameter and state structures.