### PR TITLE
Compiled `WhenFinished` Condition

### DIFF
--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -7960,7 +7960,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             *comp_param_type_list))
 
     def _get_state_ids(self):
-        return ["nodes", "projections"] + super()._get_param_ids()
+        return ["nodes", "projections"] + super()._get_state_ids()
 
     def _get_state_struct_type(self, ctx):
         node_state_type_list = (ctx.get_state_struct_type(m) for m in self._all_nodes)

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -260,12 +260,22 @@ class ConditionGenerator:
         return tuple(data)
 
     def bump_ts(self, builder, cond_ptr, count=(0, 0, 1)):
+        """
+        Increments the time structure of the composition.
+        Count should be a tuple where there is a number in only one spot, and zeroes elsewhere.
+        Indices greater than that of the one are zeroed.
+        """
+        
+        # Validate count tuple
+        assert count.count(0) == len(count) - 1
+
+        # Get timestruct pointer
         ts_ptr = builder.gep(cond_ptr, [self._zero, self._zero, self._zero])
         ts = builder.load(ts_ptr)
 
-        # run, pass, step
+        # Update run, pass, step of ts
         for idx in range(3):
-            if idx == 0 or not all(v == 0 for v in count[:idx]):
+            if all(v == 0 for v in count[:idx]):
                 el = builder.extract_value(ts, idx)
                 el = builder.add(el, self.ctx.int32_ty(count[idx]))
             else:

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -367,9 +367,14 @@ class ConditionGenerator:
                 agg_cond = builder.and_(agg_cond, cond_res)
             return agg_cond
         elif isinstance(condition, AllHaveRun):
+            # Extract dependencies
+            dependencies = self.composition.nodes
+            if len(condition.args) > 0:
+                dependencies = condition.args
+
             run_cond = ir.IntType(1)(1)
             array_ptr = builder.gep(cond_ptr, [self._zero, self._zero, self.ctx.int32_ty(1)])
-            for node in self.composition.nodes:
+            for node in dependencies:
                 node_ran = self.generate_ran_this_trial(builder, cond_ptr, node)
                 run_cond = builder.and_(run_cond, node_ran)
             return run_cond

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1195,3 +1195,36 @@ class DDM(ProcessingMechanism):
             )
             return True
         return False
+    
+    def _gen_llvm_is_finished_cond(self, ctx, builder, params, state, current):
+        # Setup pointers to internal function
+        func_state_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, 'function')
+        func_param_ptr = pnlvm.helpers.get_state_ptr(builder, self, params, 'function')
+
+        # Find the single numeric entry in previous_value
+        try:
+            prev_val_ptr = pnlvm.helpers.get_state_ptr(builder, self.function, func_state_ptr, "previous_value")
+        except ValueError:
+            return pnlvm.ir.IntType(1)(1)
+
+        # Extract scalar value from ptr
+        prev_val_ptr = builder.gep(prev_val_ptr, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(0)])
+        prev_val = builder.load(prev_val_ptr)
+
+        # Take abs of previous val
+        llvm_fabs = ctx.get_builtin("fabs", [ctx.float_ty])
+        prev_val = builder.call(llvm_fabs, [prev_val])
+
+
+        # obtain threshold value
+        threshold_ptr = pnlvm.helpers.get_param_ptr(builder,
+                                                    self.function,
+                                                    func_param_ptr,
+                                                    "threshold")
+
+        threshold_ptr = builder.gep(threshold_ptr, [ctx.int32_ty(0), ctx.int32_ty(0)])
+        threshold = builder.load(threshold_ptr)
+        is_prev_greater_or_equal = builder.fcmp_ordered('>=', prev_val, threshold)
+
+        return is_prev_greater_or_equal
+

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -3450,7 +3450,7 @@ class TestSchedulerConditions:
                              (pnl.EveryNCalls, [[.25, .25]]),
                              (pnl.WhenFinished, [[1.0, 1.0]]),
                              (pnl.All, [[1.0, 1.0]]),
-                            #  (pnl.AllHaveRun, [[.05, .05]]), #FIXME: Infinite hang
+                             (pnl.AllHaveRun, [[.05, .05]]),
                              (pnl.Always, [[0.05, 0.05]]),
                             #  (pnl.AtPass, [[.3, .3]]), #FIXME: Differing result between llvm and python
                              (pnl.AtTrial,[[0.05, 0.05]]),

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -3436,6 +3436,62 @@ class TestSystemComposition:
 #         assert 16 == output[0][0]
 #
 
+
+class TestSchedulerConditions:
+    @pytest.mark.composition
+    @pytest.mark.parametrize("mode",['Python',
+                            #  pytest.param('LLVM', marks=pytest.mark.llvm), #FIXME: Fails for `LLVM` and `LLVMExec` modes?
+                            #  pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                             pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                             pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
+                             pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])
+                             ])
+    @pytest.mark.parametrize(["condition", "expected_result"],[
+                             (pnl.EveryNCalls, [[.25, .25]]),
+                             (pnl.WhenFinished, [[1.0, 1.0]]),
+                             (pnl.All, [[1.0, 1.0]]),
+                            #  (pnl.AllHaveRun, [[.05, .05]]), #FIXME: Infinite hang
+                             (pnl.Always, [[0.05, 0.05]]),
+                            #  (pnl.AtPass, [[.3, .3]]), #FIXME: Differing result between llvm and python
+                             (pnl.AtTrial,[[0.05, 0.05]]),
+                            #  (pnl.Never), #TODO: Find a good test case for this!
+                            ])
+    def test_scheduler_conditions(self, mode, condition, expected_result):
+        print(mode, condition)
+        decisionMaker = pnl.DDM(
+                        function=pnl.DriftDiffusionIntegrator(starting_point=0,
+                                                              threshold=1,
+                                                              noise=0.0),
+                        reinitialize_when=pnl.AtTrialStart(),
+                        output_ports=[pnl.DECISION_VARIABLE, pnl.RESPONSE_TIME],
+                        name='DDM')
+
+        response = pnl.ProcessingMechanism(size=2, name="GATE")
+
+        comp = pnl.Composition()
+        comp.add_node(decisionMaker)
+        comp.add_node(response)
+        comp.add_projection(pnl.MappingProjection(), sender=decisionMaker, receiver=response)
+
+        if condition is pnl.EveryNCalls:
+            comp.scheduler.add_condition(response, condition(decisionMaker, 5))
+        elif condition is pnl.WhenFinished:
+            comp.scheduler.add_condition(response, condition(decisionMaker))
+        elif condition is pnl.All:
+            comp.scheduler.add_condition(response, condition(pnl.WhenFinished(decisionMaker)))
+        elif condition is pnl.AllHaveRun:
+            comp.scheduler.add_condition(response, condition(decisionMaker))
+        elif condition is pnl.Always:
+            comp.scheduler.add_condition(response, condition())
+        elif condition is pnl.AtPass:
+            comp.scheduler.add_condition(response, condition(5))
+        elif condition is pnl.AtTrial:
+            comp.scheduler.add_condition(response, condition(0))
+        result = comp.run([0.05], bin_execute=mode)
+        result = [x for x in np.array(result).flatten()] #HACK: The result is an object dtype in Python mode for some reason?
+        assert np.allclose(result, np.array(expected_result).flatten())
+
+
 class TestNestedCompositions:
 
     @pytest.mark.composition


### PR DESCRIPTION
This pull adds:

- A compiled `WhenFinished` condition
- A compiled `is_finished` condition for DDMs
- A bugfix for pass counting in the compiled scheduler
- Tests for scheduler conditions implemented in both Python and compiled (and some differences discovered between Python and compiled runs of certain conditions)

Fixes #1509.