### PR TITLE
autodiffcomposition: Do not hide pytorchmodelcreator import in a try block

### DIFF
--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -154,10 +154,11 @@ try:
     import torch
     from torch import nn
     import torch.optim as optim
-    from psyneulink.library.compositions.pytorchmodelcreator import PytorchModelCreator
     torch_available = True
 except ImportError:
     torch_available = False
+else:
+    from psyneulink.library.compositions.pytorchmodelcreator import PytorchModelCreator
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION

If torch is available, importing pytorchmodelcreator should succeed.
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>