### PR TITLE
travis: Bump mac os python to 3.8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ dist: bionic
 
 env:
   jobs:
-    - PYTHON=3.8.1
+    - PYTHON=3.8.2
     - PYTHON=3.7.6
     - PYTHON=3.6.8
   global:


### PR DESCRIPTION
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>