### PR TITLE
refactor/integrator_reinitialization_related_names

### DIFF
--- a/Scripts/Debug/Yotam LCA Model.py
+++ b/Scripts/Debug/Yotam LCA Model.py
@@ -186,7 +186,7 @@ def get_trained_network(bipartite_graph, num_features=3, num_hidden=200, epochs=
 							   time_step_size=0.01, 
 							   threshold=threshold, 
 							   threshold_criterion=pnl.CONVERGENCE,
-							   reinitialize_when=pnl.AtTrialStart(),
+							   reset_integrator_when=pnl.AtTrialStart(),
 							   name='lca')
 
 		# Wrapper composition used to pass values between mnet (AutodiffComposition) and lca (LCAMechanism)
@@ -316,7 +316,7 @@ def get_trained_network_multLCA(bipartite_graph, num_features=3, num_hidden=200,
 											 integrator_function=lci,
 											 name='lca',
 											 termination_threshold=threshold,
-											 reinitialize_when=pnl.AtTrialStart())
+											 reset_integrator_when=pnl.AtTrialStart())
 
 		# Wrapper composition used to pass values between mnet (AutodiffComposition) and lca (LCAMechanism)
 		wrapper_composition = pnl.Composition()

--- a/Scripts/Examples/Composition/LC Control Mechanism Composition.py
+++ b/Scripts/Examples/Composition/LC Control Mechanism Composition.py
@@ -27,7 +27,7 @@ S = Composition()
 S.add_node(A, required_roles=NodeRole.INPUT)
 S.add_linear_processing_pathway(pathway=path)
 S.add_node(LC, required_roles=NodeRole.OUTPUT)
-LC.reinitialize_when = Never()
+LC.reset_integrator_when = Never()
 
 gain_created_by_LC_output_port_1 = []
 mod_gain_assigned_to_A = []

--- a/Scripts/Examples/Composition/Tutorial/Stroop Model - EVC.py
+++ b/Scripts/Examples/Composition/Tutorial/Stroop Model - EVC.py
@@ -122,8 +122,8 @@ evc.log.set_log_conditions(VARIABLE)
 evc.log.set_log_conditions(VALUE)
 
 task.initial_value = [0.5,0.5]
-task.reinitialize_when=AtPass(n=0)
-# task.reinitialize_when=AtTrialStart()
+task.reset_integrator_when=AtPass(n=0)
+# task.reset_integrator_when=AtTrialStart()
 
 num_trials = 2
 stimuli = {color_input:[red] * num_trials,

--- a/docs/source/BasicsAndPrimer.rst
+++ b/docs/source/BasicsAndPrimer.rst
@@ -289,7 +289,7 @@ Mechanism has completed its execution, as follows::
     # Modify consruction of decision Mechanism:
     decision = DDM(name='DECISION',
                    input_format=ARRAY,
-                   reinitialize_when=AtTrialStart(),
+                   reset_integrator_when=AtTrialStart(),
                    function=DriftDiffusionIntegrator(noise=0.5, threshold=20)
                    )
     Stroop_model.run(inputs={color_input:red, word_input:green, task_input:color},
@@ -395,7 +395,7 @@ conflict in the ``output`` Mechanism on each `trial <TimeScale.TRIAL>`, and use 
 
     # Set up run and then execute it
     task.initial_value = [0.5,0.5]         # Assign "neutral" starting point for task units on each trial
-    task.reinitialize_when=AtTrialStart()  # Reinitialize task units at beginning of each trial
+    task.reset_integrator_when=AtTrialStart()  # Reinitialize task units at beginning of each trial
     num_trials = 4
     stimuli = {color_input:[red]*num_trials,
                word_input:[green]*num_trials,

--- a/docs/source/_static/stroop_conflict_monitoring.json
+++ b/docs/source/_static/stroop_conflict_monitoring.json
@@ -1058,7 +1058,7 @@
                             "net_outcome": null,
                             "outcome": null,
                             "output_labels_dict": {},
-                            "previous_value": null,
+                            "previous_integrator_value": null,
                             "simulation_ids": [],
                             "variable": [
                                 [
@@ -1258,7 +1258,7 @@
                                     "input_labels_dict": {},
                                     "input_port_variables": null,
                                     "output_labels_dict": {},
-                                    "previous_value": null,
+                                    "previous_integrator_value": null,
                                     "variable": [
                                         [
                                             0.0,
@@ -1707,7 +1707,7 @@
                                                 "input_labels_dict": {},
                                                 "input_port_variables": null,
                                                 "output_labels_dict": {},
-                                                "previous_value": null,
+                                                "previous_integrator_value": null,
                                                 "variable": [
                                                     [
                                                         0.0,
@@ -2581,7 +2581,7 @@
                                             "input_labels_dict": {},
                                             "input_port_variables": null,
                                             "output_labels_dict": {},
-                                            "previous_value": null,
+                                            "previous_integrator_value": null,
                                             "variable": [
                                                 [
                                                     0.0,
@@ -2826,7 +2826,7 @@
                             "input_labels_dict": {},
                             "input_port_variables": null,
                             "output_labels_dict": {},
-                            "previous_value": null,
+                            "previous_integrator_value": null,
                             "variable": [
                                 [
                                     0.0,
@@ -3275,7 +3275,7 @@
                                         "input_labels_dict": {},
                                         "input_port_variables": null,
                                         "output_labels_dict": {},
-                                        "previous_value": null,
+                                        "previous_integrator_value": null,
                                         "variable": [
                                             [
                                                 0.0,
@@ -3736,7 +3736,7 @@
                             "input_labels_dict": {},
                             "input_port_variables": null,
                             "output_labels_dict": {},
-                            "previous_value": null,
+                            "previous_integrator_value": null,
                             "variable": [
                                 [
                                     0.0
@@ -4247,7 +4247,7 @@
                             "input_labels_dict": {},
                             "input_port_variables": null,
                             "output_labels_dict": {},
-                            "previous_value": null,
+                            "previous_integrator_value": null,
                             "variable": [
                                 [
                                     0.0,
@@ -5106,7 +5106,7 @@
                             "input_labels_dict": {},
                             "input_port_variables": null,
                             "output_labels_dict": {},
-                            "previous_value": null,
+                            "previous_integrator_value": null,
                             "variable": [
                                 [
                                     0.0,
@@ -5602,7 +5602,7 @@
                             "input_labels_dict": {},
                             "input_port_variables": null,
                             "output_labels_dict": {},
-                            "previous_value": null,
+                            "previous_integrator_value": null,
                             "variable": [
                                 [
                                     0.0,
@@ -5884,7 +5884,7 @@
                             "input_labels_dict": {},
                             "input_port_variables": null,
                             "output_labels_dict": {},
-                            "previous_value": null,
+                            "previous_integrator_value": null,
                             "variable": [
                                 [
                                     0.0,
@@ -6166,7 +6166,7 @@
                             "input_labels_dict": {},
                             "input_port_variables": null,
                             "output_labels_dict": {},
-                            "previous_value": null,
+                            "previous_integrator_value": null,
                             "variable": [
                                 [
                                     0.0,
@@ -6625,7 +6625,7 @@
                             "input_labels_dict": {},
                             "input_port_variables": null,
                             "output_labels_dict": {},
-                            "previous_value": null,
+                            "previous_integrator_value": null,
                             "variable": [
                                 [
                                     0.0,
@@ -6907,7 +6907,7 @@
                             "input_labels_dict": {},
                             "input_port_variables": null,
                             "output_labels_dict": {},
-                            "previous_value": null,
+                            "previous_integrator_value": null,
                             "variable": [
                                 [
                                     0.0,

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -337,17 +337,17 @@ The following attributes control and provide information about the execution of 
 
 .. _Component_Reinitialize_When:
 
-* **reinitialize_when** - contains a `Condition`; when this condition is satisfied, the Component calls its
+* **reset_integrator_when** - contains a `Condition`; when this condition is satisfied, the Component calls its
   `reinitialize <Component.reinitialize>` method. The `reinitialize <Component.reinitialize>` method is executed
   without arguments, meaning that the relevant function's `initializer<IntegratorFunction.initializer>` attribute
   (or equivalent -- initialization attributes vary among functions) is used for reinitialization. Keep in mind that
-  the `reinitialize <Component.reinitialize>` method and `reinitialize_when <Component.reinitialize_when>` attribute
+  the `reinitialize <Component.reinitialize>` method and `reset_integrator_when <Component.reset_integrator_when>` attribute
   only exist for Mechanisms that have `stateful <Parameter.stateful>` Parameters, or that have a `function
   <Mechanism.function>` with `stateful <Parameter.stateful>` Parameters.
 
   .. note::
 
-        Currently, only Mechanisms reinitialize when their reinitialize_when Conditions are satisfied. Other types of
+        Currently, only Mechanisms reinitialize when their reset_integrator_when Conditions are satisfied. Other types of
         Components do not reinitialize.
 
 .. _:
@@ -747,8 +747,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
     max_executions_before_finished : bool
         see `max_executions_before_finished <Component_Max_Executions_Before_Finished>`
 
-    reinitialize_when : `Condition`
-        see `reinitialize_when <Component_Reinitialize_When>`
+    reset_integrator_when : `Condition`
+        see `reset_integrator_when <Component_Reinitialize_When>`
 
     name : str
         see `name <Component_Name>`
@@ -982,7 +982,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                  size=NotImplemented,  # 7/5/17 CW: this is a hack to check whether the user has passed in a size arg
                  function=None,
                  name=None,
-                 reinitialize_when=None,
+                 reset_integrator_when=None,
                  prefs=None,
                  **kwargs):
         """Assign default preferences; enforce required params; validate and instantiate params and execute method
@@ -1042,10 +1042,10 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
 
         self.parameters.has_initializers._set(False, context)
 
-        if reinitialize_when is not None:
-            self.reinitialize_when = reinitialize_when
+        if reset_integrator_when is not None:
+            self.reset_integrator_when = reset_integrator_when
         else:
-            self.reinitialize_when = Never()
+            self.reset_integrator_when = Never()
 
         # self.componentName = self.componentType
         try:
@@ -1157,7 +1157,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
     # ------------------------------------------------------------------------------------------------------------------
     def _get_compilation_state(self):
         # FIXME: MAGIC LIST, Use stateful tag for this
-        whitelist = {"previous_time", "previous_value", "previous_v",
+        whitelist = {"previous_time", "previous_integrator_value", "previous_v",
                      "previous_w", "random_state", "is_finished_flag",
                      "num_executions_before_finished", "num_executions",
                      "execution_count", "value"}
@@ -1204,7 +1204,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
 
     def _get_compilation_params(self):
         # FIXME: MAGIC LIST, detect used parameters automatically
-        blacklist = {"previous_time", "previous_value", "previous_v",
+        blacklist = {"previous_time", "previous_integrator_value", "previous_v",
                      "previous_w", "random_state", "is_finished_flag",
                      "num_executions_before_finished", "num_executions", "variable",
                      "value", "saved_values", "saved_samples", "grid",

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -638,11 +638,11 @@ class Function_Base(Function):
             except AttributeError:
                 raise FunctionError(f"{self} has no parameter '{param_name}'.")
 
-    def get_previous_value(self, context=None):
+    def get_previous_integrator_value(self, context=None):
         # temporary method until previous values are integrated for all parameters
-        value = self.parameters.previous_value._get(context)
+        value = self.parameters.previous_integrator_value._get(context)
         if value is None:
-            value = self.parameters.previous_value._get(Context())
+            value = self.parameters.previous_integrator_value._get(Context())
 
         return value
 

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -809,8 +809,8 @@ class GradientOptimization(OptimizationFunction):
                     :default value: 1000
                     :type: ``int``
 
-                previous_value
-                    see `previous_value <GradientOptimization.previous_value>`
+                previous_integrator_value
+                    see `previous_integrator_value <GradientOptimization.previous_integrator_value>`
 
                     :default value: [[0], [0]]
                     :type: ``list``
@@ -833,7 +833,7 @@ class GradientOptimization(OptimizationFunction):
 
         # these should be removed and use switched to .get_previous()
         previous_variable = Parameter([[0], [0]], read_only=True, pnl_internal=True, constructor_argument='default_variable')
-        previous_value = Parameter([[0], [0]], read_only=True, pnl_internal=True)
+        previous_integrator_value = Parameter([[0], [0]], read_only=True, pnl_internal=True)
 
         gradient_function = Parameter(None, stateful=False, loggable=False)
         step_size = Parameter(1.0, modulable=True)
@@ -1062,23 +1062,23 @@ class GradientOptimization(OptimizationFunction):
 
     def _convergence_condition(self, variable, value, iteration, context=None):
         previous_variable = self.parameters.previous_variable._get(context)
-        previous_value = self.parameters.previous_value._get(context)
+        previous_integrator_value = self.parameters.previous_integrator_value._get(context)
 
         if iteration == 0:
             # self._convergence_metric = self.convergence_threshold + EPSILON
             self.parameters.previous_variable._set(variable, context)
-            self.parameters.previous_value._set(value, context)
+            self.parameters.previous_integrator_value._set(value, context)
             return False
 
         # Evaluate for convergence
         if self.convergence_criterion == VALUE:
-            convergence_metric = np.abs(value - previous_value)
+            convergence_metric = np.abs(value - previous_integrator_value)
         else:
             convergence_metric = np.max(np.abs(np.array(variable) -
                                                np.array(previous_variable)))
 
         self.parameters.previous_variable._set(variable, context)
-        self.parameters.previous_value._set(value, context)
+        self.parameters.previous_integrator_value._set(value, context)
 
         return convergence_metric <= self.parameters.convergence_threshold._get(context)
 

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -65,7 +65,7 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
 
     .. _Buffer:
 
-    Append `variable <Buffer.variable>` to the end of `previous_value <Buffer.previous_value>` (i.e., right-append
+    Append `variable <Buffer.variable>` to the end of `previous_integrator_value <Buffer.previous_integrator_value>` (i.e., right-append
     to deque of previous inputs).
 
     .. note::
@@ -82,7 +82,7 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
        to `function <Buffer.function>`.
 
     If the length of the result exceeds `history <Buffer.history>`, delete the first item.
-    Return `previous_value <Buffer.previous_value>` appended with `variable <Buffer.variable>`.
+    Return `previous_integrator_value <Buffer.previous_integrator_value>` appended with `variable <Buffer.variable>`.
 
     Arguments
     ---------
@@ -135,17 +135,17 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
 
     history : int
         determines maxlen of the deque and the value returned by the `function <Buffer.function>`. If appending
-        `variable <Buffer.variable>` to `previous_value <Buffer.previous_value>` exceeds history, the first item of
-        `previous_value <Buffer.previous_value>` is deleted, and `variable <Buffer.variable>` is appended to it,
-        so that `value <Buffer.previous_value>` maintains a constant length.  If history is not specified,
+        `variable <Buffer.variable>` to `previous_integrator_value <Buffer.previous_integrator_value>` exceeds history, the first item of
+        `previous_integrator_value <Buffer.previous_integrator_value>` is deleted, and `variable <Buffer.variable>` is appended to it,
+        so that `value <Buffer.previous_integrator_value>` maintains a constant length.  If history is not specified,
         the value returned continues to be extended indefinitely.
 
     initializer : float, list or ndarray
         value assigned as the first item of the deque when the Function is initialized, or reinitialized
-        if the **new_previous_value** argument is not specified in the call to `reinitialize
+        if the **new_previous_integrator_value** argument is not specified in the call to `reinitialize
         <StatefulFUnction.reinitialize>`.
 
-    previous_value : 1d array : default class_defaults.variable
+    previous_integrator_value : 1d array : default class_defaults.variable
         state of the deque prior to appending `variable <Buffer.variable>` in the current call.
 
     owner : Component
@@ -236,17 +236,17 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
 
         self.has_initializers = True
 
-    def _initialize_previous_value(self, initializer, context=None):
+    def _initialize_previous_integrator_value(self, initializer, context=None):
         initializer = initializer or []
-        previous_value = deque(initializer, maxlen=self.parameters.history.get(context))
+        previous_integrator_value = deque(initializer, maxlen=self.parameters.history.get(context))
 
-        self.parameters.previous_value.set(previous_value, context, override=True)
+        self.parameters.previous_integrator_value.set(previous_integrator_value, context, override=True)
 
-        return previous_value
+        return previous_integrator_value
 
     def _instantiate_attributes_before_function(self, function=None, context=None):
-        self.parameters.previous_value._set(
-            self._initialize_previous_value(
+        self.parameters.previous_integrator_value._set(
+            self._initialize_previous_integrator_value(
                 self.parameters.initializer._get(context),
                 context
             ),
@@ -257,13 +257,13 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
     def reinitialize(self, *args, context=None):
         """
 
-        Clears the `previous_value <Buffer.previous_value>` deque.
+        Clears the `previous_integrator_value <Buffer.previous_integrator_value>` deque.
 
         If an argument is passed into reinitialize or if the `initializer <Buffer.initializer>` attribute contains a
-        value besides [], then that value is used to start the new `previous_value <Buffer.previous_value>` deque.
-        Otherwise, the new `previous_value <Buffer.previous_value>` deque starts out empty.
+        value besides [], then that value is used to start the new `previous_integrator_value <Buffer.previous_integrator_value>` deque.
+        Otherwise, the new `previous_integrator_value <Buffer.previous_integrator_value>` deque starts out empty.
 
-        `value <Buffer.value>` takes on the same value as  `previous_value <Buffer.previous_value>`.
+        `value <Buffer.value>` takes on the same value as  `previous_integrator_value <Buffer.previous_integrator_value>`.
 
         """
         if context.execution_id is NotImplemented:
@@ -279,17 +279,17 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
         # arguments were passed in, but there was a mistake in their specification -- raise error!
         else:
             raise FunctionError("Invalid arguments ({}) specified for {}. Either one value must be passed to "
-                                "reinitialize its stateful attribute (previous_value), or reinitialize must be called "
+                                "reinitialize its stateful attribute (previous_integrator_value), or reinitialize must be called "
                                 "without any arguments, in which case the current initializer value, will be used to "
-                                "reinitialize previous_value".format(args,
+                                "reinitialize previous_integrator_value".format(args,
                                                                      self.name))
 
         if reinitialization_value is None or reinitialization_value == []:
-            self.get_previous_value(context).clear()
+            self.get_previous_integrator_value(context).clear()
             value = deque([], maxlen=self.parameters.history.get(context))
 
         else:
-            value = self._initialize_previous_value(reinitialization_value, context=context)
+            value = self._initialize_previous_integrator_value(reinitialization_value, context=context)
 
         self.parameters.value.set(value, context, override=True)
         return value
@@ -328,18 +328,18 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
         if self.is_initializing:
             return variable
 
-        previous_value = self.get_previous_value(context)
+        previous_integrator_value = self.get_previous_integrator_value(context)
 
         # Apply rate and/or noise, if they are specified, to all stored items
-        if len(previous_value):
-            previous_value = previous_value * rate + noise
+        if len(previous_integrator_value):
+            previous_integrator_value = previous_integrator_value * rate + noise
 
-        previous_value = deque(previous_value, maxlen=self.parameters.history._get(context))
+        previous_integrator_value = deque(previous_integrator_value, maxlen=self.parameters.history._get(context))
 
-        previous_value.append(variable)
+        previous_integrator_value.append(variable)
 
-        self.parameters.previous_value._set(previous_value, context)
-        return self.convert_output_type(previous_value)
+        self.parameters.previous_integrator_value._set(previous_integrator_value, context)
+        return self.convert_output_type(previous_integrator_value)
 
 
 RETRIEVAL_PROB = 'retrieval_prob'
@@ -540,7 +540,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         function used during retrieval to evaluate the distances returned by `distance_function
         <ContentAddressableMemory.distance_function>` and select the item(s) to return.
 
-    previous_value : 1d array
+    previous_integrator_value : 1d array
         state of the `memory <ContentAddressableMemory.memory>` prior to storing `variable
         <ContentAddressableMemory.variable>` in the current call.
 
@@ -729,12 +729,12 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
             prefs=prefs,
         )
 
-        if self.previous_value.size != 0:
-            self.parameters.key_size._set(len(self.previous_value[KEYS][0]), Context())
-            self.parameters.val_size._set(len(self.previous_value[VALS][0]), Context())
+        if self.previous_integrator_value.size != 0:
+            self.parameters.key_size._set(len(self.previous_integrator_value[KEYS][0]), Context())
+            self.parameters.val_size._set(len(self.previous_integrator_value[VALS][0]), Context())
 
         self.has_initializers = True
-        self.stateful_attributes = ["random_state", "previous_value"]
+        self.stateful_attributes = ["random_state", "previous_integrator_value"]
 
     def _get_state_ids(self):
         return super()._get_state_ids() + ["ring_memory"]
@@ -753,7 +753,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
                                            ring_buffer_struct))
 
     def _get_state_initializer(self, context):
-        memory = self.get_previous_value(context)
+        memory = self.get_previous_integrator_value(context)
         mem_init = pnlvm._tupleize([memory[0], memory[1], 0, 0])
         return (*super()._get_state_initializer(context), mem_init)
 
@@ -974,22 +974,22 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
             raise FunctionError(f'Value returned by {repr(SELECTION_FUNCTION)} specified for {self.__class__} '
                                 f'({result}) must return an array of the same length it receives')
 
-    def _initialize_previous_value(self, initializer, context=None):
-        """Ensure that initializer is appropriate for assignment as memory attribute and assign as previous_value
+    def _initialize_previous_integrator_value(self, initializer, context=None):
+        """Ensure that initializer is appropriate for assignment as memory attribute and assign as previous_integrator_value
 
         - Validate, if initializer is specified, it is a 3d array
-            (must be done here rather than in validate_params as it is needed to initialize previous_value
+            (must be done here rather than in validate_params as it is needed to initialize previous_integrator_value
         - Insure that it has exactly 2 items in outer dimension (axis 0)
             and that all items in each of those two items are all arrays
         """
         # vals = [[k for k in initializer.keys()], [v for v in initializer.values()]]
 
-        previous_value = np.ndarray(shape=(2, 0))
+        previous_integrator_value = np.ndarray(shape=(2, 0))
         if len(initializer) == 0:
-            return previous_value
+            return previous_integrator_value
         else:
             # Set key_size and val_size if this is the first entry
-            self.parameters.previous_value.set(previous_value, context, override=True)
+            self.parameters.previous_integrator_value.set(previous_integrator_value, context, override=True)
             self.parameters.key_size.set(len(initializer[0][KEYS]), context)
             self.parameters.val_size.set(len(initializer[0][VALS]), context)
             for entry in initializer:
@@ -1000,8 +1000,8 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
             return np.asarray(self._memory)
 
     def _instantiate_attributes_before_function(self, function=None, context=None):
-        self.parameters.previous_value._set(
-            self._initialize_previous_value(
+        self.parameters.previous_integrator_value._set(
+            self._initialize_previous_integrator_value(
                 self.parameters.initializer._get(context),
                 context
             ),
@@ -1021,15 +1021,15 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         """
         reinitialize(<new_dictionary> default={})
 
-        Clears the memory in `previous_value <ContentAddressableMemory.previous_value>`.
+        Clears the memory in `previous_integrator_value <ContentAddressableMemory.previous_integrator_value>`.
 
         If an argument is passed into reinitialize or if the `initializer <ContentAddressableMemory.initializer>`
-        attribute contains a value besides [], then that value is used to start the new memory in `previous_value
-        <ContentAddressableMemory.previous_value>`. Otherwise, the new `previous_value
-        <ContentAddressableMemory.previous_value>` memory starts out empty.
+        attribute contains a value besides [], then that value is used to start the new memory in `previous_integrator_value
+        <ContentAddressableMemory.previous_integrator_value>`. Otherwise, the new `previous_integrator_value
+        <ContentAddressableMemory.previous_integrator_value>` memory starts out empty.
 
         `value <ContentAddressableMemory.value>` takes on the same value as
-        `previous_value <ContentAddressableMemory.previous_value>`.
+        `previous_integrator_value <ContentAddressableMemory.previous_integrator_value>`.
         """
         if context.execution_id is NotImplemented:
             context.execution_id = self.most_recent_context.execution_id
@@ -1044,16 +1044,16 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         # arguments were passed in, but there was a mistake in their specification -- raise error!
         else:
             raise FunctionError("Invalid arguments ({}) specified for {}. Either one value must be passed to "
-                                "reinitialize its stateful attribute (previous_value), or reinitialize must be called "
+                                "reinitialize its stateful attribute (previous_integrator_value), or reinitialize must be called "
                                 "without any arguments, in which case the current initializer value will be used to "
-                                "reinitialize previous_value".format(args, self.name))
+                                "reinitialize previous_integrator_value".format(args, self.name))
 
         if reinitialization_value == []:
-            self.get_previous_value(context).clear()
+            self.get_previous_integrator_value(context).clear()
             value = np.ndarray(shape=(2, 0, len(self.defaults.variable[0])))
 
         else:
-            value = self._initialize_previous_value(reinitialization_value, context=context)
+            value = self._initialize_previous_integrator_value(reinitialization_value, context=context)
 
         self.parameters.value.set(value, context, override=True)
         return value
@@ -1106,7 +1106,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
             return variable
 
         # Set key_size and val_size if this is the first entry
-        if len(self.get_previous_value(context)[KEYS]) == 0:
+        if len(self.get_previous_integrator_value(context)[KEYS]) == 0:
             self.parameters.key_size._set(len(key), context)
             self.parameters.val_size._set(len(val), context)
 
@@ -1172,7 +1172,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         #           ALSO, SHOULD PROBABILISTIC SUPPRESSION OF RETRIEVAL BE HANDLED HERE OR function (AS IT IS NOW).
 
         self._validate_key(query_key, context)
-        _memory = self.get_previous_value(context)
+        _memory = self.get_previous_integrator_value(context)
 
         # if no memory, return the zero vector
         if len(_memory[KEYS]) == 0:
@@ -1233,7 +1233,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         key = list(memory[KEYS])
         val = list(memory[VALS])
 
-        d = self.get_previous_value(context)
+        d = self.get_previous_integrator_value(context)
 
         matches = [k for k in d[KEYS] if key==list(k)]
 
@@ -1271,7 +1271,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         if len(d[KEYS]) > self.max_entries:
             d = np.delete(d, [KEYS], axis=1)
 
-        self.parameters.previous_value._set(d,context)
+        self.parameters.previous_integrator_value._set(d,context)
         self._memory = d
 
         return storage_succeeded
@@ -1324,7 +1324,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
                         memory_keys = np.delete(self._memory[KEYS],j,axis=0)
                         memory_vals = np.delete(self._memory[VALS],j,axis=0)
                         self._memory = np.array([list(memory_keys), list(memory_vals)])
-                        self.parameters.previous_value._set(self._memory, context)
+                        self.parameters.previous_integrator_value._set(self._memory, context)
 
     def _parse_memories(self, memories, method, context=None):
         """Parse passing of single vs. multiple memories, validate memories, and return ndarray"""

--- a/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
+++ b/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
@@ -51,14 +51,14 @@ class StatefulFunction(Function_Base): #  --------------------------------------
 
     .. _StatefulFunction:
 
-    Abstract base class for Functions the result of which depend on their `previous_value
-    <StatefulFunction.previous_value>` attribute.
+    Abstract base class for Functions the result of which depend on their `previous_integrator_value
+    <StatefulFunction.previous_integrator_value>` attribute.
 
     COMMENT:
     NARRATIVE HERE THAT EXPLAINS:
     A) initializers and stateful_attributes
     B) initializer (note singular) is a prespecified member of initializers
-       that contains the value with which to initiailzer previous_value
+       that contains the value with which to initiailzer previous_integrator_value
     COMMENT
 
 
@@ -69,7 +69,7 @@ class StatefulFunction(Function_Base): #  --------------------------------------
         specifies a template for `variable <StatefulFunction.variable>`.
 
     initializer : float, list or 1d array : default 0.0
-        specifies initial value for `previous_value <StatefulFunction.previous_value>`.  If it is a list or array,
+        specifies initial value for `previous_integrator_value <StatefulFunction.previous_integrator_value>`.  If it is a list or array,
         it must be the same length as `variable <StatefulFunction.variable>` (see `initializer
         <StatefulFunction.initializer>` for details).
 
@@ -103,12 +103,12 @@ class StatefulFunction(Function_Base): #  --------------------------------------
         current input value.
 
     initializer : float or 1d array
-        determines initial value assigned to `previous_value <StatefulFunction.previous_value>`. If `variable
+        determines initial value assigned to `previous_integrator_value <StatefulFunction.previous_integrator_value>`. If `variable
         <StatefulFunction.variable>` is a list or array, and initializer is a float or has a single element, it is
-        applied to each element of `previous_value <StatefulFunction.previous_value>`. If initializer is a list or
-        array,each element is applied to the corresponding element of `previous_value <Integrator.previous_value>`.
+        applied to each element of `previous_integrator_value <StatefulFunction.previous_integrator_value>`. If initializer is a list or
+        array,each element is applied to the corresponding element of `previous_integrator_value <Integrator.previous_integrator_value>`.
 
-    previous_value : 1d array
+    previous_integrator_value : 1d array
         last value returned (i.e., for which state is being maintained).
 
     initializers : list
@@ -126,7 +126,7 @@ class StatefulFunction(Function_Base): #  --------------------------------------
 
     rate : float or 1d array
         on each call to `function <StatefulFunction.function>`, applied to `variable <StatefulFunction.variable>`,
-        `previous_value <StatefulFunction.previous_value>`, neither, or both, depending on implementation by
+        `previous_integrator_value <StatefulFunction.previous_integrator_value>`, neither, or both, depending on implementation by
         subclass.  If it is a float or has a single value, it is applied to all elements of its target(s);  if it has
         more than one element, each element is applied to the corresponding element of its target(s).
 
@@ -179,8 +179,8 @@ class StatefulFunction(Function_Base): #  --------------------------------------
                     :default value: 0.0
                     :type: ``float``
 
-                previous_value
-                    see `previous_value <StatefulFunction.previous_value>`
+                previous_integrator_value
+                    see `previous_integrator_value <StatefulFunction.previous_integrator_value>`
 
                     :default value: numpy.array([0])
                     :type: ``numpy.ndarray``
@@ -193,7 +193,7 @@ class StatefulFunction(Function_Base): #  --------------------------------------
         """
         noise = Parameter(0.0, modulable=True)
         rate = Parameter(1.0, modulable=True)
-        previous_value = Parameter(np.array([0]), pnl_internal=True)
+        previous_integrator_value = Parameter(np.array([0]), pnl_internal=True)
         initializer = Parameter(np.array([0]), pnl_internal=True)
 
 
@@ -215,7 +215,7 @@ class StatefulFunction(Function_Base): #  --------------------------------------
             self.initializers = ["initializer"]
 
         if not hasattr(self, "stateful_attributes"):
-            self.stateful_attributes = ["previous_value"]
+            self.stateful_attributes = ["previous_integrator_value"]
 
         if initializer is None:
             if params is not None and INITIALIZER in params and params[INITIALIZER] is not None:
@@ -433,8 +433,8 @@ class StatefulFunction(Function_Base): #  --------------------------------------
         return param
 
     def _instantiate_attributes_before_function(self, function=None, context=None):
-        self.parameters.previous_value._set(
-            self._initialize_previous_value(
+        self.parameters.previous_integrator_value._set(
+            self._initialize_previous_integrator_value(
                 self.parameters.initializer._get(context),
                 context
             ),
@@ -456,23 +456,23 @@ class StatefulFunction(Function_Base): #  --------------------------------------
 
         super()._instantiate_attributes_before_function(function=function, context=context)
 
-    def _initialize_previous_value(self, initializer, context=None):
+    def _initialize_previous_integrator_value(self, initializer, context=None):
         val = np.atleast_1d(initializer)
         if context is None:
             # Since this is run during initialization, self.parameters will refer to self.class_parameters
             # because self.parameters has not been created yet
             with warnings.catch_warnings():
                 warnings.filterwarnings('ignore')
-                self.previous_value = val
+                self.previous_integrator_value = val
         else:
-            self.parameters.previous_value.set(val, context)
+            self.parameters.previous_integrator_value.set(val, context)
 
         return val
 
     @handle_external_context(execution_id=NotImplemented)
     def reinitialize(self, *args, context=None):
         """
-            Resets `value <StatefulFunction.previous_value>`  and `previous_value <StatefulFunction.previous_value>`
+            Resets `value <StatefulFunction.previous_integrator_value>`  and `previous_integrator_value <StatefulFunction.previous_integrator_value>`
             to the specified value(s).
 
             If arguments are passed into the reinitialize method, then reinitialize sets each of the attributes in
@@ -485,9 +485,9 @@ class StatefulFunction(Function_Base): #  --------------------------------------
             the values of each of the attributes in `initializers <StatefulFunction.initializers>`.
 
             Often, the only attribute in `stateful_attributes <StatefulFunction.stateful_attributes>` is
-            `previous_value <StatefulFunction.previous_value>` and the only attribute in `initializers
+            `previous_integrator_value <StatefulFunction.previous_integrator_value>` and the only attribute in `initializers
             <StatefulFunction.initializers>` is `initializer <StatefulFunction.initializer>`, in which case
-            the reinitialize method sets `previous_value <StatefulFunction.previous_value>` and `value
+            the reinitialize method sets `previous_integrator_value <StatefulFunction.previous_integrator_value>` and `value
             <StatefulFunction.value>` to either the value of the argument (if an argument was passed into
             reinitialize) or the current value of `initializer <StatefulFunction.initializer>`.
 

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2223,7 +2223,7 @@ class Mechanism_Base(Mechanism):
 
         .. note::
                 The reinitialize method of an IntegratorFunction Function typically resets the function's
-                `previous_value <IntegratorFunction.previous_value>` (and any other `stateful_attributes
+                `previous_integrator_value <IntegratorFunction.previous_integrator_value>` (and any other `stateful_attributes
                 <IntegratorFunction.stateful_attributes>`) and `value <IntegratorFunction.value>` to the quantity (or
                 quantities) specified. If `reinitialize <Mechanism_Base.reinitialize>` is called without arguments,
                 the `initializer <IntegratorFunction.initializer>` value (or the values of each of the attributes in
@@ -2246,7 +2246,7 @@ class Mechanism_Base(Mechanism):
             self._update_output_ports(context=context)
 
         # If the mechanism has an auxiliary integrator function:
-        # (1) reinitialize it, (2) run the primary function with the new "previous_value" as input
+        # (1) reinitialize it, (2) run the primary function with the new "previous_integrator_value" as input
         # (3) update value, (4) update output ports
         elif hasattr(self, "integrator_function"):
             if isinstance(self.integrator_function, IntegratorFunction):

--- a/psyneulink/core/components/projections/pathway/mappingprojection.py
+++ b/psyneulink/core/components/projections/pathway/mappingprojection.py
@@ -260,11 +260,11 @@ A LearningProjection `modulates <LearningSignal_Modulation>` the `function <Para
 and providing it to the MappingProjection's `function <Projection_Base.function>` (usually `LinearMatrix`).  By
 default, the function for the *MATRIX* ParameterPort is an `AccumulatorIntegrator`.  A LearningProjection
 modulates it by assigning the value of its `additive_param <AccumulatorIntegrator.additive_param>` (`increment
-<AccumulatorIntegrator.increment>`), which is added to its `previous_value <AccumulatorIntegrator.previous_value>`
+<AccumulatorIntegrator.increment>`), which is added to its `previous_integrator_value <AccumulatorIntegrator.previous_integrator_value>`
 attribute each time it is executed. The result is that each time the MappingProjection is executed, and in turn
 executes its *MATRIX* ParameterPort, the `weight changes <LearningProjection_Structure>` conveyed to the
 MappingProjection from any LearningProjection(s) are added to the record of the matrix kept by the *MATRIX*
-ParameterPort's `AccumulatorIntegrator` function in its `previous_value <AccumulatorIntegrator.previous_value>`
+ParameterPort's `AccumulatorIntegrator` function in its `previous_integrator_value <AccumulatorIntegrator.previous_integrator_value>`
 attribute. This is then the value of the matrix used  by the MappingProjection's `LinearMatrix` function when it is
 executed.  It is important to note that the accumulated weight changes received by a MappingProjection from its
 LearningProjection(s) are stored by the *MATRIX* ParameterPort's function, and not the MappingProjection's `matrix
@@ -324,7 +324,7 @@ def _mapping_projection_matrix_setter(value, owning_component=None, context=None
     owning_component.function.parameters.matrix.set(value, context)
     # KDM 11/13/18: not sure that below is correct to do here, probably is better to do this in a "reinitialize" type
     # method but this is needed for Kalanthroff model to work correctly (though untested, it is in Scripts/Models)
-    owning_component.parameter_ports["matrix"].function.parameters.previous_value.set(value, context)
+    owning_component.parameter_ports["matrix"].function.parameters.previous_integrator_value.set(value, context)
 
     return value
 

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -930,7 +930,7 @@ class Projection_Base(Projection):
             getattr(self.parameters, port_Name)._set(value, context)
             # manual setting of previous value to matrix value (happens in above param['matrix'] setting
             if port_Name == MATRIX:
-                port.function.parameters.previous_value._set(value, context)
+                port.function.parameters.previous_integrator_value._set(value, context)
 
     def add_to(self, receiver, port, context=None):
         _add_projection_to(receiver=receiver, port=port, projection_spec=self, context=context)

--- a/psyneulink/core/globals/keywords.py
+++ b/psyneulink/core/globals/keywords.py
@@ -411,7 +411,7 @@ COMPONENT = 'COMPONENT'
 VARIABLE = "variable"
 DEFAULT_VARIABLE = "default_variable"
 VALUE = "value"
-PREVIOUS_VALUE = 'previous_value'
+PREVIOUS_VALUE = 'previous_integrator_value'
 LABELS = 'labels'
 PARAMS = "params"
 NAME = "name"
@@ -860,7 +860,7 @@ FUNCTION_OUTPUT_TYPE = 'output_type'
 OUTPUT_TYPE = 'output'
 OVERWRITE = 'overwrite'
 REINITIALIZE = "reinitialize"
-REINITIALIZE_WHEN = "reinitialize_when"
+REINITIALIZE_WHEN = "reset_integrator_when"
 
 LOW = 'low'
 HIGH = 'high'

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -253,7 +253,7 @@ def gen_composition_exec(ctx, composition, *, tags:frozenset):
 
         # Check if there's anything to reinitialize
         for node in composition._all_nodes:
-            when = getattr(node, "reinitialize_when", Never())
+            when = getattr(node, "reset_integrator_when", Never())
             # FIXME: This should not be necessary. The code gets DCE'd,
             # but there are still some problems with generation
             # 'reinitialize' function

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1167,9 +1167,9 @@ class DDM(ProcessingMechanism):
 
     @handle_external_context()
     def is_finished(self, context=None):
-        # find the single numeric entry in previous_value
+        # find the single numeric entry in previous_integrator_value
         try:
-            single_value = self.function.get_previous_value(context)
+            single_value = self.function.get_previous_integrator_value(context)
         except AttributeError:
             # Analytical function so it is always finished after it is called
             return True
@@ -1201,9 +1201,9 @@ class DDM(ProcessingMechanism):
         func_state_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, 'function')
         func_param_ptr = pnlvm.helpers.get_state_ptr(builder, self, params, 'function')
 
-        # Find the single numeric entry in previous_value
+        # Find the single numeric entry in previous_integrator_value
         try:
-            prev_val_ptr = pnlvm.helpers.get_state_ptr(builder, self.function, func_state_ptr, "previous_value")
+            prev_val_ptr = pnlvm.helpers.get_state_ptr(builder, self.function, func_state_ptr, "previous_integrator_value")
         except ValueError:
             return pnlvm.ir.IntType(1)(1)
 

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -1221,7 +1221,7 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
                 # Store activity from last execution in plus phase
                 self.parameters.minus_phase_activity._set(self.parameters.current_activity._get(context), context)
                 # Use initial_value attribute to initialize, for the minus phase,
-                #    both the integrator_function's previous_value
+                #    both the integrator_function's previous_integrator_value
                 #    and the Mechanism's current activity (which is returned as its input)
                 if not self.continuous:
                     self.reinitialize(self.initial_value, context=context)

--- a/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
@@ -277,7 +277,7 @@ class LCAMechanism(RecurrentTransferMechanism):
 
     leak : value
         determines the `leak <LeakyCompetingIntegrator.leak>` for the `LeakyCompetingIntegrator` Function,
-        which scales the contribution of its `previous_value <LeakyCompetingIntegrator.previous_value>` to the
+        which scales the contribution of its `previous_integrator_value <LeakyCompetingIntegrator.previous_integrator_value>` to the
         accumulation of its `variable <LeakyCompetingIntegrator.variable>` (:math:`x_{i}`) on each time step (see
         `LeakyCompetingIntegrator` for additional details.
 

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -276,7 +276,7 @@ def _recurrent_transfer_mechanism_matrix_setter(value, owning_component=None, co
     # KDM 8/7/18: removing the below because it has bad side effects for _instantiate_from_context, and it's not clear
     # that it's the correct behavior. Similar reason for removing/not implementing auto/hetero setters
     # if hasattr(owning_component, "recurrent_projection"):
-    #     owning_component.recurrent_projection.parameter_ports["matrix"].function.parameters.previous_value._set(value, base_execution_id)
+    #     owning_component.recurrent_projection.parameter_ports["matrix"].function.parameters.previous_integrator_value._set(value, base_execution_id)
 
     try:
         value = get_matrix(value, owning_component.recurrent_size, owning_component.recurrent_size)
@@ -1009,10 +1009,10 @@ class RecurrentTransferMechanism(TransferMechanism):
     @matrix.setter
     def matrix(self, val): # simplified version of standard setter (in Component.py)
         # KDM 10/12/18: removing below because it doesn't seem to be correct, and also causes
-        # unexpected values to be set to previous_value
+        # unexpected values to be set to previous_integrator_value
         # KDM 7/1/19: reinstating below
         if hasattr(self, "recurrent_projection"):
-            self.recurrent_projection.parameter_ports["matrix"].function.previous_value = val
+            self.recurrent_projection.parameter_ports["matrix"].function.previous_integrator_value = val
 
         self.parameters.matrix._set(val, self.most_recent_context)
 
@@ -1031,7 +1031,7 @@ class RecurrentTransferMechanism(TransferMechanism):
         self.parameters.auto._set(val, self.most_recent_context)
 
         if hasattr(self, "recurrent_projection") and 'hetero' in self._parameter_ports:
-            self.recurrent_projection.parameter_ports["matrix"].function.previous_value = self.matrix
+            self.recurrent_projection.parameter_ports["matrix"].function.previous_integrator_value = self.matrix
 
 
     @property
@@ -1043,7 +1043,7 @@ class RecurrentTransferMechanism(TransferMechanism):
         self.parameters.hetero._set(val, self.most_recent_context)
 
         if hasattr(self, "recurrent_projection") and 'auto' in self._parameter_ports:
-            self.recurrent_projection.parameter_ports["matrix"].function.previous_value = self.matrix_param
+            self.recurrent_projection.parameter_ports["matrix"].function.previous_integrator_value = self.matrix_param
 
     @property
     def learning_enabled(self):
@@ -1198,7 +1198,7 @@ class RecurrentTransferMechanism(TransferMechanism):
     def _execute(self, variable=None, context=None, runtime_params=None):
 
         # if not self.is_initializing
-        #     self.parameters.previous_value._set(self.value)
+        #     self.parameters.previous_integrator_value._set(self.value)
         # self._output = super()._execute(variable=variable, runtime_params=runtime_params, context=context)
         # return self._output
         return super()._execute(variable, context, runtime_params)

--- a/psyneulink/library/compositions/gymforagercfa.py
+++ b/psyneulink/library/compositions/gymforagercfa.py
@@ -171,7 +171,7 @@ class GymForagerCFA(RegressionCFA):
         )
 
     # FIX: RENAME AS _EXECUTE_AS_REP ONCE SAME IS DONE FOR COMPOSITION
-    # def evaluate(self, control_allocation, num_samples, reinitialize_values, feature_values, context):
+    # def evaluate(self, control_allocation, num_samples, reset_integrator_nodes_to, feature_values, context):
     def evaluate(self, feature_values, control_allocation, num_estimates, context):
         """Update prediction_vector <RegressorCFA.prediction_vector>`,
         then multiply by regression_weights.

--- a/psyneulink/library/compositions/regressioncfa.py
+++ b/psyneulink/library/compositions/regressioncfa.py
@@ -329,7 +329,7 @@ class RegressionCFA(CompositionFunctionApproximator):
         )
 
     # FIX: RENAME AS _EXECUTE_AS_REP ONCE SAME IS DONE FOR COMPOSITION
-    # def evaluate(self, control_allocation, num_samples, reinitialize_values, feature_values, context):
+    # def evaluate(self, control_allocation, num_samples, reset_integrator_nodes_to, feature_values, context):
     def evaluate(self, feature_values, control_allocation, num_estimates, context):
         """Update prediction_vector <RegressorCFA.prediction_vector>`,
         then multiply by regression_weights.

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -5,8 +5,8 @@ import pytest
 class TestComponent:
 
     def test_detection_of_legal_arg_in_kwargs(self):
-        assert isinstance(pnl.ProcessingMechanism().reinitialize_when, pnl.Never)
-        assert isinstance(pnl.ProcessingMechanism(reinitialize_when=pnl.AtTrialStart()).reinitialize_when,
+        assert isinstance(pnl.ProcessingMechanism().reset_integrator_when, pnl.Never)
+        assert isinstance(pnl.ProcessingMechanism(reset_integrator_when=pnl.AtTrialStart()).reset_integrator_when,
                           pnl.AtTrialStart)
 
     def test_detection_of_illegal_arg_in_kwargs(self):

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -1354,7 +1354,7 @@ class TestModelBasedOptimizationControlMechanisms:
             Input: [0.5, 0.123],
             reward: [20, 20]
         }
-        Input.reinitialize_when = pnl.Never()
+        Input.reset_integrator_when = pnl.Never()
 
         comp.run(inputs=stim_list_dict)
 

--- a/tests/composition/test_models.py
+++ b/tests/composition/test_models.py
@@ -846,8 +846,8 @@ class TestModels:
 
         # KDM 8/23/18: below must be added because these were expected to be changed with the above matrix setting, but this has appeared
         # to be incorrect behavior, and the reason for doing it is unknown
-        color_input_weights.parameter_ports['matrix'].function.parameters.previous_value.set(color_input_weights.matrix, PCTC, override=True)
-        word_input_weights.parameter_ports['matrix'].function.parameters.previous_value.set(word_input_weights.matrix, PCTC, override=True)
+        color_input_weights.parameter_ports['matrix'].function.parameters.previous_integrator_value.set(color_input_weights.matrix, PCTC, override=True)
+        word_input_weights.parameter_ports['matrix'].function.parameters.previous_integrator_value.set(word_input_weights.matrix, PCTC, override=True)
 
         results_2 = PCTC.run(inputs=congruent_input,
                              termination_processing=terminate_trial)  # run system with congruent stimulus input until

--- a/tests/control/test_gilzenrat.py
+++ b/tests/control/test_gilzenrat.py
@@ -19,7 +19,7 @@ class TestGilzenratMechanisms:
                          competition=-1.0)
 
         # - - - - - LCAMechanism integrator functions - - - - -
-        # X = previous_value + (rate * previous_value + variable) * self.time_step_size + noise
+        # X = previous_integrator_value + (rate * previous_integrator_value + variable) * self.time_step_size + noise
         # f(X) = 1.0*X + 0
 
         np.testing.assert_allclose(G.execute(), np.array([[0.0]]))
@@ -38,7 +38,7 @@ class TestGilzenratMechanisms:
         # X = 0.0396 --- previous value 0.0396
         # f(X) = 1.0*0.0396 <--- return 0.02, recurrent projection 0.02
 
-    def test_previous_value_stored(self):
+    def test_previous_integrator_value_stored(self):
         G = LCAMechanism(integrator_mode=True,
                          leak=1.0,
                          noise=0.0,
@@ -52,12 +52,12 @@ class TestGilzenratMechanisms:
         G.output_port.value = [0.0]
 
         # - - - - - LCAMechanism integrator functions - - - - -
-        # X = previous_value + (rate * previous_value + variable) * self.time_step_size + noise
+        # X = previous_integrator_value + (rate * previous_integrator_value + variable) * self.time_step_size + noise
         # f(X) = 2.0*X + 0
 
         # - - - - - starting values - - - - -
         # variable = G.output_port.value + stimulus = 0.0 + 1.0 = 1.0
-        # previous_value = initial_value = 1.0
+        # previous_integrator_value = initial_value = 1.0
         # single_run = S.execute([[1.0]])
         # np.testing.assert_allclose(single_run, np.array([[2.0]]))
         np.testing.assert_allclose(C.execute(inputs={G:[[1.0]]}), np.array([[2.0]]))

--- a/tests/functions/test_buffer.py
+++ b/tests/functions/test_buffer.py
@@ -161,7 +161,7 @@ class TestBuffer():
                                 history=3))
 
         C = Composition(pathways=[P])
-        P.reinitialize_when = Never()
+        P.reset_integrator_when = Never()
         full_result = []
 
         def assemble_full_result():

--- a/tests/log/test_log.py
+++ b/tests/log/test_log.py
@@ -952,7 +952,7 @@ class TestLog:
                 size=2,
                 leak=0.5,
                 threshold=0.515,
-                reinitialize_when=pnl.AtTrialStart()
+                reset_integrator_when=pnl.AtTrialStart()
         )
         lca.set_log_conditions(pnl.VALUE)
         m0 = pnl.ProcessingMechanism(

--- a/tests/mechanisms/test_contrastive_hebbian_mechanism.py
+++ b/tests/mechanisms/test_contrastive_hebbian_mechanism.py
@@ -140,7 +140,7 @@ class TestContrastiveHebbian:
         assert correct_message_found
 
         m.configure_learning()
-        m.reinitialize_when=pnl.Never()
+        m.reset_integrator_when=pnl.Never()
 
         c = pnl.Composition()
         c.add_linear_processing_pathway([m,o])

--- a/tests/mechanisms/test_control_mechanism.py
+++ b/tests/mechanisms/test_control_mechanism.py
@@ -37,7 +37,7 @@ class TestLCControlMechanism:
         for output_port in LC.output_ports:
             output_port.parameters.value.set(output_port.value * starting_value_LC, C, override=True)
 
-        LC.reinitialize_when = pnl.Never()
+        LC.reset_integrator_when = pnl.Never()
 
         gain_created_by_LC_output_port_1 = []
         mod_gain_assigned_to_A = []

--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -25,7 +25,7 @@ class TestReinitialize:
             function=DriftDiffusionIntegrator(seed=0),
         )
 
-        #  returns previous_value + rate * variable * time_step_size  + noise
+        #  returns previous_integrator_value + rate * variable * time_step_size  + noise
         #  0.0 + 1.0 * 1.0 * 1.0 + 0.0
         D.execute(1.0)
         assert np.allclose(np.asfarray(D.value),  [[1.0], [1.0]])
@@ -35,7 +35,7 @@ class TestReinitialize:
         # reinitialize function
         D.function.reinitialize(2.0, 0.1)
         assert np.allclose(D.function.value[0], 2.0)
-        assert np.allclose(D.function.previous_value, 2.0)
+        assert np.allclose(D.function.previous_integrator_value, 2.0)
         assert np.allclose(D.function.previous_time, 0.1)
         assert np.allclose(np.asfarray(D.value),  [[1.0], [1.0]])
         assert np.allclose(D.output_ports[0].value[0][0], 1.0)
@@ -44,7 +44,7 @@ class TestReinitialize:
         # reinitialize function without value spec
         D.function.reinitialize()
         assert np.allclose(D.function.value[0], 0.0)
-        assert np.allclose(D.function.previous_value, 0.0)
+        assert np.allclose(D.function.previous_integrator_value, 0.0)
         assert np.allclose(D.function.previous_time, 0.0)
         assert np.allclose(np.asfarray(D.value), [[1.0], [1.0]])
         assert np.allclose(D.output_ports[0].value[0][0], 1.0)
@@ -53,7 +53,7 @@ class TestReinitialize:
         # reinitialize mechanism
         D.reinitialize(2.0, 0.1)
         assert np.allclose(D.function.value[0], 2.0)
-        assert np.allclose(D.function.previous_value, 2.0)
+        assert np.allclose(D.function.previous_integrator_value, 2.0)
         assert np.allclose(D.function.previous_time, 0.1)
         assert np.allclose(np.asfarray(D.value), [[2.0], [0.1]])
         assert np.allclose(D.output_ports[0].value, 2.0)
@@ -68,7 +68,7 @@ class TestReinitialize:
         # reinitialize mechanism without value spec
         D.reinitialize()
         assert np.allclose(D.function.value[0], 0.0)
-        assert np.allclose(D.function.previous_value, 0.0)
+        assert np.allclose(D.function.previous_integrator_value, 0.0)
         assert np.allclose(D.function.previous_time, 0.0)
         assert np.allclose(D.output_ports[0].value[0], 0.0)
         assert np.allclose(D.output_ports[1].value[0], 0.0)
@@ -78,7 +78,7 @@ class TestReinitialize:
         D.function.starting_point = 0.0
         D.reinitialize()
         assert np.allclose(D.function.value[0], 1.0)
-        assert np.allclose(D.function.previous_value, 1.0)
+        assert np.allclose(D.function.previous_integrator_value, 1.0)
         assert np.allclose(D.function.previous_time, 0.0)
         assert np.allclose(D.output_ports[0].value[0], 1.0)
         assert np.allclose(D.output_ports[1].value[0], 0.0)
@@ -165,7 +165,7 @@ class TestThreshold:
     def test_is_finished_stops_composition(self):
         D = DDM(name='DDM',
                 function=DriftDiffusionIntegrator(threshold=10.0))
-        C = Composition(pathways=[D], reinitialize_when=Never())
+        C = Composition(pathways=[D], reset_integrator_nodes_when=Never())
         C.run(inputs={D: 2.0},
               termination_processing={TimeScale.TRIAL: WhenFinished(D)})
 

--- a/tests/mechanisms/test_lca.py
+++ b/tests/mechanisms/test_lca.py
@@ -30,7 +30,7 @@ class TestLCA:
                          time_step_size=0.1)
         C = Composition()
         C.add_linear_processing_pathway([T,L])
-        L.reinitialize_when = Never()
+        L.reset_integrator_when = Never()
         #  - - - - - - - Equations to be executed  - - - - - - -
 
         # new_transfer_input =
@@ -87,7 +87,7 @@ class TestLCA:
 
         C = Composition()
         C.add_linear_processing_pathway([T,L])
-        L.reinitialize_when = Never()
+        L.reset_integrator_when = Never()
         #  - - - - - - - Equations to be executed  - - - - - - -
 
         # new_transfer_input =
@@ -296,18 +296,18 @@ class TestLCAReinitialize:
                          noise=0.0)
         C = Composition(pathways=[L])
 
-        L.reinitialize_when = Never()
-        assert np.allclose(L.integrator_function.previous_value, 0.5)
+        L.reset_integrator_when = Never()
+        assert np.allclose(L.integrator_function.previous_integrator_value, 0.5)
         assert np.allclose(L.initial_value, 0.5)
         assert np.allclose(L.integrator_function.initializer, 0.5)
 
         C.run(inputs={L: 1.0},
               num_trials=2,
-              # reinitialize_nodes_when=AtRunStart(),
-              # reinitialize_nodes_when=AtTrialStart(),
+              # reset_integrator_nodes_when=AtRunStart(),
+              # reset_integrator_nodes_when=AtTrialStart(),
               initialize_cycle_values={L: [0.0]})
 
-        # IntegratorFunction fn: previous_value + (rate*previous_value + new_value)*time_step_size + noise*(time_step_size**0.5)
+        # IntegratorFunction fn: previous_integrator_value + (rate*previous_integrator_value + new_value)*time_step_size + noise*(time_step_size**0.5)
 
         # Trial 1    |   variable = 1.0 + 0.0
         # integration: 0.5 + (0.1*0.5 + 1.0)*1.0 + 0.0 = 1.55
@@ -315,16 +315,16 @@ class TestLCAReinitialize:
         # Trial 2    |   variable = 1.0 + 1.55
         # integration: 1.55 + (0.1*1.55 + 2.55)*1.0 + 0.0 = 4.255
         #  linear fn: 4.255*1.0 = 4.255
-        assert np.allclose(L.integrator_function.parameters.previous_value.get(C), 3.755)
+        assert np.allclose(L.integrator_function.parameters.previous_integrator_value.get(C), 3.755)
 
         L.integrator_function.reinitialize(0.9, context=C)
 
-        assert np.allclose(L.integrator_function.parameters.previous_value.get(C), 0.9)
+        assert np.allclose(L.integrator_function.parameters.previous_integrator_value.get(C), 0.9)
         assert np.allclose(L.parameters.value.get(C), 3.755)
 
         L.reinitialize(0.5, context=C)
 
-        assert np.allclose(L.integrator_function.parameters.previous_value.get(C), 0.5)
+        assert np.allclose(L.integrator_function.parameters.previous_integrator_value.get(C), 0.5)
         assert np.allclose(L.parameters.value.get(C), 0.5)
 
         C.run(inputs={L: 1.0},
@@ -335,7 +335,7 @@ class TestLCAReinitialize:
         # Trial 4    |   variable = 1.0 + 2.05
         # integration: 2.05 + (0.1*2.05 + 3.05)*1.0 + 0.0 = 5.305
         #  linear fn: 5.305*1.0 = 5.305
-        assert np.allclose(L.integrator_function.parameters.previous_value.get(C), 4.705)
+        assert np.allclose(L.integrator_function.parameters.previous_integrator_value.get(C), 4.705)
         assert np.allclose(L.initial_value, 0.5)
         assert np.allclose(L.integrator_function.initializer, 0.5)
 

--- a/tests/mechanisms/test_mechanisms.py
+++ b/tests/mechanisms/test_mechanisms.py
@@ -52,16 +52,16 @@ class TestReinitializeValues:
         original_output = [A.execute(1.0)[0], A.execute(1.0)[0]]
 
         # SAVING STATE  - - - - - - - - - - - - - - - - - - - - - - - - -
-        reinitialize_values = []
+        reset_integrator_nodes_to = []
         for attr in A.function.stateful_attributes:
-            reinitialize_values.append(getattr(A.function, attr))
+            reset_integrator_nodes_to.append(getattr(A.function, attr))
 
         # Execute A twice AFTER saving the state so that it continues accumulating.
         # We expect the next two outputs to repeat once we reset the state b/c we will return it to the current state
         output_after_saving_state = [A.execute(1.0)[0], A.execute(1.0)[0]]
 
         # RESETTING STATE - - - - - - - - - - - - - - - - - - - - - - - -
-        A.reinitialize(*reinitialize_values)
+        A.reinitialize(*reset_integrator_nodes_to)
 
         # We expect these results to match the results from immediately after saving the state
         output_after_reinitialization = [A.execute(1.0)[0], A.execute(1.0)[0]]
@@ -77,17 +77,17 @@ class TestReinitializeValues:
         original_output = [A.execute(1.0), A.execute(1.0)]
 
         # SAVING STATE  - - - - - - - - - - - - - - - - - - - - - - - - -
-        reinitialize_values = []
+        reset_integrator_nodes_to = []
 
         for attr in A.integrator_function.stateful_attributes:
-            reinitialize_values.append(getattr(A.integrator_function, attr))
+            reset_integrator_nodes_to.append(getattr(A.integrator_function, attr))
 
         # Execute A twice AFTER saving the state so that it continues accumulating.
         # We expect the next two outputs to repeat once we reset the state b/c we will return it to the current state
         output_after_saving_state = [A.execute(1.0), A.execute(1.0)]
 
         # RESETTING STATE - - - - - - - - - - - - - - - - - - - - - - - -
-        A.reinitialize(*reinitialize_values)
+        A.reinitialize(*reset_integrator_nodes_to)
 
         # We expect these results to match the results from immediately after saving the state
         output_after_reinitialization = [A.execute(1.0), A.execute(1.0)]

--- a/tests/mechanisms/test_recurrent_transfer_mechanism.py
+++ b/tests/mechanisms/test_recurrent_transfer_mechanism.py
@@ -977,9 +977,9 @@ class TestRecurrentTransferMechanismReinitialize:
                  integration_rate=0.1,
                  auto=1.0,
                  noise=0.0)
-        R.reinitialize_when = Never()
+        R.reset_integrator_when = Never()
         C = Composition(pathways=[R])
-        assert np.allclose(R.integrator_function.previous_value, 0.5)
+        assert np.allclose(R.integrator_function.previous_integrator_value, 0.5)
 
         # S.run(inputs={R: 1.0},
         #       num_trials=2,
@@ -997,16 +997,16 @@ class TestRecurrentTransferMechanismReinitialize:
         # Trial 2    |   variable = 1.0 + 0.55
         # integration: 0.9*0.55 + 0.1*1.55 + 0.0 = 0.65  --->  previous value = 0.65
         # linear fn: 0.65*1.0 = 0.65
-        assert np.allclose(R.integrator_function.parameters.previous_value.get(C), 0.65)
+        assert np.allclose(R.integrator_function.parameters.previous_integrator_value.get(C), 0.65)
 
         R.integrator_function.reinitialize(0.9, context=C)
 
-        assert np.allclose(R.integrator_function.parameters.previous_value.get(C), 0.9)
+        assert np.allclose(R.integrator_function.parameters.previous_integrator_value.get(C), 0.9)
         assert np.allclose(R.parameters.value.get(C), 0.65)
 
         R.reinitialize(0.5, context=C)
 
-        assert np.allclose(R.integrator_function.parameters.previous_value.get(C), 0.5)
+        assert np.allclose(R.integrator_function.parameters.previous_integrator_value.get(C), 0.5)
         assert np.allclose(R.parameters.value.get(C), 0.5)
 
         C.run(inputs={R: 1.0}, num_trials=2)
@@ -1016,7 +1016,7 @@ class TestRecurrentTransferMechanismReinitialize:
         # Trial 4
         # integration: 0.9*0.6 + 0.1*1.6 + 0.0 = 0.7 --->  previous value = 0.7
         # linear fn: 0.7*1.0 = 0.7
-        assert np.allclose(R.integrator_function.parameters.previous_value.get(C), 0.7)
+        assert np.allclose(R.integrator_function.parameters.previous_integrator_value.get(C), 0.7)
 
 class TestClip:
     def test_clip_float(self):
@@ -1106,13 +1106,13 @@ class TestCustomCombinationFunction:
           [np.array([0.5]), np.array([0.9375])],
           [np.array([0.5]), np.array([0.96875])]]),
         ], ids=lambda x: str(x) if isinstance(x, pnl.Condition) else "")
-    def test_reinitialize_when_composition(self, mode, cond0, cond1, expected):
+    def test_reset_integrator_when_composition(self, mode, cond0, cond1, expected):
         I1 = pnl.RecurrentTransferMechanism(integrator_mode=True,
                                             integration_rate=0.5)
         I2 = pnl.RecurrentTransferMechanism(integrator_mode=True,
                                             integration_rate=0.5)
-        I1.reinitialize_when = cond0
-        I2.reinitialize_when = cond1
+        I1.reset_integrator_when = cond0
+        I2.reset_integrator_when = cond1
         C = pnl.Composition()
         C.add_node(I1)
         C.add_node(I2)
@@ -1143,14 +1143,14 @@ class TestCustomCombinationFunction:
                              ids=lambda x: "initializers1" if x else "NO initializers1")
     @pytest.mark.parametrize('has_initializers1', [True, False],
                              ids=lambda x: "initializers2" if x else "NO initializers2")
-    def test_reinitialize_when_has_initializers_composition(self, mode, cond0, cond1, expected,
+    def test_reset_integrator_when_has_initializers_composition(self, mode, cond0, cond1, expected,
                                            has_initializers1, has_initializers2):
         I1 = pnl.RecurrentTransferMechanism(integrator_mode=True,
                                             integration_rate=0.5)
         I2 = pnl.RecurrentTransferMechanism(integrator_mode=True,
                                             integration_rate=0.5)
-        I1.reinitialize_when = cond0
-        I2.reinitialize_when = cond1
+        I1.reset_integrator_when = cond0
+        I2.reset_integrator_when = cond1
         I1.has_initializers = has_initializers1
         I2.has_initializers = has_initializers2
         C = pnl.Composition()

--- a/tests/models/test_bi_percepts.py
+++ b/tests/models/test_bi_percepts.py
@@ -199,7 +199,7 @@ def test_necker_cube(benchmark, mode):
     )
 
 
-    #integrator function ((1-rate)*previous_value + rate*current_input) * mechanism_function
+    #integrator function ((1-rate)*previous_integrator_value + rate*current_input) * mechanism_function
 
     node4 = pnl.TransferMechanism(
         name='node4',

--- a/tests/scheduling/test_scheduler.py
+++ b/tests/scheduling/test_scheduler.py
@@ -179,7 +179,7 @@ class TestScheduler:
         C.run(inputs={D: [[1.0], [2.0]]},
               # termination_processing={TimeScale.TRIAL: WhenFinished(D)},
               call_after_trial=change_termination_processing,
-              reinitialize_nodes_when=pnl.AtTimeStep(0),
+              reset_integrator_nodes_when=pnl.AtTimeStep(0),
               num_trials=4)
         # Trial 0:
         # input = 1.0, termination condition = WhenFinished


### PR DESCRIPTION
Treewide:
- Renamed the following (item types in parentheses):
    - (Mechanism attribute) reinitialize_when -> reset_integrator_when
    - (Mechanism attribute) previous_value -> previous_integrator_value
    - (Argument of Composition.run) reinitialize_nodes_when -> reset_integrator_nodes_when
    - (Argument of Composition.run) reinitialize_values -> reset_integrator_nodes_to
- Reset_integrator_nodes_to can now accept a dict of {Node:Condition} pairs as its argument