### PR TITLE
Fix results shape from learning

### DIFF
--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -192,6 +192,9 @@ class CompositionRunner():
             if minibatch_size == TRAINING_SET:
                 minibatch_size = num_trials
 
+            if minibatch_size > num_trials:
+                raise Exception("The minibatch size cannot be greater than the number of trials.")
+
             early_stopper = None
             if patience is not None and (bin_execute is False or bin_execute == 'Python'):
                 early_stopper = EarlyStopping(min_delta=min_delta, patience=patience)

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -201,14 +201,11 @@ class CompositionRunner():
             self._composition.run(inputs=minibatched_input, skip_initialization=skip_initialization, context=context, skip_analyze_graph=True, bin_execute=bin_execute, *args, **kwargs)
             skip_initialization = True
 
-        # FIXME: compiled run values differ from pytorch run
-        results = self._composition.parameters.results.get(context)[-1 * num_trials * minibatch_size:] # return results from last epoch
-        # if bin_execute is not False and bin_execute != 'Python':
-        #     results = [x for x in self._composition.parameters.results.get(context)[-1 * num_trials * minibatch_size:]] # return results from last epoch
-        # else:
-        #     results = [x[0] for x in self._composition.parameters.results.get(context)[-1 * num_trials * minibatch_size:]] # return results from last epoch
+        num_epoch_results = num_trials // minibatch_size # number of results expected from final epoch
+        results = self._composition.parameters.results.get(context)[-1 * num_epoch_results:] # return results from last epoch
 
         return results
+
 class EarlyStopping(object):
     def __init__(self, mode='min', min_delta=0, patience=10):
         self.mode = mode

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -9,3 +9,59 @@ class TestCompositionMethods:
         c.add_node(A)
         result = c.run(inputs={A: [1]}, num_trials=2)
         assert result == c.output_values == [np.array([1])]
+
+
+    # test whether xor model created as autodiff composition learns properly
+    @pytest.mark.pytorch
+    @pytest.mark.parametrize("mode", ['Python',
+                                      pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                     ])
+    @pytest.mark.parametrize("minibatch_size", [
+        1,
+        2,
+        3,
+        4
+    ])
+    def test_learning_output_shape(self, mode, minibatch_size):
+        '''
+        Tests for correct output from composition.learn
+        Expected: All results from last epoch
+        '''
+        xor_in = pnl.TransferMechanism(name='xor_in',
+                                   default_variable=np.zeros(2))
+
+        xor_hid = pnl.TransferMechanism(name='xor_hid',
+                                    default_variable=np.zeros(10),
+                                    function=pnl.Logistic())
+
+        xor_out = pnl.TransferMechanism(name='xor_out',
+                                    default_variable=np.zeros(1),
+                                    function=pnl.Logistic())
+
+        hid_map = pnl.MappingProjection(matrix=np.random.rand(2,10), sender=xor_in, receiver=xor_hid)
+        out_map = pnl.MappingProjection(matrix=np.random.rand(10,1))
+
+        xor = pnl.AutodiffComposition()
+
+        xor.add_node(xor_in)
+        xor.add_node(xor_hid)
+        xor.add_node(xor_out)
+
+        xor.add_projection(sender=xor_in, projection=hid_map, receiver=xor_hid)
+        xor.add_projection(sender=xor_hid, projection=out_map, receiver=xor_out)
+
+        xor_inputs = np.array(  # the inputs we will provide to the model
+            [[0, 0], [0, 1], [1, 0], [1, 1]])
+
+        xor_targets = np.array(  # the outputs we wish to see from the model
+            [[0], [1], [1], [0]])
+
+        results = xor.learn(inputs={"inputs": {xor_in:xor_inputs},
+                                    "targets": {xor_out:xor_targets},
+                                    "epochs": 10
+                                    },
+                                    minibatch_size=minibatch_size,
+                                    bin_execute=mode)
+
+
+        assert len(results) == 4 // minibatch_size


### PR DESCRIPTION
This pull fixes a typo in `composition.learn`, which caused too many results to be returned when learning with minibatch sizes greater than 1.