### PR TITLE
Fix/composition/learning bugs

### DIFF
--- a/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
@@ -868,7 +868,7 @@ class LearningMechanism(ModulatoryMechanism_Base):
         end of each `TRIAL <TimeScale.TRIAL>` of execution of the Composition to which the LearningMechanism belongs.
 
         .. note::
-           the `learning_abled <LearningMechanism.learning_enabled>` attribute of a LearningMechanism determines the
+           the `learning_enabled <LearningMechanism.learning_enabled>` attribute of a LearningMechanism determines the
            default behavior of its `learning_projections <LearningMechanism.learning_projections>`.  However, this
            can be overridden for individual `LearningProjections <LearningProjection>` by assigning their
            `learning_enabled <LearningProjection.learning_enabled>` attributes either at or after construction.

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -8591,7 +8591,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         ret = {}
         for node, values in targets.items():
             if NodeRole.TARGET not in self.get_roles_by_node(node) and NodeRole.LEARNING not in self.get_roles_by_node(node):
-                node_efferent_mechanisms = [x.receiver.owner for x in node.efferents]
+                node_efferent_mechanisms = [x.receiver.owner for x in node.efferents if x in self.projections]
                 comparators = [x for x in node_efferent_mechanisms if (isinstance(x, ComparatorMechanism) and NodeRole.LEARNING in self.get_roles_by_node(x))]
                 comparator_afferent_mechanisms = [x.sender.owner for c in comparators for x in c.afferents]
                 target_nodes = [t for t in comparator_afferent_mechanisms if (NodeRole.TARGET in self.get_roles_by_node(t) and NodeRole.LEARNING in self.get_roles_by_node(t))]

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -5843,9 +5843,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                     pathway,
                                     learning_function:LearningFunction,
                                     loss_function=None,
-                                    learning_rate:tc.any(int,float) =0.05,
+                                    learning_rate:tc.any(int,float)=0.05,
                                     error_function=LinearCombination(),
-                                    learning_update:tc.any(bool, tc.enum(ONLINE, AFTER))=ONLINE,
+                                    learning_update:tc.any(bool, tc.enum(ONLINE, AFTER))=AFTER,
                                     name:str=None,
                                     context=None):
         """Implement learning pathway (including necessary `learning components <Composition_Learning_Components>`.
@@ -5959,9 +5959,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # Handle BackPropgation specially, since it is potentially multi-layered
         if isinstance(learning_function, type) and issubclass(learning_function, BackPropagation):
             return self._create_backpropagation_learning_pathway(pathway,
-                                                                 loss_function,
                                                                  learning_rate,
                                                                  error_function,
+                                                                 loss_function,
                                                                  learning_update,
                                                                  name=pathway_name,
                                                                  context=context)
@@ -6386,17 +6386,18 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
     def _create_backpropagation_learning_pathway(self,
                                                  pathway,
-                                                 loss_function,
                                                  learning_rate=0.05,
                                                  error_function=None,
-                                                 learning_update:tc.optional(tc.any(bool, tc.enum(ONLINE,
-                                                                                                  AFTER)))=AFTER,
+                                                 loss_function=MSE,
+                                                 learning_update=AFTER,
                                                  name=None,
                                                  context=None):
 
         # FIX: LEARNING CONSOLIDATION - Can get rid of this:
         if not error_function:
             error_function = LinearCombination()
+        if not loss_function:
+            loss_function = MSE
 
         # Add pathway to graph and get its full specification (includes all ProcessingMechanisms and MappingProjections)
         # Pass ContextFlags.INITIALIZING so that it can be passed on to _analyze_graph() and then

--- a/tests/composition/test_learning.py
+++ b/tests/composition/test_learning.py
@@ -394,27 +394,18 @@ class TestLearningPathwayMethods:
     def test_indepedence_of_learning_pathways_using_same_mechs_in_different_comps(self):
         A = TransferMechanism(name="Mech A")
         B = TransferMechanism(name="Mech B")
-        # FIX: GENERATES DIFFERENT RESULT (0.95) THAN USE OF add_backprop_learning_pathway:
-        # comp1 = Composition(pathways=([A,B], BackPropagation))
-        comp1 = Composition()
-        comp1.add_backpropagation_learning_pathway(pathway=[A,B], name='P1')
-        comp1.learn(inputs={A: 1.0},
-                    targets={B: 0.0},
+
+        comp1 = Composition(pathways=([A,B], BackPropagation))
+        comp1.learn(inputs={A: 1.0,
+                    comp1.pathways[0].target: 0.0},
                     num_trials=2)
         assert np.allclose(comp1.results, [[[1.]], [[0.9]]])
 
-        # comp2 = Composition(pathways=([A,B], BackPropagation))
         comp2 = Composition()
         comp2.add_backpropagation_learning_pathway(pathway=[A,B], name='P1')
-        comp2.learn(inputs={A: 1.0,
-                            # PASSES:
-                            # comp2.pathways[0].target: 0.0
-                            },
-                    # FAILS:
+        comp2.learn(inputs={A: 1.0},
                     targets={B: 0.0},
                     num_trials=2)
-        # Should be same with default target specification but currently fails
-        # (succeeds if comp2 uses different mechs, as per test_target_spec_default_assignment)
         assert np.allclose(comp2.results, comp1.results)
 
 class TestNoLearning:

--- a/tests/mechanisms/test_control_mechanism.py
+++ b/tests/mechanisms/test_control_mechanism.py
@@ -179,7 +179,7 @@ class TestLCControlMechanism:
         comp = pnl.Composition()
         backprop_pathway = comp.add_backpropagation_learning_pathway(
             pathway=pathway,
-            loss_function=None
+            loss_function=None,
         )
         # c.add_linear_processing_pathway(pathway=z)
         comp.add_node(Control_Mechanism)
@@ -190,10 +190,10 @@ class TestLCControlMechanism:
             backprop_pathway.target: [[0, 0, 1]]}
     
         comp.learn(num_trials=3, inputs=stim_list)
-    
-        expected_results = [[[0.81493513, 0.85129046, 0.88154205]],
-                            [[0.81250527, 0.84947508, 0.88159668]],
-                            [[0.81003707, 0.84762987, 0.88165066]]]
+
+        expected_results =[[[0.81493513, 0.85129046, 0.88154205]],
+                           [[0.81331773, 0.85008207, 0.88157851]],
+                           [[0.81168332, 0.84886047, 0.88161468]]]
         assert np.allclose(comp.results, expected_results)
     
         stim_list[Control_Mechanism]=[0.0]
@@ -203,7 +203,7 @@ class TestLCControlMechanism:
     
         stim_list[Control_Mechanism]=[2.0]
         results = comp.learn(num_trials=1, inputs=stim_list)
-        expected_results = [[0.96801676, 0.98304415, 0.99225722]]
+        expected_results = [[0.96941429, 0.9837254 , 0.99217549]]
         assert np.allclose(results, expected_results)
 
     def test_control_of_all_input_ports(self):

--- a/tests/mechanisms/test_gating_mechanism.py
+++ b/tests/mechanisms/test_gating_mechanism.py
@@ -43,7 +43,7 @@ def test_gating_with_composition():
     pathway = [Input_Layer, Input_Weights, Hidden_Layer_1, Hidden_Layer_2, Output_Layer]
     comp = Composition()
     backprop_pathway = comp.add_backpropagation_learning_pathway(pathway=pathway,
-                                                                    loss_function=None)
+                                                                 loss_function=None)
     # c.add_linear_processing_pathway(pathway=z)
     comp.add_node(Gating_Mechanism)
 
@@ -55,8 +55,9 @@ def test_gating_with_composition():
     comp.learn(num_trials=3, inputs=stim_list)
 
     expected_results = [[[0.81493513, 0.85129046, 0.88154205]],
-                        [[0.81250527, 0.84947508, 0.88159668]],
-                        [[0.81003707, 0.84762987, 0.88165066]]]
+                        [[0.81331773, 0.85008207, 0.88157851]],
+                        [[0.81168332, 0.84886047, 0.88161468]]]
+
     assert np.allclose(comp.results, expected_results)
 
     stim_list[Gating_Mechanism]=[0.0]
@@ -66,7 +67,7 @@ def test_gating_with_composition():
 
     stim_list[Gating_Mechanism]=[2.0]
     results = comp.learn(num_trials=1, inputs=stim_list)
-    expected_results = [[0.96801676, 0.98304415, 0.99225722]]
+    expected_results = [[0.96941429, 0.9837254 , 0.99217549]]
     assert np.allclose(results, expected_results)
 
 def test_gating_with_UDF_with_composition():


### PR DESCRIPTION
• composition.py
  - _infer_target_nodes:  fixed bug causing crash if same mechs belong to learning pathways in two different composition
  - _create_backpropagation_learning_pathway(): fixed bug in assignment of default params
• test_learning/TestLearningPathwayMethods:
  - added test_indepedence_of_learning_pathways_using_same_mechs_in_different_comps
