### PR TITLE
travis: Bump llvm version to 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,9 +68,9 @@ before_install:
     if [ "$TRAVIS_CPU_ARCH" != "amd64" ]; then
       # There are a lot fewer wheels distributed for non-x86 architectures.
       # We end up building a lot of them locally, install dev packages
-      export EXTRA_PKGS="build-essential gfortran llvm-8-dev libfreetype6-dev libjpeg-dev liblapack-dev zlib1g-dev"
+      export EXTRA_PKGS="build-essential gfortran llvm-9-dev libfreetype6-dev libjpeg-dev liblapack-dev zlib1g-dev"
       # Export LLVM_CONFIG for llvmlite
-      export LLVM_CONFIG=llvm-config-8
+      export LLVM_CONFIG=llvm-config-9
       # Disable coverage
       export RUN_COV=""
     fi


### PR DESCRIPTION
llvmlite-33 requires llvm-9
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>