### PR TITLE
llvm: (Fix) Add mod. inputs to input_type_list if len is >= 1

### DIFF
--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1252,12 +1252,9 @@ class RecurrentTransferMechanism(TransferMechanism):
             input_type_list.append(new_type)
 
         # Add modulatory inputs
-        mod_input_type_list = []
-        for proj in self.mod_afferents:
-            mod_input_type_list.append(ctx.get_output_struct_type(proj))
-        if len(mod_input_type_list) > 1:
-            input_type_list.append(pnlvm.ir.LiteralStructType(mod_input_type_list))
-
+        mod_input_type_list = (ctx.get_output_struct_type(proj) for proj in self.mod_afferents)
+        input_type_list.append(pnlvm.ir.LiteralStructType(mod_input_type_list))
+        
         return pnlvm.ir.LiteralStructType(input_type_list)
 
     def _get_param_ids(self):

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -911,7 +911,7 @@ class TestControlMechanisms:
                                       pytest.param("LLVMExec", marks=pytest.mark.llvm),
                                       pytest.param("LLVMRun", marks=pytest.mark.llvm),
                                      ])
-    def test_recurrent_control(self, mode, benchmark):
+    def test_recurrent_control(self, mode):
         monitor = pnl.TransferMechanism(default_variable=[[0.0]],
                                     size=1,
                                     function=pnl.Linear(slope=1, intercept=0),

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -936,12 +936,14 @@ class TestControlMechanisms:
         comp.add_node(monitor)
         comp.add_node(rtm)
         comp.add_node(controller)
-        comp.run(inputs = {
+        val = comp.run(inputs = {
                     monitor: [[1], [5], [1], [5]],
                     rtm: [[1,0], [1,0] ,[1,0], [1,0]]
                 },
             bin_execute=mode
         )
+        assert np.allclose(val[0], [5])
+        assert np.allclose(val[1], [0.7573055560600637, 0.4500512583901123])
 
 class TestModelBasedOptimizationControlMechanisms:
 


### PR DESCRIPTION
Fixes an issue where if there was only one modulatory input to a RTM, compilation would fail.