### PR TITLE
Fix user_specified for several Parameters

### DIFF
--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -192,6 +192,7 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
                     :default value: 1.0
                     :type: ``float``
         """
+        variable = Parameter([], pnl_internal=True, constructor_argument='default_variable')
         rate = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
         noise = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
         history = None
@@ -219,9 +220,6 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
                  params: tc.optional(dict) = None,
                  owner=None,
                  prefs: is_pref_set = None):
-
-        if default_variable is None:
-            default_variable = []
 
         super().__init__(
             default_variable=default_variable,

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1100,7 +1100,7 @@ class TransferMechanism(ProcessingMechanism_Base):
                  input_ports:tc.optional(tc.any(Iterable, Mechanism, OutputPort, InputPort))=None,
                  function=Linear,
                  integrator_mode=False,
-                 integrator_function=AdaptiveIntegrator,
+                 integrator_function=None,
                  initial_value=None,
                  integration_rate=0.5,
                  on_resume_integrator_mode=INSTANTANEOUS_MODE_VALUE,
@@ -1225,7 +1225,7 @@ class TransferMechanism(ProcessingMechanism_Base):
             self._validate_noise(target_set[NOISE])
 
         # Validate INTEGRATOR_FUNCTION:
-        if INTEGRATOR_FUNCTION in target_set:
+        if INTEGRATOR_FUNCTION in target_set and target_set[INTEGRATOR_FUNCTION] is not None:
             integtr_fct = target_set[INTEGRATOR_FUNCTION]
             if not (isinstance(integtr_fct, IntegratorFunction)
                     or (isinstance(integtr_fct, type) and issubclass(integtr_fct, IntegratorFunction))):

--- a/psyneulink/core/components/projections/modulatory/gatingprojection.py
+++ b/psyneulink/core/components/projections/modulatory/gatingprojection.py
@@ -242,7 +242,7 @@ class GatingProjection(ModulatoryProjection_Base):
     def __init__(self,
                  sender=None,
                  receiver=None,
-                 function=Linear(params={FUNCTION_OUTPUT_TYPE:FunctionOutputType.RAW_NUMBER}),
+                 function=None,
                  weight=None,
                  exponent=None,
                  gating_signal_params:tc.optional(dict)=None,

--- a/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
@@ -329,7 +329,7 @@ class ComparatorMechanism(ObjectiveMechanism):
                  default_variable=None,
                  sample: tc.optional(tc.any(OutputPort, Mechanism_Base, dict, is_numeric, str))=None,
                  target: tc.optional(tc.any(OutputPort, Mechanism_Base, dict, is_numeric, str))=None,
-                 function=LinearCombination(weights=[[-1], [1]]),
+                 function=None,
                  output_ports:tc.optional(tc.any(str, Iterable)) = None,
                  params=None,
                  name=None,

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -336,7 +336,6 @@ import typecheck as tc
 from psyneulink.core.components.functions.function import is_function_type
 from psyneulink.core.components.functions.learningfunctions import ContrastiveHebbian, Hebbian
 from psyneulink.core.components.functions.objectivefunctions import Distance
-from psyneulink.core.components.functions.statefulfunctions.integratorfunctions import AdaptiveIntegrator
 from psyneulink.core.components.functions.transferfunctions import Linear, get_matrix
 from psyneulink.core.components.mechanisms.mechanism import Mechanism
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
@@ -976,7 +975,7 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
                  matrix=HOLLOW_MATRIX,
                  auto=None,
                  hetero=None,
-                 integrator_function=AdaptiveIntegrator,
+                 integrator_function=None,
                  initial_value=None,
                  noise=0.0,
                  integration_rate: is_numeric_or_none=0.5,

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -194,7 +194,6 @@ from psyneulink.core.components.functions.function import Function, is_function_
 from psyneulink.core.components.functions.learningfunctions import Hebbian
 from psyneulink.core.components.functions.objectivefunctions import Stability
 from psyneulink.core.components.functions.transferfunctions import Linear, get_matrix
-from psyneulink.core.components.functions.statefulfunctions.integratorfunctions import AdaptiveIntegrator
 from psyneulink.core.components.functions.combinationfunctions import LinearCombination
 from psyneulink.core.components.functions.userdefinedfunction import UserDefinedFunction
 from psyneulink.core.components.mechanisms.modulatory.learning.learningmechanism import \
@@ -648,7 +647,7 @@ class RecurrentTransferMechanism(TransferMechanism):
                  auto=None,
                  hetero=None,
                  integrator_mode=False,
-                 integrator_function=AdaptiveIntegrator,
+                 integrator_function=None,
                  initial_value=None,
                  integration_rate: is_numeric_or_none=0.5,
                  noise=0.0,


### PR DESCRIPTION
`Parameter._user_specified` is meant to indicate whether the caller provided a value for a Parameter when constructing a Component. If a value other than None is used as a default value for an argument in __init__, `_user_specified` will always be True