### PR TITLE
llvm, functions/DriftDiffusionAnalytical: Use abs value to check magnitude

### DIFF
--- a/psyneulink/core/components/functions/distributionfunctions.py
+++ b/psyneulink/core/components/functions/distributionfunctions.py
@@ -1429,7 +1429,6 @@ class DriftDiffusionAnalytical(DistributionFunction):  # -----------------------
         starting_point = builder.fmul(starting_point, starting_point.type(2))
         starting_point = builder.fmul(starting_point, threshold)
 
-        abs_drift_rate = builder.call(abs_f, [drift_rate])
         drift_rate_limit = abs_drift_rate.type(0.01)
         small_drift = builder.fcmp_ordered("<", abs_drift_rate, drift_rate_limit)
         drift_rate = builder.select(small_drift, drift_rate_limit, drift_rate)
@@ -1443,7 +1442,7 @@ class DriftDiffusionAnalytical(DistributionFunction):  # -----------------------
         Z = pnlvm.helpers.fclamp(builder, Z, Z.type(-100), Z.type(100))
 
         abs_Z = builder.call(abs_f, [Z])
-        tiny_Z = builder.fcmp_ordered("<", Z, Z.type(0.0001))
+        tiny_Z = builder.fcmp_ordered("<", abs_Z, Z.type(0.0001))
         Z = builder.select(tiny_Z, Z.type(0.0001), Z)
 
         # Mean helpers

--- a/tests/functions/test_distribution.py
+++ b/tests/functions/test_distribution.py
@@ -18,6 +18,8 @@ test_data = [
      (1.9774974807292212, 0.012242689689501842, 1.9774974807292207, 1.3147677945132479, 1.7929299891370192, 1.9774974807292207, 1.3147677945132479, 1.7929299891370192)),
     (Functions.DriftDiffusionAnalytical, test_var, {"drift_rate": RAND1, "threshold": RAND2, "starting_point": RAND3, "t0":RAND4, "noise": RAND5}, None,
      (0.4236547993389047, -2.7755575615628914e-17, 0.5173675420165031, 0.06942854144616283, 6.302631815990666, 1.4934079600147951, 0.4288991185241868, 1.7740760781361433)),
+    (Functions.DriftDiffusionAnalytical, -test_var, {"drift_rate": RAND1, "threshold": RAND2, "starting_point": RAND3, "t0":RAND4, "noise": RAND5}, None,
+     (0.42365479933890504, 0.0, 0.5173675420165031, 0.06942854144616283, 6.302631815990666, 1.4934079600147951, 0.4288991185241868, 1.7740760781361433)),
 #    FIXME: Rounding errors result in different behaviour on different platforms
 #    (Functions.DriftDiffusionAnalytical, 1e-4, {"drift_rate": 1e-5, "threshold": RAND2, "starting_point": RAND3, "t0":RAND4, "noise": RAND5}, "Rounding errors",
 #     (0.5828813465336954, 0.04801236718458773, 0.532471083815943, 0.09633801362499317, 6.111833139205608, 1.5821207676710864, 0.5392724012504414, 1.8065252817609618)),
@@ -30,6 +32,7 @@ test_data = [
 names = [
     "DriftDiffusionAnalytical-DefaultParameters",
     "DriftDiffusionAnalytical-RandomParameters",
+    "DriftDiffusionAnalytical-NegInput",
 #    "DriftDiffusionAnalytical-SmallDriftRate",
     "NormalDist1",
     "NormalDist2",


### PR DESCRIPTION

As originally intended.
Add test.
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>