### PR TITLE
travis: Install wheel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ before_install:
   - source $HOME/venv/bin/activate
 
   - python --version
-  - pip install -U pip
+  - pip install -U pip wheel
   - pip --version
   - |
     # Install undeclared dependencies


### PR DESCRIPTION
This allows pip to build local wheels of sdist packages.
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>