### PR TITLE
llvm: Fix controller compiled shape mismatch

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1197,7 +1197,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      "monitor_for_control", "feature_values", "simulation_ids",
                      "input_labels_dict", "output_labels_dict",
                      "modulated_mechanisms", "search_space",
-                     "activation_derivative_fct"}
+                     "activation_derivative_fct", "costs"}
         # mechanism functions are handled separately
         if hasattr(self, 'ports'):
             blacklist.add("function")

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1152,11 +1152,16 @@ class OptimizationControlMechanism(ControlMechanism):
         # Construct input
         comp_input = builder.alloca(sim_f.args[3].type.pointee, name="sim_input")
 
-        num_features = len(arg_in.type.pointee) - 1
-        for i in range(num_features):
-            src = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(i + 1)])
+        for src_idx, ip in enumerate(self.input_ports):
+            if ip.shadow_inputs is None:
+                continue
+            cim_in_port = self.agent_rep.input_CIM_ports[ip.shadow_inputs][0]
+            dst_idx = self.agent_rep.input_CIM.input_ports.index(cim_in_port)
+
+            src = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(src_idx)])
             # Destination is a struct of 2d arrays
-            dst = builder.gep(comp_input, [ctx.int32_ty(0), ctx.int32_ty(i),
+            dst = builder.gep(comp_input, [ctx.int32_ty(0),
+                                           ctx.int32_ty(dst_idx),
                                            ctx.int32_ty(0)])
             builder.store(builder.load(src), dst)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,7 @@ exclude = .git/*,Scripts/*,__pytest__/*,docs/*,bin/*
 [pydocstyle]
 # for code explanation see http://www.pydocstyle.org/en/latest/error_codes.html
 add-ignore = D100,D101,D102,D103,D104,D105,D106,D107,D200,D202,D204,D205,D207,D208,D301,D400,D401,D402,D403,D412,D413,D414
-exclude = .git/*,Scripts/*,__pytest__/*,docs/*,bin/*
+match-dir = (?!Script)(?!bin)(?!docs).*
 
 [coverage:run]
 branch = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ addopts =
     --pydocstyle
     --pycodestyle
     --strict-markers
+    --ignore=Scripts
 
 markers =
 	stress: Long running tests, skipped by defaults

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -1883,6 +1883,55 @@ class TestModelBasedOptimizationControlMechanisms:
         benchmark(comp.run, inputs=inputs, num_trials=10, context='bench_outer_comp', bin_execute=mode)
         assert len(A.log.get_logged_entries()) == 0
 
+    @pytest.mark.control
+    @pytest.mark.composition
+    @pytest.mark.parametrize("mode", ["Python",
+                                      pytest.param("LLVMRun", marks=pytest.mark.llvm),
+                                     ])
+    def test_input_CIM_assignment(self, mode):
+        input_a = pnl.ProcessingMechanism(name='oa', function=pnl.Linear(slope=1))
+        input_b = pnl.ProcessingMechanism(name='ob', function=pnl.Linear(slope=1))
+        output = pnl.ProcessingMechanism(name='oc')
+        comp = pnl.Composition(name='ocomp',
+                               controller_mode=pnl.BEFORE,
+                               retain_old_simulation_data=True)
+        comp.add_linear_processing_pathway([input_a, output])
+        comp.add_linear_processing_pathway([input_b, output])
+        comp.add_controller(
+            pnl.OptimizationControlMechanism(
+                agent_rep=comp,
+                features=[input_b.input_port, input_a.input_port],
+                name="Controller",
+                objective_mechanism=pnl.ObjectiveMechanism(
+                    monitor=output.output_port,
+                    function=pnl.SimpleIntegrator,
+                    name="Output Objective Mechanism"
+                ),
+                function=pnl.GridSearch(direction=pnl.MAXIMIZE),
+                control_signals=[
+                    pnl.ControlSignal(modulates=[(pnl.SLOPE, input_a)],
+                                      intensity_cost_function=pnl.Linear(slope=0),
+                                      allocation_samples=[-1, 1]),
+                    pnl.ControlSignal(modulates=[(pnl.SLOPE, input_b)],
+                                      intensity_cost_function=pnl.Linear(slope=0),
+                                      allocation_samples=[-1, 1])
+                ]))
+        results = comp.run(inputs={input_a: [[5]], input_b: [[-2]]},
+                           bin_execute=mode)
+
+        # The controller of this model uses two control signals: one that modulates the slope of input_a and one that modulates
+        # the slope of input_b. Both control signals have two possible values: -1 or 1.
+        #
+        # In the correct case, input_a receives a control signal with value 1 and input_b receives a control signal with value
+        # -1 to maximize the output of the model given their respective input values of 5 and -2.
+        #
+        # In the errant case, the control signals are flipped so that input_b receives a control signal with value -1 and
+        # input_a receives a control signal with value 1.
+        #
+        # Thus, in the correct case, the output of the model is 7 ((5*1)+(-2*-1)) and in the errant case the output of the model is
+        # -7 ((5*-1)+(-2*1))
+        assert np.allclose(results, [[7]])
+
 class TestSampleIterator:
 
     def test_int_step(self):

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -1910,7 +1910,7 @@ class TestModelBasedOptimizationControlMechanisms:
                 function=pnl.GridSearch(direction=pnl.MAXIMIZE),
                 control_signals=[
                     pnl.ControlSignal(modulates=[(pnl.SLOPE, input_a)],
-                                      intensity_cost_function=pnl.Linear(slope=0),
+                                      intensity_cost_function=pnl.Linear(slope=1),
                                       allocation_samples=[-1, 1]),
                     pnl.ControlSignal(modulates=[(pnl.SLOPE, input_b)],
                                       intensity_cost_function=pnl.Linear(slope=0),


### PR DESCRIPTION
Fix parsing of 'evaluate' inputs into simulation inputs.
Drop 'costs' parameter, it can have an invalid shape.