### PR TITLE
Optimize Parameter inheritance

### DIFF
--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -366,6 +366,12 @@ class ParametersTemplate:
 
     __deepcopy__ = get_deepcopy_with_shared(_deepcopy_shared_keys)
 
+    def __del__(self):
+        try:
+            self._parent._children.remove(weakref.ref(self))
+        except (AttributeError, KeyError):
+            pass
+
     def __iter__(self):
         return iter([getattr(self, k) for k in self.values(show_all=True).keys()])
 


### PR DESCRIPTION
This removes the need for most getattr calls using caching. 

If a `Parameter` is marked as `_inherited=True`, then it does not store its default value (for example) explicitly but rather inherits the value in real time from its closest non-inherited parent. This was implemented by deletion of the attribute and repeated getattr calls to find the correct inherited value. 

This branch implements storage of a reference to the closest uninherited parent, which is recalculated lazily in the uncommon event that the correct parent is changed (by explicitly setting the default value for a previously inherited parent, or by calling `Parameter.reset()` on an uninherited parent in some cases).  

It also removes most getattr calls for `Parameters`, which now mostly only occurrs when setting up `ParameterAlias`es