### PR TITLE
mechanism: Count the number of completed iterations in num_executions_before_finished

### DIFF
--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2342,10 +2342,12 @@ class Mechanism_Base(Mechanism):
 
             self.parameters.num_executions_before_finished._set(num_executions + 1, override=True, context=context)
 
-            if self.is_finished(context) or not self.parameters.execute_until_finished._get(context):
+            if self.is_finished(context):
                 self.parameters.is_finished_flag._set(True, context)
                 break
             self.parameters.is_finished_flag._set(False, context)
+            if not self.parameters.execute_until_finished._get(context):
+                break
 
         # REPORT EXECUTION
         if self.prefs.reportOutputPref and (context.execution_phase & ContextFlags.PROCESSING | ContextFlags.LEARNING):

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2337,6 +2337,7 @@ class Mechanism_Base(Mechanism):
             max_executions = self.parameters.max_executions_before_finished._get(context)
 
             if  num_executions >= max_executions:
+                self.parameters.is_finished_flag._set(True, context)
                 warnings.warn(f"Maximum number of executions ({max_executions}) reached for {self.name}.")
                 break
 
@@ -2818,7 +2819,7 @@ class Mechanism_Base(Mechanism):
                                            is_finished_max)
         iter_end = builder.or_(is_finished_cond, max_reached)
         with builder.if_then(iter_end):
-            new_flag = builder.uitofp(is_finished_cond, current_flag.type)
+            new_flag = builder.uitofp(iter_end, current_flag.type)
             builder.store(new_flag, is_finished_flag_ptr)
             builder.branch(end_block)
 

--- a/tests/mechanisms/test_recurrent_transfer_mechanism.py
+++ b/tests/mechanisms/test_recurrent_transfer_mechanism.py
@@ -1233,7 +1233,7 @@ class TestCustomCombinationFunction:
                                       pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                       pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])])
     @pytest.mark.parametrize('until_finished, expected', [
-        (True, [[[[0.984375]]], [[[0.9921875]]]]), # The 5th and the 6th iteration
+        (True, [[[[0.984375]]], [[[0.99975586]]]]), # The 5th and the 10th iteration
         (False, [[[[0.5]]], [[[0.75]]]]), # The first and the second iteration
     ], ids=['until_finished', 'oneshot'])
     def test_max_executions_before_finished(self, mode, until_finished, expected):
@@ -1246,8 +1246,8 @@ class TestCustomCombinationFunction:
         C.add_node(I1)
 
         results = C.run(inputs={I1: [[1.0]]}, num_trials=1, bin_execute=mode)
-        if mode == 'Python' and not until_finished:
-            assert I1.parameters.is_finished_flag.get(C) is False
+        if mode == 'Python':
+            assert I1.parameters.is_finished_flag.get(C) is until_finished
         results2 = C.run(inputs={I1: [[1.0]]}, num_trials=1, bin_execute=mode)
         assert np.allclose(expected[0], results)
         assert np.allclose(expected[1], results2)

--- a/tests/mechanisms/test_recurrent_transfer_mechanism.py
+++ b/tests/mechanisms/test_recurrent_transfer_mechanism.py
@@ -1233,7 +1233,7 @@ class TestCustomCombinationFunction:
                                       pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                       pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])])
     @pytest.mark.parametrize('until_finished, expected', [
-        (True, [[[[0.984375]]], [[[0.99975586]]]]), # The 5th and the 10th iteration
+        (True, [[[[0.96875]]], [[[0.9990234375]]]]), # The 5th and the 10th iteration
         (False, [[[[0.5]]], [[[0.75]]]]), # The first and the second iteration
     ], ids=['until_finished', 'oneshot'])
     def test_max_executions_before_finished(self, mode, until_finished, expected):

--- a/tests/mechanisms/test_recurrent_transfer_mechanism.py
+++ b/tests/mechanisms/test_recurrent_transfer_mechanism.py
@@ -1232,21 +1232,25 @@ class TestCustomCombinationFunction:
                                       pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                       pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                       pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])])
-    def test_max_executions_before_finished(self, mode):
+    @pytest.mark.parametrize('until_finished, expected', [
+        (True, [[[[0.984375]]], [[[0.9921875]]]]), # The 5th and the 6th iteration
+        (False, [[[[0.5]]], [[[0.75]]]]), # The first and the second iteration
+    ], ids=['until_finished', 'oneshot'])
+    def test_max_executions_before_finished(self, mode, until_finished, expected):
         I1 = pnl.RecurrentTransferMechanism(integrator_mode=True,
                                             integration_rate=0.5,
                                             termination_threshold=0.0,
                                             max_executions_before_finished=5,
-                                            execute_until_finished=True)
+                                            execute_until_finished=until_finished)
         C = pnl.Composition()
         C.add_node(I1)
 
         results = C.run(inputs={I1: [[1.0]]}, num_trials=1, bin_execute=mode)
+        if mode == 'Python' and not until_finished:
+            assert I1.parameters.is_finished_flag.get(C) is False
         results2 = C.run(inputs={I1: [[1.0]]}, num_trials=1, bin_execute=mode)
-        # Result after 5 iterations
-        assert np.allclose([[[0.984375]]], results)
-        # Result after 6 iterations, PNL continue previous computation in next trial
-        assert np.allclose([[[0.9921875]]], results2)
+        assert np.allclose(expected[0], results)
+        assert np.allclose(expected[1], results2)
 
 class TestDebugProperties:
 


### PR DESCRIPTION
Leave is_finished_flag at False when in one-shot mode.
The executions that reached max_iterations_before_finished are finished.