### PR TITLE
Feat/prng/remaining functions

### DIFF
--- a/.idea/runConfigurations/pytest_in_tests2.xml
+++ b/.idea/runConfigurations/pytest_in_tests2.xml
@@ -1,16 +1,16 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" factoryName="py.test" name="pytest in tests" nameIsGenerated="true" singleton="false" type="tests">
-    <module name="" />
+  <configuration default="false" name="pytest in tests" type="tests" factoryName="py.test" singleton="false" nameIsGenerated="true">
+    <module name="PsyNeuLink" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
-    <option name="SDK_HOME" value="" />
+    <option name="SDK_HOME" value="C:\Users\Dillo\PycharmProjects\venvs\psyneulink\Scripts\python.exe" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/tests" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="_new_keywords" value="&quot;&quot;" />
-    <option name="_new_additionalArguments" value="&quot;&quot;" />
+    <option name="_new_additionalArguments" value="&quot;-n 0&quot;" />
     <option name="_new_target" value="&quot;$PROJECT_DIR$/tests&quot;" />
     <option name="_new_targetType" value="&quot;PATH&quot;" />
     <method v="2" />

--- a/psyneulink/core/components/functions/distributionfunctions.py
+++ b/psyneulink/core/components/functions/distributionfunctions.py
@@ -100,6 +100,9 @@ class NormalDist(DistributionFunction):
     mean : float : default 0.0
         The mean or center of the normal distribution.
 
+    random_state : numpy.RandomState
+        private pseudorandom number generator
+
     standard_deviation : float : default 1.0
         Standard deviation of the normal distribution; if it is 0.0, returns `mean <NormalDist.mean>`.
 
@@ -137,6 +140,12 @@ class NormalDist(DistributionFunction):
 
                     :default value: 1.0
                     :type: ``float``
+
+                random_state
+                    see `random_state <NormalDist.random_state>`
+
+                    :default value: None
+                    :type: ``numpy.random.RandomState``
         """
         mean = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
         standard_deviation = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])

--- a/psyneulink/core/components/functions/distributionfunctions.py
+++ b/psyneulink/core/components/functions/distributionfunctions.py
@@ -277,6 +277,9 @@ class UniformToNormalDist(DistributionFunction):
         function.  Values specified for parameters in the dictionary override any assigned to those parameters in
         arguments of the constructor.
 
+    random_state : numpy.RandomState
+      private pseudorandom number generator
+
     owner : Component
         `component <Component>` to which to assign the Function.
 
@@ -302,6 +305,12 @@ class UniformToNormalDist(DistributionFunction):
                     :type: ``numpy.ndarray``
                     :read only: True
 
+                random_state
+                    see `random_state <UniformToNormalDist.random_state>`
+
+                    :default value: None
+                    :type: ``numpy.random.RandomState``
+
                 mean
                     see `mean <UniformToNormalDist.mean>`
 
@@ -314,6 +323,7 @@ class UniformToNormalDist(DistributionFunction):
                     :default value: 1.0
                     :type: ``float``
         """
+        random_state = Parameter(None, stateful=True, loggable=False)
         variable = Parameter(np.array([0]), read_only=True, pnl_internal=True, constructor_argument='default_variable')
         mean = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
         standard_deviation = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
@@ -325,11 +335,19 @@ class UniformToNormalDist(DistributionFunction):
                  standard_deviation=1.0,
                  params=None,
                  owner=None,
+                 seed=None,
                  prefs: is_pref_set = None):
+
+        if seed is None:
+            seed = get_global_seed()
+
+        random_state = np.random.RandomState([seed])
+
         super().__init__(
             default_variable=default_variable,
             mean=mean,
             standard_deviation=standard_deviation,
+            random_state=random_state,
             params=params,
             owner=owner,
             prefs=prefs,
@@ -348,8 +366,9 @@ class UniformToNormalDist(DistributionFunction):
 
         mean = self._get_current_function_param(DIST_MEAN, context)
         standard_deviation = self._get_current_function_param(STANDARD_DEVIATION, context)
+        random_state = self._get_current_function_param('random_state', context)
 
-        sample = np.random.rand(1)[0]
+        sample = random_state.rand(1)[0]
         result = ((np.sqrt(2) * erfinv(2 * sample - 1)) * standard_deviation) + mean
 
         return self.convert_output_type(result)
@@ -399,6 +418,9 @@ class ExponentialDist(DistributionFunction):
     beta : float : default 1.0
         The scale parameter of the exponential distribution
 
+    random_state : numpy.RandomState
+        private pseudorandom number generator
+
     params : Dict[param keyword: param value] : default None
         a `parameter dictionary <ParameterPort_Specification>` that specifies the parameters for the
         function.  Values specified for parameters in the dictionary override any assigned to those parameters in
@@ -426,19 +448,34 @@ class ExponentialDist(DistributionFunction):
 
                     :default value: 1.0
                     :type: ``float``
+
+                random_state
+                    see `random_state <ExponentialDist.random_state>`
+
+                    :default value: None
+                    :type: ``numpy.random.RandomState``
         """
         beta = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
+        random_state = Parameter(None, stateful=True)
 
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
                  beta=1.0,
+                 seed=None,
                  params=None,
                  owner=None,
                  prefs: is_pref_set = None):
+
+        if seed is None:
+            seed = get_global_seed()
+
+        random_state = np.random.RandomState([seed])
+
         super().__init__(
             default_variable=default_variable,
             beta=beta,
+            random_state=random_state,
             params=params,
             owner=owner,
             prefs=prefs,
@@ -449,9 +486,10 @@ class ExponentialDist(DistributionFunction):
                  context=None,
                  params=None,
                  ):
-
+        random_state = self._get_current_function_param('random_state', context)
         beta = self._get_current_function_param(BETA, context)
-        result = np.random.exponential(beta)
+
+        result = random_state.exponential(beta)
 
         return self.convert_output_type(result)
 
@@ -502,6 +540,9 @@ class UniformDist(DistributionFunction):
     high : float : default 1.0
         Upper bound of the uniform distribution
 
+    random_state : numpy.RandomState
+        private pseudorandom number generator
+
     params : Dict[param keyword: param value] : default None
         a `parameter dictionary <ParameterPort_Specification>` that specifies the parameters for the
         function.  Values specified for parameters in the dictionary override any assigned to those parameters in
@@ -535,22 +576,37 @@ class UniformDist(DistributionFunction):
 
                     :default value: 0.0
                     :type: ``float``
+
+                random_state
+                    see `random_state <UniformDist.random_state>`
+
+                    :default value: None
+                    :type: ``numpy.random.RandomState``
         """
         low = Parameter(0.0, modulable=True)
         high = Parameter(1.0, modulable=True)
+        random_state = Parameter(None, stateful=True, loggable=False)
 
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
                  low=0.0,
                  high=1.0,
+                 seed=None,
                  params=None,
                  owner=None,
                  prefs: is_pref_set = None):
+
+        if seed is None:
+            seed = get_global_seed()
+
+        random_state = np.random.RandomState([seed])
+
         super().__init__(
             default_variable=default_variable,
             low=low,
             high=high,
+            random_state=random_state,
             params=params,
             owner=owner,
             prefs=prefs,
@@ -562,9 +618,10 @@ class UniformDist(DistributionFunction):
                  params=None,
                  ):
 
+        random_state = self._get_current_function_param('random_state', context)
         low = self._get_current_function_param(LOW, context)
         high = self._get_current_function_param(HIGH, context)
-        result = np.random.uniform(low, high)
+        result = random_state.uniform(low, high)
 
         return self.convert_output_type(result)
 
@@ -621,6 +678,9 @@ class GammaDist(DistributionFunction):
     dist_shape : float : default 1.0
         The shape of the gamma distribution. Should be greater than zero.
 
+    random_state : numpy.RandomState
+        private pseudorandom number generator
+
     params : Dict[param keyword: param value] : default None
         a `parameter dictionary <ParameterPort_Specification>` that specifies the parameters for the
         function.  Values specified for parameters in the dictionary override any assigned to those parameters in
@@ -650,12 +710,19 @@ class GammaDist(DistributionFunction):
                     :default value: 1.0
                     :type: ``float``
 
+                random_state
+                    see `random_state <GammaDist.random_state>`
+
+                    :default value: None
+                    :type: ``numpy.random.RandomState``
+
                 scale
                     see `scale <GammaDist.scale>`
 
                     :default value: 1.0
                     :type: ``float``
         """
+        random_state = Parameter(None, stateful=True, loggable=False)
         scale = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
         dist_shape = Parameter(1.0, modulable=True, aliases=[ADDITIVE_PARAM])
 
@@ -664,13 +731,19 @@ class GammaDist(DistributionFunction):
                  default_variable=None,
                  scale=1.0,
                  dist_shape=1.0,
+                 seed=None,
                  params=None,
                  owner=None,
                  prefs: is_pref_set = None):
+        if seed is None:
+            seed = get_global_seed()
+
+        random_state = np.random.RandomState([seed])
         super().__init__(
             default_variable=default_variable,
             scale=scale,
             dist_shape=dist_shape,
+            random_state=random_state,
             params=params,
             owner=owner,
             prefs=prefs,
@@ -682,10 +755,11 @@ class GammaDist(DistributionFunction):
                  params=None,
                  ):
 
+        random_state = self._get_current_function_param('random_state', context)
         scale = self._get_current_function_param(SCALE, context)
         dist_shape = self._get_current_function_param(DIST_SHAPE, context)
 
-        result = np.random.gamma(dist_shape, scale)
+        result = random_state.gamma(dist_shape, scale)
 
         return self.convert_output_type(result)
 
@@ -735,6 +809,9 @@ class WaldDist(DistributionFunction):
      Attributes
      ----------
 
+      random_state : numpy.RandomState
+          private pseudorandom number generator
+
      scale : float : default 1.0
          Scale parameter of the Wald distribution. Should be greater than zero.
 
@@ -763,6 +840,12 @@ class WaldDist(DistributionFunction):
             Attributes
             ----------
 
+                random_state
+                    see `random_state <WaldDist.random_state>`
+
+                    :default value: None
+                    :type: ``numpy.random.RandomState``
+
                 mean
                     see `mean <WaldDist.mean>`
 
@@ -775,6 +858,7 @@ class WaldDist(DistributionFunction):
                     :default value: 1.0
                     :type: ``float``
         """
+        random_state = Parameter(None, stateful=True, loggable=False)
         scale = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
         mean = Parameter(1.0, modulable=True, aliases=[ADDITIVE_PARAM])
 
@@ -783,12 +867,18 @@ class WaldDist(DistributionFunction):
                  default_variable=None,
                  scale=1.0,
                  mean=1.0,
+                 seed=None,
                  params=None,
                  owner=None,
                  prefs: is_pref_set = None):
+        if seed is None:
+            seed = get_global_seed()
+
+        random_state = np.random.RandomState([seed])
         super().__init__(
             default_variable=default_variable,
             scale=scale,
+            random_state=random_state,
             mean=mean,
             params=params,
             owner=owner,
@@ -801,10 +891,11 @@ class WaldDist(DistributionFunction):
                  params=None,
                  ):
 
+        random_state = self._get_current_function_param('random_state', context)
         scale = self._get_current_function_param(SCALE, context)
         mean = self._get_current_function_param(DIST_MEAN, context)
 
-        result = np.random.wald(mean, scale)
+        result = random_state.wald(mean, scale)
 
         return self.convert_output_type(result)
 

--- a/psyneulink/core/components/functions/selectionfunctions.py
+++ b/psyneulink/core/components/functions/selectionfunctions.py
@@ -144,6 +144,9 @@ class OneHot(SelectionFunction):
         determines the nature of the single non-zero value in the array returned by `function <OneHot.function>`
         (see `above <OneHot>` for options).
 
+    random_state : numpy.RandomState
+        private pseudorandom number generator
+
     owner : Component
         `component <Component>` to which the Function has been assigned.
 

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -2718,6 +2718,9 @@ class OrnsteinUhlenbeckIntegrator(IntegratorFunction):  # ----------------------
         stores previous time at which the function was executed and accumulates with each execution according to
         `time_step_size <OrnsteinUhlenbeckIntegrator.default_time_step_size>`.
 
+    random_state : numpy.RandomState
+        private pseudorandom number generator
+
     owner : Component
         `component <Component>` to which the Function has been assigned.
 
@@ -2763,6 +2766,12 @@ class OrnsteinUhlenbeckIntegrator(IntegratorFunction):  # ----------------------
                     :default value: 0.0
                     :type: ``float``
 
+                random_state
+                    see `random_state <OrnsteinUhlenbeckIntegrator.random_state>`
+
+                    :default value: None
+                    :type: ``numpy.random.RandomState``
+
                 rate
                     see `rate <OrnsteinUhlenbeckIntegrator.rate>`
 
@@ -2788,6 +2797,7 @@ class OrnsteinUhlenbeckIntegrator(IntegratorFunction):  # ----------------------
         time_step_size = Parameter(1.0, modulable=True)
         starting_point = 0.0
         previous_time = Parameter(0.0, pnl_internal=True)
+        random_state = Parameter(None, stateful=True, loggable=False)
         enable_output_type_conversion = Parameter(
             False,
             stateful=False,
@@ -2807,6 +2817,7 @@ class OrnsteinUhlenbeckIntegrator(IntegratorFunction):  # ----------------------
                  time_step_size=1.0,
                  initializer=None,
                  params: tc.optional(dict) = None,
+                 seed=None,
                  owner=None,
                  prefs: is_pref_set = None):
 
@@ -2815,6 +2826,11 @@ class OrnsteinUhlenbeckIntegrator(IntegratorFunction):  # ----------------------
 
         if not hasattr(self, "stateful_attributes"):
             self.stateful_attributes = ["previous_value", "previous_time"]
+
+        if seed is None:
+            seed = get_global_seed()
+
+        random_state = np.random.RandomState([seed])
 
         super().__init__(
             default_variable=default_variable,
@@ -2828,6 +2844,7 @@ class OrnsteinUhlenbeckIntegrator(IntegratorFunction):  # ----------------------
             previous_value=initializer,
             previous_time=starting_point,
             params=params,
+            random_state=random_state,
             owner=owner,
             prefs=prefs,
         )
@@ -2870,12 +2887,15 @@ class OrnsteinUhlenbeckIntegrator(IntegratorFunction):  # ----------------------
         noise = self._get_current_function_param(NOISE, context)
         offset = self._get_current_function_param(OFFSET, context)
         time_step_size = self._get_current_function_param(TIME_STEP_SIZE, context)
+        random_state = self._get_current_function_param('random_state', context)
 
         previous_value = np.atleast_2d(self.get_previous_value(context))
 
+        random_normal = random_state.normal()
+
         # dx = (lambda*x + A)dt + c*dW
         value = previous_value + (decay * previous_value - rate * variable) * time_step_size + np.sqrt(
-            time_step_size * noise) * np.random.normal()
+            time_step_size * noise) * random_normal
 
         # If this NOT an initialization run, update the old value and time
         # If it IS an initialization run, leave as is

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -2244,6 +2244,9 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
         *MULTIPLICATIVE_PARAM* for `modulation <ModulatorySignal_Modulation>` of `function
         <DriftDiffusionIntegrator.function>`.
 
+    random_state : numpy.RandomState
+        private pseudorandom number generator
+
     noise : float or 1d array
         scales the normally distributed random value added to integral in each call to `function
         <DriftDiffusionIntegrator.function>`. If `variable <DriftDiffusionIntegrator.variable>` is a list or array,

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -562,7 +562,8 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         maximum number of entries allowed in `memory <ContentAddressableMemory.memory>`;  if storing a memory
         exceeds the number, the oldest memory is deleted.
 
-    random_state: numpy.RandomState instance
+    random_state : numpy.RandomState
+        private pseudorandom number generator
 
     owner : Component
         `component <Component>` to which the Function has been assigned.

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -1879,7 +1879,8 @@ class GaussianDistort(TransferFunction):  #-------------------------------------
     offset : float
         determines value added to each sample after it is drawn and `scale <GaussianDistort.scale>` is applied
 
-    random_state : numpy.RandomState instance
+    random_state : numpy.RandomState
+        private pseudorandom number generator
 
     owner : Component
         `component <Component>` to which the Function has been assigned.

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -4941,7 +4941,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     # ******************************************************************************************************************
 
     @tc.typecheck
-    @handle_external_context(execution_id=NotImplemented)
+    @handle_external_context(execution_id=NotImplemented, source=ContextFlags.COMPOSITION)
     def show_graph(self,
                    show_node_structure:tc.any(bool, tc.enum(VALUES, LABELS, FUNCTIONS, MECH_FUNCTION_PARAMS,
                                                             PORT_FUNCTION_PARAMS, ROLES, ALL))=False,

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -497,6 +497,9 @@ class DDM(ProcessingMechanism):
         `DDM_Execution`, and `DDM_Output` for additional information about other values that can be reported and
         their interpretation.
 
+    random_state : numpy.RandomState
+        private pseudorandom number generator
+
     output_ports : ContentAddressableList[OutputPort]
         list of the DDM's `OutputPorts <OutputPort>`.  There are always two OutputPorts, `DECISION_VARIABLE
         <DDM_DECISION_VARIABLE>` and `RESPONSE_TIME <DDM_RESPONSE_TIME>`; additional ones may be included

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -338,7 +338,7 @@ class TestDistributionFunctions:
                 noise=UniformToNormalDist(),
                 integration_rate=1.0
             )
-            T.noise.parameters.random_state.get().seed(22)
+            T.noise.parameters.random_state.get(None).seed(22)
             val = T.execute([0, 0, 0, 0])
             assert np.allclose(val, [[-0.81177443, -0.04593492, -0.20051725, 1.07665147]])
 

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -22,7 +22,7 @@ from psyneulink.core.components.system import System
 from psyneulink.core.compositions.composition import Composition
 from psyneulink.core.globals.keywords import \
     INSTANTANEOUS_MODE_VALUE, INTEGRATOR_MODE_VALUE, REINITIALIZE, COMBINE, RESULT, GREATER_THAN
-from psyneulink.core.globals.utilities import UtilitiesError
+from psyneulink.core.globals.utilities import UtilitiesError, set_global_seed
 from psyneulink.core.scheduling.condition import Never
 from psyneulink.core.scheduling.time import TimeScale
 
@@ -282,7 +282,6 @@ class TestDistributionFunctions:
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
     def test_transfer_mech_normal_noise(self):
-
         T = TransferMechanism(
             name='T',
             default_variable=[0, 0, 0, 0],
@@ -325,7 +324,7 @@ class TestDistributionFunctions:
             integrator_mode=True,
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.4836021009022533, 1.5688961399691683, 0.7526741095365884, 0.8394328467388229]])
+        assert np.allclose(val, [[0.87558564, 2.38719447, 0.7025651 , 0.33105989]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -339,7 +338,7 @@ class TestDistributionFunctions:
                 noise=UniformToNormalDist(),
                 integration_rate=1.0
             )
-            np.random.seed(22)
+            T.noise.parameters.random_state.get().seed(22)
             val = T.execute([0, 0, 0, 0])
             assert np.allclose(val, [[-0.81177443, -0.04593492, -0.20051725, 1.07665147]])
 
@@ -368,7 +367,7 @@ class TestDistributionFunctions:
             integrator_mode=True
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.3834415188257777, 0.7917250380826646, 0.5288949197529045, 0.5680445610939323]])
+        assert np.allclose(val, [[0.58338204, 0.90811289, 0.50468686, 0.28183784]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -383,7 +382,7 @@ class TestDistributionFunctions:
             integrator_mode=True
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.4836021009022533, 1.5688961399691683, 0.7526741095365884, 0.8394328467388229]])
+        assert np.allclose(val, [[0.87558564, 2.38719447, 0.7025651 , 0.33105989]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -398,7 +397,7 @@ class TestDistributionFunctions:
             integrator_mode=True
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[1.3939555850782692, 0.25118783985272053, 1.2272797824363235, 0.1190661760253029]])
+        assert np.allclose(val, [[0.41203028, 0.40277101, 1.0678432 , 0.34512569]])
 
 
 class TestTransferMechanismFunctions:


### PR DESCRIPTION
Switched all remaining Functions that were using a global PRNG to private PRNGs. The following Functions were altered:

- WaldDist
- GammaDist
- UniformDist
- ExponentialDist
- UniformToNormalDist
- BayesGLM
- OrnsteinUhlenbeckIntegrator

Fixes: #1452, #1453, #1456, #1457, #1458, #1459, #1460.