### PR TITLE
llvm: Switch to Composition provided input parsing routine

### DIFF
--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -438,10 +438,12 @@ class CompExecution(CUDAExecution):
     def freeze_values(self):
         self.__frozen_vals = copy.deepcopy(self._data_struct)
 
-    def execute_node(self, node, inputs=None, context=None):
+    def execute_node(self, node, inputs=None):
         # We need to reconstruct the inputs here if they were not provided.
         # This happens during node execution of nested compositions.
+        assert len(self._execution_contexts) == 1
         if inputs is None and node is self._composition.input_CIM:
+            context = self._execution_contexts[0]
             # This assumes origin mechanisms are in the same order as
             # CIM input ports
             origins = (n for n in self._composition.get_nodes_by_role(NodeRole.INPUT) for iport in n.input_ports)

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -4722,7 +4722,12 @@ class TestInputSpecifications:
         assert c.parameters.results.get(c) == [[np.array([0.])], [np.array([1.])], [np.array([2.])], [np.array([3.])],
                                                [np.array([4.])], [np.array([5.])], [np.array([6.])], [np.array([7.])],
                                                [np.array([8.])], [np.array([9.])]]
-    def test_generator_as_input(self):
+
+    @pytest.mark.parametrize("mode", ['Python',
+                                      pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                      pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda]),
+                                      ])
+    def test_generator_as_input(self, mode):
         c = pnl.Composition()
 
         m1 = pnl.TransferMechanism()
@@ -4738,12 +4743,16 @@ class TestInputSpecifications:
 
         t_g = test_generator()
 
-        c.run(inputs=t_g)
+        c.run(inputs=t_g, bin_execute=mode)
         assert c.parameters.results.get(c) == [[np.array([0.])], [np.array([1.])], [np.array([2.])], [np.array([3.])],
                                                [np.array([4.])], [np.array([5.])], [np.array([6.])], [np.array([7.])],
                                                [np.array([8.])], [np.array([9.])]]
 
-    def test_generator_as_input_with_num_trials(self):
+    @pytest.mark.parametrize("mode", ['Python',
+                                      pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                      pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda]),
+                                      ])
+    def test_generator_as_input_with_num_trials(self, mode):
         c = pnl.Composition()
 
         m1 = pnl.TransferMechanism()
@@ -4759,8 +4768,7 @@ class TestInputSpecifications:
 
         t_g = test_generator()
 
-        c.run(inputs=t_g,
-              num_trials=1)
+        c.run(inputs=t_g, num_trials=1, bin_execute=mode)
         assert c.parameters.results.get(c) == [[np.array([0.])]]
 
     def test_error_on_malformed_generator(self):


### PR DESCRIPTION
Reenable node-compiled execution of nested compositions if there are no modulatory projections.
Add support for generalized generator inputs.