### PR TITLE
autodiff: Remove unused internal `bias` term (#1461)

### DIFF
--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -1227,9 +1227,8 @@ class AutodiffComposition(Composition):
                                            .format(self.name))
 
         weights = pytorch_representation.get_weights_for_projections()
-        biases = pytorch_representation.get_biases_for_mechanisms()
 
-        return weights, biases
+        return weights
 
     def _get_param_struct_type(self, ctx):
         # We only need input/output params (rest should be in pytorch model params)

--- a/psyneulink/library/compositions/pytorchmodelcreator.py
+++ b/psyneulink/library/compositions/pytorchmodelcreator.py
@@ -103,7 +103,7 @@ class PytorchModelCreator(torch.nn.Module):
                         self.projections_to_pytorch_weights[mapping_proj] = weights
                         
                 node_forward_info = {
-                    'value':value, 
+                    'value':value,
                     'function':function,
                     'afferents':afferents,
                     'component':component}

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -430,7 +430,7 @@ class TestMiscTrainingFunctionality:
 
         # call get_parameters to obtain a copy of the pytorch parameters in numpy arrays,
         # and get the parameters straight from pytorch
-        weights_get_params = xor.get_parameters()[0]
+        weights_get_params = xor.get_parameters()
         weights_straight_1 = xor.parameters.pytorch_representation.get(xor).params[0]
         weights_straight_2 = xor.parameters.pytorch_representation.get(xor).params[1]
 
@@ -2007,7 +2007,7 @@ class TestTrainingIdenticalness():
         g = g_f()
         result = sem_net.run(inputs=g_f)
 
-        comp_weights = sem_net.get_parameters()[0]
+        comp_weights = sem_net.get_parameters()
 
         # SET UP SYSTEM
         sem_net_sys = Composition()

--- a/tests/composition/test_learning.py
+++ b/tests/composition/test_learning.py
@@ -636,7 +636,7 @@ class TestBackProp:
                                   )
         if 'AUTODIFF' in models:
             result = xor_autodiff.run(inputs=inputs_dict)
-            autodiff_weights = xor_autodiff.get_parameters()[0]
+            autodiff_weights = xor_autodiff.get_parameters()
     
         # COMPARE WEIGHTS FOR PAIRS OF MODELS ----------------------------------------------------------
     


### PR DESCRIPTION
This change removes the stored 'bias' term from `pytorchmodelcreator.py`, and also refactors `autodiffcomposition.get_parameters` to only return weights.

This was done because the stored bias in `pytorchmodelcreator.py` was always being set to zero, meaning it did not have an impact on the models.

