### PR TITLE
Fix/string comparison operator/check if string first

### DIFF
--- a/psyneulink/core/components/projections/pathway/mappingprojection.py
+++ b/psyneulink/core/components/projections/pathway/mappingprojection.py
@@ -542,7 +542,8 @@ class MappingProjection(PathwayProjection_Base):
 
         matrix_spec = self.defaults.matrix
 
-        if matrix_spec == AUTO_ASSIGN_MATRIX:
+        if (type(matrix_spec) == str and
+                matrix_spec == AUTO_ASSIGN_MATRIX):
             if mapping_input_len == receiver_len:
                 matrix_spec = IDENTITY_MATRIX
             else:

--- a/tests/composition/test_interfaces.py
+++ b/tests/composition/test_interfaces.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import warnings
 
 import psyneulink.core.llvm as pnlvm
 

--- a/tests/composition/test_interfaces.py
+++ b/tests/composition/test_interfaces.py
@@ -498,6 +498,7 @@ class TestConnectCompositionsViaCIMS:
         assert np.allclose(level_2.get_output_values(level_2), [34.0])
 
     def test_warning_on_custom_cim_ports(self):
+
         comp = Composition()
         mech = ProcessingMechanism()
         warning_text = ('You are attempting to add custom ports to a CIM, which can result in unpredictable behavior and '
@@ -505,21 +506,18 @@ class TestConnectCompositionsViaCIMS:
                         'that project to or are projected to from the CIM.')
         warning_fired = False
         comp.add_node(mech)
-        with warnings.catch_warnings():
-            warnings.filterwarnings('error')
-            try:
-                comp.input_CIM.add_ports(OutputPort())
-            except Warning as w:
-                # confirm that warning fired and that its text is correct
-                assert w.args[0] == warning_text
-                warning_fired = True
+        with pytest.warns(UserWarning) as w:
+            comp.input_CIM.add_ports(OutputPort())
+            # confirm that warning fired and that its text is correct
+            for warn in w:
+                if warn.message.args[0] == warning_text:
+                    warning_fired = True
             assert warning_fired
             warning_fired = False
-            try:
-                comp._analyze_graph()
-                comp.run({mech: [[1]]})
-            except Warning:
-                if w.args[0] == warning_text:
+            comp._analyze_graph()
+            comp.run({mech: [[1]]})
+            for warn in w[1:]:
+                if warn.message.args[0] == warning_text:
                     warning_fired = True
             assert not warning_fired
 

--- a/tests/projections/test_projection_specifications.py
+++ b/tests/projections/test_projection_specifications.py
@@ -349,6 +349,27 @@ class TestProjectionSpecificationFormats:
         # assert 'Primary OutputPort of ControlMechanism-1 (ControlSignal-0) ' \
         #        'cannot be used as a sender of a Projection to OutputPort of T2' in error_text.value.args[0]
 
+    def test_no_warning_when_matrix_specified(self):
+
+        with pytest.warns(None) as w:
+            c = pnl.Composition()
+            m0 = pnl.ProcessingMechanism(
+                default_variable=[0, 0, 0, 0]
+            )
+            p0 = pnl.MappingProjection(
+                matrix=[[0, 0, 0, 0],
+                        [0, 0, 0, 0],
+                        [0, 0, 0, 0],
+                        [0, 0, 0, 0]]
+            )
+            m1 = pnl.TransferMechanism(
+                default_variable=[0, 0, 0, 0]
+            )
+            c.add_linear_processing_pathway([m0, p0, m1])
+            for warn in w:
+                if r'elementwise comparison failed; returning scalar instead' in warn.message.args[0]:
+                    raise
+
     # KDM: this is a good candidate for pytest.parametrize
     def test_masked_mapping_projection(self):
 


### PR DESCRIPTION
To prevent unnecessary warnings, check that parameter is a string before doing comparison with keyword