### PR TITLE
fix/warning/string_comp: To prevent unnecessary warnings, check if pa…

### DIFF
--- a/psyneulink/core/components/projections/pathway/mappingprojection.py
+++ b/psyneulink/core/components/projections/pathway/mappingprojection.py
@@ -542,7 +542,8 @@ class MappingProjection(PathwayProjection_Base):
 
         matrix_spec = self.defaults.matrix
 
-        if matrix_spec == AUTO_ASSIGN_MATRIX:
+        if type(matrix_spec) == str and \
+            matrix_spec == AUTO_ASSIGN_MATRIX:
             if mapping_input_len == receiver_len:
                 matrix_spec = IDENTITY_MATRIX
             else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ markers =
 	mimo: Tests using multiple inputs and outputs
 	model: Tests based on existing models
 	pytorch: Tests using Torch
+	filterwarnings
 
 pytest_plugins = ['pytest_profiling', 'helpers_namespace', 'benchmark']
 

--- a/tests/composition/test_interfaces.py
+++ b/tests/composition/test_interfaces.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import warnings
 
 import psyneulink.core.llvm as pnlvm
 
@@ -497,7 +496,9 @@ class TestConnectCompositionsViaCIMS:
         # level_2 output = 2.0 * (1.0 + 2.0 + 14.0) = 34.0
         assert np.allclose(level_2.get_output_values(level_2), [34.0])
 
+    @pytest.mark.filterwarnings("error")
     def test_warning_on_custom_cim_ports(self):
+
         comp = Composition()
         mech = ProcessingMechanism()
         warning_text = ('You are attempting to add custom ports to a CIM, which can result in unpredictable behavior and '
@@ -505,23 +506,21 @@ class TestConnectCompositionsViaCIMS:
                         'that project to or are projected to from the CIM.')
         warning_fired = False
         comp.add_node(mech)
-        with warnings.catch_warnings():
-            warnings.filterwarnings('error')
-            try:
-                comp.input_CIM.add_ports(OutputPort())
-            except Warning as w:
-                # confirm that warning fired and that its text is correct
-                assert w.args[0] == warning_text
+        try:
+            comp.input_CIM.add_ports(OutputPort())
+        except Warning as w:
+            # confirm that warning fired and that its text is correct
+            assert w.args[0] == warning_text
+            warning_fired = True
+        assert warning_fired
+        warning_fired = False
+        try:
+            comp._analyze_graph()
+            comp.run({mech: [[1]]})
+        except Warning:
+            if w.args[0] == warning_text:
                 warning_fired = True
-            assert warning_fired
-            warning_fired = False
-            try:
-                comp._analyze_graph()
-                comp.run({mech: [[1]]})
-            except Warning:
-                if w.args[0] == warning_text:
-                    warning_fired = True
-            assert not warning_fired
+        assert not warning_fired
 
 class TestInputCIMOutputPortToOriginOneToMany:
 

--- a/tests/projections/test_projection_specifications.py
+++ b/tests/projections/test_projection_specifications.py
@@ -1,7 +1,6 @@
 import psyneulink as pnl
 import numpy as np
 import pytest
-import warnings
 
 import psyneulink.core.components.functions.distributionfunctions
 import psyneulink.core.components.functions.statefulfunctions.integratorfunctions
@@ -350,6 +349,7 @@ class TestProjectionSpecificationFormats:
         # assert 'Primary OutputPort of ControlMechanism-1 (ControlSignal-0) ' \
         #        'cannot be used as a sender of a Projection to OutputPort of T2' in error_text.value.args[0]
 
+    @pytest.mark.filterwarnings("error")
     def test_no_warning_when_matrix_specified(self):
 
         warning_fired = False
@@ -366,12 +366,10 @@ class TestProjectionSpecificationFormats:
         m1 = pnl.TransferMechanism(
             default_variable=[0, 0, 0, 0]
         )
-        with warnings.catch_warnings():
-            warnings.filterwarnings('error')
-            try:
-                c.add_linear_processing_pathway([m0, p0, m1])
-            except:
-                warning_fired = True
+        try:
+            c.add_linear_processing_pathway([m0, p0, m1])
+        except:
+            warning_fired = True
         assert not warning_fired
 
     # KDM: this is a good candidate for pytest.parametrize

--- a/tests/projections/test_projection_specifications.py
+++ b/tests/projections/test_projection_specifications.py
@@ -1,6 +1,7 @@
 import psyneulink as pnl
 import numpy as np
 import pytest
+import warnings
 
 import psyneulink.core.components.functions.distributionfunctions
 import psyneulink.core.components.functions.statefulfunctions.integratorfunctions
@@ -348,6 +349,30 @@ class TestProjectionSpecificationFormats:
         #     T2 = pnl.ProcessingMechanism(name='T2', output_ports=[pnl.ControlMechanism()])
         # assert 'Primary OutputPort of ControlMechanism-1 (ControlSignal-0) ' \
         #        'cannot be used as a sender of a Projection to OutputPort of T2' in error_text.value.args[0]
+
+    def test_no_warning_when_matrix_specified(self):
+
+        warning_fired = False
+        c = pnl.Composition()
+        m0 = pnl.ProcessingMechanism(
+            default_variable=[0, 0, 0, 0]
+        )
+        p0 = pnl.MappingProjection(
+            matrix=[[0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0]]
+        )
+        m1 = pnl.TransferMechanism(
+            default_variable=[0, 0, 0, 0]
+        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error')
+            try:
+                c.add_linear_processing_pathway([m0, p0, m1])
+            except:
+                warning_fired = True
+        assert not warning_fired
 
     # KDM: this is a good candidate for pytest.parametrize
     def test_masked_mapping_projection(self):


### PR DESCRIPTION
…rameter is a string before comparing with keyword