### PR TITLE
github-actions: Do not try to upload test results if the job was canceled

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -55,7 +55,7 @@ jobs:
       with:
         name: test-results-${{ matrix.os }}-${{ matrix.python-version }}
         path: tests_out.xml
-      if: always()
+      if: job.status != 'canceled'
 
     - name: Build dist
       run: |


### PR DESCRIPTION

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>