### PR TITLE
appveyor: Install wheel

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,6 +25,7 @@ install:
   - if not exist %GRAPHVIZ_INSTALLER% appveyor-retry curl https://graphviz.gitlab.io/_pages/Download/windows/%GRAPHVIZ_INSTALLER% -o %GRAPHVIZ_INSTALLER%
   - msiexec.exe /i %GRAPHVIZ_INSTALLER% /passive
   - pip --version
+  - pip install --user wheel
   - pip install --user git+https://github.com/benureau/leabra.git@master
 
   # pytorch does not distribute windows packages over pypi. Install it directly.


### PR DESCRIPTION
This allows pip to build local wheels of sdist packages
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>