### PR TITLE
Refactor/autodiff

### DIFF
--- a/docs/source/BasicsAndPrimer.rst
+++ b/docs/source/BasicsAndPrimer.rst
@@ -724,7 +724,7 @@ a simple three-layered neural network that learns to compute the X-OR operation:
     # Create inputs:            Trial 1  Trial 2  Trial 3  Trial 4
     xor_inputs = {'stimuli':[[0, 0],  [0, 1],  [1, 0],  [1, 1]],
                   'targets':[  [0],     [1],     [1],     [0] ]}
-    xor_comp.run(inputs={input:xor_inputs['stimuli'],
+    xor_comp.learn(inputs={input:xor_inputs['stimuli'],
                          target:xor_inputs['targets']})
 
 Calling the Composition's ``show_graph`` with ``show_learning=True`` shows the network along with all of the learning
@@ -750,7 +750,7 @@ target Mechanism (that receives the input specifying the target responses)::
     target_mech = learning_components[TARGET_MECHANISM]
 
     # Run the model:
-    result = xor_model.run(inputs={input_mech:xor_inputs,
+    result = xor_model.learn(inputs={input_mech:xor_inputs,
                                    target_mech:xor_targets},
                            num_trials=2)
 

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1175,7 +1175,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      "input_port_variables", "results", "simulation_results",
                      "monitor_for_control", "feature_values", "simulation_ids",
                      "input_labels_dict", "output_labels_dict",
-                     "modulated_mechanisms"}
+                     "modulated_mechanisms", "activation_derivative_fct"}
         # mechanism functions are handled separately
         if hasattr(self, 'ports'):
             blacklist.add("function")

--- a/psyneulink/core/components/process.py
+++ b/psyneulink/core/components/process.py
@@ -2400,6 +2400,7 @@ class Process(Process_Base):
                     target_input_port.value *= 0
 
         # THEN, execute ComparatorMechanism and LearningMechanism
+        context.add_flag(ContextFlags.LEARNING_MODE)
         context.add_flag(ContextFlags.LEARNING)
         for mechanism in self._learning_mechs:
             mechanism.execute(context=context)
@@ -2453,6 +2454,7 @@ class Process(Process_Base):
                                                       projection.name))
 
         context.remove_flag(ContextFlags.LEARNING)
+        context.remove_flag(ContextFlags.LEARNING_MODE)
 
     def run(self,
             inputs,

--- a/psyneulink/core/components/system.py
+++ b/psyneulink/core/components/system.py
@@ -2861,9 +2861,10 @@ class System(System_Base):
         # Execute learning except for simulation runs
         if ContextFlags.SIMULATION not in context.execution_phase and self.learning:
             context.add_flag(ContextFlags.LEARNING)
+            context.add_flag(ContextFlags.LEARNING_MODE)
             self._execute_learning(target=target, context=context)
-
             context.remove_flag(ContextFlags.LEARNING)
+            context.add_flag(ContextFlags.LEARNING_MODE)
 
         # EXECUTE CONTROLLER
         # FIX: 1) RETRY APPENDING TO EXECUTE LIST AND COMPARING TO THIS VERSION
@@ -3018,7 +3019,6 @@ class System(System_Base):
                               'must be initialized before execution'.format(self.name))
         logger.debug('{0}.scheduler learning termination conditions: {1}'.format(self, self.termination_learning))
 
-        context.add_flag(ContextFlags.LEARNING_MODE)
         for next_execution_set in self.scheduler_learning.run(context=context, termination_conds=self.termination_learning):
             logger.debug('Running next_execution_set {0}'.format(next_execution_set))
 
@@ -3030,9 +3030,9 @@ class System(System_Base):
 
             for component in next_execution_set:
                 logger.debug('\tRunning component {0}'.format(component))
-
+                context.add_flag(ContextFlags.LEARNING_MODE)
                 context.execution_phase = ContextFlags.LEARNING
-
+                
                 if isinstance(component, Mechanism):
                     params = None
 
@@ -3071,7 +3071,8 @@ class System(System_Base):
 
                 # # TEST PRINT LEARNING:
                 # print(component._parameter_ports[MATRIX].value)
-        context.remove_flag(ContextFlags.LEARNING_MODE)
+                context.remove_flag(ContextFlags.LEARNING_MODE)
+        
         # FINALLY report outputs
         if self._report_system_output and self._report_process_output:
             # Report learning for target_nodes (and the processes to which they belong)

--- a/psyneulink/core/components/system.py
+++ b/psyneulink/core/components/system.py
@@ -3018,6 +3018,7 @@ class System(System_Base):
                               'must be initialized before execution'.format(self.name))
         logger.debug('{0}.scheduler learning termination conditions: {1}'.format(self, self.termination_learning))
 
+        context.add_flag(ContextFlags.LEARNING_MODE)
         for next_execution_set in self.scheduler_learning.run(context=context, termination_conds=self.termination_learning):
             logger.debug('Running next_execution_set {0}'.format(next_execution_set))
 
@@ -3070,7 +3071,7 @@ class System(System_Base):
 
                 # # TEST PRINT LEARNING:
                 # print(component._parameter_ports[MATRIX].value)
-
+        context.remove_flag(ContextFlags.LEARNING_MODE)
         # FINALLY report outputs
         if self._report_system_output and self._report_process_output:
             # Report learning for target_nodes (and the processes to which they belong)

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -1875,9 +1875,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         self._update_parameter_components()
 
         self.initialization_status = ContextFlags.INITIALIZED
-        #FIXME: This removes `composition.parameters.values`, as it was not being 
-        # populated correctly in the first place. `composition.parameters.results` 
-        # should be used instead - in the long run, we should look into possibly 
+        #FIXME: This removes `composition.parameters.values`, as it was not being
+        # populated correctly in the first place. `composition.parameters.results`
+        # should be used instead - in the long run, we should look into possibly
         # populating both values and results, as it would be more consistent with
         # the behavior of components
         del self.parameters.value

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6437,7 +6437,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             animate=False,
             context=None,
             base_context=Context(execution_id=None),
-            learning_mode=False,
             ):
         """Pass inputs to Composition, then execute sets of nodes that are eligible to run until termination
         conditions are met.  See `Run` for details of formatting input specifications. See `Run` for details of
@@ -6847,7 +6846,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                         runtime_params=runtime_params,
                                         skip_initialization=True,
                                         bin_execute=bin_execute,
-                                        learning_mode=learning_mode
                                         )
 
             # ---------------------------------------------------------------------------------
@@ -6969,7 +6967,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             clamp_input=SOFT_CLAMP,
             runtime_params=None,
             skip_initialization=False,
-            learning_mode=False,
             bin_execute=False,
             ):
         """

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -795,24 +795,24 @@ Learning in a Composition
 
 Learning is used to modify the `Projections <Projection>` between Mechanisms in a Composition.  More specifically,
 it modifies the `matrix <MappingProjection.matrix>` parameter of those `MappingProjections <MappingProjection>`,
-which implements the strengths ("weights") of the associations between representations in the Mechanisms they connect. 
+which implements the strengths ("weights") of the associations between representations in the Mechanisms they connect.
 
 .. _Composition_Learning_Mode:
 
 *Running a Composition in Learning Mode*
 ======================================
-A Composition only learns when ran in learning mode, and when its `disable_learning` parameter is False. To run the Composition in learning mode, use the `learn <Composition.learn>` method. 
+A Composition only learns when ran in learning mode, and when its `disable_learning` parameter is False. To run the Composition in learning mode, use the `learn <Composition.learn>` method.
 See `learn <Composition.learn>` for more details.
 
 *Implementing Learning in a Composition*
 ======================================
-There are three ways of implementing learning in a Composition: 
+There are three ways of implementing learning in a Composition:
 
 i) using `standard PsyNeuLink Components <Composition_Learning_Standard>`
 
 ii) using the `AutodiffComposition <Composition_Learning_AutodiffComposition>` -- a specialized subclass of Composition that executes learning using `PyTorch <https://pytorch.org>`_
 
-iii) using `UserDefinedFunctions <UserDefinedFunction>`.  
+iii) using `UserDefinedFunctions <UserDefinedFunction>`.
 
 The advantage of using standard PsyNeuLink compoments is that it
 assigns each operation involved in learning to a dedicated Component. This helps make clear exactly what those
@@ -1073,8 +1073,8 @@ COMMENT
 <https://pytorch.org>`_ (see `example <BasicsAndPrimer_Rumelhart_Model>` in `BasicsAndPrimer`).  The
 AutodiffComposition constructor provides arguments for configuring the PyTorch implementation in various ways; the
 Composition is then built using the same methods (e.g., `add_node`, `add_projection`, `add_linear_processing_pathway`,
-etc.) as any other Composition. Note that there is no need to use any `learning methods <Composition_Learning_Methods>` 
-— AutodiffCompositions automatically creates backpropagation learning pathways between all input - output node paths.  
+etc.) as any other Composition. Note that there is no need to use any `learning methods <Composition_Learning_Methods>`
+— AutodiffCompositions automatically creates backpropagation learning pathways between all input - output node paths.
 It can be run just as a standard Composition would - using `learn <AutodiffComposition.learn>` for learning mode, and
 `run <AutodiffComposition.run>` for test mode.
 
@@ -4260,7 +4260,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                     prev[projection] = curr_node
                     queue.append(efferent_node)
             return pathways
-        
+
         pathways = [p for n in self.get_nodes_by_role(NodeRole.INPUT) if NodeRole.TARGET not in self.get_roles_by_node(n) for p in bfs(n)]
         for pathway in pathways:
             self.add_backpropagation_learning_pathway(pathway=pathway)
@@ -6806,7 +6806,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                     next_inputs = inputs.__next__()
                 except StopIteration:
                     break
-            
+
             if callable(inputs) or isgenerator(inputs):
                 next_inputs, num_inputs_sets = self._adjust_stimulus_dict(next_inputs)
                 execution_stimuli = {}
@@ -6947,7 +6947,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 1. For each pair, the key is the node (Mechanism or Composition) and the value is an input,
                 the shape of which must match the node's default variable. This is identical to the input dict in `the run method <Composition.run>`
                 2. A dict with keys 'inputs', 'targets', and 'epochs'. The `inputs` key stores a dict that is the same structure as input specification (1) of learn. The `targets` and `epochs` keys
-                should contain values of the same shape as `targets <Composition.learn>` and `epochs` <Composition.learn>    
+                should contain values of the same shape as `targets <Composition.learn>` and `epochs` <Composition.learn>
 
             targets: { `Mechanism <Mechanism>` or `Composition <Composition>` : list }
                 a dictionary containing a key-value pair for each node in the composition that receives target values to train on from
@@ -6962,7 +6962,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 specifies the number of training epochs (that is, repetitions of the batched input set) to run with
 
             minibatch_size : int (default=1)
-                specifies the size of the minibatches to use. The input trials will be batched and ran, after which learning mechanisms with learning mode TRIAL will update weights 
+                specifies the size of the minibatches to use. The input trials will be batched and ran, after which learning mechanisms with learning mode TRIAL will update weights
 
             randomize_minibatch: bool (default=False)
                 specifies whether the order of the input trials should be randomized on each epoch
@@ -6989,7 +6989,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
             call_after_minibatch : callable
                 called after each minibatch is executed
-                
+
             Returns
             ---------
 
@@ -7015,10 +7015,10 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             context=context,
             bin_execute=bin_execute,
             *args, **kwargs)
-        
+
         context.remove_flag(ContextFlags.LEARNING_MODE)
         return learning_results
-        
+
     @handle_external_context(execution_phase=ContextFlags.PROCESSING)
     def execute(
             self,
@@ -7756,7 +7756,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                     else:
                         adjusted_stimuli[node].append(stim)
                 nums_input_sets.add(len(stimuli[node]))
-        
+
         num_trials = max(nums_input_sets)
         for node, stim in adjusted_stimuli.items():
             if len(stim) == 1:

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6757,9 +6757,15 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                     full_results.extend(results)
 
                 self.parameters.results._set(full_results, context)
+
+                if self._is_learning(context):
+                    # copies back matrix to pnl from param struct (after learning)
+                    _comp_ex._copy_params_to_pnl(context=context)
+
                 # KAM added the [-1] index after changing Composition run()
                 # behavior to return only last trial of run (11/7/18)
                 self.most_recent_context = context
+
                 return full_results[-1]
 
             except Exception as e:

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6715,7 +6715,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         if not callable(inputs) \
                 and not hasattr(inputs, '__next__'):
             # Currently, no validation if 'inputs' arg is a function
-            inputs, num_inputs_sets, _ = self._adjust_stimulus_dict(inputs)
+            inputs, num_inputs_sets = self._adjust_stimulus_dict(inputs)
 
         if num_trials is not None:
             num_trials = num_trials
@@ -7586,7 +7586,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         return (not self.disable_learning) and (ContextFlags.LEARNING_MODE in context.runmode)
 
     def _adjust_stimulus_dict(self, stimuli):
-
 
         # STEP 1A: Check that all of the nodes listed in the inputs dict are INPUT nodes in the composition
         input_nodes = self.get_nodes_by_role(NodeRole.INPUT)

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6745,13 +6745,17 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             assert not is_simulation
             try:
                 if bin_execute is True or bin_execute.startswith('LLVM'):
-                    _comp_ex = pnlvm.CompExecution(self, [context.execution_id])
+                    comp_ex_tags = []
+                    # Add learning tags if the composition is to be ran in learning mode
+                    from psyneulink.library.compositions.autodiffcomposition import AutodiffComposition
+                    if self._is_learning(context) and isinstance(self, AutodiffComposition):
+                        comp_ex_tags.append("learning")
+                    _comp_ex = pnlvm.CompExecution(self, [context.execution_id], additional_tags=comp_ex_tags)
                     results += _comp_ex.run(inputs, num_trials, num_inputs_sets)
                 elif bin_execute.startswith('PTX'):
                     self.__ptx_initialize(context)
                     EX = self._compilation_data.ptx_execution._get(context)
                     results += EX.cuda_run(inputs, num_trials, num_inputs_sets)
-
                 full_results = self.parameters.results._get(context)
                 if full_results is None:
                     full_results = results

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6746,8 +6746,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             try:
                 comp_ex_tags = frozenset({})
                 # Add learning tags if the composition is to be ran in learning mode
-                from psyneulink.library.compositions.autodiffcomposition import AutodiffComposition
-                if self._is_learning(context) and isinstance(self, AutodiffComposition):
+                if self._is_learning(context):
                     comp_ex_tags = comp_ex_tags.union(frozenset({"learning"}))
                 if bin_execute is True or bin_execute.startswith('LLVM'):
                     _comp_ex = pnlvm.CompExecution(self, [context.execution_id], additional_tags=comp_ex_tags)

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -7428,20 +7428,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                         is_simulating = False
 
 
-                    # Execute Composition
-                    # FIX: 6/12/19 WHERE IS COMPILED EXECUTION OF NESTED NODE?
-                    # autodiff compositions must be passed extra inputs
-                    pytorch_enabled = False
-                    if hasattr(node, "pytorch_representation"):
-                        if node.learning_enabled:
-                            pytorch_enabled = True
-                    # Autodiff execution
-                    if pytorch_enabled:
-                        ret = node.execute(inputs=autodiff_stimuli[node],
-                                           context=context)
-                    # Standard execution
-                    else:
-                        ret = node.execute(context=context)
+                    ret = node.execute(context=context)
 
                     if is_simulating:
                         context.add_flag(ContextFlags.SIMULATION)
@@ -7493,7 +7480,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         context.remove_flag(ContextFlags.PROCESSING)
 
         # Update matrix parameter of PathwayProjections being learned with learning_enabled==AFTER
-        if self._is_learning(context):
+        from psyneulink.library.compositions.autodiffcomposition import AutodiffComposition
+        if self._is_learning(context) and not isinstance(self, AutodiffComposition):
             context.add_flag(ContextFlags.LEARNING)
             for projection in [p for p in self.projections if
                                hasattr(p, 'has_learning_projection') and p.has_learning_projection]:

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6432,6 +6432,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             reinitialize_nodes_when=Never(),
             runtime_params=None,
             skip_initialization=False,
+            skip_analyze_graph=False,
             animate=False,
             context=None,
             base_context=Context(execution_id=None),
@@ -6647,15 +6648,18 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         #      THIS IS NEEDED HERE (AND NO LATER) TO WORK WITH test_3_mechanisms_2_origins_1_additive_control_1_terminal
         # If a scheduler was passed in, first call _analyze_graph with default scheduler
         if scheduler is not self.scheduler:
-            self._analyze_graph(context=context)
+            if not skip_analyze_graph:
+                self._analyze_graph(context=context)
         # Then call _analyze graph with scheduler actually being used (passed in or default)
         try:
             if ContextFlags.SIMULATION not in context.execution_phase:
-                self._analyze_graph(scheduler=scheduler, context=context)
+                if not skip_analyze_graph:
+                    self._analyze_graph(scheduler=scheduler, context=context)
         except AttributeError:
             # if context is None, it has not been created for this context yet,
             # so it is not in a simulation
-            self._analyze_graph(scheduler=scheduler, context=context)
+            if not skip_analyze_graph:
+                self._analyze_graph(scheduler=scheduler, context=context)
         # MODIFIED 8/27/19 END
 
         # set auto logging if it's not already set, and if log argument is True

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -7541,17 +7541,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         context.remove_flag(ContextFlags.PROCESSING)
 
-        # Update matrix parameter of PathwayProjections being learned with learning_enabled==AFTER
-        from psyneulink.library.compositions.autodiffcomposition import AutodiffComposition
-        if self._is_learning(context) and not isinstance(self, AutodiffComposition):
-            context.add_flag(ContextFlags.LEARNING)
-            for projection in [p for p in self.projections if
-                               hasattr(p, 'has_learning_projection') and p.has_learning_projection]:
-                matrix_parameter_port = projection.parameter_ports[MATRIX]
-                if any([lp for lp in matrix_parameter_port.mod_afferents if lp.learning_enabled == AFTER]):
-                    matrix_parameter_port._update(context=context)
-            context.remove_flag(ContextFlags.LEARNING)
-
         if call_after_pass:
             call_with_pruned_args(call_after_pass, context=context)
 
@@ -7609,6 +7598,17 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             output_values.append(port.parameters.value._get(context))
 
         return output_values
+
+    def _update_learning_parameters(self, context):
+        # Update matrix parameter of PathwayProjections being learned with learning_enabled==AFTER
+        if self._is_learning(context):
+            context.add_flag(ContextFlags.LEARNING)
+            for projection in [p for p in self.projections if
+                                hasattr(p, 'has_learning_projection') and p.has_learning_projection]:
+                matrix_parameter_port = projection.parameter_ports[MATRIX]
+                if any([lp for lp in matrix_parameter_port.mod_afferents if lp.learning_enabled == AFTER]):
+                    matrix_parameter_port._update(context=context)
+            context.remove_flag(ContextFlags.LEARNING)
 
     @handle_external_context(execution_id=NotImplemented)
     def reinitialize(self, values, context=NotImplemented):

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6919,19 +6919,19 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
     @handle_external_context()
     def learn(
-            self, 
-            inputs: dict, 
-            targets: dict = None, 
-            num_trials: int = None, 
+            self,
+            inputs: dict,
+            targets: dict = None,
+            num_trials: int = None,
             epochs: int = 1,
             minibatch_size: int = 1,
             patience: int = None,
             min_delta: int = 0,
             context: Context = None,
-            bin_execute=False, 
+            bin_execute=False,
             randomize_minibatches=False,
             call_before_minibatch = None,
-            call_after_minibatch = None,):
+            call_after_minibatch = None):
         
         from psyneulink.library.compositions import CompositionRunner
         runner = CompositionRunner(self)
@@ -6940,16 +6940,16 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         context.add_flag(ContextFlags.LEARNING_MODE)
 
         learning_results = runner.run_learning(
-            inputs=inputs, 
-            targets=targets, 
-            num_trials=num_trials, 
-            epochs=epochs, 
-            minibatch_size=minibatch_size, 
-            patience=patience, 
-            min_delta=min_delta, 
+            inputs=inputs,
+            targets=targets,
+            num_trials=num_trials,
+            epochs=epochs,
+            minibatch_size=minibatch_size,
+            patience=patience,
+            min_delta=min_delta,
             randomize_minibatches=randomize_minibatches,
             call_before_minibatch=call_before_minibatch,
-            call_after_minibatch=call_after_minibatch, 
+            call_after_minibatch=call_after_minibatch,
             context=context,
             bin_execute=bin_execute)
         
@@ -7359,7 +7359,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
                     # Set to LEARNING if Mechanism receives any PathwayProjections that are being learned
                     #    for which learning_enabled == True or ONLINE (i.e., not False or AFTER)
-                    #    Implementation Note: RecurrentTransferMechanisms are special cased as the AutoAssociativeMechanism 
+                    #    Implementation Note: RecurrentTransferMechanisms are special cased as the AutoAssociativeMechanism
                     #    should be handling learning - not the RTM itself.
                     if self._is_learning(context) and not isinstance(node, RecurrentTransferMechanism):
                         projections = set(self.projections).intersection(set(node.path_afferents))

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6742,10 +6742,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             # Simulations are run as part of the controller node wrapper.
             assert not is_simulation
             try:
-                comp_ex_tags = frozenset({})
-                # Add learning tags if the composition is to be ran in learning mode
-                if self._is_learning(context):
-                    comp_ex_tags = comp_ex_tags.union(frozenset({"learning"}))
+                comp_ex_tags = frozenset({"learning"}) if self._is_learning(context) else frozenset()
                 if bin_execute is True or bin_execute.startswith('LLVM'):
                     _comp_ex = pnlvm.CompExecution(self, [context.execution_id], additional_tags=comp_ex_tags)
                     results += _comp_ex.run(inputs, num_trials, num_inputs_sets)

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6946,7 +6946,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             randomize_minibatches=randomize_minibatches,
             call_before_minibatch=call_before_minibatch,
             call_after_minibatch=call_after_minibatch, 
-            context=context)
+            context=context,
+            bin_execute=bin_execute)
         
         context.remove_flag(ContextFlags.LEARNING_MODE)
         return learning_results
@@ -7606,12 +7607,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     def _adjust_stimulus_dict(self, stimuli):
 
         autodiff_stimuli = {}
-        all_stimuli_keys = list(stimuli.keys())
-        for node in all_stimuli_keys:
-            if hasattr(node, "pytorch_representation"):
-                if node.learning_enabled:
-                    autodiff_stimuli[node] = stimuli[node]
-                    del stimuli[node]
 
         # STEP 1A: Check that all of the nodes listed in the inputs dict are INPUT nodes in the composition
         input_nodes = self.get_nodes_by_role(NodeRole.INPUT)

--- a/psyneulink/core/compositions/pathwaycomposition.py
+++ b/psyneulink/core/compositions/pathwaycomposition.py
@@ -80,7 +80,6 @@ class PathwayComposition(Composition):
     def execute(
         self,
         inputs=None,
-        autodiff_stimuli=None,
         scheduler=None,
         termination_processing=None,
         call_before_time_step=None,

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -298,15 +298,6 @@ class LLVMBuilderContext:
     def gen_autodiffcomp_learning_exec(self, composition, *, tags:frozenset):
         composition._build_pytorch_representation(composition.default_execution_id)
         pytorch_model = composition.parameters.pytorch_representation.get(composition.default_execution_id)
-        learning_struct_ty = pnlvm.ir.LiteralStructType((
-            self.int32_ty,
-            self.int32_ty,
-            pytorch_model._get_learning_struct_type(self).as_pointer(),
-        ))
-        args=[
-            learning_struct_ty.as_pointer(),
-            self.get_output_struct_type(composition).as_pointer()
-        ]
         with self._gen_composition_exec_context(composition, tags=tags) as (builder, data, params, cond_gen):
             state, _, comp_in, data, cond, = builder.function.args
             pytorch_model._gen_llvm_training_function_body(self, builder, state,

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -325,18 +325,9 @@ class LLVMBuilderContext:
         pytorch_model = composition.parameters.pytorch_representation.get(composition.default_execution_id)
         with self._gen_composition_exec_context(composition, tags=tags) as (builder, data, params, cond_gen):
             state, _, comp_in, _, cond = builder.function.args
-            # Call pytorch internal compiled llvm func
-            input_cim_idx = composition._get_node_index(composition.input_CIM)
-
-            # Extract the input that should be inserted into the model
-            model_input = builder.gep(data, [self.int32_ty(0),
-                                             self.int32_ty(0),
-                                             self.int32_ty(input_cim_idx)])
-            model_output = builder.gep(data, [self.int32_ty(0)])
 
             pytorch_forward_func = self.import_llvm_function(pytorch_model, tags=tags)
-            builder.call(pytorch_forward_func, [state, params,
-                                                model_input, model_output])
+            builder.call(pytorch_forward_func, [state, params, data])
 
             node_tags = tags.union({"node_wrapper"})
             # Call output CIM

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -309,13 +309,6 @@ class LLVMBuilderContext:
             builder.block.name = "invoke_" + output_cim_f.name
             builder.call(output_cim_f, [state, params, comp_in, data, data])
 
-            forward_tags = tags.difference({"learning"})
-
-            # Call output CIM
-            output_cim_f = self.import_llvm_function(composition.output_CIM,
-                                                     tags=node_tags)
-            builder.call(output_cim_f, [state, params, comp_in, data, data])
-
             return builder.function
 
     def gen_autodiffcomp_exec(self, composition, *, tags:frozenset):

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -269,7 +269,8 @@ class CompExecution(CUDAExecution):
     def _set_bin_node(self, node):
         assert node in self._composition._all_nodes
         wrapper = self._composition._get_node_wrapper(node)
-        self.__bin_func = pnlvm.LLVMBinaryFunction.from_obj(wrapper, tags=frozenset({"node_wrapper", *self.__additional_tags}))
+        tags = frozenset({"node_wrapper"}.union(self.__additional_tags))
+        self.__bin_func = pnlvm.LLVMBinaryFunction.from_obj(wrapper, tags=tags)
 
     @property
     def _conditions(self):
@@ -435,7 +436,7 @@ class CompExecution(CUDAExecution):
     @property
     def _bin_exec_func(self):
         if self.__bin_exec_func is None:
-            tags=frozenset({*self.__additional_tags})
+            tags=frozenset(self.__additional_tags)
             self.__bin_exec_func = pnlvm.LLVMBinaryFunction.from_obj(
                 self._composition, tags=tags)
 

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -269,7 +269,7 @@ class CompExecution(CUDAExecution):
     def _set_bin_node(self, node):
         assert node in self._composition._all_nodes
         wrapper = self._composition._get_node_wrapper(node)
-        tags = frozenset({"node_wrapper"}.union(self.__additional_tags))
+        tags = frozenset(self.__additional_tags.union({"node_wrapper"}))
         self.__bin_func = pnlvm.LLVMBinaryFunction.from_obj(wrapper, tags=tags)
 
     @property

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -317,7 +317,7 @@ class CompExecution(CUDAExecution):
         return self._get_compilation_param('parameter_struct', '_get_param_initializer', 1, self._execution_contexts[0])
 
     def _copy_params_to_pnl(self, context=None, component=None, params=None):
-        # need to special case compositions 
+        # need to special case compositions
         from psyneulink.core.compositions import Composition
         from psyneulink.core.components.projections.pathway import MappingProjection
 
@@ -327,7 +327,7 @@ class CompExecution(CUDAExecution):
         if params is None:
             assert component == self._composition
             params = self._param_struct
-            
+
         if isinstance(component, Composition):
             # first handle all inner projections
             params_projections_list = getattr(params, params._fields_[1][0])
@@ -347,11 +347,11 @@ class CompExecution(CUDAExecution):
                 parameter_ctype = getattr(params, params._fields_[idx][0])
                 value = _convert_ctype_to_python(parameter_ctype)
                 if attribute == 'matrix':
-                    # special case since we have to unflatten matrix 
+                    # special case since we have to unflatten matrix
                     # FIXME: this seems to break something when generalized for all attributes
                     value = np.array(value).reshape(component.matrix.shape)
                     to_set._set(value, context=context)
-                
+
     @property
     def _state_struct(self):
         if len(self._execution_contexts) > 1:

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -506,7 +506,7 @@ class CompExecution(CUDAExecution):
 
         return self.__bin_run_multi_func
 
-    def run(self, inputs, runs=0, num_input_sets=0, learning=False):
+    def run(self, inputs, runs=0, num_input_sets=0):
         if isgenerator(inputs):
             list_inputs = list(inputs)
             inputs = {k:[list(v)] for (k,v) in list_inputs[0].items()}

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -222,7 +222,7 @@ class MechExecution(FuncExecution):
 
 class CompExecution(CUDAExecution):
 
-    def __init__(self, composition, execution_ids=[None], additional_tags=[]):
+    def __init__(self, composition, execution_ids=[None], additional_tags=frozenset()):
         super().__init__(buffers=['state_struct', 'param_struct', 'data_struct', 'conditions'])
         self._composition = composition
         self._execution_contexts = [
@@ -235,7 +235,7 @@ class CompExecution(CUDAExecution):
         self.__bin_run_multi_func = None
         self.__debug_env = debug_env
         self.__frozen_vals = None
-        self.__additional_tags = additional_tags
+        self.__additional_tags = frozenset(additional_tags)
 
         # TODO: Consolidate these
         if len(execution_ids) > 1:
@@ -520,8 +520,9 @@ class CompExecution(CUDAExecution):
     @property
     def _bin_run_func(self):
         if self.__bin_run_func is None:
+            run_tags = frozenset({"run"}.union(self.__additional_tags))
             self.__bin_run_func = pnlvm.LLVMBinaryFunction.from_obj(
-                self._composition, tags=frozenset({"run", *self.__additional_tags}))
+                self._composition, tags=run_tags)
 
         return self.__bin_run_func
 

--- a/psyneulink/library/components/mechanisms/modulatory/learning/autoassociativelearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/learning/autoassociativelearningmechanism.py
@@ -434,7 +434,7 @@ class AutoAssociativeLearningMechanism(LearningMechanism):
 
         super()._update_output_ports(context, runtime_params)
         from psyneulink.core.components.process import Process
-        if self.parameters.learning_enabled._get(context) and context.composition and not isinstance(context.composition, Process) and ContextFlags.LEARNING_MODE in context.runmode:
+        if self.parameters.learning_enabled._get(context) and context.composition and not isinstance(context.composition, Process):
             learned_projection = self.activity_source.recurrent_projection
             old_exec_phase = context.execution_phase
             context.execution_phase = ContextFlags.LEARNING

--- a/psyneulink/library/components/mechanisms/modulatory/learning/autoassociativelearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/learning/autoassociativelearningmechanism.py
@@ -433,9 +433,8 @@ class AutoAssociativeLearningMechanism(LearningMechanism):
         """
 
         super()._update_output_ports(context, runtime_params)
-
         from psyneulink.core.components.process import Process
-        if self.parameters.learning_enabled._get(context) and context.composition and not isinstance(context.composition, Process):
+        if self.parameters.learning_enabled._get(context) and context.composition and not isinstance(context.composition, Process) and ContextFlags.LEARNING_MODE in context.runmode:
             learned_projection = self.activity_source.recurrent_projection
             old_exec_phase = context.execution_phase
             context.execution_phase = ContextFlags.LEARNING

--- a/psyneulink/library/components/mechanisms/modulatory/learning/kohonenlearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/learning/kohonenlearningmechanism.py
@@ -416,7 +416,7 @@ class KohonenLearningMechanism(LearningMechanism):
 
         super()._update_output_ports(context, runtime_params)
 
-        if context.composition is not None:
+        if context.composition is not None and ContextFlags.LEARNING_MODE in context.runmode:
             context.add_flag(ContextFlags.LEARNING)
             self.learned_projection.execute(context=context)
             context.remove_flag(ContextFlags.LEARNING)

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -478,7 +478,6 @@ class AutodiffComposition(Composition):
                  patience=None,
                  min_delta=0,
                  learning_rate=None,
-                 learning_enabled=True,
                  optimizer_type='sgd',
                  weight_decay=0,
                  loss_spec='mse',
@@ -497,13 +496,11 @@ class AutodiffComposition(Composition):
                                                   patience = patience,
                                                   min_delta = min_delta,
                                                   learning_rate = learning_rate,
-                                                  learning_enabled = learning_enabled,
                                                   optimizer_type = optimizer_type,
                                                   weight_decay = weight_decay,
                                                   loss_spec = loss_spec,
                                                   randomize = randomize)
 
-        self.learning_enabled = learning_enabled
         self.optimizer_type = optimizer_type
         self.loss_spec = loss_spec
         self.randomize = randomize
@@ -623,25 +620,6 @@ class AutodiffComposition(Composition):
     def _has_required_keys(self, input_dict):
         required_keys = {"inputs", "targets"}
         return required_keys.issubset(set(input_dict.keys()))
-
-    # def _adjust_stimulus_dict(self, inputs):
-    #     if self.learning_enabled:
-    #         if isinstance(inputs, dict):
-    #             if self._has_required_keys(inputs):
-    #                 return inputs
-    #             raise AutodiffCompositionError("Invalid input specification.")
-    #         elif isinstance(inputs, list):
-    #             for input_dict in inputs:
-    #                 if not self._has_required_keys(input_dict):
-    #                     raise AutodiffCompositionError("Invalid input specification.")
-    #             return inputs
-
-    #     # If learning is disabled, but inputs are provided in the same format as used for learning,
-    #     #    ignore dict in "targets" entry, and pass dict in "inputs" entry along as inputs
-    #     elif isinstance(inputs, dict) and "inputs" in inputs.keys():
-    #         inputs = inputs["inputs"]
-
-    #     return super(AutodiffComposition, self)._adjust_stimulus_dict(inputs)
 
     # performs forward computation for one input
     def autodiff_processing(self, inputs, context=None, do_logging=False, scheduler=None):

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -733,7 +733,7 @@ class AutodiffComposition(Composition):
             elif "learning" in tags:
                 return ctx.gen_autodiffcomp_learning_exec(self, tags=tags)
             else:
-                return ctx.gen_composition_exec(self, tags=tags)
+                return ctx.gen_autodiffcomp_exec(self, tags=tags)
 
     def _infer_output_nodes(self, nodes: dict):
         """

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -816,7 +816,6 @@ class AutodiffComposition(Composition):
                 runtime_params=None,
                 bin_execute=False,
                 skip_initialization=False,
-                learning_mode=False,
                 ):
         self._assign_execution_ids(context)
         context.composition = self
@@ -825,7 +824,7 @@ class AutodiffComposition(Composition):
         if scheduler is None:
             scheduler = self.scheduler
 
-        if self.learning_enabled:
+        if self._is_learning(context):
             # TBI: How are we supposed to use base_context and statefulness here?
             # TBI: can we call _build_pytorch_representation in _analyze_graph so that pytorch
             # model may be modified between runs?

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -777,7 +777,6 @@ class AutodiffComposition(Composition):
     @handle_external_context()
     def execute(self,
                 inputs=None,
-                autodiff_stimuli=None,
                 num_trials=None,
                 minibatch_size=1,
                 do_logging=False,

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -505,7 +505,7 @@ class AutodiffComposition(Composition):
         self.loss_spec = loss_spec
         self.randomize = randomize
         self.refresh_losses = refresh_losses
-
+        self._built_pathways = False
         self.weight_decay = weight_decay
         self.force_no_retain_graph = force_no_retain_graph
         self.loss = None
@@ -773,7 +773,13 @@ class AutodiffComposition(Composition):
             if NodeRole.INPUT in self.get_roles_by_node(node) and not NodeRole.TARGET in self.get_roles_by_node(node):
                 ret[node] = values
         return ret
-
+    
+    def learn(self, *args, **kwargs):
+        if self._built_pathways is False:
+            self.infer_backpropagation_learning_pathways()
+            self._built_pathways = True
+        return super().learn(*args, **kwargs)
+        
     @handle_external_context()
     def execute(self,
                 inputs=None,

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -321,7 +321,7 @@ class AutodiffComposition(Composition):
 
     learning_rate : float : default 0.001
         the learning rate, which is passed to the optimizer.
-    
+
     disable_learning : bool: default False
         specifies whether the AutodiffComposition should disable learning (default is False). When False,
         the AutodiffComposition trains using PyTorch when ran in `learning mode <Composition.learn>`. When True, the AutodiffComposition runs like an ordinary
@@ -433,10 +433,10 @@ class AutodiffComposition(Composition):
         self.disable_learning = disable_learning
         # user indication of how to initialize pytorch parameters
         self.param_init_from_pnl = param_init_from_pnl
-        
+
         if param_init_from_pnl is False:
             warnings.warn("WARNING: Autodiffcomposition.param_init_from_pnl is deprecated! Please do not use it!")
-            
+
         # keeps track of average loss per epoch
         self.losses = []
 
@@ -483,7 +483,7 @@ class AutodiffComposition(Composition):
             self.loss = self.loss_spec
         else:
             self.loss = self._get_loss(self.loss_spec)
-        
+
         return self.parameters.pytorch_representation._get(context)
 
     def _make_optimizer(self, optimizer_type, learning_rate, weight_decay, context):
@@ -646,7 +646,7 @@ class AutodiffComposition(Composition):
                 return ctx.gen_autodiffcomp_exec(self, tags=tags)
 
     def _get_total_loss(self, num_trials: int=1, context:Context=None):
-        return sum(self.parameters.trial_losses._get(context)[-num_trials:])/num_trials
+        return sum(self.parameters.trial_losses._get(context)[-num_trials:]) /num_trials
 
     def _infer_output_nodes(self, nodes: dict):
         """
@@ -663,16 +663,16 @@ class AutodiffComposition(Composition):
                 comparators = [x for x in node_efferent_mechanisms if (isinstance(x, ComparatorMechanism) and NodeRole.LEARNING in self.get_roles_by_node(x))]
                 comparator_afferent_mechanisms = [x.sender.owner for c in comparators for x in c.afferents]
                 output_nodes = [t for t in comparator_afferent_mechanisms if (NodeRole.OUTPUT in self.get_roles_by_node(t) and NodeRole.LEARNING not in self.get_roles_by_node(t))]
-                
+
                 if len(output_nodes) != 1:
                     # Invalid specification! Either we have no valid target nodes, or there is ambiguity in which target node to choose
                     raise Exception(f"Unable to infer learning target node from output node {node}!")
-                
+
                 ret[output_nodes[0]] = values
             elif NodeRole.OUTPUT in self.get_roles_by_node(node):
                 ret[node] = values
         return ret
-    
+
     def _infer_input_nodes(self, nodes: dict):
         """
         Maps targets onto target mechanisms (as needed by learning)
@@ -686,13 +686,13 @@ class AutodiffComposition(Composition):
             if NodeRole.INPUT in self.get_roles_by_node(node) and not NodeRole.TARGET in self.get_roles_by_node(node):
                 ret[node] = values
         return ret
-    
+
     def learn(self, *args, **kwargs):
         if self._built_pathways is False:
             self.infer_backpropagation_learning_pathways()
             self._built_pathways = True
         return super().learn(*args, **kwargs)
-        
+
     @handle_external_context()
     def execute(self,
                 inputs=None,
@@ -739,7 +739,7 @@ class AutodiffComposition(Composition):
                                             scheduler)
 
             context.add_flag(ContextFlags.PROCESSING)
-            
+
             self.output_CIM.execute(output[-1], context=context)
             context.remove_flag(ContextFlags.PROCESSING)
 
@@ -843,7 +843,7 @@ class AutodiffComposition(Composition):
         weights = pytorch_representation.get_weights_for_projections()
 
         return weights
-    
+
     def _get_state_struct_type(self, ctx):
         """Gets state struct for compiled autodiff"""
         node_state_type_list = (ctx.get_state_struct_type(m) for m in self._all_nodes)

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -176,12 +176,11 @@ simple AutodiffComposition, specify its inputs and targets, and run it with lear
 # ~~~~~~~
 
 # Logging in AutodiffCompositions follows the same procedure as logging in a `Composition`. However, there are some small gotchas to be aware of;
-# Since an AutodiffComposition internally converts all of its mechanisms to an equivalent PyTorch model, 
+# Since an AutodiffComposition internally converts all of its mechanisms to an equivalent PyTorch model,
 # then its inner components are not actually executed. This means that there is limited support for logging parameters of components inside an AutodiffComposition;
 # As of present, the ones that are supported are:
 # 1) the `matrix` parameter of Projections
 # 2) the `value` parameter of its inner components
-# 
 
 .. _AutodiffComposition_Nested_Execution:
 
@@ -405,7 +404,7 @@ class AutodiffComposition(Composition):
 
         # keeps track of average loss per epoch
         self.losses = []
-        
+
         # ordered execution sets for the pytorch model
         self.execution_sets = None
 
@@ -506,7 +505,7 @@ class AutodiffComposition(Composition):
         if tracked_loss is None:
             self.parameters.tracked_loss._set(torch.zeros(1, device=self.device).double(), context=context, skip_history=True, skip_log=True)
             tracked_loss = self.parameters.tracked_loss._get(context)
-            
+
         curr_tensor_inputs = {}
         curr_tensor_targets = {}
         for component in inputs.keys():
@@ -534,7 +533,7 @@ class AutodiffComposition(Composition):
             assert (len(input_port.all_afferents) == 1)  # CW 12/05/18, this assert may eventually be outdated
             component = input_port.all_afferents[0].sender.owner
             outputs.append(curr_tensor_outputs[component].detach().cpu().numpy().copy())
-        
+
         self.parameters.tracked_loss_count._set(self.parameters.tracked_loss_count._get(context=context) + 1, context=context, skip_history=True, skip_log=True)
         return outputs
 

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -709,6 +709,7 @@ class AutodiffComposition(Composition):
 
         # backpropagate to compute gradients and perform learning update for parameters
         optimizer.zero_grad()
+        self.parameters.trial_losses._set(curr_loss.detach().numpy(), context)
         curr_loss = curr_loss / num_inputs
         printable = {}
         for component in curr_tensor_outputs.keys():
@@ -734,6 +735,9 @@ class AutodiffComposition(Composition):
                 return ctx.gen_autodiffcomp_learning_exec(self, tags=tags)
             else:
                 return ctx.gen_autodiffcomp_exec(self, tags=tags)
+
+    def _get_total_loss(self, num_trials: int=1, context:Context=None):
+        return sum(self.parameters.trial_losses._get(context)[-num_trials:])/num_trials
 
     def _infer_output_nodes(self, nodes: dict):
         """

--- a/psyneulink/library/compositions/compiledoptimizer.py
+++ b/psyneulink/library/compositions/compiledoptimizer.py
@@ -117,143 +117,143 @@ class AdamOptimizer(Optimizer):
                 ctx.get_param_struct_type(self._composition).as_pointer()]
         builder = ctx.create_llvm_function(args, self, name)
         llvm_func = builder.function
-        # optim_struct, params = llvm_func.args
+        optim_struct, params = llvm_func.args
 
-        # # setup values
-        # zero = ctx.int32_ty(0)
-        # one_float = ctx.float_ty(1)
+        # setup values
+        zero = ctx.int32_ty(0)
+        one_float = ctx.float_ty(1)
 
-        # delta_w = builder.gep(optim_struct, [zero, ctx.int32_ty(self._DELTA_W_NUM)])
-        # m_t = builder.gep(optim_struct, [zero, ctx.int32_ty(self._M_T_NUM)])
-        # v_t = builder.gep(optim_struct, [zero, ctx.int32_ty(self._V_T_NUM)])
-        # t = builder.gep(optim_struct, [zero, ctx.int32_ty(self._T_NUM)])
+        delta_w = builder.gep(optim_struct, [zero, ctx.int32_ty(self._DELTA_W_NUM)])
+        m_t = builder.gep(optim_struct, [zero, ctx.int32_ty(self._M_T_NUM)])
+        v_t = builder.gep(optim_struct, [zero, ctx.int32_ty(self._V_T_NUM)])
+        t = builder.gep(optim_struct, [zero, ctx.int32_ty(self._T_NUM)])
 
-        # # get methods needed
-        # pow = ctx.import_llvm_function("__pnl_builtin_pow")
-        # sqrt = ctx.get_builtin("sqrt", [ctx.float_ty])
+        # get methods needed
+        pow = ctx.import_llvm_function("__pnl_builtin_pow")
+        sqrt = ctx.get_builtin("sqrt", [ctx.float_ty])
 
-        # lr = ctx.float_ty(self.lr)
-        # eps = ctx.float_ty(self.eps)
-        # b1 = ctx.float_ty(self.betas[0])
-        # b2 = ctx.float_ty(self.betas[1])
-        # one_minus_b1 = builder.fsub(one_float, b1)
-        # one_minus_b2 = builder.fsub(one_float, b2)
+        lr = ctx.float_ty(self.lr)
+        eps = ctx.float_ty(self.eps)
+        b1 = ctx.float_ty(self.betas[0])
+        b2 = ctx.float_ty(self.betas[1])
+        one_minus_b1 = builder.fsub(one_float, b1)
+        one_minus_b2 = builder.fsub(one_float, b2)
 
-        # # 1) increment t
-        # builder.store(builder.fadd(builder.load(t), one_float), t)
-        # t_val = builder.load(t)
-        # # 1.5) calculate values to be used later (based on incremented t)
-        # b1_pow = builder.call(pow, [b1, t_val])
-        # b2_pow = builder.call(pow, [b2, t_val])
-        # one_minus_b1_pow = builder.fsub(one_float, b1_pow)
-        # one_minus_b2_pow = builder.fsub(one_float, b2_pow)
+        # 1) increment t
+        builder.store(builder.fadd(builder.load(t), one_float), t)
+        t_val = builder.load(t)
+        # 1.5) calculate values to be used later (based on incremented t)
+        b1_pow = builder.call(pow, [b1, t_val])
+        b2_pow = builder.call(pow, [b2, t_val])
+        one_minus_b1_pow = builder.fsub(one_float, b1_pow)
+        one_minus_b2_pow = builder.fsub(one_float, b2_pow)
         
-        # pnlvm.helpers.printf(
-        #         builder, f"%f b1_pow_sub %f\nb2 pow sub %f\n",t_val, one_minus_b1_pow, one_minus_b2_pow)
-        # alpha_mult = builder.call(sqrt, [one_minus_b2_pow])
-        # pnlvm.helpers.printf(
-        #         builder, f"%f\n",alpha_mult)
-        # alpha_mult = builder.fdiv(alpha_mult, one_minus_b1_pow)
+        pnlvm.helpers.printf(
+                builder, f"%f b1_pow_sub %f\nb2 pow sub %f\n",t_val, one_minus_b1_pow, one_minus_b2_pow)
+        alpha_mult = builder.call(sqrt, [one_minus_b2_pow])
+        pnlvm.helpers.printf(
+                builder, f"%f\n",alpha_mult)
+        alpha_mult = builder.fdiv(alpha_mult, one_minus_b1_pow)
 
-        # # this is the new learning rate to use
-        # alpha_t = builder.fmul(alpha_mult, lr)
+        # this is the new learning rate to use
+        alpha_t = builder.fmul(alpha_mult, lr)
 
-        # gradient_struct_values = self._get_listof_gradient_struct_values()
+        gradient_struct_values = self._get_listof_gradient_struct_values()
 
-        # # 2) update first moments
-        # for (node, node_idx, afferent_node, afferent_node_index, matrix, weights_dim_x, weights_dim_y) in gradient_struct_values:
-        #     pnlvm.helpers.printf(
-        #         builder, f"\t\t\t\tOPTIM UPDATE FIRST MOMENT {afferent_node.name} {node.name}\n")
+        # 2) update first moments
+        for (node, node_idx, afferent_node, afferent_node_index, matrix, weights_dim_x, weights_dim_y) in gradient_struct_values:
+            pnlvm.helpers.printf(
+                builder, f"\t\t\t\tOPTIM UPDATE FIRST MOMENT {afferent_node.name} {node.name}\n")
 
-        #     node_idx_ir = ctx.int32_ty(node_idx)
-        #     afferent_node_index_ir = ctx.int32_ty(afferent_node_index)
+            node_idx_ir = ctx.int32_ty(node_idx)
+            afferent_node_index_ir = ctx.int32_ty(afferent_node_index)
 
-        #     m_t_ptr = builder.gep(
-        #         m_t, [zero, node_idx_ir, afferent_node_index_ir])
-        #     delta_w_ptr = builder.gep(
-        #         delta_w, [zero, node_idx_ir, afferent_node_index_ir])
+            m_t_ptr = builder.gep(
+                m_t, [zero, node_idx_ir, afferent_node_index_ir])
+            delta_w_ptr = builder.gep(
+                delta_w, [zero, node_idx_ir, afferent_node_index_ir])
 
-        #     # m_t = m_t * b1
-        #     gen_inject_mat_scalar_mult(ctx, builder, m_t_ptr, b1, m_t_ptr)
+            # m_t = m_t * b1
+            gen_inject_mat_scalar_mult(ctx, builder, m_t_ptr, b1, m_t_ptr)
 
-        #     # (1 - b1)*g_t
-        #     tmp_val = gen_inject_mat_scalar_mult(ctx, builder, delta_w_ptr, one_minus_b1)
+            # (1 - b1)*g_t
+            tmp_val = gen_inject_mat_scalar_mult(ctx, builder, delta_w_ptr, one_minus_b1)
 
-        #     # m_t = m_t + (1-b1)*g_t
-        #     gen_inject_mat_add(ctx, builder, m_t_ptr, tmp_val, m_t_ptr)
+            # m_t = m_t + (1-b1)*g_t
+            gen_inject_mat_add(ctx, builder, m_t_ptr, tmp_val, m_t_ptr)
 
-        # # 3) update second moments
-        # for (node, node_idx, afferent_node, afferent_node_index, matrix, weights_dim_x, weights_dim_y) in gradient_struct_values:
-        #     pnlvm.helpers.printf(
-        #         builder, f"\t\t\t\tOPTIM UPDATE SECOND MOMENT {afferent_node.name} {node.name}\n")
+        # 3) update second moments
+        for (node, node_idx, afferent_node, afferent_node_index, matrix, weights_dim_x, weights_dim_y) in gradient_struct_values:
+            pnlvm.helpers.printf(
+                builder, f"\t\t\t\tOPTIM UPDATE SECOND MOMENT {afferent_node.name} {node.name}\n")
 
-        #     node_idx_ir = ctx.int32_ty(node_idx)
-        #     afferent_node_index_ir = ctx.int32_ty(afferent_node_index)
+            node_idx_ir = ctx.int32_ty(node_idx)
+            afferent_node_index_ir = ctx.int32_ty(afferent_node_index)
 
-        #     v_t_ptr = builder.gep(
-        #         v_t, [zero, node_idx_ir, afferent_node_index_ir])
-        #     delta_w_ptr = builder.gep(
-        #         delta_w, [zero, node_idx_ir, afferent_node_index_ir])
+            v_t_ptr = builder.gep(
+                v_t, [zero, node_idx_ir, afferent_node_index_ir])
+            delta_w_ptr = builder.gep(
+                delta_w, [zero, node_idx_ir, afferent_node_index_ir])
 
-        #     # v_t = v_t * b2
-        #     gen_inject_mat_scalar_mult(ctx, builder, v_t_ptr, b2, v_t_ptr)
+            # v_t = v_t * b2
+            gen_inject_mat_scalar_mult(ctx, builder, v_t_ptr, b2, v_t_ptr)
 
-        #     # g_t * g_t
-        #     delta_w_sqrd = gen_inject_mat_hadamard(ctx, builder, delta_w_ptr, delta_w_ptr)
+            # g_t * g_t
+            delta_w_sqrd = gen_inject_mat_hadamard(ctx, builder, delta_w_ptr, delta_w_ptr)
 
-        #     # (1-b2)*(g_t)^2
-        #     gen_inject_mat_scalar_mult(ctx, builder, delta_w_sqrd, one_minus_b2, delta_w_sqrd)
+            # (1-b2)*(g_t)^2
+            gen_inject_mat_scalar_mult(ctx, builder, delta_w_sqrd, one_minus_b2, delta_w_sqrd)
 
-        #     # v_t = v_t + (1-b2)*(g_t)^2
-        #     gen_inject_mat_add(ctx, builder, v_t_ptr, delta_w_sqrd, v_t_ptr)
+            # v_t = v_t + (1-b2)*(g_t)^2
+            gen_inject_mat_add(ctx, builder, v_t_ptr, delta_w_sqrd, v_t_ptr)
 
-        # # 4) update weights
+        # 4) update weights
 
-        # for (node, node_idx, afferent_node, afferent_node_index, matrix, weights_dim_x, weights_dim_y) in gradient_struct_values:
-        #     node_idx_ir = ctx.int32_ty(node_idx)
-        #     afferent_node_index_ir = ctx.int32_ty(afferent_node_index)
+        for (node, node_idx, afferent_node, afferent_node_index, matrix, weights_dim_x, weights_dim_y) in gradient_struct_values:
+            node_idx_ir = ctx.int32_ty(node_idx)
+            afferent_node_index_ir = ctx.int32_ty(afferent_node_index)
             
-        #     m_t_ptr = builder.gep(
-        #         m_t, [zero, node_idx_ir, afferent_node_index_ir])
-        #     v_t_ptr = builder.gep(
-        #         v_t, [zero, node_idx_ir, afferent_node_index_ir])
-        #     delta_w_ptr = builder.gep(
-        #         delta_w, [zero, node_idx_ir, afferent_node_index_ir])
-        #     # this is messy - #TODO - cleanup this
-        #     weights_llvmlite, weights_dim_x, weights_dim_y = self._pytorch_model._gen_get_node_weight_ptr(
-        #         ctx, builder, params, node, afferent_node)
-        #     pnlvm.helpers.printf(
-        #         builder, f"OPTIM UPDATE WEIGHTS {afferent_node.name} {node.name}\n",override_debug=False)
-        #     weight_row = None
-        #     with pnlvm.helpers.for_loop_zero_inc(builder, ctx.int32_ty(weights_dim_x), "optimizer_w_upd_outer") as (b1, weight_row):
-        #         weight_column = None
-        #         with pnlvm.helpers.for_loop_zero_inc(b1, ctx.int32_ty(weights_dim_y), "optimizer_w_upd_inner") as (b2, weight_column):
-        #             # sqrt(v_t) + eps
-        #             v_t_value = b2.load(b2.gep(
-        #                 v_t_ptr, [zero, weight_row, weight_column]))
-        #             value = b2.call(sqrt, [v_t_value])
-        #             value = b2.fadd(value, eps)
+            m_t_ptr = builder.gep(
+                m_t, [zero, node_idx_ir, afferent_node_index_ir])
+            v_t_ptr = builder.gep(
+                v_t, [zero, node_idx_ir, afferent_node_index_ir])
+            delta_w_ptr = builder.gep(
+                delta_w, [zero, node_idx_ir, afferent_node_index_ir])
+            # this is messy - #TODO - cleanup this
+            weights_llvmlite, weights_dim_x, weights_dim_y = self._pytorch_model._gen_get_node_weight_ptr(
+                ctx, builder, params, node, afferent_node)
+            pnlvm.helpers.printf(
+                builder, f"OPTIM UPDATE WEIGHTS {afferent_node.name} {node.name}\n",override_debug=False)
+            weight_row = None
+            with pnlvm.helpers.for_loop_zero_inc(builder, ctx.int32_ty(weights_dim_x), "optimizer_w_upd_outer") as (b1, weight_row):
+                weight_column = None
+                with pnlvm.helpers.for_loop_zero_inc(b1, ctx.int32_ty(weights_dim_y), "optimizer_w_upd_inner") as (b2, weight_column):
+                    # sqrt(v_t) + eps
+                    v_t_value = b2.load(b2.gep(
+                        v_t_ptr, [zero, weight_row, weight_column]))
+                    value = b2.call(sqrt, [v_t_value])
+                    value = b2.fadd(value, eps)
 
-        #             # alpha_t * m_t
-        #             m_t_value = b2.load(b2.gep(
-        #                 m_t_ptr, [zero, weight_row, weight_column]))
-        #             m_t_value = b2.fmul(alpha_t, m_t_value)
+                    # alpha_t * m_t
+                    m_t_value = b2.load(b2.gep(
+                        m_t_ptr, [zero, weight_row, weight_column]))
+                    m_t_value = b2.fmul(alpha_t, m_t_value)
 
-        #             # value = alpha_t * m_t / (sqrt(v_t) + eps)
-        #             value = b2.fdiv(m_t_value, value)
+                    # value = alpha_t * m_t / (sqrt(v_t) + eps)
+                    value = b2.fdiv(m_t_value, value)
 
-        #             old_weight_ptr = b2.gep(
-        #                 weights_llvmlite, [zero, weight_row, weight_column])
+                    old_weight_ptr = b2.gep(
+                        weights_llvmlite, [zero, weight_row, weight_column])
                     
-        #             # new_weight = old_weight - value
-        #             value = b2.fsub(b2.load(old_weight_ptr), value)
-        #             b2.store(value, old_weight_ptr)
+                    # new_weight = old_weight - value
+                    value = b2.fsub(b2.load(old_weight_ptr), value)
+                    b2.store(value, old_weight_ptr)
 
-        #             delta_w_val = b2.load(b2.gep(delta_w_ptr,[zero, weight_row, weight_column]))
-        #             pnlvm.helpers.printf(b2,"%f ",delta_w_val,override_debug=False)
-        #         pnlvm.helpers.printf(b1,"\n",override_debug=False)
+                    delta_w_val = b2.load(b2.gep(delta_w_ptr,[zero, weight_row, weight_column]))
+                    pnlvm.helpers.printf(b2,"%f ",delta_w_val,override_debug=False)
+                pnlvm.helpers.printf(b1,"\n",override_debug=False)
                 
-        # pnlvm.helpers.printf(builder, f"\t\t\tOPTIM DONE UPDATE\n",override_debug=False)
+        pnlvm.helpers.printf(builder, f"\t\t\tOPTIM DONE UPDATE\n",override_debug=False)
 
         builder.ret_void()
 

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -61,7 +61,7 @@ class CompositionRunner():
 
         Returns
         ---------
-        Dict mapping mechanisms to values (with TargetMechanisms inferred if needed)
+        Dict mapping mechanisms to values (with TargetMechanisms inferred from output nodes if needed)
         """
         # 1) Convert from key-value representation of values into separated representation
         if 'targets' in inputs:
@@ -74,7 +74,10 @@ class CompositionRunner():
         if targets is not None:
             targets = self._infer_target_nodes(targets)
             inputs = _recursive_update(inputs, targets)
-
+        
+        # 3) Resize inputs to be of the form [[[]]],
+        # where each level corresponds to: <TRIALS <PORTS <INPUTS> > >
+        inputs,_,_ = self._composition._adjust_stimulus_dict(inputs)
         return inputs
 
     def _infer_target_nodes(self, targets: dict):
@@ -132,7 +135,6 @@ class CompositionRunner():
         ---------
         Outputs from the final execution
         """
-
         # Handle function and generator inputs
         if callable(inputs):
             inputs = inputs()
@@ -179,7 +181,7 @@ class CompositionRunner():
                     if call_before_minibatch is not None:
                         call_before_minibatch()
 
-                    minibatch_results = self._composition.run(inputs=minibatch, skip_initialization=skip_initialization, context=context, skip_analyze_graph=skip_initialization)
+                    minibatch_results = self._composition.run(inputs=minibatch, skip_initialization=skip_initialization, context=context, skip_analyze_graph=True)
                     skip_initialization = True
                     results.extend(minibatch_results)
 

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -184,7 +184,7 @@ class CompositionRunner():
             self._composition.run(inputs=minibatched_input, skip_initialization=skip_initialization, context=context, skip_analyze_graph=True, bin_execute=bin_execute)
             skip_initialization = True
 
-            results = [x for x in self._composition.parameters.results.get(context)[-1 * num_trials * minibatch_size:]] # return results from last epoch
+            results = [x[0] for x in self._composition.parameters.results.get(context)[-1 * num_trials * minibatch_size:]] # return results from last epoch
             
         return results
 class EarlyStopping(object):

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -162,7 +162,6 @@ class CompositionRunner():
         elif epochs is None:
             epochs = inf_yield_none()
 
-        results = []
         for stim_input, stim_target, stim_epoch in zip(inputs, targets, epochs):
             if 'epochs' in stim_input:
                 stim_epoch = stim_input['epochs']
@@ -184,8 +183,12 @@ class CompositionRunner():
             self._composition.run(inputs=minibatched_input, skip_initialization=skip_initialization, context=context, skip_analyze_graph=True, bin_execute=bin_execute)
             skip_initialization = True
 
+        # FIXME: compiled run values differ from pytorch run 
+        if bin_execute is not False:
+            results = [x for x in self._composition.parameters.results.get(context)[-1 * num_trials * minibatch_size:]] # return results from last epoch
+        else:
             results = [x[0] for x in self._composition.parameters.results.get(context)[-1 * num_trials * minibatch_size:]] # return results from last epoch
-            
+
         return results
 class EarlyStopping(object):
     def __init__(self, mode='min', min_delta=0, patience=10):

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -183,7 +183,7 @@ class CompositionRunner():
             self._composition.run(inputs=minibatched_input, skip_initialization=skip_initialization, context=context, skip_analyze_graph=True, bin_execute=bin_execute)
             skip_initialization = True
 
-        # FIXME: compiled run values differ from pytorch run 
+        # FIXME: compiled run values differ from pytorch run
         if bin_execute is not False and bin_execute != 'Python':
             results = [x for x in self._composition.parameters.results.get(context)[-1 * num_trials * minibatch_size:]] # return results from last epoch
         else:

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -80,7 +80,7 @@ class CompositionRunner():
         
         # 3) Resize inputs to be of the form [[[]]],
         # where each level corresponds to: <TRIALS <PORTS <INPUTS> > >
-        inputs,_,_ = self._composition._adjust_stimulus_dict(inputs)
+        inputs,_ = self._composition._adjust_stimulus_dict(inputs)
         return inputs
 
     def _infer_target_nodes(self, targets: dict):

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -178,7 +178,7 @@ class CompositionRunner():
             if minibatch_size == TRAINING_SET:
                 minibatch_size = num_trials
 
-            if patience is not None:
+            if patience is not None and (bin_execute is False or bin_execute == 'Python'):
                 early_stopper = EarlyStopping(min_delta=min_delta, patience=patience)
 
             minibatched_input = _batch_inputs(stim_input, stim_epoch, num_trials, minibatch_size, randomize_minibatches, call_before_minibatch=call_before_minibatch, call_after_minibatch=call_after_minibatch)

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -131,7 +131,9 @@ class CompositionRunner():
                      call_before_minibatch = None,
                      call_after_minibatch = None,
                      context=None,
-                     bin_execute=False):
+                     bin_execute=False,
+                     *args,
+                     **kwargs):
         """
         Runs the composition repeatedly with the specified parameters
 
@@ -162,6 +164,8 @@ class CompositionRunner():
         elif epochs is None:
             epochs = inf_yield_none()
 
+        skip_initialization = False
+
         for stim_input, stim_target, stim_epoch in zip(inputs, targets, epochs):
             if 'epochs' in stim_input:
                 stim_epoch = stim_input['epochs']
@@ -177,10 +181,9 @@ class CompositionRunner():
             if patience is not None:
                 early_stopper = EarlyStopping(min_delta=min_delta, patience=patience)
 
-            skip_initialization = False
             minibatched_input = _batch_inputs(stim_input, stim_epoch, num_trials, minibatch_size, randomize_minibatches, call_before_minibatch=call_before_minibatch, call_after_minibatch=call_after_minibatch)
             
-            self._composition.run(inputs=minibatched_input, skip_initialization=skip_initialization, context=context, skip_analyze_graph=True, bin_execute=bin_execute)
+            self._composition.run(inputs=minibatched_input, skip_initialization=skip_initialization, context=context, skip_analyze_graph=True, bin_execute=bin_execute, *args, **kwargs)
             skip_initialization = True
 
         # FIXME: compiled run values differ from pytorch run

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -29,7 +29,6 @@ def _batch_inputs(inputs: dict, epochs: int, num_trials: int, batch_size: int = 
     """
     #This is a generator for performance reasons, since we don't want to copy any data (especially for very large inputs or epoch counts!)
     for epoch in range(epochs):
-        chunk = {}
         indices = list(range(0, num_trials))
         if randomize:
             random.shuffle(indices)
@@ -38,6 +37,7 @@ def _batch_inputs(inputs: dict, epochs: int, num_trials: int, batch_size: int = 
                 call_before_minibatch()
             curr_indices = indices[i:i + batch_size]
             for idx in curr_indices:
+                chunk = {}
                 for k, v in inputs.items():
                         chunk[k] = v[idx % len(v)]
                 yield chunk
@@ -162,7 +162,7 @@ class CompositionRunner():
         elif epochs is None:
             epochs = inf_yield_none()
 
-
+        results = []
         for stim_input, stim_target, stim_epoch in zip(inputs, targets, epochs):
             if 'epochs' in stim_input:
                 stim_epoch = stim_input['epochs']
@@ -184,8 +184,9 @@ class CompositionRunner():
             self._composition.run(inputs=minibatched_input, skip_initialization=skip_initialization, context=context, skip_analyze_graph=True, bin_execute=bin_execute)
             skip_initialization = True
 
-            return [x[0] for x in self._composition.parameters.results.get(context)[-1 * num_trials * minibatch_size:]] # return results from last epoch
-
+            results = [x for x in self._composition.parameters.results.get(context)[-1 * num_trials * minibatch_size:]] # return results from last epoch
+            
+        return results
 class EarlyStopping(object):
     def __init__(self, mode='min', min_delta=0, patience=10):
         self.mode = mode

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -122,9 +122,9 @@ class CompositionRunner():
                     yield chunk
                 if call_after_minibatch:
                     call_after_minibatch()
-                if early_stopper is not None and early_stopper.step(self._calculate_loss(num_trials, context)):
-                    # end early if patience exceeded
-                    return
+            if early_stopper is not None and early_stopper.step(self._calculate_loss(num_trials, context)):
+                # end early if patience exceeded
+                pass
 
     def run_learning(self,
                      inputs: dict,

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -184,7 +184,8 @@ class CompositionRunner():
             skip_initialization = True
 
         # FIXME: compiled run values differ from pytorch run 
-        if bin_execute is not False:
+        import pdb; pdb.set_trace()
+        if bin_execute is not False and bin_execute != 'Python':
             results = [x for x in self._composition.parameters.results.get(context)[-1 * num_trials * minibatch_size:]] # return results from last epoch
         else:
             results = [x[0] for x in self._composition.parameters.results.get(context)[-1 * num_trials * minibatch_size:]] # return results from last epoch

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -184,7 +184,6 @@ class CompositionRunner():
             skip_initialization = True
 
         # FIXME: compiled run values differ from pytorch run 
-        import pdb; pdb.set_trace()
         if bin_execute is not False and bin_execute != 'Python':
             results = [x for x in self._composition.parameters.results.get(context)[-1 * num_trials * minibatch_size:]] # return results from last epoch
         else:

--- a/psyneulink/library/compositions/pytorchmodelcreator.py
+++ b/psyneulink/library/compositions/pytorchmodelcreator.py
@@ -570,17 +570,13 @@ class PytorchModelCreator(torch.nn.Module):
                 if i == len(self.execution_sets) - 1:
                     outputs[component] = value
 
-            if scheduler is not None:
-                scheduler.get_clock(context)._increment_time(
-                    TimeScale.TIME_STEP)
-
         # Maybe need to comment this out!
         # self.copy_outputs_to_psyneulink(outputs, context)
 
         old_source = context.source
         context.source = ContextFlags.COMMAND_LINE
-        self.log_weights(context)
-        self.copy_outputs_to_psyneulink(outputs, context)
+        # self.log_weights(context)
+        # self.copy_outputs_to_psyneulink(outputs, context)
         context.source = old_source
 
         return outputs

--- a/psyneulink/library/compositions/pytorchmodelcreator.py
+++ b/psyneulink/library/compositions/pytorchmodelcreator.py
@@ -370,8 +370,6 @@ class PytorchModelCreator(torch.nn.Module):
         return builder.function
 
     def _gen_llvm_training_function_body(self, ctx, builder, state, params, data):
-        # 1) Setup autodiff learning stuff
-        # gets a reference to the autodiff_stimuli_struct from params
         composition = self._composition
 
         optimizer = self._get_compiled_optimizer()

--- a/psyneulink/library/compositions/pytorchmodelcreator.py
+++ b/psyneulink/library/compositions/pytorchmodelcreator.py
@@ -9,7 +9,7 @@ from psyneulink.library.compositions.compiledloss import MSELoss
 import ctypes
 from collections import deque
 from psyneulink.library.compositions.pytorchllvmhelper import *
-
+from psyneulink.core.globals.keywords import TARGET_MECHANISM
 debug_env = pnlvm.debug_env
 
 try:
@@ -53,9 +53,8 @@ class PytorchModelCreator(torch.nn.Module):
         self._composition = composition
 
         for i, current_exec_set in enumerate(self.execution_sets):
+            self.execution_sets[i] = current_exec_set - set(composition.get_nodes_by_role(NodeRole.LEARNING))
             for component in current_exec_set:
-                if NodeRole.LEARNING in self._composition.get_roles_by_node(component) or NodeRole.TARGET in self._composition.get_roles_by_node(component):
-                    continue
                 value = None  # the node's (its mechanism's) value
                 function = self.function_creator(
                     component, context)  # the node's function
@@ -127,14 +126,14 @@ class PytorchModelCreator(torch.nn.Module):
         return [(vertex.component,weights) for (vertex,weights) in forward_info_weights.items()]
 
     # defines input type
-    def _get_input_struct_type(self, ctx):  # Test case: {[1 x [2 x double]]}
-        input_nodes = self._composition.get_nodes_by_role(NodeRole.INPUT)
-        assert set(input_nodes) == set(self.execution_sets[0])
-        # FIXME: Why remove nesting? 'elements[0]' removes outer struct,
-        # and '.element' removes outer array dimension
-        input_list = (ctx.get_input_struct_type(node).elements[0].element for node in input_nodes)
-        input_struct = pnlvm.ir.LiteralStructType(input_list)
-        return input_struct
+    # def _get_input_struct_type(self, ctx):  # Test case: {[1 x [2 x double]]}
+    #     input_nodes = self._composition.get_nodes_by_role(NodeRole.INPUT)
+    #     assert set(input_nodes) == set(self.execution_sets[0])
+    #     # FIXME: Why remove nesting? 'elements[0]' removes outer struct,
+    #     # and '.element' removes outer array dimension
+    #     input_list = (ctx.get_input_struct_type(node).elements[0].element for node in input_nodes)
+    #     input_struct = pnlvm.ir.LiteralStructType(input_list)
+    #     return input_struct
 
     def _get_data_struct_type(self, ctx):
         # Ensures that data struct is the same as the autodiffcomp
@@ -198,15 +197,16 @@ class PytorchModelCreator(torch.nn.Module):
         with pnlvm.LLVMBuilderContext.get_global() as ctx:
             args = [ctx.get_state_struct_type(self._composition).as_pointer(),
                     ctx.get_param_struct_type(self._composition).as_pointer(),
-                    ctx.get_input_struct_type(self).as_pointer(),
-                    ctx.get_data_struct_type(self).as_pointer()
+                    ctx.get_data_struct_type(self._composition).as_pointer()
                     ]
             builder = ctx.create_llvm_function(args, self)
             llvm_func = builder.function
 
-            context, params, arg_in, arg_out = llvm_func.args
-            self._gen_llvm_forward_function_body(
-                ctx, builder, context, params, arg_in, arg_out)
+            state, params, data = llvm_func.args
+            if "learning" in tags:
+                self._gen_llvm_training_function_body(ctx, builder, state, params, data)
+            else:
+                self._gen_llvm_forward_function_body(ctx, builder, state, params, data)
             builder.ret_void()
         return llvm_func
 
@@ -215,20 +215,23 @@ class PytorchModelCreator(torch.nn.Module):
         node_idx = self._composition._get_node_index(node)
         forward_info_weights = self.component_to_forward_info[node]['afferents']
         afferent_node_index = self._get_afferent_node_index(node,afferent_node)
+        projection = [i for i in afferent_node.efferents if i.receiver.owner == node][0]
+        inner_projections = list(self._composition._inner_projections)
+        projection_idx = inner_projections.index(projection)
+        projection_params = builder.gep(params, [ctx.int32_ty(0), ctx.int32_ty(1), ctx.int32_ty(projection_idx)])
+
         for (vertex,matrix) in forward_info_weights.items():
             if vertex.component == afferent_node:
                 weight_matrix = matrix
                 break
         dim_x,dim_y = weight_matrix.detach().numpy().shape
-        node_weights = builder.gep(params, [ctx.int32_ty(0),
-                                            ctx.int32_ty(2),
-                                            ctx.int32_ty(node_idx),
-                                            ctx.int32_ty(0),
-                                            ctx.int32_ty(afferent_node_index)])
-        if "no_ref_pass" not in debug_env:
-            mem_addr = builder.load(node_weights)
-            node_weights = builder.inttoptr(mem_addr, pnlvm.ir.types.ArrayType(
-                pnlvm.ir.types.ArrayType(ctx.float_ty, dim_y), dim_x).as_pointer())
+        node_weights = ctx.get_param_ptr(projection, builder, projection_params, "matrix")
+        node_weights = builder.bitcast(node_weights, pnlvm.ir.types.ArrayType(
+                 pnlvm.ir.types.ArrayType(ctx.float_ty, dim_y), dim_x).as_pointer())
+        # if "no_ref_pass" not in debug_env:
+        #     mem_addr = builder.load(node_weights)
+        #     node_weights = builder.inttoptr(mem_addr, pnlvm.ir.types.ArrayType(
+        #         pnlvm.ir.types.ArrayType(ctx.float_ty, dim_y), dim_x).as_pointer())
 
         return node_weights,dim_x,dim_y
 
@@ -236,10 +239,8 @@ class PytorchModelCreator(torch.nn.Module):
         out_t = arg_out.type.pointee
         if isinstance(out_t, pnlvm.ir.ArrayType) and isinstance(out_t.element, pnlvm.ir.ArrayType):
             assert len(out_t) == 1
-
         z_values = {}
         for i, current_exec_set in enumerate(self.execution_sets):
-
             for component in current_exec_set:
                 component_id = self._composition._get_node_index(component)
                 value = self._get_output_value_ptr(ctx, builder, arg_out, component_id)
@@ -265,7 +266,7 @@ class PytorchModelCreator(torch.nn.Module):
 
                         # We cast the ctype weights array to llvmlite pointer
                         weights_llvmlite, _, _ = self._gen_get_node_weight_ptr(ctx, builder, params, component, source_node)
-                        pnlvm.helpers.printf_float_matrix(builder, weights_llvmlite, prefix=f"{source_node} -> {component}\tweight:\t")
+                        pnlvm.helpers.printf_float_matrix(builder, weights_llvmlite, prefix=f"{source_node} -> {component}\tweight:\n")
                         # node inputs are 2d arrays in a struct
                         input_ptr = builder.gep(mech_input, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(j)])
                         gen_inject_vxm(ctx, builder, input_value, weights_llvmlite, input_ptr)
@@ -298,8 +299,8 @@ class PytorchModelCreator(torch.nn.Module):
 
                 if store_z_values is True:
                     pnlvm.helpers.printf_float_array(builder, z_values[component], prefix=f"{component}\tforward input:\t")
-                pnlvm.helpers.printf_float_array(builder, value, prefix=f"{component}\tforward output:\t")
-
+                pnlvm.helpers.printf_float_array(builder, value, prefix=f"{component}\tforward output:\t", suffix="\t")
+                pnlvm.helpers.printf(builder, "\n")
         return z_values
 
     # generates a function responsible for a single epoch of the training
@@ -307,11 +308,8 @@ class PytorchModelCreator(torch.nn.Module):
         composition = self._composition
         args = [ctx.get_state_struct_type(composition).as_pointer(),
                 ctx.get_param_struct_type(composition).as_pointer(),
-                ctx.get_input_struct_type(self).as_pointer(),
-                ctx.get_data_struct_type(self).as_pointer(),
+                ctx.get_data_struct_type(composition).as_pointer(),
                 optimizer._get_optimizer_struct_type(ctx).as_pointer(),
-                self._get_learning_struct_type(ctx).as_pointer(), # training set
-                ctx.int32_ty  # input idx
                 ]
         name = self._composition.name + "_training_backprop"
         builder = ctx.create_llvm_function(args, self, name)
@@ -320,7 +318,8 @@ class PytorchModelCreator(torch.nn.Module):
             if isinstance(a.type, pnlvm.ir.PointerType):
                 a.attributes.add('noalias')
 
-        context, params, model_input, model_output, optim_struct, training_set, trial_num = llvm_func.args
+        context, params, model_output, optim_struct = llvm_func.args
+        model_input = builder.gep(model_output, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(self._composition._get_node_index(self._composition.input_CIM))])
         # setup useful mappings
         input_nodes = composition.get_nodes_by_role(NodeRole.INPUT)
         output_nodes = composition.get_nodes_by_role(NodeRole.OUTPUT)
@@ -330,22 +329,17 @@ class PytorchModelCreator(torch.nn.Module):
 
         # first we copy input values to data struct of input_CIM
         for i, node in enumerate(input_nodes):
-            node_input_array_ptr = builder.gep(training_set, [trial_num, ctx.int32_ty(0), ctx.int32_ty(i), ctx.int32_ty(0), ctx.int32_ty(0)])
             node_model_input = builder.gep(model_input, [ctx.int32_ty(0), ctx.int32_ty(i)])
-            gen_inject_vec_copy(ctx, builder, node_input_array_ptr, node_model_input)
-
             pnlvm.helpers.printf_float_array(builder, node_model_input, prefix=f"{node}\tinput:\t")
 
         # 2) call forward computation
-        model_params = builder.gep(params, [ctx.int32_ty(0), ctx.int32_ty(2)])
         z_values = self._gen_llvm_forward_function_body(
             ctx, builder, context, params, model_input, model_output, store_z_values=True)
         # 3) compute errors
 
-
         error_dict = {}
         backprop_queue = deque()
-        for node in output_nodes:
+        for node in set(output_nodes) - set(self._composition.get_nodes_by_role(NodeRole.LEARNING)):
             backprop_queue.append(node)
 
         loss_fn = ctx.import_llvm_function(loss)
@@ -369,11 +363,11 @@ class PytorchModelCreator(torch.nn.Module):
 
             error_dict[node] = error_val
 
-            if node in output_nodes:
+            if node in set(output_nodes) - set(self._composition.get_nodes_by_role(NodeRole.LEARNING)):
                 # We handle output layer here
                 # compute  dC/da = a_l - y(x) (TODO: Allow other cost functions! This only applies to MSE)
                 out_node_idx = output_nodes.index(node)
-                node_target = builder.gep(training_set, [trial_num, ctx.int32_ty(1), ctx.int32_ty(out_node_idx), ctx.int32_ty(0), ctx.int32_ty(0)])
+                node_target = self._get_target_value_ptr(ctx, builder, model_input, node )
                 node_output = self._get_output_value_ptr(ctx, builder, model_output, node_idx)
 
                 tmp_loss = loss.gen_inject_lossfunc_call(ctx, builder, loss_fn, node_output, node_target)
@@ -396,7 +390,7 @@ class PytorchModelCreator(torch.nn.Module):
                 # We calculate δ_(l-1) = sum (a_(l-1) W^T) ⊙ δ_l, where (l-1) is the current layer, l is layer of efferents, summed over all efferents
                 efferents = [
                     proj.receiver._owner for proj in node.efferents]
-                for efferent_node in efferents:
+                for efferent_node in set(efferents) - set(self._composition.get_nodes_by_role(NodeRole.LEARNING)):
                     efferent_node_error = error_dict[efferent_node]
 
                     weights_llvmlite, _, _ = self._gen_get_node_weight_ptr(ctx, builder, params, efferent_node, node)
@@ -454,36 +448,13 @@ class PytorchModelCreator(torch.nn.Module):
         target_struct = pnlvm.ir.LiteralStructType(ctx.get_input_struct_type(node) for node in self._composition.get_nodes_by_role(NodeRole.OUTPUT))
         return pnlvm.ir.LiteralStructType((input_struct, target_struct))
 
-    def _gen_llvm_training_function_body(self, ctx, builder, context, params, data, autodiff_stimuli_struct):
+    def _gen_llvm_training_function_body(self, ctx, builder, state, params, data):
         # 1) Setup autodiff learning stuff
         # if "ref_pass" not in debug_env:
         #    raise Exception("ref_pass must be enabled in debug!")
         # gets a reference to the autodiff_stimuli_struct from params
         composition = self._composition
 
-        epochs = builder.load(builder.gep(autodiff_stimuli_struct,
-                                          [ctx.int32_ty(0), ctx.int32_ty(0)]))
-        num_trials = builder.load(builder.gep(autodiff_stimuli_struct,
-                                              [ctx.int32_ty(0), ctx.int32_ty(1)]))
-
-        # Get pointer to the training set
-        training_set_ptr = builder.gep(autodiff_stimuli_struct,
-                                       [ctx.int32_ty(0), ctx.int32_ty(2)])
-        training_set_array = builder.load(training_set_ptr)
-
-        pnlvm.helpers.printf(builder,"Running Autodiff Training with params:\n\tepoch count: %d \n\tnum_trials: %d \n",
-                            epochs,
-                            num_trials)
-
-        pnlvm.helpers.printf(builder,"\tlearning_struct_addr: 0x%Lx \n",
-                            training_set_array)
-        input_cim_idx = composition._get_node_index(composition.input_CIM)
-        model_params = builder.gep(params, [ctx.int32_ty(0), ctx.int32_ty(2)])
-
-        # Extract the input that should be inserted into the model
-        model_input = builder.gep(data, [ctx.int32_ty(0),
-                                         ctx.int32_ty(0),
-                                         ctx.int32_ty(input_cim_idx)])
 
         # setup optimizer
         optimizer_type = self._composition.optimizer_type
@@ -508,24 +479,22 @@ class PytorchModelCreator(torch.nn.Module):
         optimizer_zero_grad = ctx.import_llvm_function(optimizer.zero_grad(ctx).name)
         optimizer.initialize_optimizer_struct(ctx, builder, optimizer_struct)
         backprop = ctx.import_llvm_function(self._gen_llvm_training_backprop(ctx, optimizer, loss).name)
-        with pnlvm.helpers.for_loop_zero_inc(builder, epochs, "epoch_loop") as (b1, epoch_idx):
-            pnlvm.helpers.printf(builder, "\033[0;32mEPOCH %d\033[0m\n", epoch_idx)
-            with pnlvm.helpers.for_loop_zero_inc(b1, num_trials, "input_loop") as (b2, trial_num):
-                pnlvm.helpers.printf(b2, "\n\033[0;31mINPUT %d\033[0m\n", trial_num)
-                pnlvm.helpers.printf(b2, "OPTIMIZER ZERO GRAD %d\n", trial_num)
-                # FIXME: converting this call to direct code results in
-                # significant longer compilation times
-                b2.call(optimizer_zero_grad, [optimizer_struct])
-                pnlvm.helpers.printf(b2, "TRIAL %d\n", trial_num)
-                b2.call(backprop, [context, params, model_input, data,
-                                   optimizer_struct, training_set_array,
-                                   trial_num])
-                pnlvm.helpers.printf(b2, "OPTIMIZER STEP %d\n", trial_num)
-                b2.call(optimizer_step_f, [optimizer_struct, params])
+        
+        # # FIXME: converting this call to direct code results in
+        # # significant longer compilation times
+        builder.call(optimizer_zero_grad, [optimizer_struct])
+        builder.call(backprop, [state, params, data,
+                            optimizer_struct])
+        builder.call(optimizer_step_f, [optimizer_struct, params])
 
 
     def _get_output_value_ptr(self, ctx, builder, arg_out, index):
         return builder.gep(arg_out, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(index), ctx.int32_ty(0)])
+    
+    def _get_target_value_ptr(self, ctx, builder, arg_in, output_node):
+        terminal_sequence = self._composition._terminal_backprop_sequences[output_node]
+        idx = self._composition.get_nodes_by_role(NodeRole.INPUT).index(terminal_sequence[TARGET_MECHANISM])
+        return builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(idx)])
 
     # performs forward computation for the model
     @handle_external_context()

--- a/psyneulink/library/compositions/pytorchmodelcreator.py
+++ b/psyneulink/library/compositions/pytorchmodelcreator.py
@@ -575,7 +575,8 @@ class PytorchModelCreator(torch.nn.Module):
 
         old_source = context.source
         context.source = ContextFlags.COMMAND_LINE
-        # self.log_weights(context)
+        #TODO: Optimize this weight logging
+        self.log_weights(context)
         # self.copy_outputs_to_psyneulink(outputs, context)
         context.source = old_source
 

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -110,7 +110,7 @@ class TestMiscTrainingFunctionality:
     @pytest.mark.parametrize("mode", ['Python',
                                       pytest.param('LLVMExec', marks=pytest.mark.llvm),
                                      ])
-    def test_training_then_processing(self,mode):
+    def test_training_then_processing(self, mode):
         xor_in = TransferMechanism(name='xor_in',
                                    default_variable=np.zeros(2))
 
@@ -133,7 +133,8 @@ class TestMiscTrainingFunctionality:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
-
+        xor.infer_backpropagation_learning_pathways()
+        
         xor_inputs = np.array(  # the inputs we will provide to the model
             [[0, 0],
              [0, 1],
@@ -150,7 +151,7 @@ class TestMiscTrainingFunctionality:
         # results_before_proc = xor.run(inputs={xor_in:xor_inputs},
         #                               targets={xor_out:xor_targets},
         #                               epochs=10)
-        results_before_proc = xor.run(inputs={"inputs": {xor_in:xor_inputs},
+        results_before_proc = xor.learn(inputs={"inputs": {xor_in:xor_inputs},
                                               "targets": {xor_out:xor_targets},
                                               "epochs": 10}, bin_execute=mode)
 
@@ -200,6 +201,7 @@ class TestMiscTrainingFunctionality:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
+        xor.infer_backpropagation_learning_pathways()
 
         xor_inputs = np.array(  # the inputs we will provide to the model
             [[0, 0],
@@ -213,14 +215,14 @@ class TestMiscTrainingFunctionality:
              [1],
              [0]])
 
-        xor.run(inputs = {"inputs": {xor_in:xor_inputs},
+        xor.learn(inputs = {"inputs": {xor_in:xor_inputs},
                           "targets": {xor_out:xor_targets},
                           "epochs": 10}, bin_execute=mode)
 
     @pytest.mark.parametrize("mode", ['Python',
                                       pytest.param('LLVMExec', marks=[pytest.mark.llvm, pytest.mark.skip]), # Not implemented?
                                      ])
-    def test_pytorch_loss_spec(self,mode):
+    def test_pytorch_loss_spec(self, mode):
         import torch
         ls = torch.nn.SoftMarginLoss(reduction='sum')
 
@@ -246,17 +248,17 @@ class TestMiscTrainingFunctionality:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
-
+        xor.infer_backpropagation_learning_pathways()
         xor_inputs = np.array(  # the inputs we will provide to the model
             [[0, 0], [0, 1], [1, 0], [1, 1]])
 
         xor_targets = np.array(  # the outputs we wish to see from the model
             [[0], [1], [1], [0]])
 
-        xor.run(inputs={"inputs": {xor_in:xor_inputs},
+        xor.learn(inputs={"inputs": {xor_in:xor_inputs},
                         "targets": {xor_out:xor_targets},
                         "epochs": 10}, bin_execute=mode)
-        xor.run(inputs={"inputs": {xor_in: xor_inputs},
+        xor.learn(inputs={"inputs": {xor_in: xor_inputs},
                         "targets": {xor_out: xor_targets},
                         "epochs": 10}, bin_execute=mode)
 
@@ -296,6 +298,7 @@ class TestMiscTrainingFunctionality:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
+        xor.infer_backpropagation_learning_pathways()
 
         xor_inputs = np.array(  # the inputs we will provide to the model
             [[0, 0], [0, 1], [1, 0], [1, 1]])
@@ -307,11 +310,11 @@ class TestMiscTrainingFunctionality:
         # results_before_proc = xor.run(inputs={xor_in:xor_inputs},
         #                               targets={xor_out:xor_targets},
         #                               epochs=10)
-        results_before_proc = xor.run(inputs={"inputs": {xor_in:xor_inputs},
+        results_before_proc = xor.learn(inputs={"inputs": {xor_in:xor_inputs},
                                               "targets": {xor_out:xor_targets},
                                               "epochs": 10}, bin_execute=mode)
 
-        benchmark(xor.run, inputs={"inputs": {xor_in:xor_inputs},
+        benchmark(xor.learn, inputs={"inputs": {xor_in:xor_inputs},
                                    "targets": {xor_out:xor_targets},
                                    "epochs": 10}, bin_execute=mode)
 
@@ -355,6 +358,7 @@ class TestMiscTrainingFunctionality:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
+        xor.infer_backpropagation_learning_pathways()
 
         xor_inputs = np.array(  # the inputs we will provide to the model
             [[0, 0], [0, 1], [1, 0], [1, 1]])
@@ -363,7 +367,7 @@ class TestMiscTrainingFunctionality:
             [[0], [1], [1], [0]])
 
         # train the model for a few epochs
-        result = xor.run(inputs={"inputs": {xor_in:xor_inputs},
+        result = xor.learn(inputs={"inputs": {xor_in:xor_inputs},
                                  "targets": {xor_out:xor_targets},
                                  "epochs": 10}, bin_execute=mode)
 
@@ -441,8 +445,9 @@ class TestMiscTrainingFunctionality:
         assert np.allclose(out_map.parameters.matrix.get(None), weights_get_params[out_map])
         assert np.allclose(weights_straight_2.detach().numpy(), weights_get_params[out_map])
 
+        xor.infer_backpropagation_learning_pathways()
         # call run to train the pytorch parameters
-        results = xor.run(inputs={"inputs": {xor_in:xor_inputs},
+        results = xor.learn(inputs={"inputs": {xor_in:xor_inputs},
                                   "targets": {xor_out:xor_targets},
                                   "epochs": 10}, bin_execute=mode)
 
@@ -496,6 +501,7 @@ class TestTrainingCorrectness:
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
 
+        xor.infer_backpropagation_learning_pathways()
         xor_inputs = np.array(  # the inputs we will provide to the model
             [[0, 0], [0, 1], [1, 0], [1, 1]])
 
@@ -503,7 +509,7 @@ class TestTrainingCorrectness:
             [[0], [1], [1], [0]])
 
         if calls == 'single':
-            results = xor.run(inputs={"inputs": {xor_in:xor_inputs},
+            results = xor.learn(inputs={"inputs": {xor_in:xor_inputs},
                                       "targets": {xor_out:xor_targets},
                                       "epochs": eps}, bin_execute=mode)
 
@@ -511,19 +517,19 @@ class TestTrainingCorrectness:
                 assert np.allclose(np.round(results[0][i][0]), xor_targets[i])
 
         else:
-            results = xor.run(inputs={"inputs": {xor_in: xor_inputs},
+            results = xor.learn(inputs={"inputs": {xor_in: xor_inputs},
                                       "targets": {xor_out: xor_targets},
                                       "epochs": 1}, bin_execute=mode)
 
             for i in range(eps - 1):
-                results = xor.run(inputs={"inputs": {xor_in: xor_inputs},
+                results = xor.learn(inputs={"inputs": {xor_in: xor_inputs},
                                           "targets": {xor_out: xor_targets},
                                           "epochs": 1}, bin_execute=mode)
 
             for i in range(len(results[eps - 1])):
                 assert np.allclose(np.round(results[eps - 1][i][0]), xor_targets[i])
 
-        benchmark(xor.run, inputs={'inputs': {xor_in: xor_inputs},
+        benchmark(xor.learn, inputs={'inputs': {xor_in: xor_inputs},
                                    'targets': {xor_out: xor_targets},
                                    'epochs': eps}, bin_execute=mode)
 
@@ -631,6 +637,7 @@ class TestTrainingCorrectness:
         sem_net.add_projection(sender=h2, projection=map_h2_has, receiver=out_sig_has)
         sem_net.add_projection(sender=h2, projection=map_h2_can, receiver=out_sig_can)
 
+        sem_net.infer_backpropagation_learning_pathways()
         # INPUTS & OUTPUTS FOR SEMANTIC NET:
 
         nouns = ['oak', 'pine', 'rose', 'daisy', 'canary', 'robin', 'salmon', 'sunfish']
@@ -701,7 +708,8 @@ class TestTrainingCorrectness:
                 targets_dict[out_sig_can].append(truth_can[i])
 
         # TRAIN THE MODEL
-        result = sem_net.run(inputs={'inputs': inputs_dict,
+        sem_net.enable_learning = False
+        result = sem_net.learn(inputs={'inputs': inputs_dict,
                                       'targets': targets_dict,
                                       'epochs': eps}, bin_execute=mode)
 
@@ -720,7 +728,7 @@ class TestTrainingCorrectness:
                 # compare model output for terminal node on current trial with target for terminal node on current trial
                 assert np.allclose(np.round(result[i][j]), correct_value)
 
-        benchmark(sem_net.run, inputs={'inputs': inputs_dict,
+        benchmark(sem_net.learn, inputs={'inputs': inputs_dict,
                                        'targets': targets_dict,
                                        'epochs': eps}, bin_execute=mode)
 
@@ -870,8 +878,7 @@ class TestTrainingCorrectness:
         mnet = AutodiffComposition(param_init_from_pnl=True,
                                    patience=patience,
                                    min_delta=min_delt,
-                                   learning_rate=learning_rate,
-                                   learning_enabled=True)
+                                   learning_rate=learning_rate)
 
         mnet.add_node(il)
         mnet.add_node(cl)
@@ -882,18 +889,20 @@ class TestTrainingCorrectness:
         mnet.add_projection(projection=pco, sender=cl, receiver=ol)
         mnet.add_projection(projection=pho, sender=hl, receiver=ol)
 
-        mnet.run(
+        mnet.infer_backpropagation_learning_pathways()
+        mnet.enable_learning = False
+        mnet.learn(
             inputs=input_set,
             minibatch_size=1,
+            patience=patience,
+            min_delta=min_delt,
             bin_execute=mode
         )
         mnet.learning_enabled = False
-
         mnet.run(
-            inputs=input_set,
+            inputs=input_set['inputs'],
             bin_execute=mode
         )
-
         output = np.array(mnet.parameters.results.get(mnet)[-15:]).reshape(225)
 
         comparator = np.array([0.02288846, 0.11646781, 0.03473711, 0.0348004, 0.01679579,
@@ -1089,8 +1098,7 @@ class TestTrainingCorrectness:
         mnet = AutodiffComposition(param_init_from_pnl=True,
                                    patience=patience,
                                    min_delta=min_delt,
-                                   learning_rate=learning_rate,
-                                   learning_enabled=True)
+                                   learning_rate=learning_rate)
 
         mnet.add_node(il)
         mnet.add_node(cl)
@@ -1101,16 +1109,20 @@ class TestTrainingCorrectness:
         mnet.add_projection(projection=pco, sender=cl, receiver=ol)
         mnet.add_projection(projection=pho, sender=hl, receiver=ol)
 
-        mnet.run(
+        mnet.infer_backpropagation_learning_pathways()
+        
+        mnet.learn(
                 inputs=input_set,
                 minibatch_size=1,
+                patience=patience,
+                min_delta=min_delt
         )
-        mnet.learning_enabled = False
 
         print(mnet.parameters.results.get(mnet))
-
+        mnet.learning_enabled = False
+        mnet.enable_learning = False
         mnet.run(
-                inputs=input_set,
+                inputs=input_set['inputs'],
         )
 
         output = np.array(mnet.parameters.results.get(mnet)[-15:]).reshape(225)
@@ -1918,7 +1930,7 @@ class TestTrainingIdenticalness():
         sem_net.add_projection(sender=h2, projection=map_h2_is, receiver=out_sig_is)
         sem_net.add_projection(sender=h2, projection=map_h2_has, receiver=out_sig_has)
         sem_net.add_projection(sender=h2, projection=map_h2_can, receiver=out_sig_can)
-
+        sem_net.infer_backpropagation_learning_pathways()
         # INPUTS & OUTPUTS FOR SEMANTIC NET:
 
         nouns = ['oak', 'pine', 'rose', 'daisy', 'canary', 'robin', 'salmon', 'sunfish']
@@ -1992,20 +2004,20 @@ class TestTrainingIdenticalness():
         inputs_dict_sys[nouns_in_sys] = inputs_dict[nouns_in]
         inputs_dict_sys[rels_in_sys] = inputs_dict[rels_in]
 
-        sem_net.learning_enabled=False
+        sem_net.enable_learning = False
+        sem_net.learning_enabled = False
         result = sem_net.run(inputs=inputs_dict)
 
         # comp_weights = sem_net.get_parameters()[0]
 
         # TRAIN COMPOSITION
-        sem_net.learning_enabled=True
-
         def g_f():
             yield {"inputs": inputs_dict,
                    "targets": targets_dict,
                    "epochs": eps}
         g = g_f()
-        result = sem_net.run(inputs=g_f)
+        sem_net.learning_enabled = True
+        result = sem_net.learn(inputs=g_f)
 
         comp_weights = sem_net.get_parameters()
 
@@ -2059,7 +2071,7 @@ class TestTrainingIdenticalness():
         inputs_dict_sys[learning_components[pnl.TARGET_MECHANISM]] = targets_dict[out_sig_can]
 
         # TRAIN SYSTEM
-        results = sem_net_sys.run(inputs=inputs_dict_sys,
+        results = sem_net_sys.learn(inputs=inputs_dict_sys,
                                   num_trials=(len(inputs_dict_sys[nouns_in_sys]) * eps))
 
         # CHECK THAT PARAMETERS FOR COMPOSITION, SYSTEM ARE SAME
@@ -2110,7 +2122,7 @@ class TestTrainingIdenticalness():
 
         xor_dict.add_projection(sender=xor_in_dict, projection=hid_map_dict, receiver=xor_hid_dict)
         xor_dict.add_projection(sender=xor_hid_dict, projection=out_map_dict, receiver=xor_out_dict)
-
+        xor_dict.infer_backpropagation_learning_pathways()
         # SET UP INPUTS AND TARGETS
 
         xor_inputs_dict = np.array(  # the inputs we will provide to the model
@@ -2134,7 +2146,7 @@ class TestTrainingIdenticalness():
                 }
             }
 
-        result_dict = xor_dict.run(inputs=input_dict)
+        result_dict = xor_dict.learn(inputs=input_dict)
 
         # SET UP MECHANISMS FOR COMPOSITION
         xor_in_func = TransferMechanism(name='xor_in',
@@ -2170,6 +2182,7 @@ class TestTrainingIdenticalness():
 
         xor_func.add_projection(sender=xor_in_func, projection=hid_map_func, receiver=xor_hid_func)
         xor_func.add_projection(sender=xor_hid_func, projection=out_map_func, receiver=xor_out_func)
+        xor_func.infer_backpropagation_learning_pathways()
 
         # SET UP INPUTS AND TARGETS
 
@@ -2195,7 +2208,7 @@ class TestTrainingIdenticalness():
                 }
             }
 
-        result_func = xor_func.run(inputs=get_inputs)
+        result_func = xor_func.learn(inputs=get_inputs)
 
         # SET UP MECHANISMS FOR COMPOSITION
         xor_in_gen = TransferMechanism(name='xor_in',
@@ -2231,7 +2244,7 @@ class TestTrainingIdenticalness():
 
         xor_gen.add_projection(sender=xor_in_gen, projection=hid_map_gen, receiver=xor_hid_gen)
         xor_gen.add_projection(sender=xor_hid_gen, projection=out_map_gen, receiver=xor_out_gen)
-
+        xor_gen.infer_backpropagation_learning_pathways()
         # SET UP INPUTS AND TARGETS
 
         xor_inputs_gen = np.array(  # the inputs we will provide to the model
@@ -2258,7 +2271,7 @@ class TestTrainingIdenticalness():
 
         g = get_inputs_gen()
 
-        result_gen = xor_gen.run(inputs=g)
+        result_gen = xor_gen.learn(inputs=g)
 
         # SET UP MECHANISMS FOR COMPOSITION
         xor_in_gen_func = TransferMechanism(name='xor_in',
@@ -2294,7 +2307,7 @@ class TestTrainingIdenticalness():
 
         xor_gen_func.add_projection(sender=xor_in_gen_func, projection=hid_map_gen_func, receiver=xor_hid_gen_func)
         xor_gen_func.add_projection(sender=xor_hid_gen_func, projection=out_map_gen_func, receiver=xor_out_gen_func)
-
+        xor_gen_func.infer_backpropagation_learning_pathways()
         # SET UP INPUTS AND TARGETS
 
         xor_inputs_gen_func = np.array(  # the inputs we will provide to the model
@@ -2319,7 +2332,7 @@ class TestTrainingIdenticalness():
                 }
             }
 
-        result_gen_func = xor_gen_func.run(inputs=get_inputs_gen_func)
+        result_gen_func = xor_gen_func.learn(inputs=get_inputs_gen_func)
 
         assert result_dict == result_func == result_gen == result_gen_func
 
@@ -2343,13 +2356,8 @@ class TestACLogging:
         out_map = MappingProjection()
 
         xor = AutodiffComposition(param_init_from_pnl=True)
-
-        xor.add_node(xor_in)
-        xor.add_node(xor_hid)
-        xor.add_node(xor_out)
-
-        xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
-        xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
+        xor.add_backpropagation_learning_pathway([xor_in, hid_map, xor_hid, out_map, xor_out])
+        hid_map.set_log_conditions('matrix', pnl.LogCondition.TRIAL)
 
         xor_inputs = np.array(  # the inputs we will provide to the model
             [[0, 0],
@@ -2365,9 +2373,9 @@ class TestACLogging:
 
         # train model for a few epochs
         num_epochs = 10
-        xor.run(inputs={"inputs": {xor_in: xor_inputs},
+        xor.learn(inputs={"inputs": {xor_in: xor_inputs},
                         "targets": {xor_out: xor_targets},
-                        "epochs": num_epochs}, do_logging=True)
+                        "epochs": num_epochs})
 
         exec_id = xor.default_execution_id
 
@@ -2375,12 +2383,12 @@ class TestACLogging:
         in_np_vals = xor_in.log.nparray()[1][1][4][1:]
 
         hid_map_np_dict_mats = hid_map.log.nparray_dictionary()[exec_id]['matrix']
-        hid_map_np_mats = np.array(hid_map.log.nparray()[1][1][4][1:])
+        hid_map_np_mats = np.array(hid_map.log.nparray()[1][1][5][1:])
 
         hid_np_dict_vals = xor_hid.log.nparray_dictionary()[exec_id]['value']
 
         out_map_np_dict_mats = out_map.log.nparray_dictionary()[exec_id]['matrix']
-        out_map_np_mats = np.array(out_map.log.nparray()[1][1][4][1:])
+        out_map_np_mats = np.array(out_map.log.nparray()[1][1][5][1:])
 
         out_np_dict_vals = xor_out.log.nparray_dictionary()[exec_id]['value']
 
@@ -2455,31 +2463,26 @@ class TestNested:
             min_delta=min_delta,
             learning_rate=learning_rate,
             randomize=False,
-            learning_enabled=True
         )
-
-        xor_autodiff.add_node(xor_in)
-        xor_autodiff.add_node(xor_hid)
-        xor_autodiff.add_node(xor_out)
-
-        xor_autodiff.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
-        xor_autodiff.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
+        xor_autodiff.add_backpropagation_learning_pathway([xor_in, hid_map, xor_hid, out_map, xor_out])
 
         # -----------------------------------------------------------------
 
         no_training_input_dict = {xor_in: xor_inputs}
-        input_dict = {'inputs': {xor_in: xor_inputs}, 'targets': {xor_out: xor_targets}, 'epochs': num_epochs}
+        input_dict = {'inputs': {xor_in: xor_inputs }, 'targets': {xor_out: xor_targets}, 'epochs': num_epochs}
 
         parentComposition = pnl.Composition()
         parentComposition.add_node(xor_autodiff)
+        
         input = {xor_autodiff: input_dict}
         no_training_input = {xor_autodiff: no_training_input_dict}
-
-        result1 = parentComposition.run(inputs=input, bin_execute=mode)
-        assert np.allclose(result1, [[0]], atol=0.1)
-
+        
+        learning_context = Context()
+        result1 = xor_autodiff.learn(inputs=input_dict, bin_execute=mode, epochs=num_epochs, context=learning_context)
+        result1 = np.array(result1).flatten()
+        assert np.allclose(result1, np.array(xor_targets).flatten(), atol=0.1)
         xor_autodiff.learning_enabled = False
-        result2 = parentComposition.run(inputs=no_training_input, bin_execute=mode)
+        result2 = parentComposition.run(inputs=no_training_input, bin_execute=mode, context=learning_context)
 
         assert np.allclose(result2, [[0]], atol=0.1)
 
@@ -2530,15 +2533,9 @@ class TestNested:
             min_delta=min_delta,
             learning_rate=learning_rate,
             randomize=False,
-            learning_enabled=False
         )
 
-        xor_autodiff.add_node(xor_in)
-        xor_autodiff.add_node(xor_hid)
-        xor_autodiff.add_node(xor_out)
-
-        xor_autodiff.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
-        xor_autodiff.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
+        xor_autodiff.add_backpropagation_learning_pathway([xor_in, hid_map, xor_hid, out_map, xor_out])
 
         # -----------------------------------------------------------------
 
@@ -2549,10 +2546,13 @@ class TestNested:
         parentComposition.add_node(xor_autodiff)
         input = {xor_autodiff: input_dict}
         no_training_input = {xor_autodiff: no_training_input_dict}
-
-        result1 = parentComposition.run(inputs=no_training_input, bin_execute=mode)
+        learning_context = Context()
+        xor_autodiff.learning_enabled = False
+        result1 = xor_autodiff.run(inputs=input[xor_autodiff]['inputs'], bin_execute=mode, context=learning_context)
         xor_autodiff.learning_enabled = True
-        result2 = parentComposition.run(inputs=input, bin_execute=mode)
+        xor_autodiff.learn(inputs=input_dict, bin_execute=mode, context=learning_context)
+        xor_autodiff.learning_enabled = False
+        result2 = parentComposition.run(inputs=no_training_input, bin_execute=mode, context=learning_context)
 
         assert np.allclose(result2, [[0]], atol=0.1)
 
@@ -2808,6 +2808,7 @@ class TestNested:
         sem_net.add_projection(sender=h2, projection=map_h2_has, receiver=out_sig_has)
         sem_net.add_projection(sender=h2, projection=map_h2_can, receiver=out_sig_can)
 
+        sem_net.infer_backpropagation_learning_pathways()
         # INPUTS & OUTPUTS FOR SEMANTIC NET:
 
         nouns = ['oak', 'pine', 'rose', 'daisy', 'canary', 'robin', 'salmon', 'sunfish']
@@ -2890,14 +2891,13 @@ class TestNested:
         input = {sem_net: input_dict}
         no_training_input = {sem_net: inputs_dict.copy()}
 
-        parentComposition.run(inputs=input, bin_execute=mode)
+        sem_net.learn(inputs=input_dict, bin_execute=mode)
 
         if mode != 'Python':
             #FIXME: Enable the rest of the test when recompilation is supported
             return
 
         sem_net.learning_enabled = False
-
         parentComposition.run(inputs=no_training_input)
 
 @pytest.mark.pytorch
@@ -2939,7 +2939,7 @@ class TestBatching:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
-
+        xor.infer_backpropagation_learning_pathways()
         # SET UP INPUTS AND TARGETS
 
         xor_inputs_1 = np.array(  # the inputs we will provide to the model
@@ -2964,7 +2964,7 @@ class TestBatching:
         def cbm(a):
             a[0] += 1
 
-        xor.run(
+        xor.learn(
             inputs=inputs_dict_1,
             call_before_minibatch=lambda: cbm(a)
         )
@@ -3008,6 +3008,7 @@ class TestBatching:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
+        xor.infer_backpropagation_learning_pathways()
 
         # SET UP INPUTS AND TARGETS
 
@@ -3033,7 +3034,7 @@ class TestBatching:
         def cam(a):
             a[0] += 1
 
-        xor.run(
+        xor.learn(
             inputs=inputs_dict_1,
             call_after_minibatch=lambda: cam(a)
         )
@@ -3082,7 +3083,7 @@ class TestBatching:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
-
+        xor.infer_backpropagation_learning_pathways()
         # SET UP INPUTS AND TARGETS
 
         xor_inputs_1 = np.array(  # the inputs we will provide to the model
@@ -3104,7 +3105,7 @@ class TestBatching:
                          "targets": {xor_out: xor_targets_1},
                          "epochs": eps}
 
-        xor.run(
+        xor.learn(
             inputs=inputs_dict_1,
             context=c1,
             minibatch_size=2
@@ -3138,12 +3139,12 @@ class TestBatching:
                          "targets": {xor_out: xor_targets_3},
                          "epochs": 1}
         for _ in range(eps):
-            xor.run(
+            xor.learn(
                 inputs=inputs_dict_2,
                 context=c2,
                 minibatch_size=TRAINING_SET
             )
-            xor.run(
+            xor.learn(
                 inputs=inputs_dict_3,
                 context=c2,
                 minibatch_size=TRAINING_SET
@@ -3152,8 +3153,8 @@ class TestBatching:
         c1_results = xor.parameters.results._get(c1)
         c2_results = xor.parameters.results._get(c2)
 
-        assert np.allclose(c1_results[0][:2], c2_results[-2])
-        assert np.allclose(c1_results[0][2:], c2_results[-1])
+        assert np.allclose(c1_results[0][:2], c2_results[0][:2])
+        assert np.allclose(c1_results[0][2:], c2_results[0][2:])
 
     def test_cross_entropy_loss(self):
         import torch

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -58,10 +58,11 @@ class TestACConstructor:
         assert comp.input_CIM.reportOutputPref == False
         assert comp.output_CIM.reportOutputPref == False
         # assert comp.target_CIM.reportOutputPref == False
-
-    def test_patience(self):
-        comp = AutodiffComposition(patience=10)
-        assert comp.patience == 10
+    
+    # FIXME: This test for patience doesn't actually test for correctness
+    # def test_patience(self):
+        # comp = AutodiffComposition()
+        # assert comp.patience == 10
 
 
 @pytest.mark.pytorch
@@ -878,8 +879,6 @@ class TestTrainingCorrectness:
         pho = MappingProjection(matrix=who)
 
         mnet = AutodiffComposition(param_init_from_pnl=True,
-                                   patience=patience,
-                                   min_delta=min_delt,
                                    learning_rate=learning_rate)
 
         mnet.add_node(il)
@@ -2454,10 +2453,7 @@ class TestNested:
 
         xor_autodiff = AutodiffComposition(
             param_init_from_pnl=True,
-            patience=patience,
-            min_delta=min_delta,
             learning_rate=learning_rate,
-            randomize=False,
         )
         xor_autodiff.add_backpropagation_learning_pathway([xor_in, hid_map, xor_hid, out_map, xor_out])
 
@@ -2473,7 +2469,7 @@ class TestNested:
         no_training_input = {xor_autodiff: no_training_input_dict}
         
         learning_context = Context()
-        result1 = xor_autodiff.learn(inputs=input_dict, bin_execute=mode, epochs=num_epochs, context=learning_context)
+        result1 = xor_autodiff.learn(inputs=input_dict, bin_execute=mode, epochs=num_epochs, context=learning_context, patience=patience, min_delta=min_delta)
         result1 = np.array(result1).flatten()
         assert np.allclose(result1, np.array(xor_targets).flatten(), atol=0.1)
         result2 = parentComposition.run(inputs=no_training_input, bin_execute=mode, context=learning_context)
@@ -2523,10 +2519,7 @@ class TestNested:
 
         xor_autodiff = AutodiffComposition(
             param_init_from_pnl=True,
-            patience=patience,
-            min_delta=min_delta,
             learning_rate=learning_rate,
-            randomize=False,
         )
 
         xor_autodiff.add_backpropagation_learning_pathway([xor_in, hid_map, xor_hid, out_map, xor_out])
@@ -2542,7 +2535,7 @@ class TestNested:
         no_training_input = {xor_autodiff: no_training_input_dict}
         learning_context = Context()
         result1 = xor_autodiff.run(inputs=input[xor_autodiff]['inputs'], bin_execute=mode, context=learning_context)
-        xor_autodiff.learn(inputs=input_dict, bin_execute=mode, context=learning_context)
+        xor_autodiff.learn(inputs=input_dict, bin_execute=mode, context=learning_context, patience=patience, min_delta=min_delta)
         result2 = parentComposition.run(inputs=no_training_input, bin_execute=mode, context=learning_context)
 
         assert np.allclose(result2, [[0]], atol=0.1)

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -108,7 +108,7 @@ class TestMiscTrainingFunctionality:
 
     # test whether processing doesn't interfere with pytorch parameters after training
     @pytest.mark.parametrize("mode", ['Python',
-                                      pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                    #   pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                      ])
     def test_training_then_processing(self, mode):
         xor_in = TransferMechanism(name='xor_in',
@@ -176,7 +176,7 @@ class TestMiscTrainingFunctionality:
         'loss', ['l1', 'poissonnll']
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                      pytest.param('LLVMExec', marks=[pytest.mark.llvm,pytest.mark.skip]), # these loss specs remain unimplemented at the moment
+                                    #   pytest.param('LLVMRun', marks=[pytest.mark.llvm,pytest.mark.skip]), # these loss specs remain unimplemented at the moment
                                      ])
     def test_various_loss_specs(self, loss, mode):
         xor_in = TransferMechanism(name='xor_in',
@@ -220,7 +220,7 @@ class TestMiscTrainingFunctionality:
                           "epochs": 10}, bin_execute=mode)
 
     @pytest.mark.parametrize("mode", ['Python',
-                                      pytest.param('LLVMExec', marks=[pytest.mark.llvm, pytest.mark.skip]), # Not implemented?
+                                    #   pytest.param('LLVMRun', marks=[pytest.mark.llvm, pytest.mark.skip]), # Not implemented?
                                      ])
     def test_pytorch_loss_spec(self, mode):
         import torch
@@ -270,7 +270,7 @@ class TestMiscTrainingFunctionality:
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                      pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                    #   pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                      ])
     def test_optimizer_specs(self, learning_rate, weight_decay, optimizer_type, mode, benchmark):
         xor_in = TransferMechanism(name='xor_in',
@@ -321,7 +321,7 @@ class TestMiscTrainingFunctionality:
 
     # test whether pytorch parameters and projections are kept separate (at diff. places in memory)
     @pytest.mark.parametrize("mode", ['Python',
-                                      pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                    #   pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                      ])
     def test_params_stay_separate(self,mode):
         xor_in = TransferMechanism(name='xor_in',
@@ -386,7 +386,7 @@ class TestMiscTrainingFunctionality:
 
     # test whether the autodiff composition's get_parameters method works as desired
     @pytest.mark.parametrize("mode", ['Python',
-                                      pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                    #   pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                      ])
     def test_get_params(self, mode):
 
@@ -473,7 +473,7 @@ class TestTrainingCorrectness:
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                      pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                    #   pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                      ])
     def test_xor_training_correctness(self, eps, calls, opt, from_pnl_or_not, mode, benchmark):
         xor_in = TransferMechanism(name='xor_in',
@@ -543,7 +543,7 @@ class TestTrainingCorrectness:
         ]
     )
     @pytest.mark.parametrize("mode", ["Python",
-                                      pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                    #   pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                      ])
     def test_semantic_net_training_correctness(self, eps, opt, from_pnl_or_not, mode, benchmark):
 
@@ -726,14 +726,14 @@ class TestTrainingCorrectness:
                         correct_value = targets_dict[node][i]
 
                 # compare model output for terminal node on current trial with target for terminal node on current trial
-                assert np.allclose(np.round(result[i][j]), correct_value)
+                assert np.allclose(np.round(result[0][i][j]), correct_value)
 
         benchmark(sem_net.learn, inputs={'inputs': inputs_dict,
                                        'targets': targets_dict,
                                        'epochs': eps}, bin_execute=mode)
 
     @pytest.mark.parametrize("mode", ["Python",
-                                pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                # pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                 ])
     def test_pytorch_equivalence_with_autodiff_composition(self, mode):
         iSs = np.array(
@@ -1189,7 +1189,7 @@ class TestTrainingTime:
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                    pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                    # pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                     ])
     def test_and_training_time(self, eps, opt,mode):
 
@@ -1306,7 +1306,7 @@ class TestTrainingTime:
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                    pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                    # pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                     ])
     def test_xor_training_time(self, eps, opt,mode):
 
@@ -2422,7 +2422,7 @@ class TestNested:
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                      pytest.param('LLVMExec', marks=[pytest.mark.llvm]),
+                                    #   pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
                                      ])
     def test_xor_nested_train_then_no_train(self, num_epochs, learning_rate,
                                             patience, min_delta, mode):
@@ -2492,7 +2492,7 @@ class TestNested:
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                      pytest.param('LLVMExec', marks=[pytest.mark.llvm]),
+                                    #   pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
                                      ])
     def test_xor_nested_no_train_then_train(self, num_epochs, learning_rate,
                                             patience, min_delta, mode):
@@ -2643,7 +2643,7 @@ class TestNested:
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                      pytest.param('LLVMExec', marks=[pytest.mark.llvm]),
+                                    #   pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
                                      ])
     def test_semantic_net_nested(self, eps, opt, mode):
 

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -108,7 +108,7 @@ class TestMiscTrainingFunctionality:
 
     # test whether processing doesn't interfere with pytorch parameters after training
     @pytest.mark.parametrize("mode", ['Python',
-                                    #   pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                      ])
     def test_training_then_processing(self, mode):
         xor_in = TransferMechanism(name='xor_in',
@@ -270,7 +270,7 @@ class TestMiscTrainingFunctionality:
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                    #   pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                      ])
     def test_optimizer_specs(self, learning_rate, weight_decay, optimizer_type, mode, benchmark):
         xor_in = TransferMechanism(name='xor_in',
@@ -322,6 +322,7 @@ class TestMiscTrainingFunctionality:
     # test whether pytorch parameters and projections are kept separate (at diff. places in memory)
     @pytest.mark.parametrize("mode", ['Python',
                                     #   pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                    #   LLVM test is disabled since parameters are currently not written back
                                      ])
     def test_params_stay_separate(self,mode):
         xor_in = TransferMechanism(name='xor_in',
@@ -387,6 +388,8 @@ class TestMiscTrainingFunctionality:
     # test whether the autodiff composition's get_parameters method works as desired
     @pytest.mark.parametrize("mode", ['Python',
                                     #   pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                    #   LLVM test is disabled since parameters are currently not written back
+
                                      ])
     def test_get_params(self, mode):
 
@@ -473,7 +476,7 @@ class TestTrainingCorrectness:
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                    #   pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                      ])
     def test_xor_training_correctness(self, eps, calls, opt, from_pnl_or_not, mode, benchmark):
         xor_in = TransferMechanism(name='xor_in',
@@ -543,7 +546,7 @@ class TestTrainingCorrectness:
         ]
     )
     @pytest.mark.parametrize("mode", ["Python",
-                                    #   pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                      ])
     def test_semantic_net_training_correctness(self, eps, opt, from_pnl_or_not, mode, benchmark):
 
@@ -732,7 +735,7 @@ class TestTrainingCorrectness:
                                        'epochs': eps}, bin_execute=mode)
 
     @pytest.mark.parametrize("mode", ["Python",
-                                # pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                 ])
     def test_pytorch_equivalence_with_autodiff_composition(self, mode):
         iSs = np.array(
@@ -1184,7 +1187,7 @@ class TestTrainingTime:
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                    # pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                    pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                     ])
     def test_and_training_time(self, eps, opt,mode):
 
@@ -1301,7 +1304,7 @@ class TestTrainingTime:
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                    # pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                    pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                     ])
     def test_xor_training_time(self, eps, opt,mode):
 

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -1095,8 +1095,6 @@ class TestTrainingCorrectness:
         pho = MappingProjection(matrix=who, learnable=False)
 
         mnet = AutodiffComposition(param_init_from_pnl=True,
-                                   patience=patience,
-                                   min_delta=min_delt,
                                    learning_rate=learning_rate)
 
         mnet.add_node(il)

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -2337,6 +2337,7 @@ class TestACLogging:
         xor = AutodiffComposition(param_init_from_pnl=True)
         xor.add_backpropagation_learning_pathway([xor_in, hid_map, xor_hid, out_map, xor_out])
         hid_map.set_log_conditions('matrix', pnl.LogCondition.TRIAL)
+        out_map.set_log_conditions('matrix', pnl.LogCondition.TRIAL)
 
         xor_inputs = np.array(  # the inputs we will provide to the model
             [[0, 0],

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -708,7 +708,6 @@ class TestTrainingCorrectness:
                 targets_dict[out_sig_can].append(truth_can[i])
 
         # TRAIN THE MODEL
-        sem_net.enable_learning = False
         result = sem_net.learn(inputs={'inputs': inputs_dict,
                                       'targets': targets_dict,
                                       'epochs': eps}, bin_execute=mode)
@@ -726,7 +725,7 @@ class TestTrainingCorrectness:
                         correct_value = targets_dict[node][i]
 
                 # compare model output for terminal node on current trial with target for terminal node on current trial
-                assert np.allclose(np.round(result[0][i][j]), correct_value)
+                assert np.allclose(np.round(result[i][j]), correct_value)
 
         benchmark(sem_net.learn, inputs={'inputs': inputs_dict,
                                        'targets': targets_dict,
@@ -890,7 +889,6 @@ class TestTrainingCorrectness:
         mnet.add_projection(projection=pho, sender=hl, receiver=ol)
 
         mnet.infer_backpropagation_learning_pathways()
-        mnet.enable_learning = False
         mnet.learn(
             inputs=input_set,
             minibatch_size=1,
@@ -898,7 +896,6 @@ class TestTrainingCorrectness:
             min_delta=min_delt,
             bin_execute=mode
         )
-        mnet.learning_enabled = False
         mnet.run(
             inputs=input_set['inputs'],
             bin_execute=mode
@@ -1119,8 +1116,6 @@ class TestTrainingCorrectness:
         )
 
         print(mnet.parameters.results.get(mnet))
-        mnet.learning_enabled = False
-        mnet.enable_learning = False
         mnet.run(
                 inputs=input_set['inputs'],
         )
@@ -2004,8 +1999,6 @@ class TestTrainingIdenticalness():
         inputs_dict_sys[nouns_in_sys] = inputs_dict[nouns_in]
         inputs_dict_sys[rels_in_sys] = inputs_dict[rels_in]
 
-        sem_net.enable_learning = False
-        sem_net.learning_enabled = False
         result = sem_net.run(inputs=inputs_dict)
 
         # comp_weights = sem_net.get_parameters()[0]
@@ -2016,7 +2009,6 @@ class TestTrainingIdenticalness():
                    "targets": targets_dict,
                    "epochs": eps}
         g = g_f()
-        sem_net.learning_enabled = True
         result = sem_net.learn(inputs=g_f)
 
         comp_weights = sem_net.get_parameters()
@@ -2481,7 +2473,6 @@ class TestNested:
         result1 = xor_autodiff.learn(inputs=input_dict, bin_execute=mode, epochs=num_epochs, context=learning_context)
         result1 = np.array(result1).flatten()
         assert np.allclose(result1, np.array(xor_targets).flatten(), atol=0.1)
-        xor_autodiff.learning_enabled = False
         result2 = parentComposition.run(inputs=no_training_input, bin_execute=mode, context=learning_context)
 
         assert np.allclose(result2, [[0]], atol=0.1)
@@ -2547,11 +2538,8 @@ class TestNested:
         input = {xor_autodiff: input_dict}
         no_training_input = {xor_autodiff: no_training_input_dict}
         learning_context = Context()
-        xor_autodiff.learning_enabled = False
         result1 = xor_autodiff.run(inputs=input[xor_autodiff]['inputs'], bin_execute=mode, context=learning_context)
-        xor_autodiff.learning_enabled = True
         xor_autodiff.learn(inputs=input_dict, bin_execute=mode, context=learning_context)
-        xor_autodiff.learning_enabled = False
         result2 = parentComposition.run(inputs=no_training_input, bin_execute=mode, context=learning_context)
 
         assert np.allclose(result2, [[0]], atol=0.1)
@@ -2897,7 +2885,6 @@ class TestNested:
             #FIXME: Enable the rest of the test when recompilation is supported
             return
 
-        sem_net.learning_enabled = False
         parentComposition.run(inputs=no_training_input)
 
 @pytest.mark.pytorch

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -177,7 +177,7 @@ class TestMiscTrainingFunctionality:
         'loss', ['l1', 'poissonnll']
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                    #   pytest.param('LLVMRun', marks=[pytest.mark.llvm,pytest.mark.skip]), # these loss specs remain unimplemented at the moment
+                                      pytest.param('LLVMRun', marks=[pytest.mark.llvm,pytest.mark.skip]), # these loss specs remain unimplemented at the moment
                                      ])
     def test_various_loss_specs(self, loss, mode):
         xor_in = TransferMechanism(name='xor_in',
@@ -323,7 +323,7 @@ class TestMiscTrainingFunctionality:
     # test whether pytorch parameters and projections are kept separate (at diff. places in memory)
     @pytest.mark.parametrize("mode", ['Python',
                                     #   pytest.param('LLVMRun', marks=pytest.mark.llvm),
-                                    #   LLVM test is disabled since parameters are currently not written back
+                                    #   LLVM test is disabled since weights are always copied back
                                      ])
     def test_params_stay_separate(self,mode):
         xor_in = TransferMechanism(name='xor_in',
@@ -388,7 +388,7 @@ class TestMiscTrainingFunctionality:
 
     # test whether the autodiff composition's get_parameters method works as desired
     @pytest.mark.parametrize("mode", ['Python',
-                                    #   pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                     #   LLVM test is disabled since parameters are currently not written back
 
                                      ])
@@ -458,8 +458,10 @@ class TestMiscTrainingFunctionality:
 
         # check that the parameter copies obtained from get_parameters have not changed with the
         # pytorch parameters during training (and are thus at a different memory location)
-        assert not np.allclose(weights_straight_1.detach().numpy(), weights_get_params[hid_map])
-        assert not np.allclose(weights_straight_2.detach().numpy(), weights_get_params[out_map])
+        # (only makes sense in Python mode)
+        if mode == 'Python':
+            assert not np.allclose(weights_straight_1.detach().numpy(), weights_get_params[hid_map])
+            assert not np.allclose(weights_straight_2.detach().numpy(), weights_get_params[out_map])
 
 
 @pytest.mark.pytorch
@@ -2414,7 +2416,7 @@ class TestNested:
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                    #   pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
+                                      pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
                                      ])
     def test_xor_nested_train_then_no_train(self, num_epochs, learning_rate,
                                             patience, min_delta, mode):
@@ -2480,7 +2482,7 @@ class TestNested:
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                    #   pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
+                                      pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
                                      ])
     def test_xor_nested_no_train_then_train(self, num_epochs, learning_rate,
                                             patience, min_delta, mode):
@@ -2625,7 +2627,7 @@ class TestNested:
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                    #   pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
+                                      pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
                                      ])
     def test_semantic_net_nested(self, eps, opt, mode):
 

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -2482,7 +2482,7 @@ class TestNested:
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
-                                      pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
+                                    #   pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
                                      ])
     def test_xor_nested_no_train_then_train(self, num_epochs, learning_rate,
                                             patience, min_delta, mode):

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -134,7 +134,6 @@ class TestMiscTrainingFunctionality:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
-        xor.infer_backpropagation_learning_pathways()
         
         xor_inputs = np.array(  # the inputs we will provide to the model
             [[0, 0],
@@ -202,7 +201,6 @@ class TestMiscTrainingFunctionality:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
-        xor.infer_backpropagation_learning_pathways()
 
         xor_inputs = np.array(  # the inputs we will provide to the model
             [[0, 0],
@@ -249,7 +247,6 @@ class TestMiscTrainingFunctionality:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
-        xor.infer_backpropagation_learning_pathways()
         xor_inputs = np.array(  # the inputs we will provide to the model
             [[0, 0], [0, 1], [1, 0], [1, 1]])
 
@@ -299,7 +296,6 @@ class TestMiscTrainingFunctionality:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
-        xor.infer_backpropagation_learning_pathways()
 
         xor_inputs = np.array(  # the inputs we will provide to the model
             [[0, 0], [0, 1], [1, 0], [1, 1]])
@@ -360,7 +356,6 @@ class TestMiscTrainingFunctionality:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
-        xor.infer_backpropagation_learning_pathways()
 
         xor_inputs = np.array(  # the inputs we will provide to the model
             [[0, 0], [0, 1], [1, 0], [1, 1]])
@@ -449,7 +444,6 @@ class TestMiscTrainingFunctionality:
         assert np.allclose(out_map.parameters.matrix.get(None), weights_get_params[out_map])
         assert np.allclose(weights_straight_2.detach().numpy(), weights_get_params[out_map])
 
-        xor.infer_backpropagation_learning_pathways()
         # call run to train the pytorch parameters
         results = xor.learn(inputs={"inputs": {xor_in:xor_inputs},
                                   "targets": {xor_out:xor_targets},
@@ -507,7 +501,6 @@ class TestTrainingCorrectness:
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
 
-        xor.infer_backpropagation_learning_pathways()
         xor_inputs = np.array(  # the inputs we will provide to the model
             [[0, 0], [0, 1], [1, 0], [1, 1]])
 
@@ -643,7 +636,6 @@ class TestTrainingCorrectness:
         sem_net.add_projection(sender=h2, projection=map_h2_has, receiver=out_sig_has)
         sem_net.add_projection(sender=h2, projection=map_h2_can, receiver=out_sig_can)
 
-        sem_net.infer_backpropagation_learning_pathways()
         # INPUTS & OUTPUTS FOR SEMANTIC NET:
 
         nouns = ['oak', 'pine', 'rose', 'daisy', 'canary', 'robin', 'salmon', 'sunfish']
@@ -892,7 +884,6 @@ class TestTrainingCorrectness:
         mnet.add_projection(projection=pco, sender=cl, receiver=ol)
         mnet.add_projection(projection=pho, sender=hl, receiver=ol)
 
-        mnet.infer_backpropagation_learning_pathways()
         mnet.learn(
             inputs=input_set,
             minibatch_size=1,
@@ -1108,7 +1099,6 @@ class TestTrainingCorrectness:
         mnet.add_projection(projection=pco, sender=cl, receiver=ol)
         mnet.add_projection(projection=pho, sender=hl, receiver=ol)
 
-        mnet.infer_backpropagation_learning_pathways()
         
         mnet.learn(
                 inputs=input_set,
@@ -1927,7 +1917,6 @@ class TestTrainingIdenticalness():
         sem_net.add_projection(sender=h2, projection=map_h2_is, receiver=out_sig_is)
         sem_net.add_projection(sender=h2, projection=map_h2_has, receiver=out_sig_has)
         sem_net.add_projection(sender=h2, projection=map_h2_can, receiver=out_sig_can)
-        sem_net.infer_backpropagation_learning_pathways()
         # INPUTS & OUTPUTS FOR SEMANTIC NET:
 
         nouns = ['oak', 'pine', 'rose', 'daisy', 'canary', 'robin', 'salmon', 'sunfish']
@@ -2116,7 +2105,6 @@ class TestTrainingIdenticalness():
 
         xor_dict.add_projection(sender=xor_in_dict, projection=hid_map_dict, receiver=xor_hid_dict)
         xor_dict.add_projection(sender=xor_hid_dict, projection=out_map_dict, receiver=xor_out_dict)
-        xor_dict.infer_backpropagation_learning_pathways()
         # SET UP INPUTS AND TARGETS
 
         xor_inputs_dict = np.array(  # the inputs we will provide to the model
@@ -2176,7 +2164,6 @@ class TestTrainingIdenticalness():
 
         xor_func.add_projection(sender=xor_in_func, projection=hid_map_func, receiver=xor_hid_func)
         xor_func.add_projection(sender=xor_hid_func, projection=out_map_func, receiver=xor_out_func)
-        xor_func.infer_backpropagation_learning_pathways()
 
         # SET UP INPUTS AND TARGETS
 
@@ -2238,7 +2225,6 @@ class TestTrainingIdenticalness():
 
         xor_gen.add_projection(sender=xor_in_gen, projection=hid_map_gen, receiver=xor_hid_gen)
         xor_gen.add_projection(sender=xor_hid_gen, projection=out_map_gen, receiver=xor_out_gen)
-        xor_gen.infer_backpropagation_learning_pathways()
         # SET UP INPUTS AND TARGETS
 
         xor_inputs_gen = np.array(  # the inputs we will provide to the model
@@ -2301,7 +2287,6 @@ class TestTrainingIdenticalness():
 
         xor_gen_func.add_projection(sender=xor_in_gen_func, projection=hid_map_gen_func, receiver=xor_hid_gen_func)
         xor_gen_func.add_projection(sender=xor_hid_gen_func, projection=out_map_gen_func, receiver=xor_out_gen_func)
-        xor_gen_func.infer_backpropagation_learning_pathways()
         # SET UP INPUTS AND TARGETS
 
         xor_inputs_gen_func = np.array(  # the inputs we will provide to the model
@@ -2792,7 +2777,6 @@ class TestNested:
         sem_net.add_projection(sender=h2, projection=map_h2_has, receiver=out_sig_has)
         sem_net.add_projection(sender=h2, projection=map_h2_can, receiver=out_sig_can)
 
-        sem_net.infer_backpropagation_learning_pathways()
         # INPUTS & OUTPUTS FOR SEMANTIC NET:
 
         nouns = ['oak', 'pine', 'rose', 'daisy', 'canary', 'robin', 'salmon', 'sunfish']
@@ -2922,7 +2906,6 @@ class TestBatching:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
-        xor.infer_backpropagation_learning_pathways()
         # SET UP INPUTS AND TARGETS
 
         xor_inputs_1 = np.array(  # the inputs we will provide to the model
@@ -2991,7 +2974,6 @@ class TestBatching:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
-        xor.infer_backpropagation_learning_pathways()
 
         # SET UP INPUTS AND TARGETS
 
@@ -3066,7 +3048,6 @@ class TestBatching:
 
         xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
         xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
-        xor.infer_backpropagation_learning_pathways()
         # SET UP INPUTS AND TARGETS
 
         xor_inputs_1 = np.array(  # the inputs we will provide to the model

--- a/tests/composition/test_learning.py
+++ b/tests/composition/test_learning.py
@@ -22,7 +22,6 @@ class TestHebbian:
         src = [1, 0, 0, 1, 0, 0, 1, 0, 0]
 
         inputs_dict = {Hebb2: np.array(src)}
-        Hebb_C.enable_learning = True
         output = Hebb_C.learn(num_trials=5,
                    inputs=inputs_dict)
 

--- a/tests/composition/test_learning.py
+++ b/tests/composition/test_learning.py
@@ -1204,7 +1204,7 @@ class TestBackProp:
                  [ 0.03080958, 1.02830959],
                  [ 2.00464242, 3.00426575],
              ])),
-            ([results_comp[-1]], [np.array([0.51044657, 0.5483048])]),
+            ([results_comp[-1][0]], [np.array([0.51044657, 0.5483048])]),
         ]
 
         for i in range(len(composition_and_expected_outputs)):

--- a/tests/composition/test_learning.py
+++ b/tests/composition/test_learning.py
@@ -789,7 +789,7 @@ class TestBackProp:
                                       num_trials=(num_epochs * xor_inputs.shape[0]),
                                       )
         if pnl.COMPOSITION in models:
-            result = xor_comp.run(inputs={input_comp:xor_inputs,
+            result = xor_comp.learn(inputs={input_comp:xor_inputs,
                                           target_mech:xor_targets},
                                   num_trials=(num_epochs * xor_inputs.shape[0]),
                                   )
@@ -1345,7 +1345,7 @@ class TestBackProp:
         pco = pnl.MappingProjection(matrix=wco)
         pho = pnl.MappingProjection(matrix=who)
 
-        mnet = pnl.Composition(enable_learning=True)
+        mnet = pnl.Composition()
 
         target_mech = mnet.add_backpropagation_learning_pathway(
             [il, pih, hl, pho, ol],
@@ -1370,10 +1370,8 @@ class TestBackProp:
             target_mech: oSs
         }
 
-        mnet.run(inputs=inputs)
-
+        mnet.learn(inputs=inputs)
         mnet.enable_learning = False
-
         mnet.run(inputs=inputs)
         
         comparator = np.array([0.02288846, 0.11646781, 0.03473711, 0.0348004, 0.01679579,

--- a/tests/log/test_log.py
+++ b/tests/log/test_log.py
@@ -1219,7 +1219,7 @@ class TestFullModels:
 
         middle_weights.set_log_conditions(('mod_matrix', pnl.PROCESSING))
 
-        comp.run(inputs=input_dictionary,
+        comp.learn(inputs=input_dictionary,
                  num_trials=10)
 
         expected_log_val = np.array(
@@ -1336,7 +1336,7 @@ class TestFullModels:
         # Clear log and test with logging of weights set to LEARNING for another 5 trials of learning
         middle_weights.log.clear_entries(entries=None, confirm=False)
         middle_weights.set_log_conditions(('mod_matrix', pnl.LEARNING))
-        comp.run(
+        comp.learn(
             num_trials=5,
             inputs=input_dictionary,
         )

--- a/tests/mechanisms/test_contrastive_hebbian_mechanism.py
+++ b/tests/mechanisms/test_contrastive_hebbian_mechanism.py
@@ -61,7 +61,7 @@ class TestContrastiveHebbian:
         C.add_node(R)
 
         inputs_dict = {R:[1,0,1,0]}
-        C.run(num_trials=4,
+        C.learn(num_trials=4,
               inputs=inputs_dict)
 
         # KDM 10/2/18: removing this test from here, as it's kind of unimportant to this specific test
@@ -87,7 +87,7 @@ class TestContrastiveHebbian:
         # Reset state so learning of new pattern is "uncontaminated" by activity from previous one
         R.output_port.parameters.value.set([0, 0, 0, 0], C, override=True)
         inputs_dict = {R:[0,1,0,1]}
-        C.run(num_trials=4,
+        C.learn(num_trials=4,
               inputs=inputs_dict)
         np.testing.assert_allclose(
             R.recurrent_projection.get_mod_matrix(C),
@@ -127,9 +127,9 @@ class TestContrastiveHebbian:
                 # auto=0,
                 hetero=np.full((size,size),0.0)
         )
+
         P=pnl.Process(pathway=[R])
         S=pnl.System(processes=[P])
-
         inputs_dict = {R:[1,0,1,0]}
         S.run(num_trials=4,
               inputs=inputs_dict)
@@ -214,7 +214,7 @@ class TestContrastiveHebbian:
         c = pnl.Composition()
         c.add_linear_processing_pathway([m,o])
         c.scheduler.add_condition(o, pnl.WhenFinished(m))
-        c.run(inputs={m:[2,2]}, num_trials=4)
+        c.learn(inputs={m:[2,2]}, num_trials=4)
         results = c.parameters.results.get(c)
         np.testing.assert_allclose(results, [[[2.671875]],
                                              [[2.84093837]],

--- a/tests/mechanisms/test_control_mechanism.py
+++ b/tests/mechanisms/test_control_mechanism.py
@@ -193,7 +193,7 @@ class TestLCControlMechanism:
             Control_Mechanism: [1.0],
             learning_components[pnl.TARGET_MECHANISM]: [[0, 0, 1]]}
     
-        comp.run(num_trials=3, inputs=stim_list)
+        comp.learn(num_trials=3, inputs=stim_list)
     
         expected_results = [[[0.81493513, 0.85129046, 0.88154205]],
                             [[0.81250527, 0.84947508, 0.88159668]],
@@ -201,12 +201,12 @@ class TestLCControlMechanism:
         assert np.allclose(comp.results, expected_results)
     
         stim_list[Control_Mechanism]=[0.0]
-        results = comp.run(num_trials=1, inputs=stim_list)
+        results = comp.learn(num_trials=1, inputs=stim_list)
         expected_results = [[[0.5, 0.5, 0.5]]]
         assert np.allclose(results, expected_results)
     
         stim_list[Control_Mechanism]=[2.0]
-        results = comp.run(num_trials=1, inputs=stim_list)
+        results = comp.learn(num_trials=1, inputs=stim_list)
         expected_results = [[0.96801676, 0.98304415, 0.99225722]]
         assert np.allclose(results, expected_results)
 

--- a/tests/mechanisms/test_gating_mechanism.py
+++ b/tests/mechanisms/test_gating_mechanism.py
@@ -52,7 +52,7 @@ def test_gating_with_composition():
         Gating_Mechanism: [1.0],
         learning_components[TARGET_MECHANISM]: [[0, 0, 1]]}
 
-    comp.run(num_trials=3, inputs=stim_list)
+    comp.learn(num_trials=3, inputs=stim_list)
 
     expected_results = [[[0.81493513, 0.85129046, 0.88154205]],
                         [[0.81250527, 0.84947508, 0.88159668]],
@@ -60,12 +60,12 @@ def test_gating_with_composition():
     assert np.allclose(comp.results, expected_results)
 
     stim_list[Gating_Mechanism]=[0.0]
-    results = comp.run(num_trials=1, inputs=stim_list)
+    results = comp.learn(num_trials=1, inputs=stim_list)
     expected_results = [[[0.5, 0.5, 0.5]]]
     assert np.allclose(results, expected_results)
 
     stim_list[Gating_Mechanism]=[2.0]
-    results = comp.run(num_trials=1, inputs=stim_list)
+    results = comp.learn(num_trials=1, inputs=stim_list)
     expected_results = [[0.96801676, 0.98304415, 0.99225722]]
     assert np.allclose(results, expected_results)
 

--- a/tests/mechanisms/test_recurrent_transfer_mechanism.py
+++ b/tests/mechanisms/test_recurrent_transfer_mechanism.py
@@ -921,7 +921,6 @@ class TestRecurrentTransferMechanismInSystem:
         assert R.learning_rate == 0.1
         assert R.learning_mechanism.learning_rate == 0.1
         # assert R.learning_mechanism.function.learning_rate == 0.1
-
         s.run(inputs=[[1.0, 1.0, 1.0, 1.0]])
         matrix_1 = [[0., 1.1, 1.1, 1.1],
                     [1.1, 0., 1.1, 1.1],


### PR DESCRIPTION
This refactor adds:

- composition.learn
    - Standard psyneulink learning and autodiffcomposition learning has been merged into one standardized api
- composition.disable_learning (instead of composition.enable_learning and composition.learning_enabled)
- A bugfix for hebbian learning 
- minibatching/patience/run_after(before)_minibatch functionality to both autodiff and psyneulink learning
- A partial restructure of the llvm compiled autodiff code
- cleanup of Autodiffcomposition code - Autodiff now uses the standard target_node input format, as used by normal learning in psyneulink
- helper methods that emulate the previous functionality of autodiff (i.e. automatic creation of backprop pathways)