### PR TITLE
requirements: restrict torch to x86_64 and CPython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ matplotlib
 numpy
 pillow
 toposort==1.4
-torch; sys_platform != 'win32'
+torch; sys_platform != 'win32' and platform_machine == 'x86_64' and platform_python_implementation == 'CPython'
 typecheck-decorator==1.2


### PR DESCRIPTION
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>