### PR TITLE
OutputPort: do not share Function instances in standard_output_ports

### DIFF
--- a/psyneulink/core/components/mechanisms/processing/processingmechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/processingmechanism.py
@@ -155,15 +155,15 @@ class ProcessingMechanism_Base(Mechanism_Base):
                                   {NAME: MAX_ABS_VAL,
                                    FUNCTION:lambda x: np.max(np.absolute(x))},
                                   {NAME: MAX_ONE_HOT,
-                                   FUNCTION: OneHot(mode=MAX_VAL).function},
+                                   FUNCTION: OneHot(mode=MAX_VAL)},
                                   {NAME: MAX_ABS_ONE_HOT,
-                                   FUNCTION: OneHot(mode=MAX_ABS_VAL).function},
+                                   FUNCTION: OneHot(mode=MAX_ABS_VAL)},
                                   {NAME: MAX_INDICATOR,
-                                   FUNCTION: OneHot(mode=MAX_INDICATOR).function},
+                                   FUNCTION: OneHot(mode=MAX_INDICATOR)},
                                   {NAME: MAX_ABS_INDICATOR,
-                                   FUNCTION: OneHot(mode=MAX_ABS_INDICATOR).function},
+                                   FUNCTION: OneHot(mode=MAX_ABS_INDICATOR)},
                                   {NAME: PROB,
-                                   FUNCTION: SoftMax(output=PROB).function}])
+                                   FUNCTION: SoftMax(output=PROB)}])
     standard_output_port_names = [i['name'] for i in standard_output_ports]
 
     def __init__(self,

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -957,7 +957,7 @@ class TransferMechanism(ProcessingMechanism_Base):
     standard_output_ports = ProcessingMechanism_Base.standard_output_ports.copy()
     standard_output_ports.extend([{NAME: COMBINE,
                                    VARIABLE: OWNER_VALUE,
-                                   FUNCTION: LinearCombination(operation=SUM).function}])
+                                   FUNCTION: LinearCombination(operation=SUM)}])
     standard_output_port_names = ProcessingMechanism_Base.standard_output_port_names.copy()
     standard_output_port_names.extend([COMBINE])
 


### PR DESCRIPTION
Fixes bug where every OutputPort created from a given standard_output_ports template would share one Function instance.