### PR TITLE
CompositionInterfaceMechanism/add_ports: emit warning when user manually adds Port to CIM

### DIFF
--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3233,7 +3233,8 @@ class Mechanism_Base(Mechanism):
         plt.show()
 
     @tc.typecheck
-    def add_ports(self, ports):
+    @handle_external_context()
+    def add_ports(self, ports, context=None):
         """
         add_ports(ports)
 

--- a/psyneulink/core/components/mechanisms/processing/compositioninterfacemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/compositioninterfacemechanism.py
@@ -58,6 +58,7 @@ Class Reference
 
 """
 
+import warnings
 import typecheck as tc
 
 from collections.abc import Iterable
@@ -69,7 +70,7 @@ from psyneulink.core.components.mechanisms.processing.processingmechanism import
 from psyneulink.core.components.ports.inputport import InputPort
 from psyneulink.core.components.ports.modulatorysignals.controlsignal import ControlSignal
 from psyneulink.core.components.ports.outputport import OutputPort
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import COMPOSITION_INTERFACE_MECHANISM, PREFERENCE_SET_NAME
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set, REPORT_OUTPUT_PREF
@@ -142,3 +143,12 @@ class CompositionInterfaceMechanism(ProcessingMechanism_Base):
                                                             name=name,
                                                             prefs=prefs,
                                                             )
+
+    @handle_external_context()
+    def add_ports(self, ports, context=None):
+        if context.source == ContextFlags.COMMAND_LINE:
+            warnings.warn(
+                'You are attempting to add custom ports to a CIM, which can result in unpredictable behavior and '
+                'is therefore recommended against. If suitable, you should instead add ports to the mechanism(s) '
+                'that project to or are projected to from the CIM.')
+        super(CompositionInterfaceMechanism, self).add_ports(ports, context)

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -1945,6 +1945,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     #                                              GRAPH
     # ******************************************************************************************************************
 
+    @handle_external_context(source=ContextFlags.COMPOSITION)
     def _analyze_graph(self, scheduler=None, context=None):
         """
         Assigns `NodeRoles <NodeRoles>` to nodes based on the structure of the `Graph`.
@@ -2035,6 +2036,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     #                                               NODES
     # ******************************************************************************************************************
 
+    @handle_external_context(source = ContextFlags.COMPOSITION)
     def add_node(self, node, required_roles=None, context=None):
         """
             Add a Composition Node (`Mechanism <Mechanism>` or `Composition`) to Composition, if it is not already added
@@ -2052,7 +2054,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         self._update_shadows_dict(node)
 
         try:
-            node._analyze_graph()
+            node._analyze_graph(context = context)
         except AttributeError:
             pass
 
@@ -2541,15 +2543,23 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 # if there is not a corresponding CIM OutputPort, add one
                 if input_port not in set(self.input_CIM_ports.keys()):
                     interface_input_port = InputPort(owner=self.input_CIM,
-                                                      variable=input_port.defaults.value,
-                                                      reference_value=input_port.defaults.value,
-                                                      name="INPUT_CIM_" + node.name + "_" + input_port.name)
+                                                     variable=input_port.defaults.value,
+                                                     reference_value=input_port.defaults.value,
+                                                     name="INPUT_CIM_" + node.name + "_" + input_port.name,
+                                                     context=context)
+
+                    self.input_CIM.add_ports([interface_input_port],
+                                             context=context)
 
                     interface_output_port = OutputPort(owner=self.input_CIM,
-                                                        variable=OWNER_VALUE,
-                                                        function=InterfacePortMap(
-                                                             corresponding_input_port=interface_input_port),
-                                                        name="INPUT_CIM_" + node.name + "_" + input_port.name)
+                                                       variable=OWNER_VALUE,
+                                                       function=InterfacePortMap(
+                                                            corresponding_input_port=interface_input_port),
+                                                       name="INPUT_CIM_" + node.name + "_" + input_port.name,
+                                                       context=context)
+
+                    self.input_CIM.add_ports([interface_output_port],
+                                             context=context)
 
                     self.input_CIM_ports[input_port] = [interface_input_port, interface_output_port]
 
@@ -2611,14 +2621,22 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                     interface_input_port = InputPort(owner=self.output_CIM,
                                                      variable=output_port.defaults.value,
                                                      reference_value=output_port.defaults.value,
-                                                     name="OUTPUT_CIM_" + node.name + "_" + output_port.name)
+                                                     name="OUTPUT_CIM_" + node.name + "_" + output_port.name,
+                                                     context=context)
+
+                    self.output_CIM.add_ports([interface_input_port],
+                                              context=context)
 
                     interface_output_port = OutputPort(
                             owner=self.output_CIM,
                             variable=OWNER_VALUE,
                             function=InterfacePortMap(corresponding_input_port=interface_input_port),
                             reference_value=output_port.defaults.value,
-                            name="OUTPUT_CIM_" + node.name + "_" + output_port.name)
+                            name="OUTPUT_CIM_" + node.name + "_" + output_port.name,
+                            context=context)
+
+                    self.output_CIM.add_ports([interface_output_port],
+                                              context=context)
 
                     self.output_CIM_ports[output_port] = [interface_input_port, interface_output_port]
 


### PR DESCRIPTION
Reworked previously reverted warning that occurs when a user manually adds a Port to a CIM