### PR TITLE
llvm: Add tags to allow multiple function variants based on one object.

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1225,13 +1225,13 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
     def _get_param_initializer(self, context):
         return pnlvm._tupleize(self._get_param_values(context))
 
-    def _gen_llvm_function(self, *, extra_args=[], tag):
+    def _gen_llvm_function(self, *, extra_args=[], tags:tuple):
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
             args = [ctx.get_param_struct_type(self).as_pointer(),
                     ctx.get_state_struct_type(self).as_pointer(),
                     ctx.get_input_struct_type(self).as_pointer(),
                     ctx.get_output_struct_type(self).as_pointer()]
-            builder = ctx.create_llvm_function(args + extra_args, self)
+            builder = ctx.create_llvm_function(args + extra_args, self, tags=tags)
             llvm_func = builder.function
 
             llvm_func.attributes.add('alwaysinline')
@@ -1240,7 +1240,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 for p in params, state, arg_in, arg_out:
                     p.attributes.add('noalias')
 
-            builder = self._gen_llvm_function_body(ctx, builder, params, state, arg_in, arg_out, tag=tag)
+            builder = self._gen_llvm_function_body(ctx, builder, params, state, arg_in, arg_out, tags=tags)
             builder.ret_void()
 
         return llvm_func

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1137,7 +1137,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         # FIXME: MAGIC LIST, Use stateful tag for this
         whitelist = {"previous_time", "previous_value", "previous_v",
                      "previous_w", "random_state", "is_finished_flag",
-                     "num_executions_before_finished"}
+                     "num_executions_before_finished", "execution_count"}
         # mechanism functions are handled separately
         blacklist = {"function"} if hasattr(self, 'ports') else {}
         def _is_compilation_state(p):

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1225,7 +1225,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
     def _get_param_initializer(self, context):
         return pnlvm._tupleize(self._get_param_values(context))
 
-    def _gen_llvm_function(self, extra_args=[]):
+    def _gen_llvm_function(self, *, extra_args=[], tag):
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
             args = [ctx.get_param_struct_type(self).as_pointer(),
                     ctx.get_state_struct_type(self).as_pointer(),
@@ -1240,7 +1240,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 for p in params, state, arg_in, arg_out:
                     p.attributes.add('noalias')
 
-            builder = self._gen_llvm_function_body(ctx, builder, params, state, arg_in, arg_out)
+            builder = self._gen_llvm_function_body(ctx, builder, params, state, arg_in, arg_out, tag=tag)
             builder.ret_void()
 
         return llvm_func

--- a/psyneulink/core/components/functions/combinationfunctions.py
+++ b/psyneulink/core/components/functions/combinationfunctions.py
@@ -1408,7 +1408,7 @@ class LinearCombination(
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
         builder.store(val, ptro)
 
-    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tag):
         # Sometimes we arg_out to 2d array
         arg_out = ctx.unwrap_2d_array(builder, arg_out)
 

--- a/psyneulink/core/components/functions/combinationfunctions.py
+++ b/psyneulink/core/components/functions/combinationfunctions.py
@@ -1408,7 +1408,7 @@ class LinearCombination(
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
         builder.store(val, ptro)
 
-    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tags:tuple):
         # Sometimes we arg_out to 2d array
         arg_out = ctx.unwrap_2d_array(builder, arg_out)
 

--- a/psyneulink/core/components/functions/distributionfunctions.py
+++ b/psyneulink/core/components/functions/distributionfunctions.py
@@ -1253,7 +1253,7 @@ class DriftDiffusionAnalytical(DistributionFunction):  # -----------------------
 
         return moments
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
 
         def load_scalar_param(name):
             param_ptr = ctx.get_param_ptr(self, builder, params, name)

--- a/psyneulink/core/components/functions/distributionfunctions.py
+++ b/psyneulink/core/components/functions/distributionfunctions.py
@@ -1253,7 +1253,7 @@ class DriftDiffusionAnalytical(DistributionFunction):  # -----------------------
 
         return moments
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:tuple):
 
         def load_scalar_param(name):
             param_ptr = ctx.get_param_ptr(self, builder, params, name)

--- a/psyneulink/core/components/functions/interfacefunctions.py
+++ b/psyneulink/core/components/functions/interfacefunctions.py
@@ -187,7 +187,7 @@ class InterfacePortMap(InterfaceFunction):
         input_type = ctx.get_input_struct_type(self)
         return input_type.elements[index]
 
-    def _gen_llvm_function_body(self, ctx, builder, _1, _2, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, _1, _2, arg_in, arg_out, *, tags:tuple):
         index = self.corresponding_input_port.position_in_mechanism
         val = builder.load(builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(index)]))
         builder.store(val, arg_out)

--- a/psyneulink/core/components/functions/interfacefunctions.py
+++ b/psyneulink/core/components/functions/interfacefunctions.py
@@ -187,7 +187,7 @@ class InterfacePortMap(InterfaceFunction):
         input_type = ctx.get_input_struct_type(self)
         return input_type.elements[index]
 
-    def _gen_llvm_function_body(self, ctx, builder, _1, _2, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, _1, _2, arg_in, arg_out, *, tag):
         index = self.corresponding_input_port.position_in_mechanism
         val = builder.load(builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(index)]))
         builder.store(val, arg_out)

--- a/psyneulink/core/components/functions/objectivefunctions.py
+++ b/psyneulink/core/components/functions/objectivefunctions.py
@@ -398,7 +398,7 @@ class Stability(ObjectiveFunction):
 
         super()._update_default_variable(new_default_variable, context)
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:tuple):
         # Dot product
         dot_out = builder.alloca(arg_in.type.pointee)
         matrix = ctx.get_param_ptr(self, builder, params, MATRIX)
@@ -971,7 +971,7 @@ class Distance(ObjectiveFunction):
         acc_y2_val = builder.fadd(acc_y2_val, y2)
         builder.store(acc_y2_val, acc_y2)
 
-    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tags):
         assert isinstance(arg_in.type.pointee, pnlvm.ir.ArrayType)
         assert isinstance(arg_in.type.pointee.element, pnlvm.ir.ArrayType)
         # FIXME python version also ignores other vectors

--- a/psyneulink/core/components/functions/objectivefunctions.py
+++ b/psyneulink/core/components/functions/objectivefunctions.py
@@ -398,7 +398,7 @@ class Stability(ObjectiveFunction):
 
         super()._update_default_variable(new_default_variable, context)
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
         # Dot product
         dot_out = builder.alloca(arg_in.type.pointee)
         matrix = ctx.get_param_ptr(self, builder, params, MATRIX)
@@ -971,7 +971,7 @@ class Distance(ObjectiveFunction):
         acc_y2_val = builder.fadd(acc_y2_val, y2)
         builder.store(acc_y2_val, acc_y2)
 
-    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tag):
         assert isinstance(arg_in.type.pointee, pnlvm.ir.ArrayType)
         assert isinstance(arg_in.type.pointee.element, pnlvm.ir.ArrayType)
         # FIXME python version also ignores other vectors

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -1346,7 +1346,7 @@ class GridSearch(OptimizationFunction):
             s.reset()
         self.grid = itertools.product(*[s for s in self.search_space])
 
-    def _gen_llvm_function(self, *, tag):
+    def _gen_llvm_function(self, *, tags):
         try:
             # self.objective_function may be bound method of
             # an OptimizationControlMechanism
@@ -1358,7 +1358,7 @@ class GridSearch(OptimizationFunction):
         except AttributeError:
             extra_args = []
 
-        f = super()._gen_llvm_function(extra_args=extra_args, tag=tag)
+        f = super()._gen_llvm_function(extra_args=extra_args, tags=tags)
         if len(extra_args) > 0:
             for a in f.args[-len(extra_args):]:
                 a.attributes.add('nonnull')
@@ -1460,7 +1460,7 @@ class GridSearch(OptimizationFunction):
             val[0] = [0.0] * len(self.search_space)
         return ctx.convert_python_struct_to_llvm_ir((val[0], val[1]))
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:tuple):
         ocm = getattr(self.objective_function, '__self__', None)
         if ocm is not None:
             assert ocm.function is self

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -1346,7 +1346,7 @@ class GridSearch(OptimizationFunction):
             s.reset()
         self.grid = itertools.product(*[s for s in self.search_space])
 
-    def _gen_llvm_function(self):
+    def _gen_llvm_function(self, *, tag):
         try:
             # self.objective_function may be bound method of
             # an OptimizationControlMechanism
@@ -1358,7 +1358,7 @@ class GridSearch(OptimizationFunction):
         except AttributeError:
             extra_args = []
 
-        f = super()._gen_llvm_function(extra_args)
+        f = super()._gen_llvm_function(extra_args=extra_args, tag=tag)
         if len(extra_args) > 0:
             for a in f.args[-len(extra_args):]:
                 a.attributes.add('nonnull')
@@ -1460,7 +1460,7 @@ class GridSearch(OptimizationFunction):
             val[0] = [0.0] * len(self.search_space)
         return ctx.convert_python_struct_to_llvm_ir((val[0], val[1]))
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
         ocm = getattr(self.objective_function, '__self__', None)
         if ocm is not None:
             assert ocm.function is self

--- a/psyneulink/core/components/functions/selectionfunctions.py
+++ b/psyneulink/core/components/functions/selectionfunctions.py
@@ -257,7 +257,7 @@ class OneHot(SelectionFunction):
                                     "array of probabilities that sum to 1".
                                     format(MODE, self.__class__.__name__, Function.__name__, PROB, prob_dist))
 
-    def _gen_llvm_function_body(self, ctx, builder, _, state, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, _, state, arg_in, arg_out, *, tags:tuple):
         idx_ptr = builder.alloca(ctx.int32_ty)
         builder.store(ctx.int32_ty(0), idx_ptr)
 

--- a/psyneulink/core/components/functions/selectionfunctions.py
+++ b/psyneulink/core/components/functions/selectionfunctions.py
@@ -257,7 +257,7 @@ class OneHot(SelectionFunction):
                                     "array of probabilities that sum to 1".
                                     format(MODE, self.__class__.__name__, Function.__name__, PROB, prob_dist))
 
-    def _gen_llvm_function_body(self, ctx, builder, _, state, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, _, state, arg_in, arg_out, *, tag):
         idx_ptr = builder.alloca(ctx.int32_ty)
         builder.store(ctx.int32_ty(0), idx_ptr)
 

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -358,7 +358,7 @@ class IntegratorFunction(StatefulFunction):  # ---------------------------------
     def _function(self, *args, **kwargs):
         raise FunctionError("IntegratorFunction is not meant to be called explicitly")
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:tuple):
         # Get rid of 2d array.
         # When part of a Mechanism, the input and output are 2d arrays.
         arg_in = ctx.unwrap_2d_array(builder, arg_in)
@@ -4112,7 +4112,7 @@ class FitzHughNagumoIntegrator(IntegratorFunction):  # -------------------------
 
         return previous_v, previous_w, previous_time
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:tuple):
         zero_i32 = ctx.int32_ty(0)
 
         # Get rid of 2d array. When part of a Mechanism the input,

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -358,7 +358,7 @@ class IntegratorFunction(StatefulFunction):  # ---------------------------------
     def _function(self, *args, **kwargs):
         raise FunctionError("IntegratorFunction is not meant to be called explicitly")
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
         # Get rid of 2d array.
         # When part of a Mechanism, the input and output are 2d arrays.
         arg_in = ctx.unwrap_2d_array(builder, arg_in)
@@ -4112,7 +4112,7 @@ class FitzHughNagumoIntegrator(IntegratorFunction):  # -------------------------
 
         return previous_v, previous_w, previous_time
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
         zero_i32 = ctx.int32_ty(0)
 
         # Get rid of 2d array. When part of a Mechanism the input,

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -763,7 +763,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         my_init = pnlvm._tupleize([random_state, [memory[0], memory[1], 0, 0]])
         return (*my_init, distance_init, selection_init)
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:tuple):
         # PRNG
         rand_struct = ctx.get_state_ptr(self, builder, state, "random_state")
         uniform_f = ctx.import_llvm_function("__pnl_builtin_mt_rand_double")

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -763,7 +763,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         my_init = pnlvm._tupleize([random_state, [memory[0], memory[1], 0, 0]])
         return (*my_init, distance_init, selection_init)
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
         # PRNG
         rand_struct = ctx.get_state_ptr(self, builder, state, "random_state")
         uniform_f = ctx.import_llvm_function("__pnl_builtin_mt_rand_double")

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -106,7 +106,7 @@ class TransferFunction(Function_Base):
         bounds = None
 
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
         # Pretend we have one huge array to work on
         # TODO: should this be invoked in parts?
         assert isinstance(arg_in.type.pointee, pnlvm.ir.ArrayType)
@@ -264,7 +264,7 @@ class Identity(TransferFunction):  # -------------------------------------------
         #       workaround.
         return ctx.get_input_struct_type(self)
 
-    def _gen_llvm_function_body(self, ctx, builder, _1, _2, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, _1, _2, arg_in, arg_out, *, tag):
         val = builder.load(arg_in)
         builder.store(val, arg_out)
         return builder
@@ -2360,7 +2360,7 @@ class SoftMax(TransferFunction):
 
         return builder
 
-    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tag):
         if self.parameters.per_item.get():
             assert isinstance(arg_in.type.pointee.element, pnlvm.ir.ArrayType)
             assert isinstance(arg_out.type.pointee.element, pnlvm.ir.ArrayType)
@@ -2930,7 +2930,7 @@ class LinearMatrix(TransferFunction):  # ---------------------------------------
             return np.array(specification)
 
 
-    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tag):
         # Restrict to 1d arrays
         if self.defaults.variable.ndim != 1:
             warnings.warn("Unexpected data shape: {} got 2D input: {}".format(self, self.defaults.variable))
@@ -4108,7 +4108,7 @@ class TransferWithCosts(TransferFunction):
         self.parameters.enabled_cost_functions.set(enabled_cost_functions, execution_context)
         return enabled_cost_functions
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
         # Run transfer function first
         transfer_f = self.parameters.transfer_fct
         trans_f = ctx.import_llvm_function(transfer_f.get())

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -106,7 +106,7 @@ class TransferFunction(Function_Base):
         bounds = None
 
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:tuple):
         # Pretend we have one huge array to work on
         # TODO: should this be invoked in parts?
         assert isinstance(arg_in.type.pointee, pnlvm.ir.ArrayType)
@@ -264,7 +264,7 @@ class Identity(TransferFunction):  # -------------------------------------------
         #       workaround.
         return ctx.get_input_struct_type(self)
 
-    def _gen_llvm_function_body(self, ctx, builder, _1, _2, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, _1, _2, arg_in, arg_out, *, tags:tuple):
         val = builder.load(arg_in)
         builder.store(val, arg_out)
         return builder
@@ -2360,7 +2360,7 @@ class SoftMax(TransferFunction):
 
         return builder
 
-    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tags:tuple):
         if self.parameters.per_item.get():
             assert isinstance(arg_in.type.pointee.element, pnlvm.ir.ArrayType)
             assert isinstance(arg_out.type.pointee.element, pnlvm.ir.ArrayType)
@@ -2930,7 +2930,7 @@ class LinearMatrix(TransferFunction):  # ---------------------------------------
             return np.array(specification)
 
 
-    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tags:tuple):
         # Restrict to 1d arrays
         if self.defaults.variable.ndim != 1:
             warnings.warn("Unexpected data shape: {} got 2D input: {}".format(self, self.defaults.variable))
@@ -4108,7 +4108,7 @@ class TransferWithCosts(TransferFunction):
         self.parameters.enabled_cost_functions.set(enabled_cost_functions, execution_context)
         return enabled_cost_functions
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:tuple):
         # Run transfer function first
         transfer_f = self.parameters.transfer_fct
         trans_f = ctx.import_llvm_function(transfer_f.get())

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2712,7 +2712,7 @@ class Mechanism_Base(Mechanism):
 
         return fun_out, builder
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out):
+    def _gen_llvm_function_internal(self, ctx, builder, params, state, arg_in, arg_out):
 
         is_output, builder = self._gen_llvm_input_ports(ctx, builder, params, state, arg_in)
 
@@ -2725,13 +2725,64 @@ class Mechanism_Base(Mechanism):
         ppval, builder = self._gen_llvm_function_postprocess(builder, ctx, value)
 
         builder = self._gen_llvm_output_ports(ctx, builder, ppval, params, state, arg_in, arg_out)
-        return builder
+        return builder, pnlvm.ir.IntType(1)(1)
 
     def _gen_llvm_function_input_parse(self, builder, ctx, func, func_in):
         return func_in, builder
 
     def _gen_llvm_function_postprocess(self, builder, ctx, mf_out):
         return mf_out, builder
+
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out):
+        mech_state = builder.gep(state, [ctx.int32_ty(0), ctx.int32_ty(2)])
+        mech_params = builder.gep(params, [ctx.int32_ty(0), ctx.int32_ty(2)])
+        is_finished_flag_ptr = ctx.get_state_ptr(self, builder, mech_state,
+                                                 "is_finished_flag")
+        is_finished_count_ptr = ctx.get_state_ptr(self, builder, mech_state,
+                                                 "num_executions_before_finished")
+        is_finished_max_ptr = ctx.get_param_ptr(self, builder, mech_params,
+                                                "max_executions_before_finished")
+
+        # Reset the flag and counter
+        builder.store(is_finished_flag_ptr.type.pointee(0), is_finished_flag_ptr)
+        builder.store(is_finished_count_ptr.type.pointee(0), is_finished_count_ptr)
+
+        # Enter the loop
+        loop_block = builder.append_basic_block(builder.basic_block.name + "_loop")
+        end_block = builder.append_basic_block(builder.basic_block.name + "_end")
+        builder.branch(loop_block)
+        builder.position_at_end(loop_block)
+
+        # Get internal function
+        args_t = [a.type for a in builder.function.args]
+        internal_builder = ctx.create_llvm_function(args_t, self,
+                                                    name=builder.function.name + "_internal",
+                                                    return_type=pnlvm.ir.IntType(1))
+        internal_builder, is_finished = self._gen_llvm_function_internal(ctx, internal_builder,
+                                                                         params, state, arg_in, arg_out)
+        internal_builder.ret(is_finished)
+
+        # Call Internal Function
+        internal_f = internal_builder.function
+        is_finished_cond = builder.call(internal_f, builder.function.args)
+
+        #FIXME: Flag and count should be int instead of float
+        is_finished_count = builder.load(is_finished_count_ptr)
+        is_finished_count = builder.fadd(is_finished_count,
+                                         is_finished_count.type(1))
+        builder.store(is_finished_count, is_finished_count_ptr)
+        is_finished_max = builder.load(is_finished_max_ptr)
+        max_reached = builder.fcmp_ordered(">=", is_finished_count,
+                                           is_finished_max)
+        is_finished_cond = builder.or_(is_finished_cond, max_reached)
+        with builder.if_then(is_finished_cond):
+            builder.store(is_finished_flag_ptr.type.pointee(1), is_finished_flag_ptr)
+            builder.branch(end_block)
+
+        builder.branch(loop_block)
+        builder.position_at_end(end_block)
+
+        return builder
 
     def _report_mechanism_execution(self, input_val=None, params=None, output=None, context=None):
 

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2744,7 +2744,7 @@ class Mechanism_Base(Mechanism):
     def _gen_llvm_function_postprocess(self, builder, ctx, mf_out):
         return mf_out, builder
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
         mech_state = builder.gep(state, [ctx.int32_ty(0), ctx.int32_ty(2)])
         mech_params = builder.gep(params, [ctx.int32_ty(0), ctx.int32_ty(2)])
         is_finished_flag_ptr = ctx.get_state_ptr(self, builder, mech_state,

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2569,6 +2569,13 @@ class Mechanism_Base(Mechanism):
 
         return (port_state_init, function_state_init, mech_state_init)
 
+    def _gen_llvm_function(self, *, extra_args=[], tag):
+        if tag.startswith("node_wrapper"):
+            node_tag = tag.replace("node_wrapper", "").lstrip("_")
+            return self.composition._gen_node_wrapper(self, tag=node_tag)
+        else:
+            return super()._gen_llvm_function(extra_args=extra_args, tag=tag)
+
     def _gen_llvm_ports(self, ctx, builder, ports,
                         get_output_ptr, fill_input_data,
                         mech_params, mech_state, mech_input):

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2569,12 +2569,12 @@ class Mechanism_Base(Mechanism):
 
         return (port_state_init, function_state_init, mech_state_init)
 
-    def _gen_llvm_function(self, *, extra_args=[], tag):
-        if tag.startswith("node_wrapper"):
-            node_tag = tag.replace("node_wrapper", "").lstrip("_")
-            return self.composition._gen_node_wrapper(self, tag=node_tag)
+    def _gen_llvm_function(self, *, extra_args=[], tags:tuple):
+        if "node_wrapper" in tags:
+            node_tags = tuple(t for t in tags if t != "node_wrapper")
+            return self.composition._gen_node_wrapper(self, tags=node_tags)
         else:
-            return super()._gen_llvm_function(extra_args=extra_args, tag=tag)
+            return super()._gen_llvm_function(extra_args=extra_args, tags=tags)
 
     def _gen_llvm_ports(self, ctx, builder, ports,
                         get_output_ptr, fill_input_data,
@@ -2751,7 +2751,7 @@ class Mechanism_Base(Mechanism):
     def _gen_llvm_function_postprocess(self, builder, ctx, mf_out):
         return mf_out, builder
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:tuple):
         mech_state = builder.gep(state, [ctx.int32_ty(0), ctx.int32_ty(2)])
         mech_params = builder.gep(params, [ctx.int32_ty(0), ctx.int32_ty(2)])
         is_finished_flag_ptr = ctx.get_state_ptr(self, builder, mech_state,

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -744,7 +744,7 @@ class DefaultAllocationFunction(Function_Base):
         # Override Component.reinitialize which requires that the Component is stateful
         pass
 
-    def _gen_llvm_function_body(self, ctx, builder, _1, _2, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, _1, _2, arg_in, arg_out, *, tags:tuple):
         val_ptr = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(0)])
         val = builder.load(val_ptr)
         with pnlvm.helpers.array_ptr_loop(builder, arg_out, "alloc_loop") as (b, idx):

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -744,7 +744,7 @@ class DefaultAllocationFunction(Function_Base):
         # Override Component.reinitialize which requires that the Component is stateful
         pass
 
-    def _gen_llvm_function_body(self, ctx, builder, _1, _2, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, _1, _2, arg_in, arg_out, *, tag):
         val_ptr = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(0)])
         val = builder.load(val_ptr)
         with pnlvm.helpers.array_ptr_loop(builder, arg_out, "alloc_loop") as (b, idx):

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1186,7 +1186,7 @@ class OptimizationControlMechanism(ControlMechanism):
 
         return llvm_func
 
-    def _gen_llvm_function(self):
+    def _gen_llvm_function(self, *, tag):
         from psyneulink.core.compositions.composition import Composition
         is_comp = isinstance(self.agent_rep, Composition)
         if is_comp:
@@ -1197,7 +1197,7 @@ class OptimizationControlMechanism(ControlMechanism):
         else:
             extra_args = []
 
-        f = super()._gen_llvm_function(extra_args)
+        f = super()._gen_llvm_function(extra_args=extra_args, tag=tag)
         if is_comp:
             for a in f.args[-len(extra_args):]:
                 a.attributes.add('nonnull')

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1109,7 +1109,7 @@ class OptimizationControlMechanism(ControlMechanism):
 
             params, state, allocation_sample, arg_out, arg_in, comp_params, base_comp_state, base_comp_data = llvm_func.args
 
-            sim_f = ctx.import_llvm_function(self.agent_rep, tag="run_simulation")
+            sim_f = ctx.import_llvm_function(self.agent_rep, tags=("run", "simulation"))
 
             # Create a simulation copy of composition state
             comp_state = builder.alloca(base_comp_state.type.pointee, name="state_copy")
@@ -1186,7 +1186,7 @@ class OptimizationControlMechanism(ControlMechanism):
 
         return llvm_func
 
-    def _gen_llvm_function(self, *, tag):
+    def _gen_llvm_function(self, *, tags:tuple):
         from psyneulink.core.compositions.composition import Composition
         is_comp = isinstance(self.agent_rep, Composition)
         if is_comp:
@@ -1197,7 +1197,7 @@ class OptimizationControlMechanism(ControlMechanism):
         else:
             extra_args = []
 
-        f = super()._gen_llvm_function(extra_args=extra_args, tag=tag)
+        f = super()._gen_llvm_function(extra_args=extra_args, tags=tags)
         if is_comp:
             for a in f.args[-len(extra_args):]:
                 a.attributes.add('nonnull')

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1109,7 +1109,7 @@ class OptimizationControlMechanism(ControlMechanism):
 
             params, state, allocation_sample, arg_out, arg_in, comp_params, base_comp_state, base_comp_data = llvm_func.args
 
-            sim_f = ctx.import_llvm_function(self.agent_rep._llvm_sim_run.name)
+            sim_f = ctx.import_llvm_function(self.agent_rep, tag="run_simulation")
 
             # Create a simulation copy of composition state
             comp_state = builder.alloca(base_comp_state.type.pointee, name="state_copy")

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1420,6 +1420,13 @@ class TransferMechanism(ProcessingMechanism_Base):
                     val = pnlvm.helpers.fclamp(b1, val, clip[0], clip[1])
                     b1.store(val, ptro)
 
+        # Update execution counter
+        mech_state = builder.gep(state, [ctx.int32_ty(0), ctx.int32_ty(2)])
+        exec_count_ptr = ctx.get_state_ptr(self, builder, mech_state, "execution_count")
+        exec_count = builder.load(exec_count_ptr)
+        exec_count = builder.fadd(exec_count, exec_count.type(1))
+        builder.store(exec_count, exec_count_ptr)
+
         builder = self._gen_llvm_output_ports(ctx, builder, mf_out, params, state, arg_in, arg_out)
         is_finished_cond = self._gen_llvm_is_finished_cond(ctx, builder,
                                                            mech_params,

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2216,7 +2216,7 @@ class Port_Base(Port):
     def _get_compilation_state(self):
         return [self.parameters.function]
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:tuple):
         state_f = ctx.import_llvm_function(self.function)
 
         # Create a local copy of the function parameters

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2216,7 +2216,7 @@ class Port_Base(Port):
     def _get_compilation_state(self):
         return [self.parameters.function]
 
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
         state_f = ctx.import_llvm_function(self.function)
 
         # Create a local copy of the function parameters

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -980,7 +980,7 @@ class Projection_Base(Projection):
         return self._parameter_ports
 
     # Provide invocation wrapper
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
         mf_state = ctx.get_state_ptr(self, builder, state, self.parameters.function.name)
         mf_params = ctx.get_param_ptr(self, builder, params, self.parameters.function.name)
         main_function = ctx.import_llvm_function(self.function)

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -980,7 +980,7 @@ class Projection_Base(Projection):
         return self._parameter_ports
 
     # Provide invocation wrapper
-    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tag):
+    def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:tuple):
         mf_state = ctx.get_state_ptr(self, builder, state, self.parameters.function.name)
         mf_params = ctx.get_param_ptr(self, builder, params, self.parameters.function.name)
         main_function = ctx.import_llvm_function(self.function)

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -7671,12 +7671,11 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     def __gen_node_wrapper(self, node, *, tag):
         name = 'comp_wrap_'
         is_mech = isinstance(node, Mechanism)
-        # TODO: pass this explicitly
-        # FIXME: Can we use node_roles here?
+        # FIXME: Replace this with tags!
         is_learning_autodiff = hasattr(node, 'learning_enabled') and node.learning_enabled
 
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
-            node_function = ctx.import_llvm_function(node)
+            node_function = ctx.import_llvm_function(node, tag=tag)
 
             data_struct_ptr = ctx.get_data_struct_type(self).as_pointer()
             args = [
@@ -7792,7 +7791,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 # Projections are listed second in param and state structure
                 proj_params = builder.gep(params, [ctx.int32_ty(0), ctx.int32_ty(1), ctx.int32_ty(proj_idx)])
                 proj_context = builder.gep(context, [ctx.int32_ty(0), ctx.int32_ty(1), ctx.int32_ty(proj_idx)])
-                proj_function = ctx.import_llvm_function(proj)
+                proj_function = ctx.import_llvm_function(proj, tag=tag)
 
                 if proj_out.type != proj_function.args[3].type:
                     warnings.warn("Shape mismatch: Projection ({}) results does not match the receiver state({}) input: {} vs. {}".format(proj, proj.receiver, proj.defaults.value, proj.receiver.defaults.variable))

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -7640,7 +7640,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                     self._gen_f = gen_f
                 def _gen_llvm_function(self, *, tag):
                     return self._gen_f(self._node, tag=tag)
-            wrapper = node_wrapper(node, self.__gen_node_wrapper)
+            wrapper = node_wrapper(node, self._gen_node_wrapper)
             self.__generated_node_wrappers[node] = wrapper
             return wrapper
 
@@ -7668,7 +7668,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         if self._compilation_data.ptx_execution._get(context) is None:
             self._compilation_data.ptx_execution._set(pnlvm.CompExecution(self, [context.execution_id]), context)
 
-    def __gen_node_wrapper(self, node, *, tag):
+    def _gen_node_wrapper(self, node, *, tag:str):
         name = 'comp_wrap_'
         is_mech = isinstance(node, Mechanism)
         # FIXME: Replace this with tags!

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -1747,7 +1747,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         # Compiled resources
         self.__generated_node_wrappers = {}
-        self.__generated_run = None
         self.__generated_simulation = None
         self.__generated_sim_run = None
 
@@ -7651,15 +7650,10 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
     def _gen_llvm_function(self, *, tag):
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
+            if tag.startswith("run"):
+                return ctx.gen_composition_run(self)
+            else:
                 return ctx.gen_composition_exec(self)
-
-    @property
-    def _llvm_run(self):
-        if self.__generated_run is None:
-            with pnlvm.LLVMBuilderContext.get_global() as ctx:
-                self.__generated_run = ctx.gen_composition_run(self)
-
-        return self.__generated_run
 
     @property
     def _llvm_simulation(self):

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -7672,7 +7672,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         name = 'comp_wrap_'
         is_mech = isinstance(node, Mechanism)
         # FIXME: Replace this with tags!
-        is_learning_autodiff = hasattr(node, 'learning_enabled') and node.learning_enabled
+        is_learning_autodiff = hasattr(node, 'learning_enabled') and "learning" in tag
 
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
             node_function = ctx.import_llvm_function(node, tag=tag)

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -1747,7 +1747,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         # Compiled resources
         self.__generated_node_wrappers = {}
-        self.__generated_simulation = None
 
         self._compilation_data = self._CompilationData(owner=self)
 
@@ -7652,15 +7651,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             if tag.startswith("run"):
                 return ctx.gen_composition_run(self, tag=tag)
             else:
-                return ctx.gen_composition_exec(self)
-
-    @property
-    def _llvm_simulation(self):
-        if self.__generated_simulation is None:
-            with pnlvm.LLVMBuilderContext.get_global() as ctx:
-                self.__generated_simulation = ctx.gen_composition_exec(self, True)
-
-        return self.__generated_simulation
+                return ctx.gen_composition_exec(self, tag=tag)
 
     @handle_external_context(execution_id=NotImplemented)
     def reinitialize(self, context=None):

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -7641,15 +7641,15 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 def __init__(self, node, gen_f):
                     self._node = node
                     self._gen_f = gen_f
-                def _gen_llvm_function(self):
-                    return self._gen_f(self._node)
+                def _gen_llvm_function(self, *, tag):
+                    return self._gen_f(self._node, tag=tag)
             wrapper = node_wrapper(node, self.__gen_node_wrapper)
             self.__generated_node_wrappers[node] = wrapper
             return wrapper
 
         return self.__generated_node_wrappers[node]
 
-    def _gen_llvm_function(self):
+    def _gen_llvm_function(self, *, tag):
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
                 return ctx.gen_composition_exec(self)
 
@@ -7692,7 +7692,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         if self._compilation_data.ptx_execution._get(context) is None:
             self._compilation_data.ptx_execution._set(pnlvm.CompExecution(self, [context.execution_id]), context)
 
-    def __gen_node_wrapper(self, node):
+    def __gen_node_wrapper(self, node, *, tag):
         name = 'comp_wrap_'
         is_mech = isinstance(node, Mechanism)
         # TODO: pass this explicitly

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -1748,7 +1748,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # Compiled resources
         self.__generated_node_wrappers = {}
         self.__generated_simulation = None
-        self.__generated_sim_run = None
 
         self._compilation_data = self._CompilationData(owner=self)
 
@@ -7651,7 +7650,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     def _gen_llvm_function(self, *, tag):
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
             if tag.startswith("run"):
-                return ctx.gen_composition_run(self)
+                return ctx.gen_composition_run(self, tag=tag)
             else:
                 return ctx.gen_composition_exec(self)
 
@@ -7662,14 +7661,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 self.__generated_simulation = ctx.gen_composition_exec(self, True)
 
         return self.__generated_simulation
-
-    @property
-    def _llvm_sim_run(self):
-        if self.__generated_sim_run is None:
-            with pnlvm.LLVMBuilderContext.get_global() as ctx:
-                self.__generated_sim_run = ctx.gen_composition_run(self, True)
-
-        return self.__generated_sim_run
 
     @handle_external_context(execution_id=NotImplemented)
     def reinitialize(self, context=None):

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -7608,25 +7608,25 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         return pnlvm.ir.LiteralStructType(data)
 
     def _get_state_initializer(self, context=None, simulation=False):
-        mech_contexts = (tuple(m._get_state_initializer(context=context))
+        mech_contexts = (m._get_state_initializer(context=context)
                          for m in self._all_nodes if m is not self.controller or not simulation)
-        proj_contexts = (tuple(p._get_state_initializer(context=context)) for p in self.projections)
+        proj_contexts = (p._get_state_initializer(context=context) for p in self.projections)
         return (tuple(mech_contexts), tuple(proj_contexts))
 
     def _get_param_initializer(self, context, simulation=False):
-        mech_params = (tuple(m._get_param_initializer(context))
+        mech_params = (m._get_param_initializer(context)
                        for m in self._all_nodes if m is not self.controller or not simulation)
-        proj_params = (tuple(p._get_param_initializer(context)) for p in self.projections)
+        proj_params = (p._get_param_initializer(context) for p in self.projections)
         return (tuple(mech_params), tuple(proj_params))
 
     def _get_data_initializer(self, context=None):
-        output = [(os.parameters.value.get(context) for os in m.output_ports) for m in self._all_nodes]
-        data = [output]
+        output = ((os.parameters.value.get(context) for os in m.output_ports) for m in self._all_nodes)
+        data = [pnlvm._tupleize(output)]
         for node in self.nodes:
             nested_data = node._get_data_initializer(context=context) \
-                if hasattr(node,'_get_data_initializer') else []
+                if hasattr(node, '_get_data_initializer') else ()
             data.append(nested_data)
-        return pnlvm._tupleize(data)
+        return tuple(data)
 
     def _get_node_index(self, node):
         node_list = list(self._all_nodes)

--- a/psyneulink/core/llvm/__init__.py
+++ b/psyneulink/core/llvm/__init__.py
@@ -96,8 +96,8 @@ class LLVMBinaryFunction:
 
     @staticmethod
     @functools.lru_cache(maxsize=32)
-    def from_obj(obj, tag=None):
-        name = LLVMBuilderContext.get_global().gen_llvm_function(obj).name
+    def from_obj(obj, *, tag:str=""):
+        name = LLVMBuilderContext.get_global().gen_llvm_function(obj, tag=tag).name
         return LLVMBinaryFunction.get(name)
 
     @staticmethod

--- a/psyneulink/core/llvm/__init__.py
+++ b/psyneulink/core/llvm/__init__.py
@@ -96,8 +96,8 @@ class LLVMBinaryFunction:
 
     @staticmethod
     @functools.lru_cache(maxsize=32)
-    def from_obj(obj, *, tag:str=""):
-        name = LLVMBuilderContext.get_global().gen_llvm_function(obj, tag=tag).name
+    def from_obj(obj, *, tags:tuple=()):
+        name = LLVMBuilderContext.get_global().gen_llvm_function(obj, tags=tags).name
         return LLVMBinaryFunction.get(name)
 
     @staticmethod

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -100,8 +100,8 @@ class LLVMBuilderContext:
             function_type = pnlvm.ir.FunctionType(args[0], [args[0], args[0]])
         return self.module.declare_intrinsic("llvm." + name, args, function_type)
 
-    def create_llvm_function(self, args, component, name=None, return_type=ir.VoidType()):
-        name = str(component) if name is None else name
+    def create_llvm_function(self, args, component, name=None, *, return_type=ir.VoidType(), tag:str=""):
+        name = "_".join((str(component), tag)) if name is None else name
 
         # Builtins are already unique and need to keep their special name
         func_name = name if name.startswith(_BUILTIN_PREFIX) else self.get_unique_name(name)

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -557,9 +557,10 @@ class LLVMBuilderContext:
 
         return builder.function
 
-    def gen_composition_run(self, composition, simulation=False):
-        name = 'run_sim_wrap_' if simulation else 'run_wrap_'
-        name += composition.name
+    def gen_composition_run(self, composition, *, tag:str):
+        assert "run" in tag
+        simulation = "simulation" in tag
+        name = "wrap_" + tag + "_" + composition.name
         args = [self.get_state_struct_type(composition).as_pointer(),
                 self.get_param_struct_type(composition).as_pointer(),
                 self.get_data_struct_type(composition).as_pointer(),

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -421,8 +421,8 @@ class LLVMBuilderContext:
 
             return builder.function
 
-    def gen_composition_exec(self, composition, simulation=False):
-
+    def gen_composition_exec(self, composition, *, tag:str):
+        simulation = "simulation" in tag
         extra_args = []
         # If there is a node that needs learning input we need to export it
         # FIXME: Should we use node roles here?
@@ -558,7 +558,7 @@ class LLVMBuilderContext:
         return builder.function
 
     def gen_composition_run(self, composition, *, tag:str):
-        assert "run" in tag
+        assert tag.startswith("run")
         simulation = "simulation" in tag
         name = "wrap_" + tag + "_" + composition.name
         args = [self.get_state_struct_type(composition).as_pointer(),
@@ -615,10 +615,8 @@ class LLVMBuilderContext:
             data_in_ptr = b.gep(data_in, [input_idx])
 
             # Call execution
-            if simulation:
-                exec_f = self.import_llvm_function(composition._llvm_simulation.name)
-            else:
-                exec_f = self.import_llvm_function(composition)
+            exec_tag = tag.replace("run", "", 1).lstrip("_")
+            exec_f = self.import_llvm_function(composition, tag=exec_tag)
             b.call(exec_f, [state, params, data_in_ptr, data, cond])
 
             if not simulation:

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -137,15 +137,16 @@ class LLVMBuilderContext:
             cache[obj] = obj._gen_llvm_function()
         return cache[obj]
 
-    def import_llvm_function(self, obj) -> ir.Function:
+    def import_llvm_function(self, fun) -> ir.Function:
         """
         Get function handle if function exists in current modele.
         Create function declaration if it exists in a older module.
         """
-        try:
-            f = self.gen_llvm_function(obj)
-        except AttributeError:
-            f = _find_llvm_function(obj, _all_modules | {self.module})
+        if isinstance(fun, str):
+            f = _find_llvm_function(fun, _all_modules | {self.module})
+        else:
+            f = self.gen_llvm_function(fun)
+
         # Add declaration to the current module
         if f.name not in self.module.globals:
             decl_f = ir.Function(self.module, f.type.pointee, f.name)

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -124,7 +124,7 @@ class LLVMBuilderContext:
 
         return builder
 
-    def gen_llvm_function(self, obj) -> ir.Function:
+    def gen_llvm_function(self, obj, *, tag:str="") -> ir.Function:
         cache = self._cache
         try:
             # HACK: allows for learning bin func and non-learning to differ
@@ -134,10 +134,10 @@ class LLVMBuilderContext:
             pass
 
         if obj not in cache:
-            cache[obj] = obj._gen_llvm_function()
+            cache[obj] = obj._gen_llvm_function(tag=tag)
         return cache[obj]
 
-    def import_llvm_function(self, fun) -> ir.Function:
+    def import_llvm_function(self, fun, *, tag:str="") -> ir.Function:
         """
         Get function handle if function exists in current modele.
         Create function declaration if it exists in a older module.
@@ -145,7 +145,7 @@ class LLVMBuilderContext:
         if isinstance(fun, str):
             f = _find_llvm_function(fun, _all_modules | {self.module})
         else:
-            f = self.gen_llvm_function(fun)
+            f = self.gen_llvm_function(fun, tag=tag)
 
         # Add declaration to the current module
         if f.name not in self.module.globals:

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -370,10 +370,8 @@ class LLVMBuilderContext:
             builder.block.name = "invoke_" + output_cim_f.name
             builder.call(output_cim_f, [state, params, comp_in, data, data])
 
-            composition.learning_enabled = False
             forward_tag = tag.replace("learning", "").replace("__", "").lstrip("_")
             exec_f = self.import_llvm_function(composition, tag=forward_tag)
-            composition.learning_enabled = True
 
             runs_ptr = builder.gep(learning, [self.int32_ty(0), self.int32_ty(1)])
             runs = builder.load(runs_ptr, "runs")
@@ -425,8 +423,7 @@ class LLVMBuilderContext:
         simulation = "simulation" in tag
         extra_args = []
         # If there is a node that needs learning input we need to export it
-        # FIXME: Use 'learning' tag here!
-        for node in filter(lambda n: hasattr(n, 'learning_enabled') and n.learning_enabled, composition.nodes):
+        for node in filter(lambda n: hasattr(n, 'learning_enabled') and "learning" in tag, composition.nodes):
             node_wrap = composition._get_node_wrapper(node)
             node_f = self.import_llvm_function(node_wrap, tag=tag)
             extra_args = [node_f.args[-1].type]

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -345,7 +345,7 @@ class LLVMBuilderContext:
 
         builder.ret_void()
 
-    def gen_autodiffcomp_learning_exec(self, composition):
+    def gen_autodiffcomp_learning_exec(self, composition, *, tag:str):
         composition._build_pytorch_representation(composition.default_execution_id)
         pytorch_model = composition.parameters.pytorch_representation.get(composition.default_execution_id)
         learning_struct_ty = pnlvm.ir.LiteralStructType((
@@ -357,7 +357,7 @@ class LLVMBuilderContext:
             learning_struct_ty.as_pointer(),
             self.get_output_struct_type(composition).as_pointer()
         ]
-        with self._gen_composition_exec_context(composition, tag="learning",
+        with self._gen_composition_exec_context(composition, tag=tag,
             extra_args=args) as (builder, data, params, cond_gen):
             state, _, comp_in, _, cond, learning, data_out = builder.function.args
             data_out.attributes.remove('nonnull')
@@ -393,12 +393,12 @@ class LLVMBuilderContext:
 
             return builder.function
 
-    def gen_autodiffcomp_exec(self, composition):
+    def gen_autodiffcomp_exec(self, composition, *, tag:str):
         """Creates llvm bin execute for autodiffcomp"""
         assert composition.controller is None
         composition._build_pytorch_representation(composition.default_execution_id)
         pytorch_model = composition.parameters.pytorch_representation.get(composition.default_execution_id)
-        with self._gen_composition_exec_context(composition, tag="") as (builder, data, params, cond_gen):
+        with self._gen_composition_exec_context(composition, tag=tag) as (builder, data, params, cond_gen):
             state, _, comp_in, _, cond = builder.function.args
             # Call pytorch internal compiled llvm func
             input_cim_idx = composition._get_node_index(composition.input_CIM)

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -435,9 +435,9 @@ class CompExecution(CUDAExecution):
     def _bin_exec_func(self):
         if self.__bin_exec_func is None:
             try:
-                learning = 'learning' if self._composition.learning_enabled else None
+                learning = "learning" if self._composition.learning_enabled else ""
             except AttributeError:
-                learning = None
+                learning = ""
             self.__bin_exec_func = pnlvm.LLVMBinaryFunction.from_obj(self._composition, tag=learning)
 
         return self.__bin_exec_func
@@ -522,7 +522,7 @@ class CompExecution(CUDAExecution):
     @property
     def _bin_run_func(self):
         if self.__bin_run_func is None:
-            self.__bin_run_func = pnlvm.LLVMBinaryFunction.get(self._composition._llvm_run.name)
+            self.__bin_run_func = pnlvm.LLVMBinaryFunction.from_obj(self._composition, tag="run")
 
         return self.__bin_run_func
 

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -50,7 +50,6 @@ class CUDAExecution:
         self._uploaded_bytes = 0
         self._downloaded_bytes = 0
         self.__debug_env = debug_env
-        self.__vo_ty = None
 
     def __del__(self):
         if "cuda_data" in self.__debug_env:
@@ -66,14 +65,6 @@ class CUDAExecution:
     def _bin_func_multirun(self):
         # CUDA uses the same function for single and multi run
         return self._bin_func
-
-    @property
-    def _vo_ty(self):
-        if self.__vo_ty is None:
-            self.__vo_ty = self._bin_func.byref_arg_types[3]
-            if len(self._execution_contexts) > 1:
-                self.__vo_ty = self.__vo_ty * len(self._execution_contexts)
-        return self.__vo_ty
 
     def _get_ctype_bytes(self, data):
         # Return dummy buffer. CUDA does not handle 0 size well.
@@ -161,6 +152,7 @@ class FuncExecution(CUDAExecution):
             self.__param_struct = None
             self.__state_struct = None
 
+        self._vo_ty = vo_ty
         self._ct_vo = vo_ty()
         self._vi_ty = vi_ty
 
@@ -510,7 +502,7 @@ class CompExecution(CUDAExecution):
                                       threads=len(self._execution_contexts))
 
         # Copy the data struct from the device
-        self._data_struct = self.download_ctype(self._cuda_data_struct, self._vo_ty)
+        self._data_struct = self.download_ctype(self._cuda_data_struct, type(self._data_struct))
 
     # Methods used to accelerate "Run"
 

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -438,6 +438,8 @@ class CompExecution(CUDAExecution):
                 learning = "learning" if self._composition.learning_enabled else ""
             except AttributeError:
                 learning = ""
+            if len([n for n in self._composition.nodes if hasattr(n, 'learning_enabled') and n.learning_enabled]):
+                learning = "learning"
             self.__bin_exec_func = pnlvm.LLVMBinaryFunction.from_obj(self._composition, tag=learning)
 
         return self.__bin_exec_func

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -101,9 +101,21 @@ class CUDAExecution:
 
         return private_attr
 
-    def __getattr__(self, attribute):
-        assert attribute.startswith("_cuda"), "Unknown attribute: {}".format(attribute)
-        return self.__get_cuda_buffer(attribute[5:])
+    @property
+    def _cuda_param_struct(self):
+        return self.__get_cuda_buffer("_param_struct")
+
+    @property
+    def _cuda_state_struct(self):
+        return self.__get_cuda_buffer("_state_struct")
+
+    @property
+    def _cuda_data_struct(self):
+        return self.__get_cuda_buffer("_data_struct")
+
+    @property
+    def _cuda_conditions(self):
+        return self.__get_cuda_buffer("_conditions")
 
     @property
     def _cuda_out(self):

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -435,12 +435,12 @@ class CompExecution(CUDAExecution):
     def _bin_exec_func(self):
         if self.__bin_exec_func is None:
             try:
-                learning = "learning" if self._composition.learning_enabled else ""
+                learning = ("learning",) if self._composition.learning_enabled else ()
             except AttributeError:
-                learning = ""
+                learning = ()
             if len([n for n in self._composition.nodes if hasattr(n, 'learning_enabled') and n.learning_enabled]):
-                learning = "learning"
-            self.__bin_exec_func = pnlvm.LLVMBinaryFunction.from_obj(self._composition, tag=learning)
+                learning = ("learning",)
+            self.__bin_exec_func = pnlvm.LLVMBinaryFunction.from_obj(self._composition, tags=learning)
 
         return self.__bin_exec_func
 
@@ -524,7 +524,7 @@ class CompExecution(CUDAExecution):
     @property
     def _bin_run_func(self):
         if self.__bin_run_func is None:
-            self.__bin_run_func = pnlvm.LLVMBinaryFunction.from_obj(self._composition, tag="run")
+            self.__bin_run_func = pnlvm.LLVMBinaryFunction.from_obj(self._composition, tags=("run",))
 
         return self.__bin_run_func
 

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -91,17 +91,19 @@ class CUDAExecution:
         jit_engine.pycuda.driver.memcpy_dtoh(out_buf, source)
         return ty.from_buffer(out_buf)
 
-    def __getattr__(self, attribute):
-        assert attribute.startswith("_cuda")
-
-        private_attr_name = "_buffer" + attribute
+    def __get_cuda_buffer(self, struct_name):
+        private_attr_name = "_buffer_cuda" + struct_name
         private_attr = getattr(self, private_attr_name)
         if private_attr is None:
             # Set private attribute to a new buffer
-            private_attr = self.upload_ctype(getattr(self, attribute[5:]))
+            private_attr = self.upload_ctype(getattr(self, struct_name))
             setattr(self, private_attr_name, private_attr)
 
         return private_attr
+
+    def __getattr__(self, attribute):
+        assert attribute.startswith("_cuda"), "Unknown attribute: {}".format(attribute)
+        return self.__get_cuda_buffer(attribute[5:])
 
     @property
     def _cuda_out(self):

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -216,7 +216,7 @@ class MechExecution(FuncExecution):
         #   a) the input is vector of input ports
         #   b) input ports take vector of projection outputs
         #   c) projection output is a vector (even 1 element vector)
-        new_var = np.asfarray([np.atleast_2d(x) for x in np.atleast_1d(variable)])
+        new_var = [np.atleast_2d(x) for x in np.atleast_1d(variable)]
         return super().execute(new_var)
 
 

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -782,9 +782,9 @@ class AutodiffComposition(Composition):
     def _gen_llvm_function(self, tag):
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
             if self.learning_enabled is True:
-                return ctx.gen_autodiffcomp_learning_exec(self)
+                return ctx.gen_autodiffcomp_learning_exec(self, tag=tag)
             else:
-                return ctx.gen_autodiffcomp_exec(self)
+                return ctx.gen_autodiffcomp_exec(self, tag=tag)
 
     @handle_external_context()
     def execute(self,

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -791,12 +791,12 @@ class AutodiffComposition(Composition):
         else:
             return outputs
 
-    def _gen_llvm_function(self, tag):
+    def _gen_llvm_function(self, *, tags:tuple):
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
-            if "learning" in tag:
-                return ctx.gen_autodiffcomp_learning_exec(self, tag=tag)
+            if "learning" in tags:
+                return ctx.gen_autodiffcomp_learning_exec(self, tags=tags)
             else:
-                return ctx.gen_autodiffcomp_exec(self, tag=tag)
+                return ctx.gen_autodiffcomp_exec(self, tags=tags)
 
     @handle_external_context()
     def execute(self,

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -1239,13 +1239,12 @@ class AutodiffComposition(Composition):
 
     def _get_param_initializer(self, context):
         mech_params = (n._get_param_initializer(context) for n in self._all_nodes)
-        proj_params = (tuple(p._get_param_initializer(context)) if (p.sender in self.input_CIM.input_ports or p.receiver in self.output_CIM.input_ports)
+        proj_params = (p._get_param_initializer(context) if (p.sender in self.input_CIM.input_ports or p.receiver in self.output_CIM.input_ports)
                        else tuple() for p in self.projections)
         self._build_pytorch_representation(self.default_execution_id)
         model = self.parameters.pytorch_representation.get(self.default_execution_id)
         pytorch_params = model._get_param_initializer()
-        param_args = (tuple(mech_params), tuple(proj_params), pytorch_params)
-        return tuple(param_args)
+        return (tuple(mech_params), tuple(proj_params), pytorch_params)
 
 class EarlyStopping(object):
     def __init__(self, mode='min', min_delta=0, patience=10):

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -784,7 +784,7 @@ class AutodiffComposition(Composition):
         else:
             return outputs
 
-    def _gen_llvm_function(self):
+    def _gen_llvm_function(self, tag):
         if self.learning_enabled is True:
             if self.__generated_learning_exec is None:
                 with pnlvm.LLVMBuilderContext.get_global() as ctx:

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -781,7 +781,7 @@ class AutodiffComposition(Composition):
 
     def _gen_llvm_function(self, tag):
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
-            if self.learning_enabled is True:
+            if "learning" in tag:
                 return ctx.gen_autodiffcomp_learning_exec(self, tag=tag)
             else:
                 return ctx.gen_autodiffcomp_exec(self, tag=tag)

--- a/psyneulink/library/compositions/compiledloss.py
+++ b/psyneulink/library/compositions/compiledloss.py
@@ -14,7 +14,7 @@ class Loss():
         self._DELTA_W_NUM = 0
 
 
-    def _gen_llvm_function(self, *, tag):
+    def _gen_llvm_function(self, *, tags:tuple):
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
             return self._gen_loss_function(ctx)
 

--- a/psyneulink/library/compositions/compiledloss.py
+++ b/psyneulink/library/compositions/compiledloss.py
@@ -14,7 +14,7 @@ class Loss():
         self._DELTA_W_NUM = 0
 
 
-    def _gen_llvm_function(self):
+    def _gen_llvm_function(self, *, tag):
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
             return self._gen_loss_function(ctx)
 

--- a/psyneulink/library/compositions/compiledoptimizer.py
+++ b/psyneulink/library/compositions/compiledoptimizer.py
@@ -74,7 +74,7 @@ class Optimizer():
     def initialize_optimizer_struct(self, ctx, builder, optim_struct):
         builder.store(optim_struct.type.pointee(None), optim_struct)
 
-    def _gen_llvm_function(self):
+    def _gen_llvm_function(self, *, tag):
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
             return self.step(ctx)
 

--- a/psyneulink/library/compositions/compiledoptimizer.py
+++ b/psyneulink/library/compositions/compiledoptimizer.py
@@ -74,7 +74,7 @@ class Optimizer():
     def initialize_optimizer_struct(self, ctx, builder, optim_struct):
         builder.store(optim_struct.type.pointee(None), optim_struct)
 
-    def _gen_llvm_function(self, *, tag):
+    def _gen_llvm_function(self, *, tags:tuple):
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
             return self.step(ctx)
 

--- a/psyneulink/library/compositions/pytorchmodelcreator.py
+++ b/psyneulink/library/compositions/pytorchmodelcreator.py
@@ -215,7 +215,7 @@ class PytorchModelCreator(torch.nn.Module):
         return pnlvm.execution._tupleize(param_list)
 
     # generates llvm function for self.forward
-    def _gen_llvm_function(self):
+    def _gen_llvm_function(self, *, tag):
         llvm_func = None
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
             args = [ctx.get_state_struct_type(self._composition).as_pointer(),

--- a/psyneulink/library/compositions/pytorchmodelcreator.py
+++ b/psyneulink/library/compositions/pytorchmodelcreator.py
@@ -191,7 +191,7 @@ class PytorchModelCreator(torch.nn.Module):
         return pnlvm.execution._tupleize(param_list)
 
     # generates llvm function for self.forward
-    def _gen_llvm_function(self, *, tag):
+    def _gen_llvm_function(self, *, tags:tuple):
         llvm_func = None
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
             args = [ctx.get_state_struct_type(self._composition).as_pointer(),

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -2478,10 +2478,6 @@ class TestNested:
         result1 = parentComposition.run(inputs=input, bin_execute=mode)
         assert np.allclose(result1, [[0]], atol=0.1)
 
-        if mode != 'Python':
-            #FIXME: Enable the rest of the test when recompilation is supported
-            return
-
         xor_autodiff.learning_enabled = False
         result2 = parentComposition.run(inputs=no_training_input, bin_execute=mode)
 
@@ -2555,10 +2551,6 @@ class TestNested:
         no_training_input = {xor_autodiff: no_training_input_dict}
 
         result1 = parentComposition.run(inputs=no_training_input, bin_execute=mode)
-        if mode != 'Python':
-            #FIXME: Enable the rest of the test when recompilation is supported
-            return
-
         xor_autodiff.learning_enabled = True
         result2 = parentComposition.run(inputs=input, bin_execute=mode)
 

--- a/tests/states/test_output_states.py
+++ b/tests/states/test_output_states.py
@@ -1,5 +1,6 @@
 import numpy as np
 import psyneulink as pnl
+import psyneulink.core.llvm as pnlvm
 import pytest
 
 import psyneulink.core.components.functions.combinationfunctions
@@ -8,10 +9,16 @@ import psyneulink.core.components.functions.transferfunctions
 
 class TestOutputPorts:
 
-    def test_output_port_variable_spec(self):
+    @pytest.mark.mechanism
+    @pytest.mark.lca_mechanism
+    @pytest.mark.benchmark(group="LCAMechanism")
+    @pytest.mark.parametrize('mode', ['Python',
+                                      pytest.param('LLVM', marks=pytest.mark.llvm),
+                                      pytest.param('PTX', marks=[pytest.mark.llvm, pytest.mark.cuda])])
+    def test_output_port_variable_spec(self, mode):
         # Test specification of OutputPort's variable
-        udf = pnl.UserDefinedFunction(custom_function=lambda x: np.array([[1], [2], [3]]))
-        mech = pnl.ProcessingMechanism(function=udf, name='MyMech',
+        mech = pnl.ProcessingMechanism(default_variable=[[1.],[2.],[3.]],
+                                       name='MyMech',
                                        output_ports=[
                                            pnl.OutputPort(name='z', variable=(pnl.OWNER_VALUE, 2)),
                                            pnl.OutputPort(name='y', variable=(pnl.OWNER_VALUE, 1)),
@@ -22,18 +29,51 @@ class TestOutputPorts:
         expected = [[3.],[2.],[1.],[[1.],[2.],[3.]], [0]]
         for i, e in zip(mech.output_values, expected):
             assert np.array_equal(i, e)
-        mech.execute([0])
-        expected = [[3.],[2.],[1.],[[1.],[2.],[3.]], [1]]
-        for i, e in zip(mech.output_values, expected):
+        if mode == 'Python':
+            EX = mech.execute
+        elif mode == 'LLVM':
+            e = pnlvm.execution.MechExecution(mech)
+            EX = e.execute
+        elif mode == 'PTX':
+            e = pnlvm.execution.MechExecution(mech)
+            EX = e.cuda_execute
+        EX([[1.],[2.],[3.]])
+        EX([[1.],[2.],[3.]])
+        EX([[1.],[2.],[3.]])
+        res = EX([[1.],[2.],[3.]])
+        if mode == "Python":
+            res = mech.output_values
+        expected = [[3.],[2.],[1.],[[1.],[2.],[3.]], [4]]
+        for i, e in zip(res, expected):
             assert np.array_equal(i, e)
+
+    @pytest.mark.mechanism
+    @pytest.mark.lca_mechanism
+    @pytest.mark.benchmark(group="LCAMechanism")
+    @pytest.mark.parametrize('mode', ['Python',
+                                      pytest.param('LLVM', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                      pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
+                                      pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])])
+    def test_output_port_variable_spec_composition(self, mode):
+        # Test specification of OutputPort's variable
         # OutputPort mech.output_ports['all'] has a different dimensionality than the other OutputPorts;
         #    as a consequence, when added as a terminal node, the Composition can't construct an IDENTITY_MATRIX
         #    from the mech's OutputPorts to the Composition's output_CIM.
         # FIX: Remove the following line and correct assertions below once above condition is resolved
-        mech.remove_ports(ports=mech.output_ports['all'])
+        mech = pnl.ProcessingMechanism(default_variable=[[1.],[2.],[3.]],
+                                       name='MyMech',
+                                       output_ports=[
+                                           pnl.OutputPort(name='z', variable=(pnl.OWNER_VALUE, 2)),
+                                           pnl.OutputPort(name='y', variable=(pnl.OWNER_VALUE, 1)),
+                                           pnl.OutputPort(name='x', variable=(pnl.OWNER_VALUE, 0)),
+#                                           pnl.OutputPort(name='all', variable=(pnl.OWNER_VALUE)),
+                                           pnl.OutputPort(name='execution count', variable=(pnl.OWNER_EXECUTION_COUNT))
+                                       ])
         C = pnl.Composition(name='MyComp')
         C.add_node(node=mech)
-        outs = C.run(inputs={mech: np.array([[0]])})
-        assert np.array_equal(outs, np.array([[3], [2], [1], [2]]))
-        outs = C.run(inputs={mech: np.array([[0]])})
-        assert np.array_equal(outs, np.array([[3], [2], [1], [3]]))
+        outs = C.run(inputs={mech: [[1.],[2.],[3.]]}, bin_execute=mode)
+        assert np.array_equal(outs, [[3], [2], [1], [1]])
+        outs = C.run(inputs={mech: [[1.],[2.],[3.]]}, bin_execute=mode)
+        assert np.array_equal(outs, [[3], [2], [1], [2]])


### PR DESCRIPTION
Rework caching of generated functions based on tags.
Switch 'learning' code generation based on tag rather than PNL parameter.
Enable switching of 'learning_enabled' in nested learning tests
Add support for OWNER_EXECUTION_COUNT output port specification.
