### PR TITLE
components: Drop 'random_state' from 'stateful_attributes'

### DIFF
--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -1294,8 +1294,6 @@ class GridSearch(OptimizationFunction):
             prefs=prefs,
         )
 
-        self.stateful_attributes = ["random_state"]
-
     def _validate_params(self, request_set, target_set=None, context=None):
 
         super()._validate_params(request_set=request_set, target_set=target_set, context=context)

--- a/psyneulink/core/components/functions/selectionfunctions.py
+++ b/psyneulink/core/components/functions/selectionfunctions.py
@@ -212,8 +212,6 @@ class OneHot(SelectionFunction):
             seed = get_global_seed()
 
         random_state = np.random.RandomState([seed])
-        if not hasattr(self, "stateful_attributes"):
-            self.stateful_attributes = ["random_state"]
 
         reset_default_variable_flexibility = False
         if mode in {PROB, PROB_INDICATOR} and default_variable is None:

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -2408,10 +2408,10 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
             seed = get_global_seed()
 
         if not hasattr(self, "initializers"):
-            self.initializers = ["initializer", "starting_point", "seed"]
+            self.initializers = ["initializer", "starting_point"]
 
         if not hasattr(self, "stateful_attributes"):
-            self.stateful_attributes = ["previous_value", "previous_time", "random_state"]
+            self.stateful_attributes = ["previous_value", "previous_time"]
 
         random_state = np.random.RandomState([seed])
 

--- a/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
+++ b/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
@@ -449,10 +449,8 @@ class StatefulFunction(Function_Base): #  --------------------------------------
         # create all stateful attributes and initialize their values to the current values of their
         # corresponding initializer attributes
         for i, attr_name in enumerate(self.stateful_attributes):
-            # FIXME: HACK: Do not reinitialize random_state
-            if attr_name != "random_state":
-                initializer_value = getattr(self, self.initializers[i]).copy()
-                setattr(self, attr_name, initializer_value)
+            initializer_value = getattr(self, self.initializers[i]).copy()
+            setattr(self, attr_name, initializer_value)
 
         self.has_initializers = True
 
@@ -565,8 +563,6 @@ class StatefulFunction(Function_Base): #  --------------------------------------
     def _gen_llvm_function_reinitialize(self, ctx, builder, params, state, arg_in, arg_out, *, tags:frozenset):
         assert "reinitialize" in tags
         for i, a in enumerate(self.stateful_attributes):
-            if a == "random_state":
-                continue
             source_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, self.initializers[i])
             dest_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, a)
             if source_ptr.type != dest_ptr.type:

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -1956,8 +1956,6 @@ class GaussianDistort(TransferFunction):  #-------------------------------------
             seed = get_global_seed()
 
         random_state = np.random.RandomState([seed])
-        if not hasattr(self, "stateful_attributes"):
-            self.stateful_attributes = ["random_state"]
 
         super().__init__(
             default_variable=default_variable,

--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -34,7 +34,7 @@ class TestReinitialize:
         assert np.allclose(D.output_ports[1].value[0][0], 1.0)
 
         # reinitialize function
-        D.function.reinitialize(2.0, 0.1, 0)
+        D.function.reinitialize(2.0, 0.1)
         assert np.allclose(D.function.value[0], 2.0)
         assert np.allclose(D.function.previous_value, 2.0)
         assert np.allclose(D.function.previous_time, 0.1)
@@ -52,7 +52,7 @@ class TestReinitialize:
         assert np.allclose(D.output_ports[1].value[0][0], 1.0)
 
         # reinitialize mechanism
-        D.reinitialize(2.0, 0.1, 0)
+        D.reinitialize(2.0, 0.1)
         assert np.allclose(D.function.value[0], 2.0)
         assert np.allclose(D.function.previous_value, 2.0)
         assert np.allclose(D.function.previous_time, 0.1)


### PR DESCRIPTION
It should not be reset during reinitialize.
The runtime compiler does not rely on this list anymore either.
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>