### PR TITLE
llvm: fixes

### DIFF
--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -4208,7 +4208,7 @@ class FitzHughNagumoIntegrator(IntegratorFunction):  # -------------------------
         def _get_state_ptr(x):
             ptr = pnlvm.helpers.get_state_ptr(builder, self, state, x)
             return pnlvm.helpers.unwrap_2d_array(builder, ptr)
-        prev = {s: _get_state_ptr(s) for s in self._get_state_ids()}
+        prev = {s: _get_state_ptr(s) for s in self.llvm_state_ids}
 
         # Output locations
         def _get_out_ptr(i):
@@ -4220,7 +4220,7 @@ class FitzHughNagumoIntegrator(IntegratorFunction):  # -------------------------
         def _get_param_val(x):
             ptr = pnlvm.helpers.get_param_ptr(builder, self, params, x)
             return pnlvm.helpers.load_extract_scalar_array_one(builder, ptr)
-        param_vals = {p: _get_param_val(p) for p in self._get_param_ids()}
+        param_vals = {p: _get_param_val(p) for p in self.llvm_param_ids}
 
         inner_args = {"ctx": ctx, "var_ptr": arg_in, "param_vals": param_vals,
                       "out_v": out['v'], "out_w": out['w'],

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2637,7 +2637,7 @@ class Mechanism_Base(Mechanism):
         builder.store(builder.load(params_in), params_out)
 
         # Filter out param ports without corresponding params for this function
-        param_ports = [p for p in self._parameter_ports if p.name in obj._get_param_ids()]
+        param_ports = [p for p in self._parameter_ports if p.name in obj.llvm_param_ids]
 
         def _get_output_ptr(b, i):
             ptr = pnlvm.helpers.get_param_ptr(b, obj, params_out,

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2773,8 +2773,9 @@ class Mechanism_Base(Mechanism):
         internal_builder = ctx.create_llvm_function(args_t, self,
                                                     name=builder.function.name + "_internal",
                                                     return_type=pnlvm.ir.IntType(1))
+        iparams, istate, iin, iout = internal_builder.function.args[:4]
         internal_builder, is_finished = self._gen_llvm_function_internal(ctx, internal_builder,
-                                                                         params, state, arg_in, arg_out)
+                                                                         iparams, istate, iin, iout)
         internal_builder.ret(is_finished)
 
         # Call Internal Function

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1551,16 +1551,17 @@ class TransferMechanism(ProcessingMechanism_Base):
         # Update previous value to make sure that repeated executions work
         builder.store(builder.load(current), prev_val_ptr)
 
-        if self.parameters.termination_threshold.get(None) is None:
+        threshold_ptr = pnlvm.helpers.get_param_ptr(builder, self, params,
+                                                    "termination_threshold")
+        if isinstance(threshold_ptr.type.pointee, pnlvm.ir.LiteralStructType):
             # Threshold is not defined, return the old value of finished flag
+            assert len(threshold_ptr.type.pointee) == 0
             is_finished_ptr = pnlvm.helpers.get_state_ptr(builder, self, state,
                                                           "is_finished_flag")
             is_finished_flag = builder.load(is_finished_ptr)
             return builder.fcmp_ordered("!=", is_finished_flag,
                                               is_finished_flag.type(0))
 
-        threshold_ptr = pnlvm.helpers.get_param_ptr(builder, self, params,
-                                                    "termination_threshold")
         threshold = builder.load(threshold_ptr)
         cmp_val_ptr = builder.alloca(threshold.type)
         builder.store(threshold, cmp_val_ptr)

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1564,7 +1564,6 @@ class TransferMechanism(ProcessingMechanism_Base):
 
         threshold = builder.load(threshold_ptr)
         cmp_val_ptr = builder.alloca(threshold.type)
-        builder.store(threshold, cmp_val_ptr)
         if self.termination_measure is max:
             assert self._termination_measure_num_items_expected == 1
             # Get inside of the structure

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -46,7 +46,6 @@ def gen_node_wrapper(ctx, composition, node, *, tags:frozenset):
 
     builder = ctx.create_llvm_function(args, node, "comp_wrap_" + node_function.name)
     llvm_func = builder.function
-    llvm_func.attributes.add('alwaysinline')
     for a in llvm_func.args:
         a.attributes.add('nonnull')
 

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -343,7 +343,7 @@ class CompExecution(CUDAExecution):
                 self._copy_params_to_pnl(context=context, component=node, params=node_params)
         elif isinstance(component, MappingProjection):
             # we copy all ids back
-            for idx, attribute in enumerate(component._get_param_ids()):
+            for idx, attribute in enumerate(component.llvm_param_ids):
                 to_set = getattr(component.parameters, attribute)
                 parameter_ctype = getattr(params, params._fields_[idx][0])
                 value = _convert_ctype_to_python(parameter_ctype)

--- a/psyneulink/library/compositions/pytorchmodelcreator.py
+++ b/psyneulink/library/compositions/pytorchmodelcreator.py
@@ -510,7 +510,6 @@ class PytorchModelCreator(torch.nn.Module):
         args = [float_ptr_ty, ctx.int32_ty, float_ptr_ty]
         builder = ctx.create_llvm_function(args, self,name )
         llvm_func = builder.function
-        llvm_func.attributes.add('alwaysinline')
 
         input_vector, dim, output_vector = llvm_func.args
         def get_fct_param_value(param_name):


### PR DESCRIPTION
Drop 'alwaysinline' attribute.
Use cached property instead of generating the list of compiled params.
Use a structural check instead of python param value.