### PR TITLE
travis: List pip cache location explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,10 @@ env:
     - COVERALLS_PARALLEL=true
 
 # Cache downloaded and built python packages
-cache: pip
+# This needs to be explicit, 'cache: pip' only works with 'language: python'
+cache:
+  directories:
+    - $HOME/.cache/pip
 
 addons:
   apt:


### PR DESCRIPTION
'cache: pip' seems to only work with 'language: python'
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>