### PR TITLE
Fix/composition/pathway single list spec

### DIFF
--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -4995,12 +4995,12 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # Possible specifications for **pathways** arg:
         # 1  Single node:  NODE
         #    Single pathway spec (list, tuple or dict):
-        # 2   single list:    PWAY = [NODE] or [NODE...] in which *all* are NODES
-        # 3   single tuple:   (PWAY, LearningFunction) = (NODE, LearningFunction) or
+        # 2   single list:   PWAY = [NODE] or [NODE...] in which *all* are NODES with optional intercolated Projections
+        # 3   single tuple:  (PWAY, LearningFunction) = (NODE, LearningFunction) or
         #                                                ([NODE...], LearningFunction)
-        # 4   single dict:    {NAME: PWAY} = {NAME: NODE} or
-        #                                    {NAME: [NODE...]} or
-        #                                    {NAME: ([NODE...], LearningFunction)}
+        # 4   single dict:   {NAME: PWAY} = {NAME: NODE} or
+        #                                   {NAME: [NODE...]} or
+        #                                   {NAME: ([NODE...], LearningFunction)}
         #   Multiple pathway specs (outer list):
         # 5   list with list: [PWAY] = [NODE, [NODE]] or [[NODE...]...]
         # 6   list with tuple:  [(PWAY, LearningFunction)...] = [(NODE..., LearningFunction)...] or
@@ -5028,7 +5028,11 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             pathways = convert_to_list(pathways)
 
         # Possibility 2 (list is a single pathway spec):
-        if isinstance(pathways, list) and all(_is_node_spec(p) for p in pathways):
+        # # MODIFIED 5/17/20 OLD:
+        # if isinstance(pathways, list) and all(_is_node_spec(p) for p in pathways):
+        # MODIFIED 5/17/20 NEW:
+        if isinstance(pathways, list) and all(_is_pathway_entry_spec(p, ANY) for p in pathways):
+        # MODIFIED 5/17/20 END
             # Place in outter list (to conform to processing of multiple pathways below)
             pathways = [pathways]
         # If pathways is not now a list it must be illegitimate

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -5031,7 +5031,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # # MODIFIED 5/17/20 OLD:
         # if isinstance(pathways, list) and all(_is_node_spec(p) for p in pathways):
         # MODIFIED 5/17/20 NEW:
-        if isinstance(pathways, list) and all(_is_pathway_entry_spec(p, ANY) for p in pathways):
+        if (isinstance(pathways, list)
+                and _is_node_spec(pathways[0]) and all(_is_pathway_entry_spec(p, ANY) for p in pathways)):
         # MODIFIED 5/17/20 END
             # Place in outter list (to conform to processing of multiple pathways below)
             pathways = [pathways]

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -2395,8 +2395,9 @@ PORT_FUNCTION_PARAMS = "PORT_FUNCTION_PARAMS"
 class Composition(Composition_Base, metaclass=ComponentsMeta):
     """
     Composition(                           \
-        nodes=None,                        \
         pathways=None,                     \
+        nodes=None,                        \
+        projections=None,                  \
         disable_learning=False,            \
         controller=None,                   \
         enable_controller=None,            \
@@ -2412,6 +2413,10 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     Arguments
     ---------
 
+    pathways : Pathway specification or list[Pathway specification...]
+        specifies one or more Pathways to add to the Compositions (see **pathways** argument of `add_pathways
+        `Composition.add_pathways` for specification format).
+
     nodes : `Mechanism <Mechanism>`, `Composition` or list[`Mechanism <Mechanism>`, `Composition`] : default None
         specifies one or more `Nodes <Composition_Nodes>` to add to the Composition;  these are each treated as
         `SINGLETONs <NodeRole.SINGLETON>` unless they are explicitly assigned `Projections <Projection>`.
@@ -2419,10 +2424,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     projections : `Projection <Projection>` or list[`Projection <Projection>`] : default None
         specifies one or more `Projections <Projection>` to add to the Composition;  these are not functional
         unless they are explicitly assigned a `sender <Projection.sender>` and `receiver <Projection.receiver>`.
-
-    pathways : Pathway specification or list[Pathway specification...]
-        specifies one or more Pathways to add to the Compositions (see **pathways** argument of `add_pathways
-        `Composition.add_pathways` for specification format).
 
     disable_learning: bool : default False
         specifies whether `LearningMechanisms <LearningMechanism>` in the Composition are executed when run in
@@ -2653,10 +2654,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
     def __init__(
             self,
-            # nodes:tc.optional(_is_node_spec)=None,
+            pathways=None,
             nodes=None,
             projections=None,
-            pathways=None,
             disable_learning:bool=False,
             controller:ControlMechanism=None,
             enable_controller=None,


### PR DESCRIPTION
• composition.py
  - add_pathways:  fixed bug in which specifying pathways with a single list 
         that includes a Projection caused an error
  - __init__():  made pathways first arg, so can use positionally w/o keyword
