### PR TITLE
github-actions: Upload test results artifacts on both success and failure

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -55,7 +55,7 @@ jobs:
       with:
         name: test-results-${{ matrix.os }}-${{ matrix.python-version }}
         path: tests_out.xml
-      if: job.status != 'canceled'
+      if: success() || failure()
 
     - name: Build dist
       run: |


### PR DESCRIPTION

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>