### PR TITLE
github-actions: Don't use fail-fast strategy.

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
         python-architecture: ['x64']


### PR DESCRIPTION
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>