### PR TITLE
Context: Change SIMULATION from an execution_phase to a runmode

### DIFF
--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -9659,7 +9659,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 self._reset_stateful_functions_when_cache[node] = node.reset_stateful_function_when
                 node.reset_stateful_function_when = reset_stateful_functions_when[node]
 
-        if ContextFlags.SIMULATION not in context.execution_phase:
+        if ContextFlags.SIMULATION not in context.runmode:
             try:
                 self.parameters.input_specification._set(copy(inputs), context)
             except:
@@ -9667,12 +9667,12 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         # DS 1/7/20: Check to see if any Components are still in deferred init. If so, attempt to initialize them.
         # If they can not be initialized, raise a warning.
-        if ContextFlags.SIMULATION not in context.execution_phase:
+        if ContextFlags.SIMULATION not in context.runmode:
             self._check_projection_initialization_status()
 
         # MODIFIED 8/27/19 OLD:
         # try:
-        #     if ContextFlags.SIMULATION not in context.execution_phase:
+        #     if ContextFlags.SIMULATION not in context.runmode:
         #         self._analyze_graph()
         # except AttributeError:
         #     # if context is None, it has not been created for this context yet, so it is not
@@ -9690,7 +9690,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 self._analyze_graph(context=context)
         # Then call _analyze graph with scheduler actually being used (passed in or default)
         try:
-            if ContextFlags.SIMULATION not in context.execution_phase:
+            if ContextFlags.SIMULATION not in context.runmode:
                 if not skip_analyze_graph:
                     self._analyze_graph(scheduler=scheduler, context=context)
         except AttributeError:
@@ -9738,13 +9738,13 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # called repeatedly (this init is repeated in Composition.execute)
         # initialize from base context but don't overwrite any values already set for this context
         if (not skip_initialization
-            and (context is None or ContextFlags.SIMULATION not in context.execution_phase)):
+            and (context is None or ContextFlags.SIMULATION not in context.runmode)):
             self._initialize_from_context(context, base_context, override=False)
 
         context.composition = self
 
         is_simulation = (context is not None and
-                         ContextFlags.SIMULATION in context.execution_phase)
+                         ContextFlags.SIMULATION in context.runmode)
 
         if (bin_execute is True or str(bin_execute).endswith('Run')):
             # There's no mode to run simulations.
@@ -9828,7 +9828,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             else:
                 result_copy = trial_output
 
-            if ContextFlags.SIMULATION not in context.execution_phase:
+            if ContextFlags.SIMULATION not in context.runmode:
                 results.append(result_copy)
                 self.parameters.results._set(results, context)
 
@@ -10137,7 +10137,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # but still after the context has been initialized
         if bin_execute:
             is_simulation = (context is not None and
-                             ContextFlags.SIMULATION in context.execution_phase)
+                             ContextFlags.SIMULATION in context.runmode)
             # Try running in Exec mode first
             if (bin_execute is True or str(bin_execute).endswith('Exec')):
                 # There's no mode to execute simulations.
@@ -10246,7 +10246,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             assert not nested or len(self.parameter_CIM.afferents) == 0
         elif nested:
             # check that inputs are specified - autodiff does not in some cases
-            if ContextFlags.SIMULATION in context.execution_phase and inputs is not None:
+            if ContextFlags.SIMULATION in context.runmode and inputs is not None:
                 self.input_CIM.execute(build_CIM_input, context=context)
             else:
                 assert inputs is None, "Ignoring composition input!"
@@ -10297,7 +10297,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             # FIX: SHOULD SET CONTEXT AS CONTROL HERE AND RESET AT END (AS DONE FOR animation BELOW)
             if (
                     self.initialization_status != ContextFlags.INITIALIZING
-                    and ContextFlags.SIMULATION not in context.execution_phase
+                    and ContextFlags.SIMULATION not in context.runmode
             ):
                 if self.controller and not bin_execute:
                     # FIX: REMOVE ONCE context IS SET TO CONTROL ABOVE
@@ -10491,7 +10491,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
                     # Pass outer context to nested Composition
                     context.composition = node
-                    if ContextFlags.SIMULATION in context.execution_phase:
+                    if ContextFlags.SIMULATION in context.runmode:
                         is_simulating = True
                         context.remove_flag(ContextFlags.SIMULATION)
                     else:
@@ -10580,7 +10580,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             # control phase
             if (
                     self.initialization_status != ContextFlags.INITIALIZING
-                    and ContextFlags.SIMULATION not in context.execution_phase
+                    and ContextFlags.SIMULATION not in context.runmode
             ):
                 context.add_flag(ContextFlags.CONTROL)
                 if self.controller and not bin_execute:

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -7344,7 +7344,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                  skip_initialization=True,
                  )
         context.remove_flag(ContextFlags.SIMULATION_MODE)
-        context.add_flag(ContextFlags.CONTROL)
+        context.execution_phase = ContextFlags.CONTROL
         if buffer_animate_state:
             self._animate = buffer_animate_state
 
@@ -10233,7 +10233,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # method to properly validate input for those nodes.
         # -DS
 
-        context.add_flag(ContextFlags.PROCESSING)
+        context.execution_phase = ContextFlags.PROCESSING
         if inputs is not None:
             inputs = self._validate_execution_inputs(inputs)
             build_CIM_input = self._build_variable_for_input_CIM(inputs)
@@ -10302,7 +10302,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 if self.controller and not bin_execute:
                     # FIX: REMOVE ONCE context IS SET TO CONTROL ABOVE
                     # FIX: END REMOVE
-                    context.add_flag(ContextFlags.PROCESSING)
+                    context.execution_phase = ContextFlags.PROCESSING
                     self.controller.execute(context=context)
 
                 if bin_execute:
@@ -10311,7 +10311,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 context.remove_flag(ContextFlags.PROCESSING)
 
                 # Animate controller (before execution)
-                context.add_flag(ContextFlags.CONTROL)
+                context.execution_phase = ContextFlags.CONTROL
                 if self._animate != False and SHOW_CONTROLLER in self._animate and self._animate[SHOW_CONTROLLER]:
                     self._animate_execution(self.controller, context)
                 context.remove_flag(ContextFlags.CONTROL)
@@ -10320,7 +10320,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         # PREPROCESS (get inputs, call_before_pass, animate first frame) ----------------------------------
 
-        context.add_flag(ContextFlags.PROCESSING)
+        context.execution_phase = ContextFlags.PROCESSING
 
         if call_before_pass:
             call_with_pruned_args(call_before_pass, context=context)
@@ -10377,7 +10377,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
             # ANIMATE execution_set ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             if self._animate is not False and self._animate_unit == EXECUTION_SET:
-                context.add_flag(ContextFlags.PROCESSING)
+                context.execution_phase = ContextFlags.PROCESSING
                 self._animate_execution(next_execution_set, context)
 
             # EXECUTE EACH NODE IN EXECUTION SET ----------------------------------------------------------------------
@@ -10417,7 +10417,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                                                                                  context))
 
                     # (Re)set context.execution_phase to PROCESSING by default
-                    context.add_flag(ContextFlags.PROCESSING)
+                    context.execution_phase = ContextFlags.PROCESSING
 
                     # Set to LEARNING if Mechanism receives any PathwayProjections that are being learned
                     #   for which learning_enabled == True or ONLINE (i.e., not False or AFTER)
@@ -10552,7 +10552,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         #Update matrix parameter of PathwayProjections being learned with learning_enabled==AFTER
         from psyneulink.library.compositions.autodiffcomposition import AutodiffComposition
         if self._is_learning(context) and not isinstance(self, AutodiffComposition):
-            context.add_flag(ContextFlags.LEARNING)
+            context.execution_phase = ContextFlags.LEARNING
             for projection in [p for p in self.projections if
                                hasattr(p, 'has_learning_projection') and p.has_learning_projection]:
                 matrix_parameter_port = projection.parameter_ports[MATRIX]
@@ -10582,7 +10582,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                     self.initialization_status != ContextFlags.INITIALIZING
                     and ContextFlags.SIMULATION_MODE not in context.runmode
             ):
-                context.add_flag(ContextFlags.CONTROL)
+                context.execution_phase = ContextFlags.CONTROL
                 if self.controller and not bin_execute:
                     self.controller.execute(context=context)
 
@@ -10608,9 +10608,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             _comp_ex.execute_node(self.output_CIM)
             return _comp_ex.extract_node_output(self.output_CIM)
 
-        context.add_flag(ContextFlags.PROCESSING)
+        context.execution_phase = ContextFlags.PROCESSING
         self.output_CIM.execute(context=context)
-        context.remove_flag(ContextFlags.PROCESSING)
+        context.execution_phase = ContextFlags.IDLE
 
         output_values = []
         for port in self.output_CIM.output_ports:

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -7333,7 +7333,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             animate = False
             buffer_animate_state = self._animate
 
-        context.add_flag(ContextFlags.SIMULATION)
+        context.add_flag(ContextFlags.SIMULATION_MODE)
         context.remove_flag(ContextFlags.CONTROL)
         results = self.run(inputs=inputs,
                  context=context,
@@ -7343,7 +7343,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                  bin_execute=execution_mode,
                  skip_initialization=True,
                  )
-        context.remove_flag(ContextFlags.SIMULATION)
+        context.remove_flag(ContextFlags.SIMULATION_MODE)
         context.add_flag(ContextFlags.CONTROL)
         if buffer_animate_state:
             self._animate = buffer_animate_state
@@ -9659,7 +9659,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 self._reset_stateful_functions_when_cache[node] = node.reset_stateful_function_when
                 node.reset_stateful_function_when = reset_stateful_functions_when[node]
 
-        if ContextFlags.SIMULATION not in context.runmode:
+        if ContextFlags.SIMULATION_MODE not in context.runmode:
             try:
                 self.parameters.input_specification._set(copy(inputs), context)
             except:
@@ -9667,12 +9667,12 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         # DS 1/7/20: Check to see if any Components are still in deferred init. If so, attempt to initialize them.
         # If they can not be initialized, raise a warning.
-        if ContextFlags.SIMULATION not in context.runmode:
+        if ContextFlags.SIMULATION_MODE not in context.runmode:
             self._check_projection_initialization_status()
 
         # MODIFIED 8/27/19 OLD:
         # try:
-        #     if ContextFlags.SIMULATION not in context.runmode:
+        #     if ContextFlags.SIMULATION_MODE not in context.runmode:
         #         self._analyze_graph()
         # except AttributeError:
         #     # if context is None, it has not been created for this context yet, so it is not
@@ -9690,7 +9690,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 self._analyze_graph(context=context)
         # Then call _analyze graph with scheduler actually being used (passed in or default)
         try:
-            if ContextFlags.SIMULATION not in context.runmode:
+            if ContextFlags.SIMULATION_MODE not in context.runmode:
                 if not skip_analyze_graph:
                     self._analyze_graph(scheduler=scheduler, context=context)
         except AttributeError:
@@ -9738,13 +9738,13 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # called repeatedly (this init is repeated in Composition.execute)
         # initialize from base context but don't overwrite any values already set for this context
         if (not skip_initialization
-            and (context is None or ContextFlags.SIMULATION not in context.runmode)):
+            and (context is None or ContextFlags.SIMULATION_MODE not in context.runmode)):
             self._initialize_from_context(context, base_context, override=False)
 
         context.composition = self
 
         is_simulation = (context is not None and
-                         ContextFlags.SIMULATION in context.runmode)
+                         ContextFlags.SIMULATION_MODE in context.runmode)
 
         if (bin_execute is True or str(bin_execute).endswith('Run')):
             # There's no mode to run simulations.
@@ -9828,7 +9828,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             else:
                 result_copy = trial_output
 
-            if ContextFlags.SIMULATION not in context.runmode:
+            if ContextFlags.SIMULATION_MODE not in context.runmode:
                 results.append(result_copy)
                 self.parameters.results._set(results, context)
 
@@ -10127,7 +10127,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 not skip_initialization
                 and not nested
                 or context is None
-                and context.execution_phase is not ContextFlags.SIMULATION
+                and context.execution_phase is not ContextFlags.SIMULATION_MODE
             ):
                 self._initialize_from_context(context, base_context, override=False)
                 context.composition = self
@@ -10137,7 +10137,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # but still after the context has been initialized
         if bin_execute:
             is_simulation = (context is not None and
-                             ContextFlags.SIMULATION in context.runmode)
+                             ContextFlags.SIMULATION_MODE in context.runmode)
             # Try running in Exec mode first
             if (bin_execute is True or str(bin_execute).endswith('Exec')):
                 # There's no mode to execute simulations.
@@ -10246,7 +10246,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             assert not nested or len(self.parameter_CIM.afferents) == 0
         elif nested:
             # check that inputs are specified - autodiff does not in some cases
-            if ContextFlags.SIMULATION in context.runmode and inputs is not None:
+            if ContextFlags.SIMULATION_MODE in context.runmode and inputs is not None:
                 self.input_CIM.execute(build_CIM_input, context=context)
             else:
                 assert inputs is None, "Ignoring composition input!"
@@ -10297,7 +10297,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             # FIX: SHOULD SET CONTEXT AS CONTROL HERE AND RESET AT END (AS DONE FOR animation BELOW)
             if (
                     self.initialization_status != ContextFlags.INITIALIZING
-                    and ContextFlags.SIMULATION not in context.runmode
+                    and ContextFlags.SIMULATION_MODE not in context.runmode
             ):
                 if self.controller and not bin_execute:
                     # FIX: REMOVE ONCE context IS SET TO CONTROL ABOVE
@@ -10491,9 +10491,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
                     # Pass outer context to nested Composition
                     context.composition = node
-                    if ContextFlags.SIMULATION in context.runmode:
+                    if ContextFlags.SIMULATION_MODE in context.runmode:
                         is_simulating = True
-                        context.remove_flag(ContextFlags.SIMULATION)
+                        context.remove_flag(ContextFlags.SIMULATION_MODE)
                     else:
                         is_simulating = False
 
@@ -10510,7 +10510,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                         _comp_ex.insert_node_output(node, ret)
 
                     if is_simulating:
-                        context.add_flag(ContextFlags.SIMULATION)
+                        context.add_flag(ContextFlags.SIMULATION_MODE)
 
                     context.composition = self
 
@@ -10580,7 +10580,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             # control phase
             if (
                     self.initialization_status != ContextFlags.INITIALIZING
-                    and ContextFlags.SIMULATION not in context.runmode
+                    and ContextFlags.SIMULATION_MODE not in context.runmode
             ):
                 context.add_flag(ContextFlags.CONTROL)
                 if self.controller and not bin_execute:

--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -126,62 +126,62 @@ class ContextFlags(enum.IntFlag):
     UNSET = 0
 
     # initialization_status flags:
-    DEFERRED_INIT = 1 << 1  # 2
+    DEFERRED_INIT = enum.auto()
     """Set if flagged for deferred initialization."""
-    INITIALIZING  = 1 << 2  # 4
+    INITIALIZING = enum.auto()
     """Set during initialization of the Component."""
-    VALIDATING    = 1 << 3  # 8
+    VALIDATING = enum.auto()
     """Set during validation of the value of a Component or its attribute."""
-    INITIALIZED   = 1 << 4  # 16
+    INITIALIZED = enum.auto()
     """Set after completion of initialization of the Component."""
-    RESET = 1 << 4  # 16
+    RESET = enum.auto()
     """Set on stateful Components when they are re-initialized."""
-    UNINITIALIZED = 1 << 17
+    UNINITIALIZED = enum.auto()
     """Default value set before initialization"""
     INITIALIZATION_MASK = DEFERRED_INIT | INITIALIZING | VALIDATING | INITIALIZED | RESET | UNINITIALIZED
 
     # execution_phase flags:
-    PREPARING    = 1 << 5   # 32
+    PREPARING = enum.auto()
     """Set while `Composition is preparing to `execute <Composition_Execution>`."""
-    PROCESSING    = 1 << 6  # 64
+    PROCESSING = enum.auto()
     """Set while `Composition is `executing <Composition_Execution>` `ProcessingMechanisms <ProcessingMechanism>`."""
-    LEARNING      = 1 << 7 # 128
+    LEARNING = enum.auto()
     """Set while `Composition is `executing <Composition_Execution>` `LearningMechanisms <LearningMechanism>`."""
-    CONTROL       = 1 << 8 # 256
+    CONTROL = enum.auto()
     """Set while Composition's `controller <Composition.controller>` or its `ObjectiveMechanism` is executing."""
-    SIMULATION    = 1 << 9  # 512
+    SIMULATION = enum.auto()
     """Set during simulation by Composition.controller"""
-    IDLE = 1 << 18
+    IDLE = enum.auto()
     """Identifies condition in which no flags in the `execution_phase <Context.execution_phase>` are set.
     """
     EXECUTING = PROCESSING | LEARNING | CONTROL | SIMULATION
     EXECUTION_PHASE_MASK = IDLE | PREPARING | EXECUTING
 
     # source (source-of-call) flags:
-    COMMAND_LINE  = 1 << 10  # 1024
+    COMMAND_LINE = enum.auto()
     """Direct call by user (either interactively from the command line, or in a script)."""
-    CONSTRUCTOR   = 1 << 11 # 2048
+    CONSTRUCTOR = enum.auto()
     """Call from Component's constructor method."""
-    INSTANTIATE   = 1 << 12 # 4096
+    INSTANTIATE = enum.auto()
     """Call by an instantiation method."""
-    COMPONENT     = 1 << 13 # 8192
+    COMPONENT = enum.auto()
     """Call by Component __init__."""
-    METHOD        = 1 << 14 # 16384
+    METHOD = enum.auto()
     """Call by method of the Component other than its constructor."""
-    PROPERTY      = 1 << 15 # 32768
+    PROPERTY = enum.auto()
     """Call by property of the Component."""
-    COMPOSITION   = 1 << 16 #
+    COMPOSITION = enum.auto()
     """Call by a/the Composition to which the Component belongs."""
 
-    NONE      = 1 << 21
+    NONE = enum.auto()
 
     """Call by a/the Composition to which the Component belongs."""
     SOURCE_MASK = COMMAND_LINE | CONSTRUCTOR | INSTANTIATE | COMPONENT | METHOD | PROPERTY | COMPOSITION | NONE
 
     # runmode flags:
-    DEFAULT_MODE = 1 << 19
+    DEFAULT_MODE = enum.auto()
     """Default mode"""
-    LEARNING_MODE = 1 << 20
+    LEARNING_MODE = enum.auto()
     """Set during `compositon.learn`"""
     RUN_MODE_MASK = LEARNING_MODE | DEFAULT_MODE
 

--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -181,10 +181,10 @@ class ContextFlags(enum.IntFlag):
     """Default mode"""
     LEARNING_MODE = enum.auto()
     """Set during `compositon.learn`"""
-    SIMULATION = enum.auto()
+    SIMULATION_MODE = enum.auto()
     """Set during simulation by Composition.controller"""
 
-    RUN_MODE_MASK = LEARNING_MODE | DEFAULT_MODE | SIMULATION
+    RUN_MODE_MASK = LEARNING_MODE | DEFAULT_MODE | SIMULATION_MODE
 
     ALL_FLAGS = INITIALIZATION_MASK | EXECUTION_PHASE_MASK | SOURCE_MASK | RUN_MODE_MASK
 
@@ -265,7 +265,7 @@ SOURCE_FLAGS = {ContextFlags.COMMAND_LINE,
 RUN_MODE_FLAGS = {
     ContextFlags.LEARNING_MODE,
     ContextFlags.DEFAULT_MODE,
-    ContextFlags.SIMULATION,
+    ContextFlags.SIMULATION_MODE,
 }
 
 
@@ -451,7 +451,7 @@ class Context():
         """Check that a flag is one and only one run mode flag"""
         if (
             flag in RUN_MODE_FLAGS
-            or (flag & ~ContextFlags.SIMULATION) in RUN_MODE_FLAGS
+            or (flag & ~ContextFlags.SIMULATION_MODE) in RUN_MODE_FLAGS
         ):
             self._runmode = flag
         elif not flag:

--- a/psyneulink/core/globals/log.py
+++ b/psyneulink/core/globals/log.py
@@ -407,7 +407,7 @@ class LogCondition(enum.IntFlag):
 
     .. note::
       The values of LogCondition are subset of (and directly reference) the ContextFlags bitwise enum,
-      with the exception of TRIAL and RUN, which are bit-shifted to follow the ContextFlags.SIMULATION value.
+      with the exception of TRIAL and RUN, which are bit-shifted to follow the ContextFlags.SIMULATION_MODE value.
     """
     OFF = ContextFlags.UNSET
     """No recording."""
@@ -424,11 +424,11 @@ class LogCondition(enum.IntFlag):
     """Set during the `learning phase <System_Execution_Learning>` of execution of a Composition."""
     CONTROL = ContextFlags.CONTROL
     """Set during the `control phase System_Execution_Control>` of execution of a Composition."""
-    SIMULATION = ContextFlags.SIMULATION
+    SIMULATION = ContextFlags.SIMULATION_MODE
     # Set during simulation by Composition.controller
-    TRIAL = ContextFlags.SIMULATION << 1
+    TRIAL = ContextFlags.SIMULATION_MODE << 1
     """Set at the end of a 'TRIAL'."""
-    RUN = ContextFlags.SIMULATION << 2
+    RUN = ContextFlags.SIMULATION_MODE << 2
     """Set at the end of a 'RUN'."""
     ALL_ASSIGNMENTS = (
         INITIALIZATION | VALIDATION | EXECUTION | PROCESSING | LEARNING | CONTROL

--- a/psyneulink/library/components/mechanisms/modulatory/learning/kohonenlearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/learning/kohonenlearningmechanism.py
@@ -417,7 +417,7 @@ class KohonenLearningMechanism(LearningMechanism):
         super()._update_output_ports(context, runtime_params)
 
         if context.composition is not None and ContextFlags.LEARNING_MODE in context.runmode:
-            context.add_flag(ContextFlags.LEARNING)
+            context.execution_phase = ContextFlags.LEARNING
             self.learned_projection.execute(context=context)
             context.remove_flag(ContextFlags.LEARNING)
 


### PR DESCRIPTION
- SIMULATION is now renamed to SIMULATION_MODE
- Context.execution_phase can now only have one flag
- Context.runmode can now have two flags only if SIMULATION is one of them
- calls to `add_flag` for Context.execution_phase are replaced with simple attribute setting