### PR TITLE
appveyor: Do not build branches with open PRs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,6 @@
 version: '{build}'
 clone_depth: 25
+skip_branch_with_pr: true
 
 branches:
   only:


### PR DESCRIPTION
These builds are redundant and just increase CI load.
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>