### PR TITLE
travis: Bump macos python 3.7 to 3.7.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ dist: bionic
 env:
   jobs:
     - PYTHON=3.8.2
-    - PYTHON=3.7.6
+    - PYTHON=3.7.7
     - PYTHON=3.6.8
   global:
     - PYTHONWARNINGS="ignore::DeprecationWarning"


### PR DESCRIPTION
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>