### PR TITLE
composition/property/output_values: output_values property now return…

### DIFF
--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -8138,8 +8138,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
     @property
     def output_values(self):
-        """Returns values of all OutputPorts that belong to the Output CompositionInterfaceMechanism"""
-        return self.get_output_values()
+        """Returns values of all OutputPorts that belong to the Output CompositionInterfaceMechanism in the most recently executed context"""
+        return self.get_output_values(self.most_recent_context)
 
     def get_output_values(self, context=None):
         return [output_port.parameters.value.get(context) for output_port in self.output_CIM.output_ports]

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1,3 +1,11 @@
 import psyneulink as pnl
 import pytest
 import numpy as np
+
+class TestCompositionMethods:
+    def test_get_output_values_prop(self):
+        A = pnl.ProcessingMechanism()
+        c = pnl.Composition()
+        c.add_node(A)
+        result = c.run(inputs={A: [1]}, num_trials=2)
+        assert result == c.output_values == [np.array([1])]

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -4987,6 +4987,12 @@ class TestProperties:
         res = comp.run(inputs=inputs, bin_execute=mode)
         assert np.allclose(res, [[20.0, 40.0], [60.0, 80.0]])
 
+    def test_get_output_values_prop(self):
+        A = pnl.ProcessingMechanism()
+        c = pnl.Composition()
+        c.add_node(A)
+        result = c.run(inputs={A: [1]}, num_trials=2)
+        assert result == c.output_values == [np.array([1])]
 
 class TestAuxComponents:
     def test_two_transfer_mechanisms(self):


### PR DESCRIPTION
…s the values of OutputPorts in the most recent context instead of the context with the None execution id.