### PR TITLE
llvm: Cleanup and simplify RecurrentTransferMechanism

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1156,9 +1156,9 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         whitelist = {"previous_time", "previous_value", "previous_v",
                      "previous_w", "random_state", "is_finished_flag",
                      "num_executions_before_finished", "num_executions",
-                     "execution_count"}
+                     "execution_count", "value"}
         # mechanism functions are handled separately
-        blacklist = {"function"} if hasattr(self, 'ports') else {}
+        blacklist = {"function"} if hasattr(self, 'ports') else {"value"}
         def _is_compilation_state(p):
             val = p.get()   # memoize for this function
             return val is not None and p.name not in blacklist and \

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -241,28 +241,6 @@ class Identity(TransferFunction):  # -------------------------------------------
 
         return variable
 
-    def _get_input_struct_type(self, ctx):
-        #FIXME: Workaround for CompositionInterfaceMechanism that
-        #       does not udpate its defaults shape
-        from psyneulink.core.components.mechanisms.processing.compositioninterfacemechanism import CompositionInterfaceMechanism
-        if isinstance(self.owner, CompositionInterfaceMechanism):
-            variable = [port.defaults.value for port in self.owner.input_ports]
-            # Python list does not care about ndarrays of different lengths
-            # we do care, so convert to tuple to create struct
-            if all(type(x) == np.ndarray for x in variable) and not all(len(x) == len(variable[0]) for x in variable):
-                variable = tuple(variable)
-
-            return ctx.convert_python_struct_to_llvm_ir(variable)
-        default_var = self.defaults.variable
-        return ctx.convert_python_struct_to_llvm_ir(default_var)
-
-    def _get_output_struct_type(self, ctx):
-        #FIXME: Workaround for CompositionInterfaceMechanism that
-        #       does not update its defaults shape
-        #       Standalone function works OK with defaults as well as this
-        #       workaround.
-        return ctx.get_input_struct_type(self)
-
     def _gen_llvm_function_body(self, ctx, builder, _1, _2, arg_in, arg_out, *, tags:frozenset):
         val = builder.load(arg_in)
         builder.store(val, arg_out)

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -283,9 +283,10 @@ class LLVMBuilderContext:
         if type(t) is list:
             if len(t) == 0:
                 return ir.LiteralStructType([])
-            assert all(type(x) is type(t[0]) for x in t)
-            elem_t = self.convert_python_struct_to_llvm_ir(t[0])
-            return ir.ArrayType(elem_t, len(t))
+            elems_t = [self.convert_python_struct_to_llvm_ir(x) for x in t]
+            if all(x == elems_t[0] for x in elems_t):
+                return ir.ArrayType(elems_t[0], len(elems_t))
+            return ir.LiteralStructType(elems_t)
         elif type(t) is tuple:
             elems_t = (self.convert_python_struct_to_llvm_ir(x) for x in t)
             return ir.LiteralStructType(elems_t)

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -113,11 +113,6 @@ def gen_node_wrapper(ctx, composition, node, *, tags:frozenset):
             assert proj in rec_port.pathway_projections
             projection_idx = rec_port.pathway_projections.index(proj)
 
-            # Adjust for AutoAssociative projections
-            for i in range(projection_idx):
-                p = rec_port.pathway_projections[i]
-                if p.sender.owner is p.receiver.owner:
-                    projection_idx -= 1
             if not is_mech and node.parameter_CIM.afferents:
                 # If there are afferent projections to parameter_CIM
                 # the input structure is split between input_CIM

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1299,76 +1299,6 @@ class RecurrentTransferMechanism(TransferMechanism):
         builder.store(prev_val_ptr.type.pointee(None), prev_val_ptr)
         return builder
 
-    def _gen_llvm_is_finished_cond(self, ctx, builder, params, state, current):
-        #FIXME: This should really be in TransferMechanism, but those don't
-        #       support 'is_finished' yet
-        # previous_value is appended before AutoProjection in state struct
-        # FIXME: This should use standard "previous_value" param
-        prev_val_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, "old_val")
-
-        # preserve the old prev value
-        prev_val = builder.load(prev_val_ptr)
-        # Update previous value to make sure that repeated executions work
-        builder.store(builder.load(current), prev_val_ptr)
-
-        if self.parameters.termination_threshold.get(None) is None:
-            # Threshold is not defined, return the old value of finished flag
-            is_finished_ptr = pnlvm.helpers.get_state_ptr(builder, self, state,
-                                                          "is_finished_flag")
-            is_finished_flag = builder.load(is_finished_ptr)
-            return builder.fcmp_ordered("!=", is_finished_flag,
-                                              is_finished_flag.type(0))
-
-        threshold_ptr = pnlvm.helpers.get_param_ptr(builder, self, params,
-                                                    "termination_threshold")
-        threshold = builder.load(threshold_ptr)
-        cmp_val_ptr = builder.alloca(threshold.type)
-        builder.store(threshold, cmp_val_ptr)
-        if self.termination_measure is max:
-            assert self._termination_measure_num_items_expected == 1
-            # Get inside of the structure
-            val = builder.gep(current, [ctx.int32_ty(0), ctx.int32_ty(0)])
-            first_val = builder.load(builder.gep(val, [ctx.int32_ty(0), ctx.int32_ty(0)]))
-            builder.store(first_val, cmp_val_ptr)
-            with pnlvm.helpers.array_ptr_loop(builder, val, "max_loop") as (b, idx):
-                test_val = b.load(b.gep(val, [ctx.int32_ty(0), idx]))
-                max_val = b.load(cmp_val_ptr)
-                cond = b.fcmp_ordered(">=", test_val, max_val)
-                max_val = b.select(cond, test_val, max_val)
-                b.store(max_val, cmp_val_ptr)
-        elif isinstance(self.termination_measure, Function):
-            # FIXME: HACK the distance function is not initialized
-            self.termination_measure.defaults.variable = np.zeros_like([self.defaults.value[0], self.defaults.value[0]])
-            self.termination_measure.defaults.value = float(0)
-            warnings.warn("Shape mismatch: Termination measure is not initialized")
-
-            func = ctx.import_llvm_function(self.termination_measure)
-            func_params = pnlvm.helpers.get_param_ptr(builder, self, params, "termination_measure")
-            func_state = pnlvm.helpers.get_state_ptr(builder, self, state, "termination_measure")
-            func_in = builder.alloca(func.args[2].type.pointee)
-            # Populate input
-            func_in_current_ptr = builder.gep(func_in, [ctx.int32_ty(0),
-                                                        ctx.int32_ty(0)])
-            current_ptr = builder.gep(current, [ctx.int32_ty(0), ctx.int32_ty(0)])
-            builder.store(builder.load(current_ptr), func_in_current_ptr)
-
-            func_in_prev_ptr = builder.gep(func_in, [ctx.int32_ty(0),
-                                                     ctx.int32_ty(1)])
-            builder.store(builder.extract_value(prev_val, 0), func_in_prev_ptr)
-
-            builder.call(func, [func_params, func_state, func_in, cmp_val_ptr])
-        elif isinstance(self.termination_measure, TimeScale):
-            ptr = builder.gep(pnlvm.helpers.get_state_ptr(builder, self, state, "num_executions"), [ctx.int32_ty(0), ctx.int32_ty(self.termination_measure.value)])
-            ptr_val = builder.sitofp(builder.load(ptr), threshold.type)
-            pnlvm.helpers.printf(builder, f"TERM MEASURE {self.termination_measure} %d %d\n",ptr_val, threshold)
-            builder.store(ptr_val, cmp_val_ptr)
-        else:
-            assert False, "Not Supported: {}".format(self.termination_measure)
-
-        cmp_val = builder.load(cmp_val_ptr)
-        cmp_str = self.parameters.termination_comparison_op.get(None)
-        return builder.fcmp_ordered(cmp_str, cmp_val, threshold)
-
     def _gen_llvm_input_ports(self, ctx, builder, params, state, arg_in):
         recurrent_state = pnlvm.helpers.get_state_ptr(builder, self, state,
                                             "recurrent_projection")
@@ -1395,6 +1325,15 @@ class RecurrentTransferMechanism(TransferMechanism):
             builder.call(recurrent_f, [recurrent_params, recurrent_state, recurrent_in, recurrent_out])
 
         return super()._gen_llvm_input_ports(ctx, builder, params, state, arg_in)
+
+    def _gen_llvm_output_ports(self, ctx, builder, value,
+                               mech_params, mech_state, mech_in, mech_out):
+        ret = super()._gen_llvm_output_ports(ctx, builder, value, mech_params,
+                                             mech_state, mech_in, mech_out)
+
+        old_val = pnlvm.helpers.get_state_ptr(builder, self, mech_state, "old_val")
+        builder.store(builder.load(mech_out), old_val)
+        return ret
 
     @property
     def _dependent_components(self):

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1285,8 +1285,7 @@ class RecurrentTransferMechanism(TransferMechanism):
 
         # Initialize to OutputPort defaults.
         # That is what the recurrent projection finds.
-        # FIXME: This should use standard 'previous_value' stateful param
-        retval_init = (tuple(os.defaults.value) if not np.isscalar(os.defaults.value) else os.defaults.value for os in self.output_ports)
+        retval_init = (tuple(op.parameters.value.get(context)) if not np.isscalar(op.parameters.value.get(context)) else op.parameters.value.get(context) for op in self.output_ports)
         return (*transfer_init, tuple(retval_init), projection_init)
 
     def _gen_llvm_function_reinitialize(self, ctx, builder, params, state, arg_in, arg_out, *, tags:frozenset):

--- a/tests/composition/test_learning.py
+++ b/tests/composition/test_learning.py
@@ -1,6 +1,6 @@
-import psyneulink as pnl
 import numpy as np
 import pytest
+import psyneulink as pnl
 
 class TestHebbian:
 
@@ -473,7 +473,7 @@ class TestNestedLearning:
             target_mech: oSs
         }
 
-        outer = Composition("outer-composition")
+        outer = pnl.Composition("outer-composition")
         outer.add_node(mnet)
         mnet.learn(inputs=inputs)
 
@@ -1416,16 +1416,10 @@ class TestBackProp:
 
         assert np.allclose(comparator, np.array(mnet.parameters.results.get(mnet)[-15:]).reshape(225))
 
-import pytest
-import psyneulink as pnl
-import psyneulink.core.components.functions.transferfunctions
-from psyneulink.core.components.functions.transferfunctions import Logistic
-from psyneulink.core.compositions.composition import Composition, NodeRole
-
 def validate_learning_mechs(comp):
 
     def get_learning_mech(name):
-        return next(lm for lm in comp.get_nodes_by_role(NodeRole.LEARNING) if lm.name == name)
+        return next(lm for lm in comp.get_nodes_by_role(pnl.NodeRole.LEARNING) if lm.name == name)
 
     REP_IN_to_REP_HIDDEN_LM = get_learning_mech('LearningMechanism for MappingProjection from REP_IN to REP_HIDDEN')
     REP_HIDDEN_to_REL_HIDDEN_LM = get_learning_mech('LearningMechanism for MappingProjection from REP_HIDDEN to REL_HIDDEN')
@@ -1473,16 +1467,14 @@ class TestRumelhartSemanticNetwork:
 
         rep_in = pnl.TransferMechanism(size=10, name='REP_IN')
         rel_in = pnl.TransferMechanism(size=11, name='REL_IN')
-        rep_hidden = pnl.TransferMechanism(size=4,
-                                           function=psyneulink.core.components.functions.transferfunctions.Logistic,
-                                           name='REP_HIDDEN')
-        rel_hidden = pnl.TransferMechanism(size=5, function=Logistic, name='REL_HIDDEN')
-        rep_out = pnl.TransferMechanism(size=10, function=Logistic, name='REP_OUT')
-        prop_out = pnl.TransferMechanism(size=12, function=Logistic, name='PROP_OUT')
-        qual_out = pnl.TransferMechanism(size=13, function=Logistic, name='QUAL_OUT')
-        act_out = pnl.TransferMechanism(size=14, function=Logistic, name='ACT_OUT')
+        rep_hidden = pnl.TransferMechanism(size=4, function=pnl.Logistic, name='REP_HIDDEN')
+        rel_hidden = pnl.TransferMechanism(size=5, function=pnl.Logistic, name='REL_HIDDEN')
+        rep_out = pnl.TransferMechanism(size=10, function=pnl.Logistic, name='REP_OUT')
+        prop_out = pnl.TransferMechanism(size=12, function=pnl.Logistic, name='PROP_OUT')
+        qual_out = pnl.TransferMechanism(size=13, function=pnl.Logistic, name='QUAL_OUT')
+        act_out = pnl.TransferMechanism(size=14, function=pnl.Logistic, name='ACT_OUT')
 
-        comp = Composition()
+        comp = pnl.Composition()
 
         # comp.add_backpropagation_learning_pathway(pathway=[rep_in, rep_hidden, rel_hidden])
         comp.add_backpropagation_learning_pathway(pathway=[rel_in, rel_hidden])
@@ -1510,12 +1502,12 @@ class TestRumelhartSemanticNetwork:
     #
     #     rep_in = pnl.TransferMechanism(size=10, name='REP_IN')
     #     rel_in = pnl.TransferMechanism(size=11, name='REL_IN')
-    #     rep_hidden = pnl.TransferMechanism(size=4, function=Logistic, name='REP_HIDDEN')
-    #     rel_hidden = pnl.TransferMechanism(size=5, function=Logistic, name='REL_HIDDEN')
-    #     rep_out = pnl.TransferMechanism(size=10, function=Logistic, name='REP_OUT')
-    #     prop_out = pnl.TransferMechanism(size=12, function=Logistic, name='PROP_OUT')
-    #     qual_out = pnl.TransferMechanism(size=13, function=Logistic, name='QUAL_OUT')
-    #     act_out = pnl.TransferMechanism(size=14, function=Logistic, name='ACT_OUT')
+    #     rep_hidden = pnl.TransferMechanism(size=4, function=pnl.Logistic, name='REP_HIDDEN')
+    #     rel_hidden = pnl.TransferMechanism(size=5, function=pnl.Logistic, name='REL_HIDDEN')
+    #     rep_out = pnl.TransferMechanism(size=10, function=pnl.Logistic, name='REP_OUT')
+    #     prop_out = pnl.TransferMechanism(size=12, function=pnl.Logistic, name='PROP_OUT')
+    #     qual_out = pnl.TransferMechanism(size=13, function=pnl.Logistic, name='QUAL_OUT')
+    #     act_out = pnl.TransferMechanism(size=14, function=pnl.Logistic, name='ACT_OUT')
     #
     #     rep_proc = pnl.Process(pathway=[rep_in, rep_hidden, rel_hidden, rep_out],
     #                            learning=pnl.LEARNING,
@@ -1553,12 +1545,12 @@ class TestRumelhartSemanticNetwork:
     #
     #     rep_in = pnl.TransferMechanism(size=10, name='REP_IN')
     #     rel_in = pnl.TransferMechanism(size=11, name='REL_IN')
-    #     rep_hidden = pnl.TransferMechanism(size=4, function=Logistic, name='REP_HIDDEN')
-    #     rel_hidden = pnl.TransferMechanism(size=5, function=Logistic, name='REL_HIDDEN')
-    #     rep_out = pnl.TransferMechanism(size=10, function=Logistic, name='REP_OUT')
-    #     prop_out = pnl.TransferMechanism(size=12, function=Logistic, name='PROP_OUT')
-    #     qual_out = pnl.TransferMechanism(size=13, function=Logistic, name='QUAL_OUT')
-    #     act_out = pnl.TransferMechanism(size=14, function=Logistic, name='ACT_OUT')
+    #     rep_hidden = pnl.TransferMechanism(size=4, function=pnl.Logistic, name='REP_HIDDEN')
+    #     rel_hidden = pnl.TransferMechanism(size=5, function=pnl.Logistic, name='REL_HIDDEN')
+    #     rep_out = pnl.TransferMechanism(size=10, function=pnl.Logistic, name='REP_OUT')
+    #     prop_out = pnl.TransferMechanism(size=12, function=pnl.Logistic, name='PROP_OUT')
+    #     qual_out = pnl.TransferMechanism(size=13, function=pnl.Logistic, name='QUAL_OUT')
+    #     act_out = pnl.TransferMechanism(size=14, function=pnl.Logistic, name='ACT_OUT')
     #
     #     rep_proc = pnl.Process(pathway=[rep_in, rep_hidden, rel_hidden, rep_out],
     #                            learning=pnl.LEARNING,


### PR DESCRIPTION
Add and use 'value' stateful param.
move 'is_finished' to TransferMechanism.
Drop unnecessary input struct workarounds.