### PR TITLE
Add pathway registry to the list of primary_registries

### DIFF
--- a/psyneulink/__init__.py
+++ b/psyneulink/__init__.py
@@ -78,6 +78,7 @@ primary_registries = [
     FunctionRegistry,
     GatingMechanismRegistry,
     MechanismRegistry,
+    PathwayRegistry,
     PortRegistry,
     PreferenceSetRegistry,
     ProcessRegistry,

--- a/psyneulink/__init__.py
+++ b/psyneulink/__init__.py
@@ -72,9 +72,16 @@ for handler in _logging.root.handlers:
     ))
 
 primary_registries = [
-    CompositionRegistry, ControlMechanismRegistry, DeferredInitRegistry,
-    FunctionRegistry, GatingMechanismRegistry, MechanismRegistry,
-    PreferenceSetRegistry, ProcessRegistry, ProjectionRegistry, PortRegistry,
+    CompositionRegistry,
+    ControlMechanismRegistry,
+    DeferredInitRegistry,
+    FunctionRegistry,
+    GatingMechanismRegistry,
+    MechanismRegistry,
+    PortRegistry,
+    PreferenceSetRegistry,
+    ProcessRegistry,
+    ProjectionRegistry,
     SystemRegistry
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ license_file = LICENSE.txt
 addopts =
     -s
     -vv
-    -n 0
+    -n auto
     --benchmark-disable
     --benchmark-disable-gc
     --benchmark-warmup=on


### PR DESCRIPTION
This allows it to be cleared after every test, avoiding memory leak.
Fixes failing CI due to OOM condition.

Allow parallel test runs by default.