### PR TITLE
Fix learning correctness

### DIFF
--- a/Scripts/Debug/Yotam LCA Model.py
+++ b/Scripts/Debug/Yotam LCA Model.py
@@ -147,7 +147,7 @@ def get_trained_network(bipartite_graph, num_features=3, num_hidden=200, epochs=
 	}
 
 	# Build network
-	mnet = pnl.AutodiffComposition(param_init_from_pnl=True,
+	mnet = pnl.AutodiffComposition(
                            patience=patience,
                            min_delta=min_delt,
                            learning_rate=learning_rate,
@@ -273,7 +273,7 @@ def get_trained_network_multLCA(bipartite_graph, num_features=3, num_hidden=200,
 	}
 
 	# Build network
-	mnet = pnl.AutodiffComposition(param_init_from_pnl=True,
+	mnet = pnl.AutodiffComposition(
                            patience=patience,
                            min_delta=min_delt,
                            learning_rate=learning_rate,

--- a/Scripts/Examples/Tutorial/Rumelhart Semantic Network (autodiff).py
+++ b/Scripts/Examples/Tutorial/Rumelhart Semantic Network (autodiff).py
@@ -180,7 +180,6 @@ map_hm_can = pnl.MappingProjection(
 #This block of code constructs the network
 
 RumelNet = pnl.AutodiffComposition(
-        param_init_from_pnl=True,
         patience=10,
         min_delta=0.00001,
         learning_rate=1,

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -731,8 +731,12 @@ class Exponential(TransferFunction):  # ----------------------------------------
 
 
         """
-        return self._get_current_function_param(RATE, context) * input + self._get_current_function_param(BIAS, context)
+        from math import e
+        rate = self._get_current_function_param(RATE, context)
+        scale = self._get_current_function_param(SCALE, context)
+        bias = self._get_current_function_param(BIAS, context)
 
+        return rate * scale * e**(rate * input + bias)
 
 # **********************************************************************************************************************
 #                                                   Logistic

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -1241,7 +1241,6 @@ class Tanh(TransferFunction):  # -----------------------------------------------
         bias_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, BIAS)
         x_0_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, X_0)
         offset_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, OFFSET)
-        scale_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, SCALE)
 
         gain = pnlvm.helpers.load_extract_scalar_array_one(builder, gain_ptr)
         bias = pnlvm.helpers.load_extract_scalar_array_one(builder, bias_ptr)

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -1511,7 +1511,11 @@ class ReLU(TransferFunction):  # -----------------------------------------------
         gain = self._get_current_function_param(GAIN, context)
         leak = self._get_current_function_param(LEAK, context)
 
-        return gain if input > 0 else gain * leak
+        input = np.asarray(input).copy()
+        input[input>0] = gain
+        input[input<=0] = gain * leak
+
+        return input
 
 
 # **********************************************************************************************************************

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2945,8 +2945,8 @@ class Mechanism_Base(Mechanism):
                                        mech_params, mech_state, mech_in)
         return builder
 
-    def _gen_llvm_invoke_function(self, ctx, builder, function, params, state, variable):
-        fun = ctx.import_llvm_function(function)
+    def _gen_llvm_invoke_function(self, ctx, builder, function, params, state, variable, *, tags:frozenset):
+        fun = ctx.import_llvm_function(function, tags=tags)
         fun_in, builder = self._gen_llvm_function_input_parse(builder, ctx, fun, variable)
         fun_out = builder.alloca(fun.args[3].type.pointee)
 
@@ -2957,7 +2957,7 @@ class Mechanism_Base(Mechanism):
     def _gen_llvm_is_finished_cond(self, ctx, builder, params, state, current):
         return pnlvm.ir.IntType(1)(1)
 
-    def _gen_llvm_function_internal(self, ctx, builder, params, state, arg_in, arg_out):
+    def _gen_llvm_function_internal(self, ctx, builder, params, state, arg_in, arg_out, *, tags:frozenset):
 
         ip_output, builder = self._gen_llvm_input_ports(ctx, builder,
                                                         params, state, arg_in)

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2967,7 +2967,7 @@ class Mechanism_Base(Mechanism):
                 self.function, f_params_ptr, ctx, builder, params, state, arg_in)
 
         f_state = pnlvm.helpers.get_state_ptr(builder, self, state, "function")
-        value, builder = self._gen_llvm_invoke_function(ctx, builder, self.function, f_params, f_state, ip_output)
+        value, builder = self._gen_llvm_invoke_function(ctx, builder, self.function, f_params, f_state, ip_output, tags=tags)
 
         # Update execution counter
         exec_count_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, "execution_count")
@@ -3030,7 +3030,7 @@ class Mechanism_Base(Mechanism):
                                                     return_type=pnlvm.ir.IntType(1))
         iparams, istate, iin, iout = internal_builder.function.args[:4]
         internal_builder, is_finished = self._gen_llvm_function_internal(ctx, internal_builder,
-                                                                         iparams, istate, iin, iout)
+                                                                         iparams, istate, iin, iout, tags=tags)
         internal_builder.ret(is_finished)
 
         # Call Internal Function

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1228,7 +1228,7 @@ class OptimizationControlMechanism(ControlMechanism):
 
         return f
 
-    def _gen_llvm_invoke_function(self, ctx, builder, function, params, context, variable):
+    def _gen_llvm_invoke_function(self, ctx, builder, function, params, context, variable, *, tags:frozenset):
         fun = ctx.import_llvm_function(function)
         fun_in, builder = self._gen_llvm_function_input_parse(builder, ctx, fun, variable)
         fun_out = builder.alloca(fun.args[3].type.pointee)

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1645,7 +1645,7 @@ class TransferMechanism(ProcessingMechanism_Base):
                     params, state, arg_in)
 
             mf_in, builder = self._gen_llvm_invoke_function(
-                    ctx, builder, self.integrator_function, if_params, if_state, ip_out)
+                    ctx, builder, self.integrator_function, if_params, if_state, ip_out, tags=tags)
         else:
             mf_in = ip_out
 
@@ -1654,7 +1654,7 @@ class TransferMechanism(ProcessingMechanism_Base):
         mf_params, builder = self._gen_llvm_param_ports_for_obj(
                 self.function, mf_param_ptr, ctx, builder, params, state, arg_in)
 
-        mf_out, builder = self._gen_llvm_invoke_function(ctx, builder, self.function, mf_params, mf_state, mf_in)
+        mf_out, builder = self._gen_llvm_invoke_function(ctx, builder, self.function, mf_params, mf_state, mf_in, tags=tags)
 
         # FIXME: Convert to runtime instead of compile time
         clip = self.parameters.clip.get()

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1632,7 +1632,7 @@ class TransferMechanism(ProcessingMechanism_Base):
         cmp_str = self.parameters.termination_comparison_op.get(None)
         return builder.fcmp_ordered(cmp_str, cmp_val, threshold)
 
-    def _gen_llvm_function_internal(self, ctx, builder, params, state, arg_in, arg_out):
+    def _gen_llvm_function_internal(self, ctx, builder, params, state, arg_in, arg_out, *, tags:frozenset):
         ip_out, builder = self._gen_llvm_input_ports(ctx, builder, params, state, arg_in)
 
         if self.integrator_mode:

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6624,7 +6624,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                         p.insert(0, curr_node)
                         curr_node = prev[curr_node]
                     p.insert(0, curr_node)
-                    pathways.append(p)
+                    # we only consider input -> projection -> ... -> output pathways (since we can't learn on only one mechanism)
+                    if len(p) >= 3:
+                        pathways.append(p)
                     continue
                 for projection, efferent_node in [(p, p.receiver.owner) for p in curr_node.efferents]:
                     if (not hasattr(projection,'learnable')) or (projection.learnable is False):

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -151,9 +151,9 @@ class CUDAExecution:
 
 class FuncExecution(CUDAExecution):
 
-    def __init__(self, component, execution_ids=[None]):
+    def __init__(self, component, execution_ids=[None], *, tags=frozenset()):
         super().__init__()
-        self._bin_func = pnlvm.LLVMBinaryFunction.from_obj(component)
+        self._bin_func = pnlvm.LLVMBinaryFunction.from_obj(component, tags=tags)
         self._execution_contexts = [
             Context(execution_id=eid) for eid in execution_ids
         ]

--- a/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
@@ -836,9 +836,9 @@ class LCControlMechanism(ControlMechanism):
 
         return gain_t, output_values[0], output_values[1], output_values[2]
 
-    def _gen_llvm_invoke_function(self, ctx, builder, function, params, state, variable):
+    def _gen_llvm_invoke_function(self, ctx, builder, function, params, state, variable, *, tags:frozenset):
         assert function is self.function
-        mf_out, builder = super()._gen_llvm_invoke_function(ctx, builder, function, params, state, variable)
+        mf_out, builder = super()._gen_llvm_invoke_function(ctx, builder, function, params, state, variable, tags=tags)
 
         # prepend gain type (matches output[1] type)
         gain_ty = mf_out.type.pointee.elements[1]

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1078,8 +1078,8 @@ class DDM(ProcessingMechanism):
                 return_value[self.DECISION_VARIABLE_INDEX] = threshold
             return return_value
 
-    def _gen_llvm_invoke_function(self, ctx, builder, function, params, state, variable):
-        mf_out, builder = super()._gen_llvm_invoke_function(ctx, builder, function, params, state, variable)
+    def _gen_llvm_invoke_function(self, ctx, builder, function, params, state, variable, *, tags:frozenset):
+        mf_out, builder = super()._gen_llvm_invoke_function(ctx, builder, function, params, state, variable, tags=tags)
 
         mech_out_ty = ctx.convert_python_struct_to_llvm_ir(self.defaults.value)
         mech_out = builder.alloca(mech_out_ty)

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -423,8 +423,6 @@ class AutodiffComposition(Composition):
     def _gen_llvm_function(self, *, ctx:pnlvm.LLVMBuilderContext, tags:frozenset):
         if "run" in tags:
             return pnlvm.codegen.gen_composition_run(ctx, self, tags=tags)
-        elif "learning" in tags:
-            return pnlvm.codegen.gen_autodiffcomp_learning_exec(ctx, self, tags=tags)
         else:
             return pnlvm.codegen.gen_autodiffcomp_exec(ctx, self, tags=tags)
 

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -539,23 +539,6 @@ class AutodiffComposition(Composition):
                                                         bin_execute=bin_execute,
                                                         )
 
-    # gives user weights and biases of the model (from the pytorch representation)
-    @handle_external_context(execution_id=NotImplemented)
-    def get_parameters(self, context=None):
-        if context.execution_id is NotImplemented:
-            context.execution_id = self.default_execution_id
-
-        pytorch_representation = self.parameters.pytorch_representation._get(context)
-
-        if pytorch_representation is None:
-            raise AutodiffCompositionError("{0} has not been run yet so parameters have not been created "
-                                           "in Pytorch."
-                                           .format(self.name))
-
-        weights = pytorch_representation.get_weights_for_projections()
-
-        return weights
-
     def _get_state_struct_type(self, ctx):
         node_state_type_list = (ctx.get_state_struct_type(m) for m in self._all_nodes)
         proj_state_type_list = (ctx.get_state_struct_type(p) for p in self._inner_projections)

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -225,7 +225,6 @@ class AutodiffComposition(Composition):
 
     # TODO (CW 9/28/18): add compositions to registry so default arg for name is no longer needed
     def __init__(self,
-                 param_init_from_pnl=True,
                  learning_rate=None,
                  optimizer_type='sgd',
                  weight_decay=0,
@@ -255,11 +254,6 @@ class AutodiffComposition(Composition):
         self.force_no_retain_graph = force_no_retain_graph
         self.loss = None
         self.disable_learning = disable_learning
-        # user indication of how to initialize pytorch parameters
-        self.param_init_from_pnl = param_init_from_pnl
-
-        if param_init_from_pnl is False:
-            warnings.warn("WARNING: Autodiffcomposition.param_init_from_pnl is deprecated! Please do not use it!")
 
         # keeps track of average loss per epoch
         self.losses = []

--- a/psyneulink/library/compositions/compiledloss.py
+++ b/psyneulink/library/compositions/compiledloss.py
@@ -7,8 +7,6 @@ __all__ = ['MSELoss']
 class Loss():
 
     def __init__(self):
-        self._structs = []
-
         self._DELTA_W_NUM = 0
 
 

--- a/psyneulink/library/compositions/compiledoptimizer.py
+++ b/psyneulink/library/compositions/compiledoptimizer.py
@@ -1,39 +1,32 @@
 from psyneulink.core import llvm as pnlvm
 from psyneulink.library.compositions.pytorchllvmhelper import *
-from psyneulink.core.compositions.composition import NodeRole
 
 __all__ = ['AdamOptimizer', 'SGDOptimizer']
-
 
 class Optimizer():
 
     def __init__(self, pytorch_model):
         self._pytorch_model = pytorch_model
         self._composition = pytorch_model._composition
-        self._structs = []
 
         self._DELTA_W_NUM = 0
 
     # gets the type of the delta_w struct
     def _get_delta_w_struct_type(self, ctx):
-        delta_w = [None] * len(set(self._composition.nodes) - set(self._composition.get_nodes_by_role(NodeRole.LEARNING)))
-        for node in set(self._composition.nodes) - set(self._composition.get_nodes_by_role(NodeRole.LEARNING)):
-            node_idx = self._composition._get_node_index(node)
-            afferent_nodes = self._pytorch_model._get_afferent_nodes(node)
-            delta_w[node_idx] = [None] * len(afferent_nodes)
-            for (afferent_node, matrix) in afferent_nodes:
-                afferent_node_index = self._pytorch_model._get_afferent_node_index(
-                    node, afferent_node)
-                weights_dim_x, weights_dim_y = matrix.shape
-                delta_w_array = pnlvm.ir.ArrayType(
-                    pnlvm.ir.ArrayType(
-                        ctx.float_ty,
-                        weights_dim_y
-                    ),
-                    weights_dim_x
-                )
-                delta_w[node_idx][afferent_node_index] = delta_w_array
-            delta_w[node_idx] = pnlvm.ir.types.LiteralStructType(delta_w[node_idx])
+        delta_w = [None] * len(self._pytorch_model.projections)
+        for idx, proj in enumerate(self._pytorch_model.projections):
+            proj_matrix = proj.matrix
+            dim_x, dim_y = proj_matrix.shape
+
+            matrix = pnlvm.ir.ArrayType(
+                pnlvm.ir.ArrayType(
+                    ctx.float_ty,
+                    dim_y
+                ),
+                dim_x
+            )
+            delta_w[idx] = matrix
+
         delta_w = pnlvm.ir.types.LiteralStructType(delta_w)
         return delta_w
 
@@ -41,20 +34,7 @@ class Optimizer():
         structs = (self._get_delta_w_struct_type(ctx), *extra_types)
         return pnlvm.ir.types.LiteralStructType(structs)
 
-    def _get_listof_gradient_struct_values(self):
-        values = []
-        for node in set(self._composition.nodes) - set(self._composition.get_nodes_by_role(NodeRole.LEARNING)):
-            node_idx = self._composition._get_node_index(node)
-            afferent_nodes = self._pytorch_model._get_afferent_nodes(node)
-            for (afferent_node, matrix) in afferent_nodes:
-                afferent_node_index = self._pytorch_model._get_afferent_node_index(
-                    node, afferent_node)
-                weights_dim_x, weights_dim_y = matrix.shape
-                values.append((node, node_idx, afferent_node,
-                               afferent_node_index, matrix, weights_dim_x, weights_dim_y))
-        return values
     # inserts logic that zeroes out a gradient struct
-
     def _gen_zero_gradient_struct(self, ctx, builder, grad_struct):
         builder.store(grad_struct.type.pointee(None),grad_struct)
 
@@ -72,9 +52,6 @@ class Optimizer():
         builder.ret_void()
 
         return llvm_func
-
-    def initialize_optimizer_struct(self, ctx, builder, optim_struct):
-        builder.store(optim_struct.type.pointee(None), optim_struct)
 
     def _gen_llvm_function(self, *, ctx:pnlvm.LLVMBuilderContext, tags:frozenset):
         return self.step(ctx)
@@ -146,31 +123,16 @@ class AdamOptimizer(Optimizer):
         b2_pow = builder.call(pow, [b2, t_val])
         one_minus_b1_pow = builder.fsub(one_float, b1_pow)
         one_minus_b2_pow = builder.fsub(one_float, b2_pow)
-        
+
         pnlvm.helpers.printf(
                 builder, f"%f b1_pow_sub %f\nb2 pow sub %f\n",t_val, one_minus_b1_pow, one_minus_b2_pow)
-        alpha_mult = builder.call(sqrt, [one_minus_b2_pow])
-        pnlvm.helpers.printf(
-                builder, f"%f\n",alpha_mult)
-        alpha_mult = builder.fdiv(alpha_mult, one_minus_b1_pow)
-
-        # this is the new learning rate to use
-        alpha_t = builder.fmul(alpha_mult, lr)
-
-        gradient_struct_values = self._get_listof_gradient_struct_values()
 
         # 2) update first moments
-        for (node, node_idx, afferent_node, afferent_node_index, matrix, weights_dim_x, weights_dim_y) in gradient_struct_values:
-            pnlvm.helpers.printf(
-                builder, f"\t\t\t\tOPTIM UPDATE FIRST MOMENT {afferent_node.name} {node.name}\n")
+        for idx, proj in enumerate(self._pytorch_model.projections):
+            proj_idx_ir = ctx.int32_ty(idx)
 
-            node_idx_ir = ctx.int32_ty(node_idx)
-            afferent_node_index_ir = ctx.int32_ty(afferent_node_index)
-
-            m_t_ptr = builder.gep(
-                m_t, [zero, node_idx_ir, afferent_node_index_ir])
-            delta_w_ptr = builder.gep(
-                delta_w, [zero, node_idx_ir, afferent_node_index_ir])
+            m_t_ptr = builder.gep(m_t, [zero, proj_idx_ir])
+            delta_w_ptr = builder.gep(delta_w, [zero, proj_idx_ir])
 
             # m_t = m_t * b1
             gen_inject_mat_scalar_mult(ctx, builder, m_t_ptr, b1, m_t_ptr)
@@ -181,18 +143,13 @@ class AdamOptimizer(Optimizer):
             # m_t = m_t + (1-b1)*g_t
             gen_inject_mat_add(ctx, builder, m_t_ptr, tmp_val, m_t_ptr)
 
+            pnlvm.helpers.printf_float_matrix(builder, m_t_ptr, prefix=f"mt val: {proj.sender._mechanism} -> {proj.receiver._mechanism}\n", override_debug=False)
         # 3) update second moments
-        for (node, node_idx, afferent_node, afferent_node_index, matrix, weights_dim_x, weights_dim_y) in gradient_struct_values:
-            pnlvm.helpers.printf(
-                builder, f"\t\t\t\tOPTIM UPDATE SECOND MOMENT {afferent_node.name} {node.name}\n")
+        for idx, proj in enumerate(self._pytorch_model.projections):
+            proj_idx_ir = ctx.int32_ty(idx)
 
-            node_idx_ir = ctx.int32_ty(node_idx)
-            afferent_node_index_ir = ctx.int32_ty(afferent_node_index)
-
-            v_t_ptr = builder.gep(
-                v_t, [zero, node_idx_ir, afferent_node_index_ir])
-            delta_w_ptr = builder.gep(
-                delta_w, [zero, node_idx_ir, afferent_node_index_ir])
+            v_t_ptr = builder.gep(v_t, [zero, proj_idx_ir])
+            delta_w_ptr = builder.gep(delta_w, [zero, proj_idx_ir])
 
             # v_t = v_t * b2
             gen_inject_mat_scalar_mult(ctx, builder, v_t_ptr, b2, v_t_ptr)
@@ -207,51 +164,56 @@ class AdamOptimizer(Optimizer):
             gen_inject_mat_add(ctx, builder, v_t_ptr, delta_w_sqrd, v_t_ptr)
 
         # 4) update weights
+        # this is the new learning rate to use
+        # NOTE: This differs from the version specified in the paper to numerically match with pytorch's implementation
+        step_size = builder.fdiv(lr, one_minus_b1_pow)
+        step_size = pnlvm.helpers.fneg(builder, step_size)
 
-        for (node, node_idx, afferent_node, afferent_node_index, matrix, weights_dim_x, weights_dim_y) in gradient_struct_values:
-            node_idx_ir = ctx.int32_ty(node_idx)
-            afferent_node_index_ir = ctx.int32_ty(afferent_node_index)
-            
+        for idx, proj in enumerate(self._pytorch_model.projections):
+            proj_idx_ir = ctx.int32_ty(idx)
+
             m_t_ptr = builder.gep(
-                m_t, [zero, node_idx_ir, afferent_node_index_ir])
+                m_t, [zero, proj_idx_ir])
             v_t_ptr = builder.gep(
-                v_t, [zero, node_idx_ir, afferent_node_index_ir])
+                v_t, [zero, proj_idx_ir])
             delta_w_ptr = builder.gep(
-                delta_w, [zero, node_idx_ir, afferent_node_index_ir])
-            # this is messy - #TODO - cleanup this
-            weights_llvmlite, weights_dim_x, weights_dim_y = self._pytorch_model._gen_get_node_weight_ptr(
-                ctx, builder, params, node, afferent_node)
-            pnlvm.helpers.printf(
-                builder, f"OPTIM UPDATE WEIGHTS {afferent_node.name} {node.name}\n",override_debug=False)
-            weight_row = None
-            with pnlvm.helpers.for_loop_zero_inc(builder, ctx.int32_ty(weights_dim_x), "optimizer_w_upd_outer") as (b1, weight_row):
-                weight_column = None
-                with pnlvm.helpers.for_loop_zero_inc(b1, ctx.int32_ty(weights_dim_y), "optimizer_w_upd_inner") as (b2, weight_column):
-                    # sqrt(v_t) + eps
-                    v_t_value = b2.load(b2.gep(
-                        v_t_ptr, [zero, weight_row, weight_column]))
-                    value = b2.call(sqrt, [v_t_value])
-                    value = b2.fadd(value, eps)
+                delta_w, [zero, proj_idx_ir])
 
+            pnlvm.helpers.printf_float_matrix(builder, delta_w_ptr, prefix=f"grad val: {proj.sender._mechanism} -> {proj.receiver._mechanism}\n", override_debug=False)
+            
+            # this is messy - #TODO - cleanup this
+            weights_llvmlite = proj._extract_llvm_matrix(ctx, builder, params)
+            dim_x, dim_y = proj.matrix.shape
+            
+            weight_row = None
+            pnlvm.helpers.printf(builder, "biascorr2 %.20f\n", one_minus_b2_pow, override_debug=False)
+            with pnlvm.helpers.for_loop_zero_inc(builder, ctx.int32_ty(dim_x), "optimizer_w_upd_outer") as (b1, weight_row):
+                weight_column = None
+                with pnlvm.helpers.for_loop_zero_inc(b1, ctx.int32_ty(dim_y), "optimizer_w_upd_inner") as (b2, weight_column):
+                    # sqrt(v_t) + eps
+                    v_t_value = b2.load(b2.gep(v_t_ptr, [zero, weight_row, weight_column]))
+                    value = b2.call(sqrt, [v_t_value])
+                    denom = b2.call(sqrt, [one_minus_b2_pow])
+                    value = b2.fdiv(value, denom)
+                    value = b2.fadd(value, eps)
+                    pnlvm.helpers.printf(builder, "val %.20f\n", value, override_debug=False)
                     # alpha_t * m_t
                     m_t_value = b2.load(b2.gep(
                         m_t_ptr, [zero, weight_row, weight_column]))
-                    m_t_value = b2.fmul(alpha_t, m_t_value)
 
                     # value = alpha_t * m_t / (sqrt(v_t) + eps)
                     value = b2.fdiv(m_t_value, value)
+                    value = b2.fmul(step_size, value)
 
                     old_weight_ptr = b2.gep(
                         weights_llvmlite, [zero, weight_row, weight_column])
-                    
+
                     # new_weight = old_weight - value
-                    value = b2.fsub(b2.load(old_weight_ptr), value)
+                    value = b2.fadd(b2.load(old_weight_ptr), value)
                     b2.store(value, old_weight_ptr)
 
-                    delta_w_val = b2.load(b2.gep(delta_w_ptr,[zero, weight_row, weight_column]))
-                    pnlvm.helpers.printf(b2,"%f ",delta_w_val,override_debug=False)
-                pnlvm.helpers.printf(b1,"\n",override_debug=False)
-                
+                pnlvm.helpers.printf(b1, "\n", override_debug=False)
+
         pnlvm.helpers.printf(builder, f"\t\t\tOPTIM DONE UPDATE\n",override_debug=False)
 
         builder.ret_void()
@@ -280,20 +242,15 @@ class SGDOptimizer(Optimizer):
         delta_w = builder.gep(optim_struct, [zero, ctx.int32_ty(self._DELTA_W_NUM)])
 
         lr = ctx.float_ty(self.lr)
-       
-        gradient_struct_values = self._get_listof_gradient_struct_values()
-        
-        # update weights
-        for (node, node_idx, afferent_node, afferent_node_index, matrix, _, _) in gradient_struct_values:
-            node_idx_ir = ctx.int32_ty(node_idx)
-            afferent_node_index_ir = ctx.int32_ty(afferent_node_index)
 
-            delta_w_ptr = builder.gep(delta_w,[zero,node_idx_ir,afferent_node_index_ir])
-            weights_llvmlite, _, _ = self._pytorch_model._gen_get_node_weight_ptr(ctx, builder, params, node, afferent_node)
-            
+        # update weights
+        for idx, proj in enumerate(self._pytorch_model.projections):
+            delta_w_ptr = builder.gep(delta_w, [zero, ctx.int32_ty(idx)])
+            weights_llvmlite = proj._extract_llvm_matrix(ctx, builder, params)
+
             multiplied_delta_w = gen_inject_mat_scalar_mult(ctx, builder, delta_w_ptr, lr)
             gen_inject_mat_sub(ctx, builder, weights_llvmlite, multiplied_delta_w, weights_llvmlite)
-                
+
         builder.ret_void()
 
         return llvm_func

--- a/psyneulink/library/compositions/pytorchcomponents.py
+++ b/psyneulink/library/compositions/pytorchcomponents.py
@@ -1,0 +1,257 @@
+from psyneulink.core.components.functions.transferfunctions import Linear, Logistic, ReLU
+from psyneulink.library.compositions.pytorchllvmhelper import *
+from psyneulink.core.globals.log import LogCondition
+from psyneulink.core import llvm as pnlvm
+
+import torch
+
+__all__ = ['PytorchMechanismWrapper', 'PytorchProjectionWrapper']
+
+def pytorch_function_creator(function, device, context=None):
+    """
+    Converts a PsyNeuLink function into an equivalent PyTorch lambda function.
+    NOTE: This is needed due to PyTorch limitations (see: https://github.com/PrincetonUniversity/PsyNeuLink/pull/1657#discussion_r437489990)
+    """
+    def get_fct_param_value(param_name):
+        val = function._get_current_function_param(
+            param_name, context=context)
+        if val is None:
+            val = getattr(function.defaults, param_name)
+
+        return float(val)
+
+    if isinstance(function, Linear):
+        slope = get_fct_param_value('slope')
+        intercept = get_fct_param_value('intercept')
+        return lambda x: x * slope + intercept
+
+    elif isinstance(function, Logistic):
+        gain = get_fct_param_value('gain')
+        bias = get_fct_param_value('bias')
+        offset = get_fct_param_value('offset')
+        return lambda x: 1 / (1 + torch.exp(-gain * (x + bias) + offset))
+
+    elif isinstance(function, ReLU):
+        gain = get_fct_param_value('gain')
+        bias = get_fct_param_value('bias')
+        leak = get_fct_param_value('leak')
+        return lambda x: (torch.max(input=(x - bias), other=torch.tensor([0], device=device).double()) * gain +
+                            torch.min(input=(x - bias), other=torch.tensor([0], device=device).double()) * leak)
+
+    else:
+        raise Exception(f"Function {function} is not currently supported in AutodiffCompositions!")
+
+def bin_function_derivative_creator(ctx, node, context=None):
+    """
+    Returns the compiled derivative version of a PsyNeuLink node
+    TODO: Add functionality for derivitives into base PsyNeuLink Functions, and move this functionality there
+    """
+    # first try to get cached func
+    name = node.name + "_" + node.function.name + "_derivative"
+    try:
+        llvm_func = ctx.import_llvm_function(name)
+        return llvm_func
+    except Exception as e:
+        pass
+
+    # args: 1) ptr to input vector
+    #       2) sizeof vector
+    #       3) ptr to output vector
+    float_ptr_ty = ctx.float_ty.as_pointer()
+    args = [float_ptr_ty, ctx.int32_ty, float_ptr_ty]
+    builder = ctx.create_llvm_function(args, node, name)
+    llvm_func = builder.function
+
+    input_vector, dim, output_vector = llvm_func.args
+
+    def get_fct_param_value(param_name):
+        val = node.function._get_current_function_param(
+            param_name, context)
+        if val is None:
+            val = node.function._get_current_function_param(
+                param_name, None)
+        return ctx.float_ty(val[0])
+
+    if isinstance(node.function, Linear):  # f(x) = mx + b, f'(x) = m
+        slope = get_fct_param_value('slope')
+
+        def modify_value(x):
+            return slope
+
+    elif isinstance(node.function, Logistic):  # f'(x) = f(x)(1-f(x))
+        gain = pnlvm.helpers.fneg(builder, get_fct_param_value('gain'))
+        bias = get_fct_param_value('bias')
+        offset = get_fct_param_value('offset')
+        one = ctx.float_ty(1)
+        exp = ctx.import_llvm_function("__pnl_builtin_exp")
+
+        def modify_value(x):
+            arg = builder.fadd(x, bias)
+            arg = builder.fmul(gain, arg)
+            arg = builder.fadd(arg, offset)
+
+            f_x = builder.call(exp, [arg])
+            f_x = builder.fadd(one, f_x)
+            f_x = builder.fdiv(one, f_x)
+
+            ret = builder.fsub(one, f_x)
+            ret = builder.fmul(f_x, ret)
+            return ret
+
+    else:
+        raise Exception(
+            f"Function type {node.function} is currently unsupported by compiled execution!")
+
+    # do computations
+    with pnlvm.helpers.for_loop_zero_inc(builder, dim, "derivative_loop") as (builder, iterator):
+        val_ptr = builder.gep(input_vector, [iterator])
+        val = builder.load(val_ptr)
+        val = modify_value(val)
+        output_location = builder.gep(output_vector, [iterator])
+        builder.store(val, output_location)
+
+    builder.ret_void()
+
+    return llvm_func
+
+
+class PytorchMechanismWrapper():
+    """
+    An interpretation of a mechanism as an equivalent pytorch object
+    """
+    def __init__(self, mechanism, component_idx, device, context=None):
+        self._mechanism = mechanism
+        self._idx = component_idx
+        self._context = context
+
+        self.function = pytorch_function_creator(mechanism.function, device, context)
+        self._context = context
+        self.value = None
+        self.afferents = []
+        self.efferents = []
+
+        self._target_mechanism = None
+
+    def add_efferent(self, efferent):
+        assert efferent not in self.efferents
+        self.efferents.append(efferent)
+
+    def add_afferent(self, afferent):
+        assert afferent not in self.afferents
+        self.afferents.append(afferent)
+
+
+    def collate_afferents(self):
+        """
+        Returns weight-multiplied sum of all afferent projections
+        """
+        return sum((proj.execute(proj.sender.value) for proj in self.afferents))
+
+    def execute(self, variable):
+        self.value = self.function(variable)
+
+        return self.value
+
+    def _gen_execute_llvm(self, ctx, builder, state, params, mech_input, data):
+        mech_func = ctx.import_llvm_function(self._mechanism)
+
+        mech_param = builder.gep(params, [ctx.int32_ty(0),
+                                          ctx.int32_ty(0),
+                                          ctx.int32_ty(self._idx)])
+
+        mech_state = builder.gep(state, [ctx.int32_ty(0),
+                                         ctx.int32_ty(0),
+                                         ctx.int32_ty(self._idx)])
+
+        mech_output = builder.gep(data, [ctx.int32_ty(0),
+                                         ctx.int32_ty(0),
+                                         ctx.int32_ty(self._idx)])
+
+        builder.call(mech_func, [mech_param,
+                                 mech_state,
+                                 mech_input,
+                                 mech_output])
+
+        pnlvm.helpers.printf_float_array(builder, builder.gep(mech_output, [ctx.int32_ty(0), ctx.int32_ty(0)]), prefix=f"{self} output:\n", override_debug=False)
+
+        return mech_output
+
+    def log_value(self):
+        if self._mechanism.parameters.value.log_condition != LogCondition.OFF:
+            detached_value = self.value.detach().cpu().numpy()
+            self._mechanism.output_port.parameters.value._set(detached_value, self._context)
+            self._mechanism.parameters.value._set(detached_value, self._context)
+
+    def _gen_execute_derivative_func_llvm(self, ctx, builder, mech_input):
+        derivative_func = ctx.import_llvm_function(
+                    bin_function_derivative_creator(ctx, self._mechanism, context=self._context).name)
+        return gen_inject_unary_function_call(ctx, builder, derivative_func, mech_input)
+
+    def __repr__(self):
+        return "PytorchWrapper for: " +self._mechanism.__repr__()
+
+class PytorchProjectionWrapper():
+    """
+    An interpretation of a projection as an equivalent pytorch object
+    """
+    def __init__(self, projection, component_idx, port_idx, device, sender=None, receiver=None, context=None):
+        self._projection = projection
+        self._idx = component_idx
+        self._context = context
+
+        self.sender = sender
+        self.receiver = receiver
+        self._port_idx = port_idx
+
+        matrix = projection.parameters.matrix.get(
+                            context=context)
+        if matrix is None:
+            matrix = projection.parameters.matrix.get(
+                context=None
+            )
+        self.matrix = torch.nn.Parameter(torch.tensor(matrix.copy(),
+                                         device=device,
+                                         dtype=torch.double))
+
+        if projection.learnable is False:
+            self.matrix.requires_grad = False
+
+    def execute(self, variable):
+        return torch.matmul(variable, self.matrix)
+
+    def log_matrix(self):
+        if self._projection.parameters.matrix.log_condition != LogCondition.OFF:
+            detached_matrix = self.matrix.detach().cpu().numpy()
+            self._projection.parameters.matrix._set(detached_matrix, context=self._context)
+            self._projection.parameter_ports['matrix'].parameters.value._set(detached_matrix, context=self._context)
+
+    def _extract_llvm_matrix(self, ctx, builder, params):
+        proj_params = builder.gep(params, [ctx.int32_ty(0),
+                                           ctx.int32_ty(1),
+                                           ctx.int32_ty(self._idx)])
+
+        dim_x, dim_y = self.matrix.detach().numpy().shape
+        proj_matrix = pnlvm.helpers.get_param_ptr(builder, self._projection, proj_params, "matrix")
+        proj_matrix = builder.bitcast(proj_matrix, pnlvm.ir.types.ArrayType(
+            pnlvm.ir.types.ArrayType(ctx.float_ty, dim_y), dim_x).as_pointer())
+
+        return proj_matrix
+
+    def _gen_execute_llvm(self, ctx, builder, state, params, data):
+        proj_matrix = self._extract_llvm_matrix(ctx, builder, params)
+
+        input_vec = builder.gep(data, [ctx.int32_ty(0),
+                                       ctx.int32_ty(0),
+                                       ctx.int32_ty(self.sender._idx),
+                                       ctx.int32_ty(self._port_idx)])
+
+        output_vec = gen_inject_vxm(ctx, builder, input_vec, proj_matrix)
+
+        pnlvm.helpers.printf_float_array(builder, input_vec, prefix=f"{self.sender._mechanism} -> {self.receiver._mechanism} input:\n", override_debug=False)
+        pnlvm.helpers.printf_float_matrix(builder, proj_matrix, prefix=f"{self.sender._mechanism} -> {self.receiver._mechanism} mat:\n", override_debug=False)
+        pnlvm.helpers.printf_float_array(builder, output_vec, prefix=f"{self.sender._mechanism} -> {self.receiver._mechanism} output:\n", override_debug=False)
+
+        return output_vec
+
+    def __repr__(self):
+        return "PytorchWrapper for: " +self._projection.__repr__()

--- a/psyneulink/library/compositions/pytorchllvmhelper.py
+++ b/psyneulink/library/compositions/pytorchllvmhelper.py
@@ -1,5 +1,19 @@
 from psyneulink.core import llvm as pnlvm
 
+__all__ = ["gen_inject_unary_function_call",
+           "gen_inject_vec_copy",
+           "gen_inject_vec_binop",
+           "gen_inject_vec_add",
+           "gen_inject_vec_sub",
+           "gen_inject_vec_hadamard",
+           "gen_inject_mat_binop",
+           "gen_inject_mat_add",
+           "gen_inject_mat_sub",
+           "gen_inject_mat_hadamard",
+           "gen_inject_mat_scalar_mult",
+           "gen_inject_vxm",
+           "gen_inject_vxm_transposed"]
+
 def gen_inject_unary_function_call(ctx, builder, unary_func, vector, output_vec=None):
     dim = len(vector.type.pointee)
     if output_vec is None:

--- a/psyneulink/library/compositions/pytorchmodelcreator.py
+++ b/psyneulink/library/compositions/pytorchmodelcreator.py
@@ -1,17 +1,13 @@
-import numpy as np
 from psyneulink.core.scheduling.time import TimeScale
 from psyneulink.core.compositions.composition import NodeRole
 from psyneulink.core.components.functions.transferfunctions import Linear, Logistic, ReLU
-from psyneulink.core.globals.context import Context, ContextFlags, handle_external_context
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core import llvm as pnlvm
-from psyneulink.library.compositions.compiledoptimizer import AdamOptimizer,SGDOptimizer
+from psyneulink.library.compositions.compiledoptimizer import AdamOptimizer, SGDOptimizer
 from psyneulink.library.compositions.compiledloss import MSELoss
-import ctypes
-from collections import deque
 from psyneulink.library.compositions.pytorchllvmhelper import *
 from psyneulink.core.globals.keywords import TARGET_MECHANISM
-from psyneulink.core.globals.log import LogCondition
-debug_env = pnlvm.debug_env
+from .pytorchcomponents import *
 
 try:
     import torch
@@ -21,19 +17,10 @@ except ImportError:
     torch_available = False
 
 __all__ = ['PytorchModelCreator']
-# Class that is called to create pytorch representations of autodiff compositions based on their processing graphs.
-# Called to do so when the composition is run for the first time.
-
-# Note on notation: the "nodes" that are constantly referred to are vertices of the composition's processing
-# graph. For general compositions, the component a node represents can be a mechanism or a nested composition,
-# but for autodiff compositions, nodes always represent mechanisms. "Nodes" can be thought of as
-# (but are not literally) mechanisms.
-
 
 class PytorchModelCreator(torch.nn.Module):
-
     # sets up parameters of model & the information required for forward computation
-    def __init__(self, processing_graph, param_init_from_pnl, execution_sets, device, context=None, composition=None):
+    def __init__(self, composition, device, context=None):
 
         if not torch_available:
             raise Exception('Pytorch python module (torch) is not installed. Please install it with '
@@ -41,89 +28,53 @@ class PytorchModelCreator(torch.nn.Module):
 
         super(PytorchModelCreator, self).__init__()
 
-        self.execution_sets = execution_sets  # saved for use in the forward method
-        # dict mapping PNL nodes to their forward computation information
-        self.component_to_forward_info = {}
-        # dict mapping PNL projections to Pytorch weights
-        self.projections_to_pytorch_weights = {}
-        # list that Pytorch optimizers will use to keep track of parameters
+        # Maps Mechanism -> PytorchMechanismWrapper
+        self.nodes = []
+        self.component_map = {}
+
+        # Maps Projections -> PytorchProjectionWrappers
+        self.projections = []
+        self.projection_map = {}
+
         self.params = nn.ParameterList()
         self.device = device
-
         self._composition = composition
+        
+        # Instantiate pytorch mechanisms
+        for node in set(composition.nodes) - set(composition.get_nodes_by_role(NodeRole.LEARNING)):
+            pytorch_node = PytorchMechanismWrapper(node, self._composition._get_node_index(node), device, context=context)
+            self.component_map[node] = pytorch_node
+            self.nodes.append(pytorch_node)
 
-        for i, current_exec_set in enumerate(self.execution_sets):
-            self.execution_sets[i] = current_exec_set - set(composition.get_nodes_by_role(NodeRole.LEARNING))
-            for component in current_exec_set:
-                value = None  # the node's (its mechanism's) value
-                function = self.function_creator(
-                    component, context)  # the node's function
-                afferents = {}  # dict for keeping track of afferent nodes and their connecting weights
-                if param_init_from_pnl:
-                    if component.parameters.value._get(context) is None:
-                        value = torch.tensor(component.parameters.value.get(None)[0], device=self.device)
-                    else:
-                        value = torch.tensor(component.parameters.value._get(context)[0], device=self.device)
-                else:
-                    input_length = len(
-                        component.input_ports[0].parameters.value.get(None))
-                    value = torch.zeros(
-                        input_length, device=self.device).double()
+        # Instantiate pytorch projections
+        for projection in composition.projections:
+            if projection.sender.owner in self.component_map and projection.receiver.owner in self.component_map:
+                proj_send = self.component_map[projection.sender.owner]
+                proj_recv = self.component_map[projection.receiver.owner]
 
-                # if `node` is not an origin node (origin nodes don't have biases or afferent connections)
-                if i != 0:
-                    # iterate over incoming projections and set up pytorch weights for them
-                    for mapping_proj in component.path_afferents:
+                port_idx = projection.sender.owner.output_ports.index(projection.sender)
+                new_proj = PytorchProjectionWrapper(projection, list(self._composition._inner_projections).index(projection), port_idx, device, sender=proj_send, receiver=proj_recv, context=context)
+                proj_send.add_efferent(new_proj)
+                proj_recv.add_afferent(new_proj)
+                self.projection_map[projection] = new_proj
+                self.projections.append(new_proj)
+                self.params.append(new_proj.matrix)
 
-                        # get projection, sender node--pdb for projection
-                        input_component = mapping_proj.sender.owner
-                        input_node = processing_graph.comp_to_vertex[input_component]
-
-                        # CW 12/3/18: Check this logic later
-                        proj_matrix = mapping_proj.parameters.matrix._get(
-                            context)
-                        if proj_matrix is None:
-                            proj_matrix = mapping_proj.parameters.matrix.get(
-                                None)
-                        # set up pytorch weights that correspond to projection. If copying params from psyneulink,
-                        # copy weight values from projection. Otherwise, use random values.
-                        if param_init_from_pnl:
-                            weights = nn.Parameter(
-                                    torch.tensor(
-                                            proj_matrix.copy(),
-                                            device=self.device).double(),
-                                    requires_grad=mapping_proj.learnable)
-                        else:
-                            weights = nn.Parameter(torch.rand(
-                                np.shape(proj_matrix), device=self.device).double())
-                        afferents[input_node] = weights
-                        self.params.append(weights)
-                        self.projections_to_pytorch_weights[mapping_proj] = weights
-                        
-                node_forward_info = {
-                    'value':value,
-                    'function':function,
-                    'afferents':afferents,
-                    'component':component}
-
-                self.component_to_forward_info[component] = node_forward_info
-
-        # CW 12/3/18: this copies by reference so in theory it only needs to be called during init
-        # but we call copy_weights_to_psyneulink after every run in order to make Autodiff less stateful
-        self.copy_weights_to_psyneulink(context)
-
+        # Setup execution sets
+        # 1) Remove all learning-specific nodes
+        self.execution_sets = [x - set(composition.get_nodes_by_role(NodeRole.LEARNING)) for x in composition.scheduler.run(context=context)]
+        # 2) Convert to pytorchcomponent representation
+        self.execution_sets = [{self.component_map[comp] for comp in s if comp in self.component_map} for s in self.execution_sets]
+        # 3) Remove empty execution sets
+        self.execution_sets = [x for x in self.execution_sets if len(x) > 0]
 
     # gets the index of 'afferent_node' in the forward info weights list
-    def _get_afferent_node_index(self,node,afferent_node):
-        forward_info_weights = self.component_to_forward_info[node]['afferents']
-        for (idx,vertex) in enumerate(forward_info_weights):
-            if vertex.component == afferent_node:
-                return idx
+    def _get_afferent_node_index(self, node, afferent_node):
+        return [proj.receiver for proj in node.afferents].index(self.component_map[afferent_node])
 
-    # returns a list of all efferent nodes and weights stored in component_to_forward_info
-    def _get_afferent_nodes(self,node):
-        forward_info_weights = self.component_to_forward_info[node]['afferents']
-        return [(vertex.component,weights) for (vertex,weights) in forward_info_weights.items()]
+    def _get_afferent_nodes(self, node):
+        forward_info_weights = self.component_map[node].afferents
+        return [(vertex.component, weights) for (vertex, weights) in forward_info_weights.items()]
 
     # generates llvm function for self.forward
     def _gen_llvm_function(self, *, ctx:pnlvm.LLVMBuilderContext, tags:frozenset):
@@ -143,93 +94,31 @@ class PytorchModelCreator(torch.nn.Module):
         builder.ret_void()
         return builder.function
 
-    # gets a pointer for the weights matrix between node and afferent_node
-    def _gen_get_node_weight_ptr(self, ctx, builder, params, node, afferent_node):
-        node_idx = self._composition._get_node_index(node)
-        forward_info_weights = self.component_to_forward_info[node]['afferents']
-        afferent_node_index = self._get_afferent_node_index(node,afferent_node)
-        projection = [i for i in afferent_node.efferents if i.receiver.owner == node][0]
-        inner_projections = list(self._composition._inner_projections)
-        projection_idx = inner_projections.index(projection)
-        projection_params = builder.gep(params, [ctx.int32_ty(0), ctx.int32_ty(1), ctx.int32_ty(projection_idx)])
-
-        for (vertex,matrix) in forward_info_weights.items():
-            if vertex.component == afferent_node:
-                weight_matrix = matrix
-                break
-        dim_x,dim_y = weight_matrix.detach().numpy().shape
-        node_weights = pnlvm.helpers.get_param_ptr(builder, projection, projection_params, "matrix")
-        node_weights = builder.bitcast(node_weights, pnlvm.ir.types.ArrayType(
-                 pnlvm.ir.types.ArrayType(ctx.float_ty, dim_y), dim_x).as_pointer())
-
-        return node_weights,dim_x,dim_y
-
-    def _gen_llvm_forward_function_body(self, ctx, builder, state, params, arg_in, arg_out, store_z_values=False):
-        out_t = arg_out.type.pointee
-        if isinstance(out_t, pnlvm.ir.ArrayType) and isinstance(out_t.element, pnlvm.ir.ArrayType):
-            assert len(out_t) == 1
-        z_values = {}
-        for i, current_exec_set in enumerate(self.execution_sets):
+    def _gen_llvm_forward_function_body(self, ctx, builder, state, params, arg_in, data):
+        z_values = {}  # dict for storing values of terminal (output) nodes
+        for current_exec_set in self.execution_sets:
             for component in current_exec_set:
-                component_id = self._composition._get_node_index(component)
-                value = self._get_output_value_ptr(ctx, builder, arg_out, component_id)
-                afferents = self.component_to_forward_info[component]['afferents']
+                mech_input_ty = ctx.get_input_struct_type(component._mechanism)
+                variable = builder.alloca(mech_input_ty)
+                z_values[component] = builder.alloca(mech_input_ty.elements[0].elements[0])
+                builder.store(z_values[component].type.pointee(None),z_values[component])
 
-                mech_input_ty = ctx.get_input_struct_type(component)
-                mech_input = builder.alloca(mech_input_ty)
+                if NodeRole.INPUT in self._composition.get_roles_by_node(component._mechanism):
+                    input_ptr = builder.gep(
+                        variable, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(0)])
+                    input_id = component._idx
+                    mech_in = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(input_id)])
+                    builder.store(builder.load(mech_in), input_ptr)
+                for (proj_idx, proj) in enumerate(component.afferents):
+                    input_ptr = builder.gep(
+                        variable, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(proj_idx)])
+                    proj_output = proj._gen_execute_llvm(ctx, builder, state, params, data)
+                    # store in input ports struct
+                    builder.store(builder.load(proj_output), input_ptr)
+                    # HACK: Add to z_values struct
+                    gen_inject_vec_add(ctx, builder, proj_output, z_values[component], z_values[component])
+                component._gen_execute_llvm(ctx, builder, state, params, variable, data)
 
-                if i == 0:
-                    # input struct provides data for input nodes
-                    input_id = self._composition.get_nodes_by_role(NodeRole.INPUT).index(component)
-                    cmp_arg = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(input_id)])
-                    # node inputs are 2d arrays in a struct
-                    input_ptr = builder.gep(mech_input, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(0)])
-                    builder.store(builder.load(cmp_arg), input_ptr)
-                else:
-                    # is_set keeps track of if we already have valid (i.e. non-garbage) values inside the alloc'd value
-                    is_set = False
-                    for j, (input_vertex, weights) in enumerate(afferents.items()):
-                        source_node = input_vertex.component
-                        source_node_idx = self._composition._get_node_index(source_node)
-                        input_value = self._get_output_value_ptr(ctx, builder, arg_out, source_node_idx)
-
-                        # We cast the ctype weights array to llvmlite pointer
-                        weights_llvmlite, _, _ = self._gen_get_node_weight_ptr(ctx, builder, params, component, source_node)
-                        pnlvm.helpers.printf_float_matrix(builder, weights_llvmlite, prefix=f"{source_node} -> {component}\tweight:\n")
-                        # node inputs are 2d arrays in a struct
-                        input_ptr = builder.gep(mech_input, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(j)])
-                        gen_inject_vxm(ctx, builder, input_value, weights_llvmlite, input_ptr)
-                        if store_z_values:
-                            if is_set == False:
-                                # copy weighted_inp to value
-                                gen_inject_vec_copy(ctx, builder, input_ptr, value)
-                                is_set = True
-                            else:
-                                # add to value
-                                gen_inject_vec_add(ctx, builder, input_ptr, value, value)
-
-                    cmp_arg = value
-                # Apply Activation Func to values
-                if store_z_values is True:
-                    z_values[component] = gen_inject_vec_copy(ctx, builder, cmp_arg)
-
-                mech_func = ctx.import_llvm_function(component)
-                mech_param = builder.gep(params, [ctx.int32_ty(0),
-                                                  ctx.int32_ty(0),
-                                                  ctx.int32_ty(component_id)])
-                mech_state = builder.gep(state, [ctx.int32_ty(0),
-                                                 ctx.int32_ty(0),
-                                                 ctx.int32_ty(component_id)])
-                mech_output = builder.gep(arg_out, [ctx.int32_ty(0),
-                                                    ctx.int32_ty(0),
-                                                    ctx.int32_ty(component_id)])
-                builder.call(mech_func, [mech_param, mech_state,
-                                         mech_input, mech_output])
-
-                if store_z_values is True:
-                    pnlvm.helpers.printf_float_array(builder, z_values[component], prefix=f"{component}\tforward input:\t")
-                pnlvm.helpers.printf_float_array(builder, value, prefix=f"{component}\tforward output:\t", suffix="\t")
-                pnlvm.helpers.printf(builder, "\n")
         return z_values
 
     # generates a function responsible for a single epoch of the training
@@ -247,110 +136,111 @@ class PytorchModelCreator(torch.nn.Module):
             if isinstance(a.type, pnlvm.ir.PointerType):
                 a.attributes.add('noalias')
 
-        context, params, model_output, optim_struct = llvm_func.args
-        model_input = builder.gep(model_output, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(self._composition._get_node_index(self._composition.input_CIM))])
+        context, params, data, optim_struct = llvm_func.args
+        model_input = builder.gep(data, [ctx.int32_ty(0),
+                                         ctx.int32_ty(0),
+                                         ctx.int32_ty(self._composition._get_node_index(self._composition.input_CIM))])
+        model_output = data
         # setup useful mappings
-        input_nodes = composition.get_nodes_by_role(NodeRole.INPUT)
-        output_nodes = composition.get_nodes_by_role(NodeRole.OUTPUT)
+        input_nodes = set(self._composition.get_nodes_by_role(NodeRole.INPUT))
 
         # initialize optimizer params:
         delta_w = builder.gep(optim_struct, [ctx.int32_ty(0), ctx.int32_ty(optimizer._DELTA_W_NUM)])
 
-
         # 2) call forward computation
         z_values = self._gen_llvm_forward_function_body(
-            ctx, builder, context, params, model_input, model_output, store_z_values=True)
+            ctx, builder, context, params, model_input, data)
+        
         # 3) compute errors
-
-        error_dict = {}
-        backprop_queue = deque()
-        for node in set(output_nodes) - set(self._composition.get_nodes_by_role(NodeRole.LEARNING)):
-            backprop_queue.append(node)
-
         loss_fn = ctx.import_llvm_function(loss)
         total_loss = builder.alloca(ctx.float_ty)
-        builder.store(ctx.float_ty(0),total_loss)
+        builder.store(ctx.float_ty(0), total_loss)
+        
+        error_dict = {}
+        for exec_set in reversed(self.execution_sets):
+            for node in exec_set:
+                if node._mechanism in input_nodes:
+                    continue
+                node_z_value = z_values[node]
+                activation_func_derivative = node._gen_execute_derivative_func_llvm(ctx, builder, node_z_value)
+                error_val = builder.alloca(z_values[node].type.pointee)
+                error_dict[node] = error_val
 
-        while(len(backprop_queue) > 0):
-            node = backprop_queue.popleft()
-            if node in error_dict or not hasattr(node, "afferents") or node == composition.input_CIM or node in input_nodes:
-                continue
+                if NodeRole.OUTPUT in self._composition.get_roles_by_node(node._mechanism):
+                    # We handle output layer here
+                    # compute  dC/da = a_l - y(x) (TODO: Allow other cost functions! This only applies to MSE)
+                    
+                    # 1) Lookup desired target value
+                    terminal_sequence = self._composition._terminal_backprop_sequences[node._mechanism]
+                    target_idx = self._composition.get_nodes_by_role(
+                        NodeRole.INPUT).index(terminal_sequence[TARGET_MECHANISM])
+                    node_target = builder.gep(model_input, [ctx.int32_ty(0), ctx.int32_ty(target_idx)])
 
-            for (afferent_node,weights) in self._get_afferent_nodes(node):
-                backprop_queue.append(afferent_node)
+                    # 2) Lookup desired output value
+                    node_output = builder.gep(model_output, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(node._idx), ctx.int32_ty(0)])
 
-            node_idx = composition._get_node_index(node)
+                    tmp_loss = loss.gen_inject_lossfunc_call(
+                        ctx, builder, loss_fn, node_output, node_target)
 
-            activation_func_derivative_bin_func = ctx.import_llvm_function(self.bin_function_derivative_creator(ctx,node).name)
-            activation_func_derivative = gen_inject_unary_function_call(ctx, builder, activation_func_derivative_bin_func, z_values[node])
+                    pnlvm.helpers.printf_float_array(
+                        builder, node_target, prefix=f"{node}\ttarget:\t")
+                    pnlvm.helpers.printf_float_array(
+                        builder, node_output, prefix=f"{node}\tvalue:\t")
 
-            error_val = builder.alloca(z_values[node].type.pointee)
+                    pnlvm.helpers.printf(
+                        builder, f"{node}\tloss:\t%f\n", tmp_loss, override_debug=False)
+                    builder.store(builder.fadd(builder.load(
+                        total_loss), tmp_loss), total_loss)
+                    loss_derivative = loss._gen_inject_loss_differential(
+                        ctx, builder, node_output, node_target)
+                    # compute δ_l = dσ/da ⊙ σ'(z)
 
-            error_dict[node] = error_val
+                    gen_inject_vec_hadamard(
+                        ctx, builder, activation_func_derivative, loss_derivative, error_val)
 
-            if node in set(output_nodes) - set(self._composition.get_nodes_by_role(NodeRole.LEARNING)):
-                # We handle output layer here
-                # compute  dC/da = a_l - y(x) (TODO: Allow other cost functions! This only applies to MSE)
-                out_node_idx = output_nodes.index(node)
-                node_target = self._get_target_value_ptr(ctx, builder, model_input, node )
-                node_output = self._get_output_value_ptr(ctx, builder, model_output, node_idx)
+                else:
+                    # We propagate error backwards from next layer
+                    for proj_idx, proj in enumerate(node.efferents):
+                        efferent_node = proj.receiver
+                        efferent_node_error = error_dict[efferent_node]
 
-                tmp_loss = loss.gen_inject_lossfunc_call(ctx, builder, loss_fn, node_output, node_target)
+                        weights_llvmlite = proj._extract_llvm_matrix(ctx, builder, params)
 
-                pnlvm.helpers.printf_float_array(builder, node_target, prefix=f"{node}\ttarget:\t")
-                pnlvm.helpers.printf_float_array(builder, node_output, prefix=f"{node}\tvalue:\t")
+                        if proj_idx == 0:
+                            gen_inject_vxm_transposed(
+                                ctx, builder, efferent_node_error, weights_llvmlite, error_val)
+                        else:
+                            new_val = gen_inject_vxm_transposed(
+                                ctx, builder, efferent_node_error, weights_llvmlite)
 
-                pnlvm.helpers.printf(builder,f"{node}\tloss:\t%f\n",tmp_loss)
-                builder.store(builder.fadd(builder.load(total_loss),tmp_loss),total_loss)
-                loss_derivative = loss._gen_inject_loss_differential(ctx, builder, node_output, node_target)
-                # compute δ_l = dσ/da ⊙ σ'(z)
+                            gen_inject_vec_add(
+                                ctx, builder, new_val, error_val, error_val)
 
-                gen_inject_vec_hadamard(ctx, builder, activation_func_derivative, loss_derivative, error_val)
+                    gen_inject_vec_hadamard(
+                        ctx, builder, activation_func_derivative, error_val, error_val)
 
-            else:
-                # We propagate error backwards from next layer
-
-                is_set = False
-
-                # We calculate δ_(l-1) = sum (a_(l-1) W^T) ⊙ δ_l, where (l-1) is the current layer, l is layer of efferents, summed over all efferents
-                efferents = [
-                    proj.receiver._owner for proj in node.efferents]
-                for efferent_node in set(efferents) - set(self._composition.get_nodes_by_role(NodeRole.LEARNING)):
-                    efferent_node_error = error_dict[efferent_node]
-
-                    weights_llvmlite, _, _ = self._gen_get_node_weight_ptr(ctx, builder, params, efferent_node, node)
-
-                    if is_set is False:
-                        gen_inject_vxm_transposed(ctx, builder, efferent_node_error, weights_llvmlite, error_val)
-                        is_set = True
-                    else:
-                        new_val = gen_inject_vxm_transposed(ctx, builder, efferent_node_error, weights_llvmlite)
-
-                        gen_inject_vec_add(ctx, builder, new_val, error_val, error_val)
-
-                gen_inject_vec_hadamard(ctx, builder, activation_func_derivative, error_val, error_val)
-
-            pnlvm.helpers.printf_float_array(builder, activation_func_derivative, prefix=f"{node}\tdSigma:\t")
-            pnlvm.helpers.printf_float_array(builder, error_val, prefix=f"{node}\terror:\t")
+                pnlvm.helpers.printf_float_array(
+                    builder, activation_func_derivative, prefix=f"{node}\tdSigma:\t")
+                pnlvm.helpers.printf_float_array(
+                    builder, error_val, prefix=f"{node}\terror:\t")
 
         # 4) compute weight gradients
         for (node, err_val) in error_dict.items():
             if node in input_nodes:
                 continue
-            node_idx = self._composition._get_node_index(node)
-            for (afferent_node,weight) in self._get_afferent_nodes(node):
+            for proj in node.afferents:
                 # get a_(l-1)
-                afferent_node_idx = self._get_afferent_node_index(node,afferent_node)
-
-                afferent_node_activation = self._get_output_value_ptr(ctx,builder,model_output,self._composition._get_node_index(afferent_node))
+                afferent_node_activation = builder.gep(model_output, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(proj.sender._idx), ctx.int32_ty(0)])
 
                 # get dimensions of weight matrix
-                weights_llvmlite,weights_dim_x,weights_dim_y = self._gen_get_node_weight_ptr(ctx, builder, params, node, afferent_node)
+                weights_llvmlite = proj._extract_llvm_matrix(ctx, builder, params)
+                pnlvm.helpers.printf_float_matrix(builder, weights_llvmlite, prefix= f"{proj.sender._mechanism} -> {proj.receiver._mechanism}\n", override_debug=False)
                 # update delta_W
-                node_delta_w = builder.gep(delta_w,[ctx.int32_ty(0),ctx.int32_ty(node_idx), ctx.int32_ty(afferent_node_idx)])
+                node_delta_w = builder.gep(delta_w, [ctx.int32_ty(0), ctx.int32_ty(proj._idx)])
 
-                with pnlvm.helpers.for_loop_zero_inc(builder, ctx.int32_ty(weights_dim_x), "weight_update_loop_outer") as (b1, weight_row):
-                    with pnlvm.helpers.for_loop_zero_inc(b1, ctx.int32_ty(weights_dim_y), "weight_update_loop_inner") as (b2, weight_column):
+                dim_x, dim_y = proj.matrix.shape
+                with pnlvm.helpers.for_loop_zero_inc(builder, ctx.int32_ty(dim_x), "weight_update_loop_outer") as (b1, weight_row):
+                    with pnlvm.helpers.for_loop_zero_inc(b1, ctx.int32_ty(dim_y), "weight_update_loop_inner") as (b2, weight_column):
                         a_val = b2.load(b2.gep(afferent_node_activation,
                                                [ctx.int32_ty(0), weight_row]))
                         d_val = b2.load(b2.gep(err_val,
@@ -360,9 +250,9 @@ class PytorchModelCreator(torch.nn.Module):
                         new_val = b2.fadd(old_val, b2.fmul(a_val, d_val))
                         b2.store(new_val, b2.gep(node_delta_w,
                                                  [ctx.int32_ty(0), weight_row, weight_column]))
-                    
-        builder.store(builder.fmul(ctx.float_ty(.5),builder.load(total_loss)),total_loss)
-        pnlvm.helpers.printf(builder,"TOTAL LOSS:\t%f\n",builder.load(total_loss))
+
+        pnlvm.helpers.printf(builder, "TOTAL LOSS:\t%.20f\n",
+                             builder.load(total_loss), override_debug=False)
         builder.ret_void()
 
         return builder.function
@@ -376,102 +266,67 @@ class PytorchModelCreator(torch.nn.Module):
         if loss_type == 'mse':
             loss = MSELoss()
         else:
-            raise Exception("LOSS TYPE",loss_type,"NOT SUPPORTED")
+            raise Exception("LOSS TYPE", loss_type, "NOT SUPPORTED")
 
         optimizer_step_f = ctx.import_llvm_function(optimizer)
         optimizer_struct_idx = len(state.type.pointee.elements) - 1
         optimizer_struct = builder.gep(state, [ctx.int32_ty(0), ctx.int32_ty(optimizer_struct_idx)])
         optimizer_zero_grad = ctx.import_llvm_function(optimizer.zero_grad(ctx).name)
         backprop = ctx.import_llvm_function(self._gen_llvm_training_backprop(ctx, optimizer, loss).name)
-        
+
         # # FIXME: converting this call to inlined code results in
         # # significant longer compilation times
         builder.call(optimizer_zero_grad, [optimizer_struct])
         builder.call(backprop, [state, params, data,
-                            optimizer_struct])
+                                optimizer_struct])
         builder.call(optimizer_step_f, [optimizer_struct, params])
-
-
-    def _get_output_value_ptr(self, ctx, builder, arg_out, index):
-        return builder.gep(arg_out, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(index), ctx.int32_ty(0)])
-    
-    def _get_target_value_ptr(self, ctx, builder, arg_in, output_node):
-        terminal_sequence = self._composition._terminal_backprop_sequences[output_node]
-        idx = self._composition.get_nodes_by_role(NodeRole.INPUT).index(terminal_sequence[TARGET_MECHANISM])
-        return builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(idx)])
 
     def _get_compiled_optimizer(self):
         # setup optimizer
         optimizer_type = self._composition.optimizer_type
         if optimizer_type == 'adam':
-            optimizer = AdamOptimizer(self,lr = self._composition.learning_rate)
+            optimizer = AdamOptimizer(self, lr=self._composition.learning_rate)
         elif optimizer_type == 'sgd':
-            optimizer = SGDOptimizer(self,lr = self._composition.learning_rate)
+            optimizer = SGDOptimizer(self, lr=self._composition.learning_rate)
         else:
-            raise Exception("OPTIMIZER TYPE",optimizer_type,"NOT SUPPORTED")
+            raise Exception("OPTIMIZER TYPE", optimizer_type, "NOT SUPPORTED")
         return optimizer
+
     # performs forward computation for the model
     @handle_external_context()
-    def forward(self, inputs, context=None, do_logging=True, scheduler=None):
+    def forward(self, inputs, context=None):
         outputs = {}  # dict for storing values of terminal (output) nodes
-
-        for i, current_exec_set in enumerate(self.execution_sets):
-            frozen_values = {}
+        for current_exec_set in self.execution_sets:
             for component in current_exec_set:
-                if NodeRole.LEARNING in self._composition.get_roles_by_node(component) or NodeRole.TARGET in self._composition.get_roles_by_node(component):
-                    continue
-                frozen_values[component] = self.component_to_forward_info[component]['value']
-            for component in current_exec_set:
-                if NodeRole.LEARNING in self._composition.get_roles_by_node(component) or NodeRole.TARGET in self._composition.get_roles_by_node(component):
-                    continue
-                # get forward computation info for current component
-                function = self.component_to_forward_info[component]['function']
-                afferents = self.component_to_forward_info[component]['afferents']
-                # forward computation if we have origin node
-                if i == 0:
-                    value = function(inputs[component])
-                # forward computation if we do not have origin node
+                if NodeRole.INPUT in self._composition.get_roles_by_node(component._mechanism):
+                    component.execute(inputs[component._mechanism])
                 else:
-                    value = torch.zeros(
-                        len(component.input_ports[0].defaults.value), device=self.device).double()
-                    for input_node, weights in afferents.items():
-                        if input_node.component in current_exec_set:
-                            input_value = frozen_values[input_node.component]
-                        else:
-                            input_value = self.component_to_forward_info[input_node.component]['value']
-                        value += torch.matmul(input_value, weights)
-                    value = function(value)
-                # store the current value of the node
-                self.component_to_forward_info[component]['value'] = value
-                old_source = context.source
-                context.source = ContextFlags.COMMAND_LINE
-                detached_value = value.detach().cpu().numpy()
-                component.parameters.value._set(detached_value, context)
-                context.source = old_source
+                    variable = component.collate_afferents()
+                    component.execute(variable)
 
                 # save value in output list if we're at a node in the last execution set
-                if i == len(self.execution_sets) - 1:
-                    outputs[component] = value
+                if NodeRole.OUTPUT in self._composition.get_roles_by_node(component._mechanism):
+                    outputs[component._mechanism] = component.value
 
-        # Maybe need to comment this out!
-        # self.copy_outputs_to_psyneulink(outputs, context)
-
+        # NOTE: Context source needs to be set to COMMAND_LINE to force logs to update independantly of timesteps
         old_source = context.source
         context.source = ContextFlags.COMMAND_LINE
-        self.log_weights(context)
-        self.copy_outputs_to_psyneulink(outputs, context)
+        self.log_values()
+        self.log_weights()
         context.source = old_source
 
         return outputs
 
     def detach_all(self):
-        for component, info in self.component_to_forward_info.items():
-            info['value'].detach_()
+        for projection in self.projection_map.values():
+            projection.matrix.detach()
 
     def copy_weights_to_psyneulink(self, context=None):
-        for projection, weights in self.projections_to_pytorch_weights.items():
+        for projection, pytorch_rep in self.projection_map.items():
             projection.parameters.matrix._set(
-                weights.detach().cpu().numpy(), context)
+                pytorch_rep.matrix.detach().cpu().numpy(), context)
+            projection.parameter_ports['matrix'].parameters.value._set(
+                pytorch_rep.matrix.detach().cpu().numpy(), context)
 
     def copy_outputs_to_psyneulink(self, outputs, context=None):
         for component, value in outputs.items():
@@ -481,120 +336,10 @@ class PytorchModelCreator(torch.nn.Module):
             component.output_port.parameters.value._set(
                 detached_value, context, skip_history=True, skip_log=True)
 
-    @handle_external_context()
-    def log_weights(self, context=None):
-        for projection, weights in self.projections_to_pytorch_weights.items():
-            if projection.parameters.matrix.log_condition != LogCondition.OFF:
-                projection.parameters.matrix._set(
-                    weights.detach().cpu().numpy(), context)
+    def log_weights(self):
+        for proj in self.projections:
+            proj.log_matrix()
 
-    # Helper method that creates a bin func that returns the derivative of the function into the builder
-    # FIXME: Add compiled derivative functions, and move these calls there
-    @handle_external_context()
-    def bin_function_derivative_creator(self, ctx, node, context=None):
-        # first try to get cached func
-        name = node.name + "_" + node.function.name + "_derivative"
-        try:
-            llvm_func = ctx.import_llvm_function(name)
-            return llvm_func
-        except Exception as e:
-            pass
-
-
-        # args: 1) ptr to input vector
-        #       2) sizeof vector
-        #       3) ptr to output vector
-        float_ptr_ty = ctx.float_ty.as_pointer()
-        args = [float_ptr_ty, ctx.int32_ty, float_ptr_ty]
-        builder = ctx.create_llvm_function(args, self,name )
-        llvm_func = builder.function
-
-        input_vector, dim, output_vector = llvm_func.args
-        def get_fct_param_value(param_name):
-            val = node.function._get_current_function_param(
-                param_name, context)
-            if val is None:
-                val = node.function._get_current_function_param(
-                    param_name, None)
-            return ctx.float_ty(val[0])
-
-        if isinstance(node.function, Linear): # f(x) = mx + b, f'(x) = m
-            slope = get_fct_param_value('slope')
-            def modify_value(x):
-                return slope
-
-        elif isinstance(node.function, Logistic):# f'(x) = f(x)(1-f(x))
-
-            neg_one = ctx.float_ty(-1)
-            gain = builder.fmul(neg_one, get_fct_param_value('gain'))
-            bias = get_fct_param_value('bias')
-            offset = get_fct_param_value('offset')
-            one = ctx.float_ty(1)
-            exp = ctx.import_llvm_function("__pnl_builtin_exp")
-
-            def modify_value(x):
-                arg = builder.fadd(x, bias)
-                arg = builder.fmul(gain, arg)
-                arg = builder.fadd(arg, offset)
-
-                f_x = builder.call(exp, [arg])
-                f_x = builder.fadd(one, f_x)
-                f_x = builder.fdiv(one, f_x)
-
-                ret = builder.fsub(one ,f_x)
-                ret = builder.fmul(f_x, ret)
-                return ret
-
-        else:
-            raise Exception(f"Function type {node.function} is currently unsupported by compiled execution!")
-
-        # do computations
-        with pnlvm.helpers.for_loop_zero_inc(builder, dim, "derivative_loop") as (builder, iterator):
-            val_ptr = builder.gep(input_vector,[iterator])
-            val = builder.load(val_ptr)
-            val = modify_value(val)
-            output_location = builder.gep(output_vector,[iterator])
-            builder.store(val,output_location)
-
-        builder.ret_void()
-
-        return llvm_func
-
-    # helper method that identifies the type of function used by a node, gets the function
-    # parameters and uses them to create a function object representing the function, then returns it
-    def function_creator(self, node, context=None):
-        def get_fct_param_value(param_name):
-            val = node.function._get_current_function_param(
-                param_name, context)
-            if val is None:
-                val = node.function._get_current_function_param(
-                    param_name, Context(execution_id=None))
-            return float(val)
-
-        if isinstance(node.function, Linear):
-            slope = get_fct_param_value('slope')
-            intercept = get_fct_param_value('intercept')
-            return lambda x: x * slope + intercept
-
-        elif isinstance(node.function, Logistic):
-            gain = get_fct_param_value('gain')
-            bias = get_fct_param_value('bias')
-            offset = get_fct_param_value('offset')
-            return lambda x: 1 / (1 + torch.exp(-gain * (x + bias) + offset))
-
-        # if we have relu function (the only other kind of function allowed by the autodiff composition)
-        else:
-            gain = get_fct_param_value('gain')
-            bias = get_fct_param_value('bias')
-            leak = get_fct_param_value('leak')
-            return lambda x: (torch.max(input=(x - bias), other=torch.tensor([0], device=self.device).double()) * gain +
-                              torch.min(input=(x - bias), other=torch.tensor([0], device=self.device).double()) * leak)
-
-    # returns dict mapping psyneulink projections to corresponding pytorch weights. Pytorch weights are copied
-    # over from tensors inside Pytorch's Parameter data type to numpy arrays (and thus copied to a different
-    # memory location). This keeps the weights - and Pytorch in general - away from the user
-    def get_weights_for_projections(self):
-        weights_in_numpy = {}
-        for projection, weights in self.projections_to_pytorch_weights.items():
-            weights_in_numpy[projection] = weights.detach().cpu().numpy().copy()
-        return weights_in_numpy
+    def log_values(self):
+        for node in self.nodes:
+            node.log_value()

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -27,12 +27,12 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.pytorch
 @pytest.mark.parametrize("mode", ['Python',
-                                    pytest.param('LLVMRun', marks=pytest.mark.llvm),
-                                    ])
+                                  pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                 ])
 def test_autodiff_forward(mode):
-            # create xor model mechanisms and projections
+    # create xor model mechanisms and projections
     xor_in = TransferMechanism(name='xor_in',
-                                default_variable=np.zeros(2))
+                               default_variable=np.zeros(2))
 
     xor_hid = TransferMechanism(name='xor_hid',
                                 default_variable=np.zeros(10),
@@ -93,7 +93,6 @@ class TestACConstructor:
     # def test_patience(self):
         # comp = AutodiffComposition()
         # assert comp.patience == 10
-
 
 @pytest.mark.pytorch
 @pytest.mark.acmisc

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -46,7 +46,7 @@ def test_autodiff_forward(mode):
     out_map = MappingProjection(matrix=np.random.rand(10,1))
 
     # put the mechanisms and projections together in an autodiff composition (AC)
-    xor = AutodiffComposition(param_init_from_pnl=True)
+    xor = AutodiffComposition()
 
     xor.add_node(xor_in)
     xor.add_node(xor_hid)
@@ -99,8 +99,7 @@ class TestACConstructor:
 class TestMiscTrainingFunctionality:
 
     # test whether pytorch parameters are initialized to be identical to the Autodiff Composition's
-    # projections when AC is initialized with the "param_init_from_pnl" argument set to True
-    def test_param_init_from_pnl(self):
+    def test_weight_initialization(self):
 
         # create xor model mechanisms and projections
         xor_in = TransferMechanism(name='xor_in',
@@ -118,7 +117,7 @@ class TestMiscTrainingFunctionality:
         out_map = MappingProjection(matrix=np.random.rand(10,1))
 
         # put the mechanisms and projections together in an autodiff composition (AC)
-        xor = AutodiffComposition(param_init_from_pnl=True)
+        xor = AutodiffComposition()
 
         xor.add_node(xor_in)
         xor.add_node(xor_hid)
@@ -155,7 +154,7 @@ class TestMiscTrainingFunctionality:
         hid_map = MappingProjection()
         out_map = MappingProjection()
 
-        xor = AutodiffComposition(param_init_from_pnl=True)
+        xor = AutodiffComposition()
 
         xor.add_node(xor_in)
         xor.add_node(xor_hid)
@@ -222,7 +221,7 @@ class TestMiscTrainingFunctionality:
         hid_map = MappingProjection()
         out_map = MappingProjection()
 
-        xor = AutodiffComposition(param_init_from_pnl=True, loss_spec=loss)
+        xor = AutodiffComposition(loss_spec=loss)
 
         xor.add_node(xor_in)
         xor.add_node(xor_hid)
@@ -268,7 +267,7 @@ class TestMiscTrainingFunctionality:
         hid_map = MappingProjection()
         out_map = MappingProjection()
 
-        xor = AutodiffComposition(param_init_from_pnl=True, loss_spec=ls)
+        xor = AutodiffComposition(loss_spec=ls)
 
         xor.add_node(xor_in)
         xor.add_node(xor_hid)
@@ -314,8 +313,7 @@ class TestMiscTrainingFunctionality:
         hid_map = MappingProjection()
         out_map = MappingProjection()
 
-        xor = AutodiffComposition(param_init_from_pnl=True,
-                                  learning_rate=learning_rate,
+        xor = AutodiffComposition(learning_rate=learning_rate,
                                   optimizer_type=optimizer_type,
                                   weight_decay=weight_decay)
 
@@ -375,8 +373,7 @@ class TestMiscTrainingFunctionality:
                                     sender=xor_hid,
                                     receiver=xor_out)
 
-        xor = AutodiffComposition(param_init_from_pnl=True,
-                                  learning_rate=10.0,
+        xor = AutodiffComposition(learning_rate=10.0,
                                   optimizer_type="sgd")
 
         xor.add_node(xor_in)
@@ -425,7 +422,7 @@ class TestTrainingCorrectness:
     @pytest.mark.parametrize("mode", ['Python',
                                       pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                      ])
-    def test_xor_training_correctness(self, eps, calls, opt, from_pnl_or_not, mode, benchmark, expected):
+    def test_xor_training_correctness(self, eps, calls, opt, mode, benchmark, expected):
         xor_in = TransferMechanism(name='xor_in',
                                    default_variable=np.zeros(2))
 
@@ -440,8 +437,7 @@ class TestTrainingCorrectness:
         hid_map = MappingProjection(matrix=np.random.rand(2, 10))
         out_map = MappingProjection(matrix=np.random.rand(10, 1))
 
-        xor = AutodiffComposition(param_init_from_pnl=from_pnl_or_not,
-                                  optimizer_type=opt,
+        xor = AutodiffComposition(optimizer_type=opt,
                                   learning_rate=0.1)
 
         xor.add_node(xor_in)
@@ -481,15 +477,14 @@ class TestTrainingCorrectness:
     # tests whether semantic network created as autodiff composition learns properly
     @pytest.mark.benchmark(group="Semantic net")
     @pytest.mark.parametrize(
-        'eps, opt, from_pnl_or_not', [
-            (500, 'adam', True),
-            # (300, 'adam', False)
+        'eps, opt', [
+            (500, 'adam'),
         ]
     )
     @pytest.mark.parametrize("mode", ['Python',
                                       pytest.param('LLVMRun', marks=pytest.mark.llvm),
                                      ])
-    def test_semantic_net_training_correctness(self, eps, opt, from_pnl_or_not, mode, benchmark):
+    def test_semantic_net_training_correctness(self, eps, opt, mode, benchmark):
 
         # MECHANISMS FOR SEMANTIC NET:
 
@@ -561,8 +556,7 @@ class TestTrainingCorrectness:
                                        receiver=out_sig_can)
 
         # COMPOSITION FOR SEMANTIC NET
-        sem_net = AutodiffComposition(param_init_from_pnl=from_pnl_or_not,
-                                      optimizer_type=opt, learning_rate=.001)
+        sem_net = AutodiffComposition(optimizer_type=opt, learning_rate=.001)
 
         sem_net.add_node(nouns_in)
         sem_net.add_node(rels_in)
@@ -903,8 +897,7 @@ class TestTrainingCorrectness:
         pco = MappingProjection(matrix=wco)
         pho = MappingProjection(matrix=who)
 
-        mnet = AutodiffComposition(param_init_from_pnl=True,
-                                   learning_rate=learning_rate)
+        mnet = AutodiffComposition(learning_rate=learning_rate)
 
         mnet.add_node(il)
         mnet.add_node(cl)
@@ -1118,8 +1111,7 @@ class TestTrainingCorrectness:
         pco = MappingProjection(matrix=wco)
         pho = MappingProjection(matrix=who, learnable=False)
 
-        mnet = AutodiffComposition(param_init_from_pnl=True,
-                                   learning_rate=learning_rate)
+        mnet = AutodiffComposition(learning_rate=learning_rate)
 
         mnet.add_node(il)
         mnet.add_node(cl)
@@ -1245,7 +1237,7 @@ class TestTrainingTime:
 
         # SET UP COMPOSITION
 
-        and_net = AutodiffComposition(param_init_from_pnl=True)
+        and_net = AutodiffComposition()
 
         and_net.add_node(and_in)
         and_net.add_node(and_out)
@@ -1348,7 +1340,7 @@ class TestTrainingTime:
 
         # SET UP COMPOSITION
 
-        xor = AutodiffComposition(param_init_from_pnl=True,bin_execute=mode)
+        xor = AutodiffComposition(bin_execute=mode)
 
         xor.add_node(xor_in)
         xor.add_node(xor_hid)
@@ -1553,7 +1545,7 @@ class TestTrainingTime:
 
         # COMPOSITION FOR SEMANTIC NET
 
-        sem_net = AutodiffComposition(param_init_from_pnl=True)
+        sem_net = AutodiffComposition()
 
         sem_net.add_node(nouns_in)
         sem_net.add_node(rels_in)
@@ -1819,8 +1811,7 @@ class TestTrainingIdenticalness():
                                            receiver=out_sig_can_sys)
 
         # SET UP COMPOSITION FOR SEMANTIC NET
-        sem_net = AutodiffComposition(param_init_from_pnl=True,
-                                      learning_rate=0.5,
+        sem_net = AutodiffComposition(learning_rate=0.5,
                                       optimizer_type=opt,
                                       )
 
@@ -2016,7 +2007,7 @@ class TestTrainingIdenticalness():
 
         # SET UP COMPOSITION
 
-        xor_dict = AutodiffComposition(param_init_from_pnl=True)
+        xor_dict = AutodiffComposition()
 
         xor_dict.add_node(xor_in_dict)
         xor_dict.add_node(xor_hid_dict)
@@ -2075,7 +2066,7 @@ class TestTrainingIdenticalness():
 
         # SET UP COMPOSITION
 
-        xor_func = AutodiffComposition(param_init_from_pnl=True)
+        xor_func = AutodiffComposition()
 
         xor_func.add_node(xor_in_func)
         xor_func.add_node(xor_hid_func)
@@ -2136,7 +2127,7 @@ class TestTrainingIdenticalness():
 
         # SET UP COMPOSITION
 
-        xor_gen = AutodiffComposition(param_init_from_pnl=True)
+        xor_gen = AutodiffComposition()
 
         xor_gen.add_node(xor_in_gen)
         xor_gen.add_node(xor_hid_gen)
@@ -2198,7 +2189,7 @@ class TestTrainingIdenticalness():
 
         # SET UP COMPOSITION
 
-        xor_gen_func = AutodiffComposition(param_init_from_pnl=True)
+        xor_gen_func = AutodiffComposition()
 
         xor_gen_func.add_node(xor_in_gen_func)
         xor_gen_func.add_node(xor_hid_gen_func)
@@ -2253,7 +2244,7 @@ class TestACLogging:
         hid_map = MappingProjection()
         out_map = MappingProjection()
 
-        xor = AutodiffComposition(param_init_from_pnl=True)
+        xor = AutodiffComposition()
 
         xor.add_node(xor_in)
         xor.add_node(xor_hid)
@@ -2337,7 +2328,7 @@ class TestACLogging:
         hid_map = MappingProjection()
         out_map = MappingProjection()
 
-        xor = AutodiffComposition(param_init_from_pnl=True)
+        xor = AutodiffComposition()
 
         xor.add_node(xor_in)
         xor.add_node(xor_hid)
@@ -2421,7 +2412,6 @@ class TestNested:
         # -----------------------------------------------------------------
 
         xor_autodiff = AutodiffComposition(
-            param_init_from_pnl=True,
             learning_rate=learning_rate,
         )
 
@@ -2493,7 +2483,6 @@ class TestNested:
         # -----------------------------------------------------------------
 
         xor_autodiff = AutodiffComposition(
-            param_init_from_pnl=True,
             learning_rate=learning_rate,
         )
 
@@ -2565,7 +2554,6 @@ class TestNested:
     #     # -----------------------------------------------------------------
     #
     #     xor_autodiff = AutodiffComposition(
-    #         param_init_from_pnl=True,
     #         patience=patience,
     #         min_delta=min_delta,
     #         learning_rate=learning_rate,
@@ -2751,8 +2739,7 @@ class TestNested:
 
         # SET UP COMPOSITION FOR SEMANTIC NET
 
-        sem_net = AutodiffComposition(param_init_from_pnl=True,
-                                      learning_rate=0.5,
+        sem_net = AutodiffComposition(learning_rate=0.5,
                                       optimizer_type=opt)
 
         sem_net.add_node(nouns_in)
@@ -2890,8 +2877,7 @@ class TestBatching:
 
         # SET UP COMPOSITION
 
-        xor = AutodiffComposition(param_init_from_pnl=True,
-                                  learning_rate=10)
+        xor = AutodiffComposition(learning_rate=10)
 
         xor.add_node(xor_in)
         xor.add_node(xor_hid)
@@ -2958,8 +2944,7 @@ class TestBatching:
 
         # SET UP COMPOSITION
 
-        xor = AutodiffComposition(param_init_from_pnl=True,
-                                  learning_rate=10)
+        xor = AutodiffComposition(learning_rate=10)
 
         xor.add_node(xor_in)
         xor.add_node(xor_hid)
@@ -3030,8 +3015,7 @@ class TestBatching:
 
         # SET UP COMPOSITION
 
-        xor = AutodiffComposition(param_init_from_pnl=True,
-                                  learning_rate=10,
+        xor = AutodiffComposition(learning_rate=10,
                                   # optimizer_type=opt
                                   )
 

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -546,11 +546,9 @@ class TestTrainingCorrectness:
             for i in range(eps):
                 results = xor.learn(inputs=input_dict, bin_execute=mode)
 
-        # FIXME: Improve accuracy
-        atol = 0.1 if not from_pnl_or_not and mode == 'LLVMRun' else 0.001
         assert len(results) == len(expected)
         for r, t in zip(results, expected):
-            assert np.allclose(r[0], t, atol=atol)
+            assert np.allclose(r[0], t)
 
         benchmark(xor.learn, inputs={"inputs": {xor_in: xor_inputs},
                                      "targets": {xor_out: xor_targets},
@@ -834,10 +832,7 @@ class TestTrainingCorrectness:
 
         for res, exp in zip(results, expected):
             for r, e in zip(res, exp):
-                if mode == 'Python':
-                    assert np.allclose(r, e)
-                else:
-                    assert np.allclose(r, e, atol=0.01)
+                assert np.allclose(r, e)
         benchmark(sem_net.learn, inputs={'inputs': inputs_dict,
                                          'targets': targets_dict,
                                          'epochs': eps}, bin_execute=mode)

--- a/tests/composition/test_learning.py
+++ b/tests/composition/test_learning.py
@@ -2020,6 +2020,10 @@ class TestBackProp:
                                                                               output_comp],
                                                                              learning_rate=10)
             target_mech = backprop_pathway.target
+            inputs_dict = {"inputs": {input_comp:xor_inputs},
+                           "targets": {output_comp:xor_targets},
+                           "epochs": num_epochs}
+            result_comp = xor_comp.learn(inputs=inputs_dict)
 
         # AutodiffComposition
         if 'AUTODIFF' in models:
@@ -2060,20 +2064,13 @@ class TestBackProp:
             inputs_dict = {"inputs": {input_autodiff:xor_inputs},
                            "targets": {output_autodiff:xor_targets},
                            "epochs": num_epochs}
-        # RUN MODELS -----------------------------------------------------------------------------------
-        if pnl.COMPOSITION in models:
-            result = xor_comp.learn(inputs={input_comp:xor_inputs,
-                                            target_mech:xor_targets},
-                                    num_trials=(num_epochs * xor_inputs.shape[0]),
-                                    )
-        if 'AUTODIFF' in models:
-            result = xor_autodiff.learn(inputs=inputs_dict)
-            autodiff_weights = xor_autodiff.get_parameters()
+            result_autodiff = xor_autodiff.learn(inputs=inputs_dict)
 
         # COMPARE WEIGHTS FOR PAIRS OF MODELS ----------------------------------------------------------
         if all(m in models for m in {pnl.COMPOSITION, 'AUTODIFF'}):
-            assert np.allclose(autodiff_weights[in_to_hidden_autodiff], in_to_hidden_comp.get_mod_matrix(xor_comp))
-            assert np.allclose(autodiff_weights[hidden_to_out_autodiff], hidden_to_out_comp.get_mod_matrix(xor_comp))
+            assert np.allclose(in_to_hidden_autodiff.parameters.matrix.get(xor_autodiff), in_to_hidden_comp.get_mod_matrix(xor_comp))
+            assert np.allclose(hidden_to_out_autodiff.parameters.matrix.get(xor_autodiff), hidden_to_out_comp.get_mod_matrix(xor_comp))
+            assert np.allclose(result_comp, result_autodiff)
 
     @pytest.mark.parametrize('configuration', [
         'Y UP',

--- a/tests/composition/test_learning.py
+++ b/tests/composition/test_learning.py
@@ -2049,9 +2049,8 @@ class TestBackProp:
                                         sender=hidden_autodiff,
                                         receiver=output_autodiff)
     
-            xor_autodiff = pnl.AutodiffComposition(param_init_from_pnl=True,
-                                      learning_rate=10,
-                                      optimizer_type='sgd')
+            xor_autodiff = pnl.AutodiffComposition(learning_rate=10,
+                                                   optimizer_type='sgd')
     
             xor_autodiff.add_node(input_autodiff)
             xor_autodiff.add_node(hidden_autodiff)


### PR DESCRIPTION
- Fix correctness issues in learning (now should be numerically exact)
- Reorder operations in the ADAM optimizer to conform to the exact ordering used in PyTorch
- Cleanup compiled learning code + setup for compiled RNN
- Add additional tests for autodiff correctness
- Remove autodiff.get_parameters (obsoleted by the ability to get matrices directly from the projections)
