### PR TITLE
Feat/component/num executions

### DIFF
--- a/.idea/runConfigurations/EVC_Gratton_Composition.xml
+++ b/.idea/runConfigurations/EVC_Gratton_Composition.xml
@@ -1,12 +1,12 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="EVC-Gratton Composition" type="PythonConfigurationType" factoryName="Python">
-    <module name="PsyNeuLink (Dropbox)" />
+  <configuration default="false" factoryName="Python" name="EVC-Gratton Composition" type="PythonConfigurationType">
+    <module name="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python37/bin/python" />
+    <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Scripts/Examples/Composition" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/.idea/runConfigurations/Make_HTML.xml
+++ b/.idea/runConfigurations/Make_HTML.xml
@@ -1,9 +1,9 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Make HTML" type="docs" factoryName="Sphinx task" singleton="false">
-    <module name="PsyNeuLink (Dropbox)" />
+  <configuration default="false" factoryName="Sphinx task" name="Make HTML" singleton="false" type="docs">
+    <module name="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
-    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python37/bin/python" />
+    <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/docs" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/.idea/runConfigurations/Make_HTML.xml
+++ b/.idea/runConfigurations/Make_HTML.xml
@@ -1,9 +1,9 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" factoryName="Sphinx task" name="Make HTML" singleton="false" type="docs">
-    <module name="" />
+  <configuration default="false" name="Make HTML" type="docs" factoryName="Sphinx task" singleton="false">
+    <module name="PsyNeuLink (Dropbox)" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
-    <option name="SDK_HOME" value="" />
+    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python37/bin/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/docs" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/.idea/runConfigurations/Scratch_Pad.xml
+++ b/.idea/runConfigurations/Scratch_Pad.xml
@@ -1,12 +1,12 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Scratch Pad" type="PythonConfigurationType" factoryName="Python">
-    <module name="PsyNeuLink (Dropbox)" />
+  <configuration default="false" factoryName="Python" name="Scratch Pad" type="PythonConfigurationType">
+    <module name="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python37/bin/python" />
+    <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Scripts" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/.idea/runConfigurations/Scratch_Pad.xml
+++ b/.idea/runConfigurations/Scratch_Pad.xml
@@ -1,12 +1,12 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" factoryName="Python" name="Scratch Pad" type="PythonConfigurationType">
-    <module name="" />
+  <configuration default="false" name="Scratch Pad" type="PythonConfigurationType" factoryName="Python">
+    <module name="PsyNeuLink (Dropbox)" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="" />
+    <option name="SDK_HOME" value="$USER_HOME$/anaconda/envs/python37/bin/python" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/Scripts" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/.idea/runConfigurations/Stroop_Model___Conflict_Monitoring.xml
+++ b/.idea/runConfigurations/Stroop_Model___Conflict_Monitoring.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Stroop Model - Conflict Monitoring" type="PythonConfigurationType" factoryName="Python">
-    <module name="PsyNeuLink (Dropbox)" />
+  <configuration default="false" factoryName="Python" name="Stroop Model - Conflict Monitoring" type="PythonConfigurationType">
+    <module name="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1191,7 +1191,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         blacklist = {"previous_time", "previous_value", "previous_v",
                      "previous_w", "random_state", "is_finished_flag",
                      "num_executions_before_finished", "num_executions", "variable",
-                     "value", "saved_values", "saved_samples", "grid", 
+                     "value", "saved_values", "saved_samples", "grid",
                      # Invalid types
                      "input_port_variables", "results", "simulation_results",
                      "monitor_for_control", "feature_values", "simulation_ids",

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2598,8 +2598,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             'non-TimeScale value provided in time_scales argument of _increment_num_executions'
         curr_num_execs = self.parameters.num_executions._get(context)
         for time_scale in time_scales:
-            new_val = curr_num_execs._get_time_by_scale(time_scale) + count
-            curr_num_execs._set_time_by_scale(time_scale, new_val)
+            new_val = curr_num_execs._get_by_time_scale(time_scale) + count
+            curr_num_execs._set_by_time_scale(time_scale, new_val)
         self.parameters.num_executions.set(curr_num_execs, override=True)
         return curr_num_execs
 

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2552,7 +2552,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         else:
             if self.initialization_status & ~(ContextFlags.VALIDATING | ContextFlags.INITIALIZING):
                 self._increment_execution_count()
-                self._increment_num_executions(context, TimeScale.TIME_STEP)
+                self._increment_num_executions(context,
+                                               [TimeScale.TIME_STEP, TimeScale.PASS, TimeScale.TRIAL, TimeScale.RUN])
             self._update_current_execution_time(context=context)
 
         # CALL FUNCTION
@@ -2590,11 +2591,15 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         self.parameters.execution_count.set(self.execution_count + count, override=True)
         return self.execution_count
 
-    def _increment_num_executions(self, context, time_scale:TimeScale, count=1):
+    def _increment_num_executions(self, context, time_scales:(list, TimeScale), count=1):
         # get relevant Time object:
+        time_scales = list(time_scales)
+        assert [isinstance(i, TimeScale) for i in time_scales], \
+            'non-TimeScale value provided in time_scales argument of _increment_num_executions'
         curr_num_execs = self.parameters.num_executions._get(context)
-        new_val = curr_num_execs._get_time_by_scale(time_scale) + count
-        curr_num_execs._set_time_by_scale(time_scale, new_val)
+        for time_scale in time_scales:
+            new_val = curr_num_execs._get_time_by_scale(time_scale) + count
+            curr_num_execs._set_time_by_scale(time_scale, new_val)
         self.parameters.num_executions.set(curr_num_execs, override=True)
         return curr_num_execs
 

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -366,9 +366,9 @@ Component_Execution_Termination
 
 * **num_executions_before_finished** -- contains the number of times the Component has executed prior to finishing
   (and since it last finished);  depending upon the class, these may all be within a single call to the Component's
-  `execute <Component.execute>` method, or extend over several calls.  Note that this is distinct from the
-  `execution_count <Comopnent.execution_count>` attribute, that contains the total number of times the Component
-  has executed in its "life."
+  `execute <Component.execute>` method, or extend over several calls.  It is set to 0 each time `is_finished` evalutes
+  to True. Note that this is distinct from the `execution_count <Component_Execution_Count>` and `num_executions
+  <Component_Num_Executions>` attributes.
 
 .. _Component_Max_Executions_Before_Finished:
 
@@ -389,8 +389,15 @@ Component_Execution_Termination
   *excluding*  executions carried out during initialization and validation, but including all others whether they are
   of the Component on its own are as part of a `Composition`, and irresective of the `context <Context>` in which
   they are occur. The value can be changed "manually" or programmatically by assigning an integer
-  value directly to the attribute.  Note that this is the distinct from the `num_executions_before_finished
-  <Component_Num_Executions_Before_Finished>` attribute.
+  value directly to the attribute.  Note that this is the distinct from the `num_executions <Component_Num_Executions>`
+  and `num_executions_before_finished <Component_Num_Executions_Before_Finished>` attributes.
+
+.. _Component_Num_Executions:
+
+* **num_executions** -- maintains a record of the number of times a Component has executed in a particular `context
+  <Context>` and at different `TimeScales <TimeScale>` in a `Time` object. The value cannot be changed. Note that this
+  is the distinct from the `execution_count <Component_Execution_Count>` and `num_executions_before_finished
+  <Component_Num_Executions_Before_Finished>` attributes.
 
 .. _Component_Current_Execution_Time:
 
@@ -457,6 +464,7 @@ from psyneulink.core.globals.keywords import \
     MODULATORY_SPEC_KEYWORDS, NAME, OUTPUT_PORTS, PARAMS, PREFS_ARG, \
     REINITIALIZE_WHEN, SIZE, VALUE, VARIABLE
 from psyneulink.core.globals.log import LogCondition
+from psyneulink.core.scheduling.time import Time, TimeScale
 from psyneulink.core.globals.parameters import Defaults, Parameter, ParameterAlias, ParameterError, ParametersBase, copy_parameter_value
 from psyneulink.core.globals.preferences.basepreferenceset import BasePreferenceSet, VERBOSE_PREF
 from psyneulink.core.globals.preferences.preferenceset import \
@@ -719,6 +727,9 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
     execution_count : int
         see `execution_count <Component_Execution_Count>`
 
+    num_executions : Time
+        see `num_executions <_Component_Num_Executions>`
+
     current_execution_time : tuple(`Time.RUN`, `Time.TRIAL`, `Time.PASS`, `Time.TIME_STEP`)
         see `current_execution_time <Component_Current_Execution_Time>`
 
@@ -832,6 +843,13 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                     :type: ``int``
                     :read only: True
 
+                num_executions
+                    see `num_executions <_Component_Num_Executions>`
+
+                    :default value:
+                    :type: ``Time``
+                    :read only: True
+
                 has_initializers
                     see `has_initializers <Component.has_initializers>`
 
@@ -871,7 +889,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                                     pnl_internal=True)
         is_finished_flag = Parameter(True, loggable=False, stateful=True)
         execute_until_finished = True
-        num_executions_before_finished = Parameter(0, read_only=True)
+        num_executions = Parameter(Time(), read_only=True, modulable=False)
+        num_executions_before_finished = Parameter(0, read_only=True, modulable=False)
         max_executions_before_finished = Parameter(1000, modulable=False)
 
         def _parse_variable(self, variable):
@@ -2533,6 +2552,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         else:
             if self.initialization_status & ~(ContextFlags.VALIDATING | ContextFlags.INITIALIZING):
                 self._increment_execution_count()
+                self._increment_num_executions(context)
             self._update_current_execution_time(context=context)
 
         # CALL FUNCTION
@@ -2569,6 +2589,14 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
     def _increment_execution_count(self, count=1):
         self.parameters.execution_count.set(self.execution_count + count, override=True)
         return self.execution_count
+
+    def _increment_num_executions(self, context, time_scale:TimeScale, count=1):
+        # get relevant Time object:
+        curr_num_execs = self.parameters.num_executions._get(context)
+        new_val = curr_num_execs._get_time_by_scale(time_scale) + count
+        curr_num_execs._set_time_by_scale(time_scale, new_val)
+        self.parameters.num_executions.set(curr_num_execs, override=True)
+        return curr_num_execs
 
     @property
     def current_execution_time(self):

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -889,7 +889,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                                     pnl_internal=True)
         is_finished_flag = Parameter(True, loggable=False, stateful=True)
         execute_until_finished = True
-        num_executions = Parameter(Time(), read_only=True, modulable=False)
+        num_executions = Parameter(Time(), read_only=True, modulable=False, loggable=False)
         num_executions_before_finished = Parameter(0, read_only=True, modulable=False)
         max_executions_before_finished = Parameter(1000, modulable=False)
 

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -861,7 +861,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         variable = Parameter(np.array([0]), read_only=True, pnl_internal=True, constructor_argument='default_variable')
         value = Parameter(np.array([0]), read_only=True, pnl_internal=True)
         has_initializers = Parameter(False, setter=_has_initializers_setter, pnl_internal=True)
-        # execution_count ios not stateful because it is a global counter;
+        # execution_count is not stateful because it is a global counter;
         #    for context-specific counts should use schedulers which store this info
         execution_count = Parameter(0,
                                     read_only=True,

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2552,7 +2552,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         else:
             if self.initialization_status & ~(ContextFlags.VALIDATING | ContextFlags.INITIALIZING):
                 self._increment_execution_count()
-                self._increment_num_executions(context)
+                self._increment_num_executions(context, TimeScale.TIME_STEP)
             self._update_current_execution_time(context=context)
 
         # CALL FUNCTION

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -394,8 +394,8 @@ Component_Execution_Termination
 
 .. _Component_Num_Executions:
 
-* **num_executions** -- maintains a record of the number of times a Component has executed in a particular `context
-  <Context>` and at different `TimeScales <TimeScale>` in a `Time` object. The value cannot be changed. Note that this
+* **num_executions** -- maintains a record, in a `Time` object, of the number of times a Component has executed in a
+  particular `context <Context>` and at different `TimeScales <TimeScale>`. The value cannot be changed. Note that this
   is the distinct from the `execution_count <Component_Execution_Count>` and `num_executions_before_finished
   <Component_Num_Executions_Before_Finished>` attributes.
 

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -206,7 +206,7 @@ def is_Function(x):
 def is_function_type(x):
     if not x:
         return False
-    elif isinstance(x, (Function, types.FunctionType, types.MethodType)):
+    elif isinstance(x, (Function, types.FunctionType, types.MethodType, types.BuiltinFunctionType, types.BuiltinMethodType)):
         return True
     elif issubclass(x, Function):
         return True

--- a/psyneulink/core/components/functions/objectivefunctions.py
+++ b/psyneulink/core/components/functions/objectivefunctions.py
@@ -1150,7 +1150,7 @@ class Distance(ObjectiveFunction):
         except TypeError:
             v2 = variable[1]
 
-        # Maximum of  Hadamard (elementwise) difference of v1 and v2
+        # Maximum of Hadamard (elementwise) difference of v1 and v2
         if self.metric is MAX_ABS_DIFF:
             result = np.max(abs(v1 - v2))
 

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -498,6 +498,7 @@ accepts a single argument that is a 2d array with two entries.
     ``attention`` executes 3 times in pass 0 as it did in trial 0;  however, ``decision`` executes only 3 times
     since it begins closer to its threshold in that trial.
 
+
 .. _TransferMechanism_Reinitialization:
 
 *Reinitialization*

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -301,7 +301,14 @@ executions that have taken place since the last time the termination condition w
 `num_executions_before_finished <Component.num_executions_before_finished>`; this is set to 0 each time the termination
 condition is met.
 
-By default, a TransferMechanism uses a convergence criterion to terminate integration, as in the following example::
+   .. note::
+     A TransferMechanism will continue to execute even after its termination condition is met, carrying out one
+     additional step of integration each time it is executed.  This can be useful in cases where the initial execution
+     of the Mechanism is meant to bring it to some state (e.g., as an initial "settling process"), after which
+     subsequent executions are meant to occur in step with the execution of other Mechanisms in a Composition.
+
+By default, `execute_until_finished <Component.execute_until_finished>` is True, and a convergence criterion is used to
+terminate integration, as in the following example::
 
     >>> my_mech = pnl.TransferMechanism(size=2,
     ...                                 integrator_mode=True,
@@ -332,7 +339,7 @@ accepts a single argument that is a 2d array with two entries.
 
 *Boundary termination* -- There are two types of boundaries:  value or time.
 
-    *Value boundary*.  This terminates execution when the Mechanism's `value <Mechanism_Base.value>` reaches the
+    *Termination by value*.  This terminates execution when the Mechanism's `value <Mechanism_Base.value>` reaches the
     the value specified by the **threshold** argument.  This implemented by specifying **termination_measure** with
     a function that accepts a 2d array with a *single entry* as its argument and returns a scalar.  The single
     entry is the TransferMechanism's current `value <Mechanism_Base.value>` (that is, `previous_value
@@ -356,27 +363,21 @@ accepts a single argument that is a 2d array with two entries.
     the string ">=", which is a key in the `comparison_operators` dict for the Python ``operator.ge``; any of these
     can be used to specify **termination_comparison_op**).
 
-    *Time boundary*.  This terminates execution when the Mechanism has executed a number of times specified by the
-    **threshold** argument. This is implemented by specifying the **termination_measure** using one of the following
-    keywords: *EXECUTION_COUNT*, which terminates execution when the Mechanism's `execution_count
-    <Component.execution_count>` parameter reaches **threshold**; or *NUM_EXECUTIONS_BEFORE_FINISHED*, which terminates
-    execution when the `num_executions_before_finished <Component.num_executions_before_finished>` parameter reaches
-    **threshold** (in both cases, any specification of **termination_comparison_op** is ignored, and
-    `termination_comparison_op <TransferMechanism.termination_comparison_op>` is automatically set to
-    *GREATER_THAN_OR_EQUAL*). In the following example, ``my_mech`` is configured to execute only twice::
+    *Termination by time*.  This terminates execution when the Mechanism has executed a number of times specified by the
+    **threshold** argument. This is specified by assigning a `TimeScale` to **termination_measure**;  execution
+    terminates when the number of executions at that TimeScale equals **termination_threshold**  (in this case, any
+    specification of **termination_comparison_op** is ignored, and `termination_comparison_op
+    <TransferMechanism.termination_comparison_op>` is automatically set to *GREATER_THAN_OR_EQUAL*).
+    In the following example, ``my_mech`` is configured to execute only twice per trial::
 
         >>> my_mech = pnl.TransferMechanism(size=2,
         ...                                 integrator_mode=True,
-        ...                                 termination_measure=NUM_EXECUTIONS_BEFORE_FINISHED,
+        ...                                 termination_measure=TimeScale.TRIAL,
         ...                                 termination_threshold=2)
         >>> my_mech.execute([0.5, 1])
         array([[0.375, 0.75 ]])
         >>> my_mech.num_executions_before_finished
         2
-
-    The difference between using *EXECUTION_COUNT* and *NUM_EXECUTIONS_BEFORE_FINISHED* is that the former continues
-    to increment for the life of the Mechanism until it is explicity reset, whereas the latter is reset to 0 each time
-    the termination condition is met.
 
 .. _TransferMechanism_Reinitialization:
 

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -402,7 +402,7 @@ accepts a single argument that is a 2d array with two entries.
     Mechanism to continue to integrate the instruction and impact stimulus processing once the stimulus is presented::
 
         >>> stim_input = pnl.ProcessingMechanism(size=2)
-        >>> stim_percept = pnl.TransferMechanism(name='Stimulus', size=2, function=pnl.Logistic)
+        >>> stim_percept = pnl.TransferMechanism(size=2, function=pnl.Logistic)
         >>> decision = pnl.TransferMechanism(name='Decision', size=2,
         ...                                  integrator_mode=True,
         ...                                  execute_until_finished=False,
@@ -414,21 +414,21 @@ accepts a single argument that is a 2d array with two entries.
         ...                              leak=8, competition=8, self_excitation=0, time_step_size=.1,
         ...                              termination_threshold=3,
         ...                              termination_measure = pnl.TimeScale.TRIAL)
-        >>> response = pnl.ProcessingMechanism(size=2)
-
+        >>> response = pnl.ProcessingMechanism(name='Response', size=2)
+        ...
         >>> comp = pnl.Composition()
         >>> comp.add_linear_processing_pathway([stim_input, [[1,-1],[-1,1]], stim_percept, decision, response]) #doctest: +SKIP
         >>> comp.add_linear_processing_pathway([instruction_input, attention, stim_percept]) #doctest: +SKIP
-        >>> comp.scheduler.add_condition(response, pnl.WhenFinished(decision))#doctest: +SKIP
-
+        >>> comp.scheduler.add_condition(response, pnl.WhenFinished(decision)) #doctest: +SKIP
+        ...
         >>> stim_percept.set_log_conditions([pnl.RESULT])
         >>> attention.set_log_conditions([pnl.RESULT])
         >>> decision.set_log_conditions([pnl.RESULT])
         >>> response.set_log_conditions(['OutputPort-0'])
-
+        ...
         >>> inputs = {stim_input:        [[1, 1], [1, 1]],
         ...           instruction_input: [[1, -1], [-1, 1]]}
-        >>> comp.run(inputs=inputs)
+        >>> comp.run(inputs=inputs) # doctest: +SKIP
 
     This example implements a simple model of attentional selection in perceptual decision making. In the model,
     ``stim_input`` represents the stimulus input, which is passed to ``stim_percept``, which also receives input
@@ -455,7 +455,7 @@ accepts a single argument that is a 2d array with two entries.
     Mechanisms have now had an opportunity to execute). The value of the ``attention`` and ``decision`` Mechanisms
     after each execution are shown below::
 
-        >>> attention.log.print_entries(display=[pnl.TIME, pnl.VALUE])
+        >>> attention.log.print_entries(display=[pnl.TIME, pnl.VALUE]) #doctest: +SKIP
         Log for Attention:
         Logged Item:   Time          Value
         'RESULT'       0:0:0:1      [0.64565631 0.19781611]  # Trial 0
@@ -471,7 +471,7 @@ accepts a single argument that is a 2d array with two entries.
         'RESULT'       0:1:1:1      [0.1235536  0.74936691]
         'RESULT'       0:1:2:1      [0.12011584 0.75402671]
 
-        >>> decision.log.print_entries(display=[pnl.TIME, pnl.VALUE])
+        >>> decision.log.print_entries(display=[pnl.TIME, pnl.VALUE]) #doctest: +SKIP
         Log for Decision:
         Logged Item:   Time          Value
         'RESULT'       0:0:0:3      [0.33917677 0.2657116 ]  # Trial 0
@@ -483,7 +483,7 @@ accepts a single argument that is a 2d array with two entries.
         'RESULT'       0:1:1:3      [0.56360108 0.6367389 ]
         'RESULT'       0:1:2:3      [0.54679699 0.65839718]
 
-        >>> response.log.print_entries(display=[pnl.TIME, pnl.VALUE])
+        >>> response.log.print_entries(display=[pnl.TIME, pnl.VALUE]) #doctest: +SKIP
         Log for Response:
         Logged Item:   Time          Value
         'OutputPort-0' 0:0:4:4      [0.65908142 0.51319226]  # Trial 0

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -402,24 +402,24 @@ accepts a single argument that is a 2d array with two entries.
     Mechanism to continue to integrate the instruction and impact stimulus processing once the stimulus is presented::
 
         >>> stim_input = pnl.ProcessingMechanism(size=2)
-        >>> stim_percept = pnl.TransferMechanism(name='Stimulus', size=2, function=Logistic)
+        >>> stim_percept = pnl.TransferMechanism(name='Stimulus', size=2, function=pnl.Logistic)
         >>> decision = pnl.TransferMechanism(name='Decision', size=2,
         ...                                  integrator_mode=True,
         ...                                  execute_until_finished=False,
         ...                                  termination_threshold=0.65,
         ...                                  termination_measure=max,
-        ...                                  termination_comparison_op=GREATER_THAN)
-        >>> instruction_input = pnl.ProcessingMechanism(size=2, function=Linear(slope=10))
+        ...                                  termination_comparison_op=pnl.GREATER_THAN)
+        >>> instruction_input = pnl.ProcessingMechanism(size=2, function=pnl.Linear(slope=10))
         >>> attention = pnl.LCAMechanism(name='Attention', size=2, function=pnl.Logistic,
         ...                              leak=8, competition=8, self_excitation=0, time_step_size=.1,
         ...                              termination_threshold=3,
-        ...                              termination_measure = TimeScale.TRIAL)
+        ...                              termination_measure = pnl.TimeScale.TRIAL)
         >>> response = pnl.ProcessingMechanism(size=2)
 
         >>> comp = pnl.Composition()
-        >>> comp.add_linear_processing_pathway([stim_input, [[1,-1],[-1,1]], stim_percept, decision, response])
-        >>> comp.add_linear_processing_pathway([instruction_input, attention, stim_percept])
-        >>> comp.scheduler.add_condition(response, WhenFinished(decision))
+        >>> comp.add_linear_processing_pathway([stim_input, [[1,-1],[-1,1]], stim_percept, decision, response]) #doctest: +SKIP
+        >>> comp.add_linear_processing_pathway([instruction_input, attention, stim_percept]) #doctest: +SKIP
+        >>> comp.scheduler.add_condition(response, pnl.WhenFinished(decision))#doctest: +SKIP
 
         >>> stim_percept.set_log_conditions([pnl.RESULT])
         >>> attention.set_log_conditions([pnl.RESULT])
@@ -455,7 +455,7 @@ accepts a single argument that is a 2d array with two entries.
     Mechanisms have now had an opportunity to execute). The value of the ``attention`` and ``decision`` Mechanisms
     after each execution are shown below::
 
-        >>> attention.log.print_entries(display=[TIME, VALUE])
+        >>> attention.log.print_entries(display=[pnl.TIME, pnl.VALUE])
         Log for Attention:
         Logged Item:   Time          Value
         'RESULT'       0:0:0:1      [0.64565631 0.19781611]  # Trial 0
@@ -471,7 +471,7 @@ accepts a single argument that is a 2d array with two entries.
         'RESULT'       0:1:1:1      [0.1235536  0.74936691]
         'RESULT'       0:1:2:1      [0.12011584 0.75402671]
 
-        >>> decision.log.print_entries(display=[TIME, VALUE])
+        >>> decision.log.print_entries(display=[pnl.TIME, pnl.VALUE])
         Log for Decision:
         Logged Item:   Time          Value
         'RESULT'       0:0:0:3      [0.33917677 0.2657116 ]  # Trial 0
@@ -483,7 +483,7 @@ accepts a single argument that is a 2d array with two entries.
         'RESULT'       0:1:1:3      [0.56360108 0.6367389 ]
         'RESULT'       0:1:2:3      [0.54679699 0.65839718]
 
-        >>> response.log.print_entries(display=[TIME, VALUE])
+        >>> response.log.print_entries(display=[pnl.TIME, pnl.VALUE])
         Log for Response:
         Logged Item:   Time          Value
         'OutputPort-0' 0:0:4:4      [0.65908142 0.51319226]  # Trial 0

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -370,7 +370,7 @@ accepts a single argument that is a 2d array with two entries.
         ...                                 termination_measure=NUM_EXECUTIONS_BEFORE_FINISHED,
         ...                                 termination_threshold=2)
         >>> my_mech.execute([0.5, 1])
-        array([[0.46875, 0.9375 ]])
+        array([[0.375, 0.75 ]])
         >>> my_mech.num_executions_before_finished
         2
 

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -363,8 +363,7 @@ accepts a single argument that is a 2d array with two entries.
     execution when the `num_executions_before_finished <Component.num_executions_before_finished>` parameter reaches
     **threshold** (in both cases, any specification of **termination_comparison_op** is ignored, and
     `termination_comparison_op <TransferMechanism.termination_comparison_op>` is automatically set to
-    *GREATER_THAN_OR_EQUAL*). The following example mimics the one above, but using number of executions rather than
-    the Mechanism's current value to determine when to terminate::
+    *GREATER_THAN_OR_EQUAL*). In the following example, ``my_mech`` is configured to execute only twice::
 
         >>> my_mech = pnl.TransferMechanism(size=2,
         ...                                 integrator_mode=True,
@@ -375,10 +374,9 @@ accepts a single argument that is a 2d array with two entries.
         >>> my_mech.num_executions_before_finished
         2
 
-    Note that, in this case, ``my_mech`` executed only twice.  The difference between using
-    *EXECUTION_COUNT* and *NUM_EXECUTIONS_BEFORE_FINISHED* is that the former continues to increment for the
-    life of the Mechanism until it is explicity reset, whereas the latter is reset to 0 each time the termination
-    condition is met.
+    The difference between using *EXECUTION_COUNT* and *NUM_EXECUTIONS_BEFORE_FINISHED* is that the former continues
+    to increment for the life of the Mechanism until it is explicity reset, whereas the latter is reset to 0 each time
+    the termination condition is met.
 
 .. _TransferMechanism_Reinitialization:
 

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -328,14 +328,7 @@ accepts a single argument that is a 2d array with two entries.
 *Boundary termination* -- execution terminates when the TransferMechanism's current `value <Mechanism_Base.value>`
 meets the condition specified by the **termination_measure**, **termination_comparison_op** and
 **termination_threshold** arguments, without considering its `previous_value <Mechanism_Base.previous_value>`. There
-are two types of boundaries:  time or value.
-
-    *Time boundary*.  This terminates execution when the Mechanism has executed a number of times specified by the
-    **threshold** argument.  This is implemented by specifying the **termination_measure** using one of the following
-    keywords: *EXECUTION_COUNT*, which terminates execution when the Mechanism's `execution_count
-    <Component.execution_count>` parameter reaches **threshold**; or *NUM_EXECUTIONS_BEFORE_FINISHED*, which terminates
-    execution when the `num_executions_before_finished <Component.num_executions_before_finished>` parameter reaches
-    **threshold**.
+are two types of boundaries:  value or time.
 
     *Value boundary*.  This terminates execution when the Mechanism's `value <Mechanism_Base.value>` reaches the
     the value specified by the **threshold** argument.  This implemented by specifying **termination_measure** with
@@ -363,6 +356,25 @@ are two types of boundaries:  time or value.
     are assigned to the TransferMechanism's `termination_threshold <TransferMechanism.termination_threshold>`,
     `termination_measure <TransferMechanism.termination_measure>`, and `termination_comparison_op
     <TransferMechanism.termination_comparison_op>` attributes, respectively.
+
+    *Time boundary*.  This terminates execution when the Mechanism has executed a number of times specified by the
+    **threshold** argument.  This is implemented by specifying the **termination_measure** using one of the following
+    keywords: *EXECUTION_COUNT*, which terminates execution when the Mechanism's `execution_count
+    <Component.execution_count>` parameter reaches **threshold**; or *NUM_EXECUTIONS_BEFORE_FINISHED*, which terminates
+    execution when the `num_executions_before_finished <Component.num_executions_before_finished>` parameter reaches
+    **threshold**.  The following example mimics the one above, but using a time rather than a value boundary::
+
+        >>> my_mech = pnl.TransferMechanism(size=2,
+        ...                                 integrator_mode=True,
+        ...                                 termination_measure=NUM_EXECUTIONS_BEFORE_FINISHED,
+        ...                                 termination_threshold=2)
+        >>> my_mech.execute([0.5, 1])
+        array([[0.46875, 0.9375 ]])
+        >>> my_mech.num_executions_before_finished
+        2
+
+    Note that, in this case, ``my_mech`` executed only twice.
+
 
 .. _TransferMechanism_Reinitialization:
 
@@ -497,9 +509,10 @@ from psyneulink.core.components.ports.inputport import InputPort
 from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import \
-    COMBINE, comparison_operators, EXECUTION_COUNT, FUNCTION, INITIALIZER, INSTANTANEOUS_MODE_VALUE, \
-    LESS_THAN_OR_EQUAL, MAX_ABS_DIFF, NAME, NOISE, NUM_EXECUTIONS_BEFORE_FINISHED, OWNER_VALUE, \
-    RATE, REINITIALIZE, RESULT, RESULTS, SELECTION_FUNCTION_TYPE, TRANSFER_FUNCTION_TYPE, TRANSFER_MECHANISM, VARIABLE
+    COMBINE, comparison_operators, EXECUTION_COUNT, FUNCTION, GREATER_THAN_OR_EQUAL, \
+    INITIALIZER, INSTANTANEOUS_MODE_VALUE, LESS_THAN_OR_EQUAL, MAX_ABS_DIFF, \
+    NAME, NOISE, NUM_EXECUTIONS_BEFORE_FINISHED, OWNER_VALUE, RATE, REINITIALIZE, RESULT, RESULTS, \
+    SELECTION_FUNCTION_TYPE, TRANSFER_FUNCTION_TYPE, TRANSFER_MECHANISM, VARIABLE
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
@@ -1555,6 +1568,7 @@ class TransferMechanism(ProcessingMechanism_Base):
 
         if measure in termination_keywords:
             self._termination_measure_num_items_expected = 0
+            self.parameters.termination_comparison_op._set(GREATER_THAN_OR_EQUAL, context)
             return
 
         try:

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6597,7 +6597,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             if num_execs is None:
                 node.parameters.num_executions._set(Time(), context)
             else:
-                node.parameters.num_executions._set_by_time_scale(TimeScale.RUN, 0)
+                node.parameters.num_executions._get(context)._set_by_time_scale(TimeScale.RUN, 0)
 
         if initial_values is not None:
             for node in initial_values:

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6848,7 +6848,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                         )
 
             # ---------------------------------------------------------------------------------
-            # store the result of this execute in case it will be the final result
+            # store the result of this execution in case it will be the final result
 
             # object.results.append(result)
             if isinstance(trial_output, collections.abc.Iterable):

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -1279,7 +1279,7 @@ from psyneulink.core.globals.registry import register_category
 from psyneulink.core.globals.utilities import ContentAddressableList, NodeRole, call_with_pruned_args, convert_to_list
 from psyneulink.core.scheduling.condition import All, Always, Condition, EveryNCalls, Never
 from psyneulink.core.scheduling.scheduler import Scheduler
-from psyneulink.core.scheduling.time import TimeScale
+from psyneulink.core.scheduling.time import Time, TimeScale
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel, PreferenceSet, _assign_prefs
 from psyneulink.core.globals.preferences.basepreferenceset import BasePreferenceSet
 from psyneulink.library.components.projections.pathway.autoassociativeprojection import AutoAssociativeProjection
@@ -6593,13 +6593,16 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             termination_processing = new_conds
 
         for node in self.nodes:
-            node.parameters.num_executions.get(context)._set_by_time_scale(TimeScale.RUN, 0)
+            num_execs = node.parameters.num_executions._get(context)
+            if num_execs is None:
+                node.parameters.num_executions._set(Time(), context)
+            else:
+                node.parameters.num_executions._set_by_time_scale(TimeScale.RUN, 0)
 
         if initial_values is not None:
             for node in initial_values:
                 if node not in self.nodes:
-                    raise CompositionError("{} (entry in initial_values arg) is not a node in \'{}\'".
-                                           format(node.name, self.name))
+                    raise CompositionError(f"{node.name} (entry in initial_values arg) is not a node in '{self.name}'")
 
         if reinitialize_values is None:
             reinitialize_values = {}
@@ -7367,9 +7370,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             # execute each node with EXECUTING in context
             for node in next_execution_set:
 
-                node.parameters.num_executions.get(context)._set_time_by_scale(TimeScale.TIME_STEP, 0)
+                node.parameters.num_executions.get(context)._set_by_time_scale(TimeScale.TIME_STEP, 0)
                 if new_pass:
-                    node.parameters.num_executions.get(context)._set_time_by_scale(TimeScale.PASS, 0)
+                    node.parameters.num_executions.get(context)._set_by_time_scale(TimeScale.PASS, 0)
 
 
                 # Store values of all nodes in this execution_set for use by other nodes in the execution set

--- a/psyneulink/core/globals/json.py
+++ b/psyneulink/core/globals/json.py
@@ -181,6 +181,7 @@ import types
 from psyneulink.core.globals.keywords import MODEL_SPEC_ID_COMPOSITION, MODEL_SPEC_ID_GENERIC, MODEL_SPEC_ID_NODES, MODEL_SPEC_ID_PARAMETER_SOURCE, MODEL_SPEC_ID_PARAMETER_VALUE, MODEL_SPEC_ID_PROJECTIONS, MODEL_SPEC_ID_PSYNEULINK, MODEL_SPEC_ID_RECEIVER_MECH, MODEL_SPEC_ID_SENDER_MECH, MODEL_SPEC_ID_TYPE
 from psyneulink.core.globals.sampleiterator import SampleIterator
 from psyneulink.core.globals.utilities import get_all_explicit_arguments, parse_string_to_psyneulink_object_string, parse_valid_identifier, safe_equals
+from psyneulink.core.scheduling.time import Time
 
 __all__ = [
     'PNLJSONError', 'JSONDumpable', 'PNLJSONEncoder',
@@ -241,6 +242,10 @@ class PNLJSONEncoder(json.JSONEncoder):
             return o.name
         elif isinstance(o, SampleIterator):
             return f'{o.__class__.__name__}({repr(o.specification)})'
+        # MODIFIED  NEW: [JDC]
+        elif isinstance(o, Time):
+            return f'{o.life}:{o.run}:{o.trial}:{o.pass_}:{o.time_step}'
+        # MODIFIED  END
         elif isinstance(o, numpy.ndarray):
             return list(o)
         elif isinstance(o, numpy.random.RandomState):

--- a/psyneulink/core/globals/keywords.py
+++ b/psyneulink/core/globals/keywords.py
@@ -81,6 +81,7 @@ __all__ = [
     'MODEL_SPEC_ID_PARAMETER_SOURCE', 'MODEL_SPEC_ID_PARAMETER_VALUE', 'MODEL_SPEC_ID_TYPE', 'MSE',
     'MULTIPLICATIVE', 'MULTIPLICATIVE_PARAM', 'MUTUAL_ENTROPY',
     'NAME', 'NEWEST',  'NODE', 'NodeRoles', 'NOISE', 'NORMAL_DIST_FUNCTION', 'NORMED_L0_SIMILARITY', 'NOT_EQUAL',
+    'NUM_EXECUTIONS_BEFORE_FINISHED',
     'OBJECTIVE_FUNCTION_TYPE', 'OBJECTIVE_MECHANISM', 'OBJECTIVE_MECHANISM_OBJECT', 'OFF', 'OFFSET', 'OLDEST',
     'ON',  'ONLINE', 'OPERATION', 'OPTIMIZATION_FUNCTION_TYPE', 'ORIGIN','ORNSTEIN_UHLENBECK_INTEGRATOR_FUNCTION',
     'OUTCOME', 'OUTCOME_FUNCTION', 'OUTPUT', 'OUTPUT_LABELS_DICT',
@@ -484,9 +485,9 @@ NAME = "name"
 PREFS_ARG = "prefs"
 CONTEXT = "context"
 STANDARD_ARGS = {NAME, VARIABLE, VALUE, PARAMS, PREFS_ARG, CONTEXT}
-EXECUTION_COUNT = 'execution_count'
-EXECUTE_UNTIL_FINISHED = 'execute_until_finished'
-NUM_EXECUTIONS_BEFORE_FINISHED = 'num_executions_before_finished'
+EXECUTION_COUNT = 'execution_count' # Total number of executions of a Component
+EXECUTE_UNTIL_FINISHED = 'execute_until_finished' # Specifies mode of execution
+NUM_EXECUTIONS_BEFORE_FINISHED = 'num_executions_before_finished' # Number of executions since last finished
 MAX_EXECUTIONS_BEFORE_FINISHED = 'max_executions_before_finished'
 
 INITIAL_VALUES = 'initial_values'

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -396,6 +396,10 @@ class AutodiffComposition(Composition):
         self.parameters.tracked_loss_count._set(self.parameters.tracked_loss_count._get(context=context) + 1, context=context, skip_history=True, skip_log=True)
         return outputs
 
+    def clear_losses(self, context=None):
+        self.losses = []
+        self.parameters.losses.set([], context=context)
+
     def _update_learning_parameters(self, context):
         """
         Updates parameters based on trials ran since last update.

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -2399,6 +2399,59 @@ class TestACLogging:
 
         xor_out.log.print_entries()
 
+    def test_autodiff_loss_tracking(self):
+        xor_in = TransferMechanism(name='xor_in',
+                                   default_variable=np.zeros(2))
+
+        xor_hid = TransferMechanism(name='xor_hid',
+                                    default_variable=np.zeros(10),
+                                    function=Logistic())
+
+        xor_out = TransferMechanism(name='xor_out',
+                                    default_variable=np.zeros(1),
+                                    function=Logistic())
+
+        hid_map = MappingProjection()
+        out_map = MappingProjection()
+
+        xor = AutodiffComposition(param_init_from_pnl=True)
+
+        xor.add_node(xor_in)
+        xor.add_node(xor_hid)
+        xor.add_node(xor_out)
+
+        xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
+        xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
+
+        xor_inputs = np.array(  # the inputs we will provide to the model
+            [[0, 0],
+             [0, 1],
+             [1, 0],
+             [1, 1]])
+
+        xor_targets = np.array(  # the outputs we wish to see from the model
+            [[0],
+             [1],
+             [1],
+             [0]])
+
+        # train model for a few epochs
+        num_epochs = 100
+        xor.learn(inputs={"inputs": {xor_in: xor_inputs},
+                        "targets": {xor_out: xor_targets},
+                        "epochs": num_epochs})
+
+        losses = xor.losses
+        # Since the losses track average losses per weight update, and weights are updated every minibatch,
+        # and minibatch_size is 1, then there should be num_epochs * num_minibatches = num_epochs * 4
+        # total entries
+        expected_loss_length = num_epochs * len(xor_inputs)
+        assert len(losses) == expected_loss_length
+
+        # test clearing ad losses
+        xor.clear_losses(context=xor)
+        assert len(xor.losses) == 0
+
 @pytest.mark.pytorch
 @pytest.mark.acnested
 class TestNested:

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -2335,7 +2335,14 @@ class TestACLogging:
         out_map = MappingProjection()
 
         xor = AutodiffComposition(param_init_from_pnl=True)
-        xor.add_backpropagation_learning_pathway([xor_in, hid_map, xor_hid, out_map, xor_out])
+
+        xor.add_node(xor_in)
+        xor.add_node(xor_hid)
+        xor.add_node(xor_out)
+
+        xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
+        xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
+
         hid_map.set_log_conditions('matrix', pnl.LogCondition.TRIAL)
         out_map.set_log_conditions('matrix', pnl.LogCondition.TRIAL)
 
@@ -2441,7 +2448,13 @@ class TestNested:
             param_init_from_pnl=True,
             learning_rate=learning_rate,
         )
-        xor_autodiff.add_backpropagation_learning_pathway([xor_in, hid_map, xor_hid, out_map, xor_out])
+
+        xor_autodiff.add_node(xor_in)
+        xor_autodiff.add_node(xor_hid)
+        xor_autodiff.add_node(xor_out)
+
+        xor_autodiff.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
+        xor_autodiff.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
 
         # -----------------------------------------------------------------
 
@@ -2508,7 +2521,12 @@ class TestNested:
             learning_rate=learning_rate,
         )
 
-        xor_autodiff.add_backpropagation_learning_pathway([xor_in, hid_map, xor_hid, out_map, xor_out])
+        xor_autodiff.add_node(xor_in)
+        xor_autodiff.add_node(xor_hid)
+        xor_autodiff.add_node(xor_out)
+
+        xor_autodiff.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
+        xor_autodiff.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
 
         # -----------------------------------------------------------------
 


### PR DESCRIPTION
This branch builds on feat/transfermechanism/terminate_by_time, 
Add Component.num_executions: a stateful Time object that tracks number of executions of Component in different contexts and at different TimeScales

• Composition:
  - add calls to reset num_executions at each TimeScale

• Component
  - make num_exeuctions not loggable to suppress test_log failures

• json
  PNLJSONEncoder.default:  Time added

• llvm: add support for `num_executions` param
