### PR TITLE
Enforce variable shape compatibility for Components and Function-Parameters

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1406,9 +1406,9 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             if default_variable is None or default_variable is NotImplemented:
                 return None
             else:
-                self._default_variable_flexibility = DefaultsFlexibility.RIGID
+                self._variable_shape_flexibility = DefaultsFlexibility.RIGID
         else:
-            self._default_variable_flexibility = DefaultsFlexibility.RIGID
+            self._variable_shape_flexibility = DefaultsFlexibility.RIGID
 
         return convert_to_np_array(default_variable, dimension=1)
 
@@ -1426,7 +1426,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             doing anything. Be aware that if size is NotImplemented, then variable is never cast to a particular shape.
         """
         if size is not NotImplemented:
-            self._default_variable_flexibility = DefaultsFlexibility.RIGID
+            self._variable_shape_flexibility = DefaultsFlexibility.RIGID
             # region Fill in and infer variable and size if they aren't specified in args
             # if variable is None and size is None:
             #     variable = self.class_defaults.variable
@@ -2550,12 +2550,12 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 owner_str = ''
                 if hasattr(self, 'owner') and self.owner is not None:
                     owner_str = f' of {repr(self.owner.name)}'
-                if function._default_variable_flexibility is DefaultsFlexibility.RIGID:
+                if function._variable_shape_flexibility is DefaultsFlexibility.RIGID:
                     raise ComponentError(f'Variable format ({function.defaults.variable}) of {function.name} '
                                          f'is not compatible with the variable format ({function_variable}) '
                                          f'of {repr(self.name)}{owner_str} to which it is being assigned.')
                                          # f'Make sure variable for {function.name} is 2d.')
-                elif function._default_variable_flexibility is DefaultsFlexibility.INCREASE_DIMENSION:
+                elif function._variable_shape_flexibility is DefaultsFlexibility.INCREASE_DIMENSION:
                     function_increased_dim = np.asarray([function.defaults.variable])
                     if not iscompatible(function_variable, function_increased_dim):
                         raise ComponentError(f'Variable format ({function.defaults.variable}) of {function.name} '
@@ -3168,16 +3168,16 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         return [param.name for param in self.parameters if param.loggable and param.user]
 
     @property
-    def _default_variable_flexibility(self):
+    def _variable_shape_flexibility(self):
         try:
-            return self.__default_variable_flexibility
+            return self.__variable_shape_flexibility
         except AttributeError:
-            self.__default_variable_flexibility = DefaultsFlexibility.FLEXIBLE
-            return self.__default_variable_flexibility
+            self.__variable_shape_flexibility = DefaultsFlexibility.FLEXIBLE
+            return self.__variable_shape_flexibility
 
-    @_default_variable_flexibility.setter
-    def _default_variable_flexibility(self, value):
-        self.__default_variable_flexibility = value
+    @_variable_shape_flexibility.setter
+    def _variable_shape_flexibility(self, value):
+        self.__variable_shape_flexibility = value
 
     @classmethod
     def get_constructor_defaults(cls):

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2552,7 +2552,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
 
         # Specification is an already implemented Function
         elif isinstance(function, Function):
-            if not iscompatible(function_variable, function.defaults.variable):
+            if function_variable.shape != function.defaults.variable.shape:
                 owner_str = ''
                 if hasattr(self, 'owner') and self.owner is not None:
                     owner_str = f' of {repr(self.owner.name)}'
@@ -2563,7 +2563,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                                          # f'Make sure variable for {function.name} is 2d.')
                 elif function._variable_shape_flexibility is DefaultsFlexibility.INCREASE_DIMENSION:
                     function_increased_dim = np.asarray([function.defaults.variable])
-                    if not iscompatible(function_variable, function_increased_dim):
+                    if function_variable.shape != function_increased_dim.shape:
                         raise ComponentError(f'Variable format ({function.defaults.variable}) of {function.name} '
                                              f'is not compatible with the variable format ({function_variable})'
                                              f' of {repr(self.name)}{owner_str} to which it is being assigned.')

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -875,6 +875,12 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         False otherwise
     """
 
+    _specified_variable_shape_flexibility = DefaultsFlexibility.RIGID
+    """
+        The `DefaultsFlexibility` ._variable_shape_flexibility takes on
+        when variable shape was manually specified
+    """
+
     class Parameters(ParametersBase):
         """
             The `Parameters` that are associated with all `Components`
@@ -1406,9 +1412,9 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             if default_variable is None or default_variable is NotImplemented:
                 return None
             else:
-                self._variable_shape_flexibility = DefaultsFlexibility.RIGID
+                self._variable_shape_flexibility = self._specified_variable_shape_flexibility
         else:
-            self._variable_shape_flexibility = DefaultsFlexibility.RIGID
+            self._variable_shape_flexibility = self._specified_variable_shape_flexibility
 
         return convert_to_np_array(default_variable, dimension=1)
 
@@ -1426,7 +1432,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             doing anything. Be aware that if size is NotImplemented, then variable is never cast to a particular shape.
         """
         if size is not NotImplemented:
-            self._variable_shape_flexibility = DefaultsFlexibility.RIGID
+            self._variable_shape_flexibility = self._specified_variable_shape_flexibility
             # region Fill in and infer variable and size if they aren't specified in args
             # if variable is None and size is None:
             #     variable = self.class_defaults.variable

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -669,6 +669,12 @@ class ComponentsMeta(ABCMeta):
             if not hasattr(self, param.name):
                 setattr(self, param.name, make_parameter_property(param.name))
 
+            try:
+                if param.default_value.owner is None:
+                    param.default_value.owner = param
+            except AttributeError:
+                pass
+
     # consider removing this for explicitness
     # but can be useful for simplicity
     @property
@@ -1106,7 +1112,10 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             self.defaults.variable = default_variable
             self.parameters.variable._user_specified = True
 
-        self.parameters.has_initializers._set(False, context)
+        # we must know the final variable shape before setting up parameter
+        # Functions or they will mismatch
+        self._instantiate_parameter_classes(context)
+        self._validate_subfunctions()
 
         if reset_stateful_function_when is not None:
             self.reset_stateful_function_when = reset_stateful_function_when
@@ -1850,13 +1859,29 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                                       context=context)
 
     def _initialize_parameters(self, context=None, **param_defaults):
+        from psyneulink.core.components.shellclasses import (
+            Composition_Base, Function, Mechanism, Port, Process_Base,
+            Projection, System_Base
+        )
+
+        # excludes Function
+        shared_types = (
+            Mechanism,
+            Port,
+            Projection,
+            System_Base,
+            Process_Base,
+            Composition_Base,
+            ComponentsMeta,
+            types.MethodType
+        )
         alias_names = {p.name for p in self.class_parameters if isinstance(p, ParameterAlias)}
 
         self.parameters = self.Parameters(owner=self, parent=self.class_parameters)
 
         # assign defaults based on pass in params and class defaults
         defaults = {
-            k: copy.deepcopy(v) for (k, v) in self.class_defaults.values(show_all=True).items()
+            k: v for (k, v) in self.class_defaults.values(show_all=True).items()
             if not k in alias_names
         }
 
@@ -1878,32 +1903,37 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             for p in d:
                 try:
                     parameter_obj = getattr(self.parameters, p)
-                    if parameter_obj.structural:
-                        parameter_obj.spec = d[p]
-
-                    if parameter_obj.modulable:
-                        # later, validate this
-                        try:
-                            modulable_param_parser = self.parameters._get_prefixed_method(
-                                parse=True,
-                                modulable=True
-                            )
-                            parsed = modulable_param_parser(p, d[p])
-
-                            if parsed is not d[p]:
-                                # we have a modulable param spec
-                                parameter_obj.spec = d[p]
-                                d[p] = parsed
-                                param_defaults[p] = parsed
-                        except AttributeError:
-                            pass
-
-                    d[p] = copy_parameter_value(d[p])
                 except AttributeError:
                     # p in param_defaults does not correspond to a Parameter
-                    pass
+                    continue
+
+                if parameter_obj.structural:
+                    parameter_obj.spec = d[p]
+
+                if parameter_obj.modulable:
+                    # later, validate this
+                    try:
+                        modulable_param_parser = self.parameters._get_prefixed_method(
+                            parse=True,
+                            modulable=True
+                        )
+                        parsed = modulable_param_parser(p, d[p])
+
+                        if parsed is not d[p]:
+                            # we have a modulable param spec
+                            parameter_obj.spec = d[p]
+                            d[p] = parsed
+                            param_defaults[p] = parsed
+                    except AttributeError:
+                        pass
 
             defaults.update(d)
+
+        for k in defaults:
+            defaults[k] = copy_parameter_value(
+                defaults[k],
+                shared_types=shared_types
+            )
 
         self.defaults = Defaults(owner=self, **defaults)
 
@@ -1935,17 +1965,31 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
 
             # copy spec so it is not overwritten later
             # TODO: check if this is necessary
-            if not isinstance(p.spec, (Component, ComponentsMeta)):
-                p.spec = copy_parameter_value(p.spec)
+            p.spec = copy_parameter_value(p.spec)
 
             # set default to None context to ensure it exists
             if p.getter is None and p._get(context) is None:
                 if p._user_specified:
                     val = param_defaults[p.name]
+
+                    if isinstance(val, Function):
+                        if val.owner is not None:
+                            val = copy.deepcopy(val)
+
+                        val.owner = self
                 else:
-                    val = copy_parameter_value(p.default_value)
+                    val = copy_parameter_value(
+                        p.default_value,
+                        shared_types=shared_types
+                    )
+
+                    if isinstance(val, Function):
+                        val.owner = self
 
                 p.set(val, context=context, skip_history=True, override=True)
+
+            if isinstance(p.default_value, Function):
+                p.default_value.owner = p
 
     def _instantiate_parameter_classes(self, context=None):
         """
@@ -1960,10 +2004,66 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 val = p._get(context)
                 if (
                     p.name != FUNCTION
-                    and inspect.isclass(val)
-                    and issubclass(val, Function)
+                    and not p.reference
                 ):
-                    p._set(val(), context)
+                    if (
+                        inspect.isclass(val)
+                        and issubclass(val, Function)
+                    ):
+                        val = val()
+                        val.owner = self
+                        p._set(val, context)
+
+        self._update_parameter_class_variables(context)
+
+    def _update_parameter_class_variables(self, context=None):
+        from psyneulink.core.components.shellclasses import Function
+        for p in self.parameters:
+            if p.getter is None:
+                val = p._get(context)
+                if (
+                    p.name != FUNCTION
+                    and not p.reference
+                    and isinstance(val, Function)
+                ):
+                    try:
+                        parse_variable_method = getattr(
+                            self,
+                            f'_parse_{p.name}_variable'
+                        )
+                        function_default_variable = copy.deepcopy(
+                            parse_variable_method(self.defaults.variable)
+                        )
+                    except AttributeError:
+                        # no parsing method, assume same shape as owner
+                        function_default_variable = copy.deepcopy(
+                            self.defaults.variable
+                        )
+
+                    incompatible = False
+
+                    if function_default_variable.shape != val.defaults.variable.shape:
+                        incompatible = True
+                        if val._variable_shape_flexibility is DefaultsFlexibility.INCREASE_DIMENSION:
+                            increased_dim = np.asarray([val.defaults.variable])
+
+                            if increased_dim.shape == function_default_variable.shape:
+                                function_default_variable = increased_dim
+                                incompatible = False
+                        elif val._variable_shape_flexibility is DefaultsFlexibility.FLEXIBLE:
+                            incompatible = False
+
+                    if not incompatible:
+                        val._update_default_variable(
+                            function_default_variable,
+                            context
+                        )
+
+                        if isinstance(p.default_value, Function):
+                            p.default_value._update_default_variable(
+                                function_default_variable,
+                                context
+                            )
 
     @handle_external_context()
     def reset_params(self, mode=ResetMode.INSTANCE_TO_CLASS, context=None):
@@ -2384,6 +2484,48 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 raise ComponentError("Value of {} param for {} ({}) is not compatible with {}".
                                     format(param_name, self.name, param_value, type_name))
 
+    def _validate_subfunctions(self):
+        from psyneulink.core.components.shellclasses import Function
+
+        for p in self.parameters:
+            if (
+                p.name != FUNCTION  # has specialized validation
+                and isinstance(p.default_value, Function)
+                and not p.reference
+                and not p.function_parameter
+            ):
+                # TODO: assert it's not stateful?
+                function_variable = p.default_value.defaults.variable
+                expected_function_variable = self.defaults.variable
+
+                try:
+                    parse_variable_method = getattr(
+                        self,
+                        f'_parse_{p.name}_variable'
+                    )
+                    expected_function_variable = parse_variable_method(
+                        expected_function_variable
+                    )
+
+                except AttributeError:
+                    pass
+
+                if not function_variable.shape == expected_function_variable.shape:
+                    def _create_justified_line(k, v, error_line_len=110):
+                        return f'{k}: {v.rjust(error_line_len - len(k))}'
+
+                    raise ParameterError(
+                        f'Variable shape incompatibility between {self} and its {p.name} Parameter'
+                        + _create_justified_line(
+                            f'\n{self}.variable',
+                            f'{expected_function_variable}    (numpy.array shape: {np.asarray(expected_function_variable).shape})'
+                        )
+                        + _create_justified_line(
+                            f'\n{self}.{p.name}.variable',
+                            f'{function_variable}    (numpy.array shape: {np.asarray(function_variable).shape})'
+                        )
+                    )
+
     def _get_param_value_for_modulatory_spec(self, param_name, param_value):
         from psyneulink.core.globals.keywords import MODULATORY_SPEC_KEYWORDS
         if isinstance(param_value, str):
@@ -2572,8 +2714,29 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             # class default functions should always be copied, otherwise anything this component
             # does with its function will propagate to anything else that wants to use
             # the default
-            if function.owner is None and not function.is_pnl_inherent:
+            if function.owner is None:
                 self.function = function
+            elif function.owner is self:
+                try:
+                    if function._is_pnl_inherent:
+                        # This will most often occur if a Function instance is
+                        # provided as a default argument in a constructor. These
+                        # should instead be added as default values for the
+                        # corresponding Parameter.
+                        # Adding the function as a default constructor argument
+                        # will lead to incorrect setting of
+                        # Parameter._user_specified
+                        warnings.warn(
+                            f'{function} is generated once during import of'
+                            ' psyneulink, and is now being reused. Please report'
+                            ' this, including the script you were using, to the'
+                            ' psyneulink developers at'
+                            ' psyneulinkhelp@princeton.edu or'
+                            ' https://github.com/PrincetonUniversity/PsyNeuLink/issues'
+                        )
+                        self.function = copy.deepcopy(function)
+                except AttributeError:
+                    self.function = function
             else:
                 self.function = copy.deepcopy(function)
 

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -575,11 +575,6 @@ class Function_Base(Function):
             pass
         return new
 
-    def _initialize_parameters(self, context=None, **param_defaults):
-        super()._initialize_parameters(context=context, **param_defaults)
-        # instantiate auxiliary Functions
-        self._instantiate_parameter_classes(context)
-
     @handle_external_context()
     def function(self,
                  variable=None,

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -148,7 +148,7 @@ from enum import Enum, IntEnum
 import numpy as np
 import typecheck as tc
 
-from psyneulink.core.components.component import ComponentError
+from psyneulink.core.components.component import ComponentError, DefaultsFlexibility
 from psyneulink.core.components.shellclasses import Function, Mechanism
 from psyneulink.core.globals.context import Context, ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import (
@@ -476,6 +476,8 @@ class Function_Base(Function):
     classPreferenceLevel = PreferenceLevel.CATEGORY
 
     _model_spec_id_parameters = 'args'
+
+    _specified_variable_shape_flexibility = DefaultsFlexibility.INCREASE_DIMENSION
 
     class Parameters(Function.Parameters):
         """

--- a/psyneulink/core/components/functions/learningfunctions.py
+++ b/psyneulink/core/components/functions/learningfunctions.py
@@ -37,7 +37,7 @@ from psyneulink.core.globals.keywords import \
     MSE, SSE
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
-from psyneulink.core.globals.utilities import is_numeric, scalar_distance, get_global_seed
+from psyneulink.core.globals.utilities import is_numeric, scalar_distance, get_global_seed, convert_to_np_array
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 
 __all__ = ['LearningFunction', 'Kohonen', 'Hebbian', 'ContrastiveHebbian',
@@ -1351,7 +1351,7 @@ class ContrastiveHebbian(LearningFunction):  # ---------------------------------
 
         # Generate the column array from the variable
         # col = variable.reshape(len(variable),1)
-        col = np.atleast_2d(variable).transpose()
+        col = convert_to_np_array(variable, 2).transpose()
 
         # Calculate weight chhange matrix
         weight_change_matrix = variable * col

--- a/psyneulink/core/components/functions/objectivefunctions.py
+++ b/psyneulink/core/components/functions/objectivefunctions.py
@@ -240,7 +240,7 @@ class Stability(ObjectiveFunction):
         )
 
         # MODIFIED 6/12/19 NEW: [JDC]
-        self._default_variable_flexibility = DefaultsFlexibility.FLEXIBLE
+        self._variable_shape_flexibility = DefaultsFlexibility.FLEXIBLE
         # MODIFIED 6/12/19 END
 
     def _validate_variable(self, variable, context=None):

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -841,6 +841,7 @@ class GradientOptimization(OptimizationFunction):
         annealing_function = Parameter(None, stateful=False, loggable=False)
         convergence_threshold = Parameter(.001, modulable=True)
         max_iterations = Parameter(1000, modulable=True)
+        search_space = Parameter([SampleIterator([0, 0])], stateful=False, loggable=False)
 
         direction = ASCENT
         convergence_criterion = Parameter(VALUE, pnl_internal=True)

--- a/psyneulink/core/components/functions/selectionfunctions.py
+++ b/psyneulink/core/components/functions/selectionfunctions.py
@@ -216,10 +216,10 @@ class OneHot(SelectionFunction):
 
         random_state = np.random.RandomState([seed])
 
-        reset_default_variable_flexibility = False
+        reset_variable_shape_flexibility = False
         if mode in {PROB, PROB_INDICATOR} and default_variable is None:
             default_variable = [[0], [0]]
-            reset_default_variable_flexibility = True
+            reset_variable_shape_flexibility = True
 
         super().__init__(
             default_variable=default_variable,
@@ -230,8 +230,8 @@ class OneHot(SelectionFunction):
             prefs=prefs,
         )
 
-        if reset_default_variable_flexibility:
-            self._default_variable_flexibility = DefaultsFlexibility.FLEXIBLE
+        if reset_variable_shape_flexibility:
+            self._variable_shape_flexibility = DefaultsFlexibility.FLEXIBLE
 
     def _validate_params(self, request_set, target_set=None, context=None):
 

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -1076,7 +1076,7 @@ class AdaptiveIntegrator(IntegratorFunction):  # -------------------------------
                     #       object to which the function parameter belongs (e.g., the IntegratorMechanism);
                     #       in that case, the IntegratorFunction gets instantiated using its class_defaults.variable ([[0]])
                     #       before the object itself, thus does not see the array specification for the input.
-                    if self._default_variable_flexibility is DefaultsFlexibility.FLEXIBLE:
+                    if self._variable_shape_flexibility is DefaultsFlexibility.FLEXIBLE:
                         self._instantiate_defaults(variable=np.zeros_like(np.array(rate)), context=context)
                         if self.verbosePref:
                             warnings.warn(
@@ -1605,7 +1605,7 @@ class DualAdaptiveIntegrator(IntegratorFunction):  # ---------------------------
                     #       object to which the function parameter belongs (e.g., the IntegratorMechanism);
                     #       in that case, the IntegratorFunction gets instantiated using its class_defaults.variable ([[0]]) before
                     #       the object itself, thus does not see the array specification for the input.
-                    if self._default_variable_flexibility is DefaultsFlexibility.FLEXIBLE:
+                    if self._variable_shape_flexibility is DefaultsFlexibility.FLEXIBLE:
                         self._instantiate_defaults(variable=np.zeros_like(np.array(rate)), context=context)
                         if self.verbosePref:
                             warnings.warn(

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -263,6 +263,13 @@ class IntegratorFunction(StatefulFunction):  # ---------------------------------
                         _instantiate_attributes_before_function below
         """
 
+
+        super()._validate_params(
+            request_set=request_set,
+            target_set=target_set,
+            context=context
+        )
+
         # Use dict to be able to report names of params that are in violating set
         params_to_check = {}
 
@@ -284,16 +291,12 @@ class IntegratorFunction(StatefulFunction):  # ---------------------------------
             if violators:
                 raise FunctionError(f"The following parameters with len>1 specified for {self.name} "
                                     f"don't have the same length as its {repr(DEFAULT_VARIABLE)} "
-                                    f"({default_variable_len}): {violators}.")
+                                    f"({default_variable_len}): {violators}.", component=self)
 
         # Check that all function_arg params with length > 1 have the same length
         elif any(len(v)!=len(values[0]) for v in values):
             raise FunctionError(f"The parameters with len>1 specified for {self.name} "
                                 f"({list(params_to_check.keys())}) don't all have the same length")
-
-        super()._validate_params(request_set=request_set,
-                         target_set=target_set,
-                         context=context)
     # MODIFIED 6/21/19 END
 
     # MODIFIED 6/21/19 NEW: [JDC]
@@ -1062,6 +1065,11 @@ class AdaptiveIntegrator(IntegratorFunction):  # -------------------------------
         self.has_initializers = True
 
     def _validate_params(self, request_set, target_set=None, context=None):
+        super()._validate_params(
+            request_set=request_set,
+            target_set=target_set,
+            context=context
+        )
 
         # Handle list or array for rate specification
         if RATE in request_set:
@@ -1090,11 +1098,6 @@ class AdaptiveIntegrator(IntegratorFunction):  # -------------------------------
                             f"The length ({len(rate)}) of the array specified for the rate parameter ({rate}) "
                             f"of {self.name} must match the length ({np.array(self.defaults.variable).size}) "
                             f"of the default input ({self.defaults.variable}).")
-
-        super()._validate_params(request_set=request_set,
-                                 target_set=target_set,
-                                 context=context)
-
 
         # FIX: 12/9/18 [JDC] REPLACE WITH USE OF all_within_range
         if self.parameters.rate._user_specified:

--- a/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
+++ b/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
@@ -262,7 +262,7 @@ class StatefulFunction(Function_Base): #  --------------------------------------
                     #       object to which the function parameter belongs (e.g., the IntegratorMechanism); in that
                     #       case, the StatefulFunction gets instantiated using its class_defaults.variable ([[0]]) before
                     #       the object itself, thus does not see the array specification for the input.
-                    if self._default_variable_flexibility is DefaultsFlexibility.FLEXIBLE:
+                    if self._variable_shape_flexibility is DefaultsFlexibility.FLEXIBLE:
                         self._instantiate_defaults(variable=np.zeros_like(np.array(rate)), context=context)
                         if self.verbosePref:
                             warnings.warn(
@@ -335,7 +335,7 @@ class StatefulFunction(Function_Base): #  --------------------------------------
 
             if isinstance(rate, np.ndarray) and not iscompatible(rate, self.defaults.variable):
                 if len(rate) != 1 and len(rate) != np.array(self.defaults.variable).size:
-                    if self._default_variable_flexibility is DefaultsFlexibility.FLEXIBLE:
+                    if self._variable_shape_flexibility is DefaultsFlexibility.FLEXIBLE:
                         self.defaults.variable = np.zeros_like(np.array(rate))
                         if self.verbosePref:
                             warnings.warn(
@@ -350,7 +350,7 @@ class StatefulFunction(Function_Base): #  --------------------------------------
                                 self.defaults.variable,
                             )
                         self._instantiate_value()
-                        self._default_variable_flexibility = DefaultsFlexibility.INCREASE_DIMENSION
+                        self._variable_shape_flexibility = DefaultsFlexibility.INCREASE_DIMENSION
                     else:
                         raise FunctionError(
                             "The length of the array specified for the rate parameter of {} ({})"

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -3755,7 +3755,7 @@ class TransferWithCosts(TransferFunction):
         )
 
         # # MODIFIED 6/12/19 NEW: [JDC]
-        # self._default_variable_flexibility = DefaultsFlexibility.FLEXIBLE
+        # self._variable_shape_flexibility = DefaultsFlexibility.FLEXIBLE
         # # MODIFIED 6/12/19 END
 
     def _instantiate_attributes_before_function(self, function=None, context=None):

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -736,7 +736,7 @@ class DefaultAllocationFunction(Function_Base):
         result = np.array([variable[0]] * num_ctl_sigs)
         return self.convert_output_type(result)
 
-    def reset(self, *args, context=None):
+    def reset(self, *args, force=False, context=None):
         # Override Component.reset which requires that the Component is stateful
         pass
 
@@ -1695,7 +1695,7 @@ class ControlMechanism(ModulatoryMechanism_Base):
         based on specified `control_allocation <ControlMechanism.control_allocation>`
         (used by controller of a Composition in simulations)
         """
-        value = [np.atleast_1d(a) for a in control_allocation]
+        value = [a for a in control_allocation]
         self.parameters.value._set(value, context)
         self._update_output_ports(runtime_params, context)
 

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -833,7 +833,7 @@ class OptimizationControlMechanism(ControlMechanism):
         # Workaround this issue here, and explicitly allow the function's
         # default variable to be modified
         if isinstance(function, Function):
-            function._default_variable_flexibility = DefaultsFlexibility.FLEXIBLE
+            function._variable_shape_flexibility = DefaultsFlexibility.FLEXIBLE
 
         super()._instantiate_function(function, function_params, context)
 

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -680,7 +680,7 @@ class OptimizationControlMechanism(ControlMechanism):
                     :type:
         """
         function = Parameter(None, stateful=False, loggable=False)
-        feature_function = Parameter(None, stateful=False, loggable=False)
+        feature_function = Parameter(None, reference=True, stateful=False, loggable=False)
         search_function = Parameter(None, stateful=False, loggable=False)
         search_termination_function = Parameter(None, stateful=False, loggable=False)
         comp_execution_mode = Parameter('Python', stateful=False, loggable=False, pnl_internal=True)

--- a/psyneulink/core/components/ports/inputport.py
+++ b/psyneulink/core/components/ports/inputport.py
@@ -909,9 +909,9 @@ class InputPort(Port_Base):
         self._use_1d_variable = False
         if not isinstance(self.function, CombinationFunction):
             self._use_1d_variable = True
-            self.function._default_variable_flexibility = DefaultsFlexibility.RIGID
+            self.function._variable_shape_flexibility = DefaultsFlexibility.RIGID
         else:
-            self.function._default_variable_flexibility = DefaultsFlexibility.FLEXIBLE
+            self.function._variable_shape_flexibility = DefaultsFlexibility.FLEXIBLE
 
     def _instantiate_projections(self, projections, context=None):
         """Instantiate Projections specified in PROJECTIONS entry of params arg of Port's constructor

--- a/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
@@ -428,7 +428,7 @@ from psyneulink.core.globals.sampleiterator import is_sample_spec
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import \
-    is_numeric, iscompatible, kwCompatibilityLength, kwCompatibilityNumeric, kwCompatibilityType
+    is_numeric, iscompatible, kwCompatibilityLength, kwCompatibilityNumeric, kwCompatibilityType, convert_all_elements_to_np_array
 from psyneulink.core.globals.sampleiterator import SampleSpec, SampleIterator
 
 __all__ = ['ControlSignal', 'ControlSignalError', 'COST_OPTIONS']
@@ -852,6 +852,21 @@ class ControlSignal(ModulatorySignal):
         # invalid. Is it that tc.typecheck only runs if an argument is specified at
         # construction?
         # _validate_modulation = get_validator_by_function(_is_modulation_param)
+
+        def _validate_allocation_samples(self, allocation_samples):
+            try:
+                samples_as_array = convert_all_elements_to_np_array(allocation_samples)
+                first_item_type = type(allocation_samples[0])
+                first_item_shape = samples_as_array[0].shape
+
+                for i in range(1, len(allocation_samples)):
+                    if not isinstance(allocation_samples[i], first_item_type):
+                        return 'all items must have the same type'
+                    if not samples_as_array[i].shape == first_item_shape:
+                        return 'all items must have the same shape'
+            except (TypeError, IndexError):
+                # not iterable, so assume single value
+                pass
 
     portAttributes = ModulatorySignal.portAttributes | {ALLOCATION_SAMPLES,
                                                           COST_OPTIONS,

--- a/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
@@ -777,6 +777,7 @@ class ControlSignal(ModulatorySignal):
             Linear,
             stateful=False,
             loggable=False,
+            function_parameter=True
         )
 
         value = Parameter(
@@ -794,33 +795,53 @@ class ControlSignal(ModulatorySignal):
             setter=_cost_options_setter,
             valid_types=(CostFunctions, list)
         )
-        intensity_cost = Parameter(None, read_only=True, getter=_intensity_cost_getter)
-        adjustment_cost = Parameter(0, read_only=True, getter=_adjustment_cost_getter)
-        duration_cost = Parameter(0, read_only=True, getter=_duration_cost_getter)
+        intensity_cost = Parameter(
+            None,
+            read_only=True,
+            getter=_intensity_cost_getter,
+            function_parameter=True
+        )
+        adjustment_cost = Parameter(
+            0,
+            read_only=True,
+            getter=_adjustment_cost_getter,
+            function_parameter=True
+        )
+        duration_cost = Parameter(
+            0,
+            read_only=True,
+            getter=_duration_cost_getter,
+            function_parameter=True
+        )
+
         cost = Parameter(None, read_only=True, getter=_cost_getter)
 
         intensity_cost_function = Parameter(
             Exponential,
             stateful=False,
             loggable=False,
+            function_parameter=True,
             getter=_intensity_cost_function_getter
         )
         adjustment_cost_function = Parameter(
             Linear,
             stateful=False,
             loggable=False,
+            function_parameter=True,
             getter=_adjustment_cost_function_getter
         )
         duration_cost_function = Parameter(
             SimpleIntegrator,
             stateful=False,
             loggable=False,
+            function_parameter=True,
             getter=_duration_cost_function_getter
         )
         combine_costs_function = Parameter(
             Reduce(operation=SUM),
             stateful=False,
             loggable=False,
+            function_parameter=True,
             getter=_combine_costs_function_getter
         )
         _validate_intensity_cost_function = get_validator_by_function(is_function_type)

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -1499,10 +1499,10 @@ class Port_Base(Port):
                     self.defaults.variable = np.append(variable, np.atleast_2d(projection.defaults.value), axis=0)
 
                 # assign identical default variable to function if it can be modified
-                if self.function._default_variable_flexibility is DefaultsFlexibility.FLEXIBLE:
+                if self.function._variable_shape_flexibility is DefaultsFlexibility.FLEXIBLE:
                     self.function.defaults.variable = self.defaults.variable.copy()
                 elif (
-                    self.function._default_variable_flexibility is DefaultsFlexibility.INCREASE_DIMENSION
+                    self.function._variable_shape_flexibility is DefaultsFlexibility.INCREASE_DIMENSION
                     and np.array([self.function.defaults.variable]).shape == self.defaults.variable.shape
                 ):
                     self.function.defaults.variable = np.array([self.defaults.variable])

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -1116,11 +1116,6 @@ class Port_Base(Port):
         if context.source == ContextFlags.COMMAND_LINE:
             owner.add_ports([self])
 
-    def _initialize_parameters(self, context=None, **param_defaults):
-        super()._initialize_parameters(context=context, **param_defaults)
-        # instantiate auxiliary Functions
-        self._instantiate_parameter_classes(context)
-
     def _handle_size(self, size, variable):
         """Overwrites the parent method in Component.py, because the variable of a Port
             is generally 1D, rather than 2D as in the case of Mechanisms

--- a/psyneulink/core/components/projections/modulatory/learningprojection.py
+++ b/psyneulink/core/components/projections/modulatory/learningprojection.py
@@ -426,8 +426,8 @@ class LearningProjection(ModulatoryProjection_Base):
         """
         value = Parameter(np.array([0]), read_only=True, aliases=['weight_change_matrix'], pnl_internal=True)
         function = Parameter(Linear, stateful=False, loggable=False)
-        error_function = Parameter(LinearCombination(weights=[[-1], [1]]), stateful=False, loggable=False)
-        learning_function = Parameter(BackPropagation, stateful=False, loggable=False)
+        error_function = Parameter(LinearCombination(weights=[[-1], [1]]), stateful=False, loggable=False, reference=True)
+        learning_function = Parameter(BackPropagation, stateful=False, loggable=False, reference=True)
         learning_rate = Parameter(None, modulable=True)
         learning_signal = Parameter(None, read_only=True,
                                     getter=_learning_signal_getter,

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -664,6 +664,18 @@ class Parameter(types.SimpleNamespace):
 
             :default: None
 
+        reference
+            if False, the Parameter is not used in computation for its
+            owning Component. Instead, it is just meant to store a value
+            that may be used to initialize other Components
+
+            :default: False
+
+            :Developer Notes: Parameters with Function values marked as
+            reference will not be automatically instantiated in
+            _instantiate_parameter_classes or validated for variable
+            shape
+
     """
     # The values of these attributes will never be inherited from parent Parameters
     # KDM 7/12/18: consider inheriting ONLY default_value?
@@ -723,6 +735,7 @@ class Parameter(types.SimpleNamespace):
         spec=None,
         parse_spec=False,
         valid_types=None,
+        reference=False,
         _owner=None,
         _inherited=False,
         # this stores a reference to the Parameter object that is the
@@ -777,6 +790,7 @@ class Parameter(types.SimpleNamespace):
             spec=spec,
             parse_spec=parse_spec,
             valid_types=valid_types,
+            reference=reference,
             _inherited=_inherited,
             _inherited_source=_inherited_source,
             _user_specified=_user_specified,

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1153,7 +1153,7 @@ class DDM(ProcessingMechanism):
         return mech_out, builder
 
     @handle_external_context(execution_id=NotImplemented)
-    def reset(self, *args, context=None):
+    def reset(self, *args, force=False, context=None):
         from psyneulink.core.components.functions.statefulfunctions.integratorfunctions import IntegratorFunction
 
         if context.execution_id is NotImplemented:

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -1236,7 +1236,7 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
                 # Use initial_value attribute to initialize, for the minus phase,
                 #    both the integrator_function's previous_value
                 #    and the Mechanism's current activity (which is returned as its input)
-                if not self.continuous:
+                if not self.continuous and self.parameters.integrator_mode._get(context):
                     self.reset(self.initial_value, context=context)
                     self.parameters.current_activity._set(self.parameters.initial_value._get(context), context)
                 self.parameters.current_termination_threshold._set(self.plus_phase_termination_threshold, context)
@@ -1252,6 +1252,10 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
     def _parse_function_variable(self, variable, context=None):
         function_variable = self.combination_function(variable=variable, context=context)
         return super(RecurrentTransferMechanism, self)._parse_function_variable(function_variable, context=context)
+
+    def _parse_phase_convergence_function_variable(self, variable):
+        # determines shape only
+        return np.asarray([variable[0], variable[0]])
 
     def combination_function(self, variable=None, context=None):
         # IMPLEMENTATION NOTE: use try and except here for efficiency: care more about execution than initialization

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -331,6 +331,7 @@ Class Reference
 
 from collections.abc import Iterable
 
+import copy
 import numpy as np
 import typecheck as tc
 from psyneulink.core.components.functions.function import get_matrix, is_function_type
@@ -1120,6 +1121,12 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
             plus_phase_activity=self.input_ports[RECURRENT].socket_template,
             execution_phase=None,
         )
+        self.defaults.initial_value = copy.deepcopy(self.input_ports[RECURRENT].socket_template)
+        self.defaults.current_activity = copy.deepcopy(self.input_ports[RECURRENT].socket_template)
+        self.defaults.minus_phase_activity = copy.deepcopy(self.input_ports[RECURRENT].socket_template)
+        self.defaults.plus_phase_activity = copy.deepcopy(self.input_ports[RECURRENT].socket_template)
+        self.defaults.execution_phase = None
+
         if self._target_included:
             self.parameters.output_activity._set(self.input_ports[TARGET].socket_template, context)
 

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -931,7 +931,12 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
 
         minus_phase_termination_condition = Parameter(CONVERGENCE, stateful=False, loggable=False)
         plus_phase_termination_condition = Parameter(CONVERGENCE, stateful=False, loggable=False)
-        learning_function = Parameter(ContrastiveHebbian, stateful=False, loggable=False)
+        learning_function = Parameter(
+            ContrastiveHebbian,
+            stateful=False,
+            loggable=False,
+            reference=True
+        )
         max_passes = Parameter(1000, stateful=False)
 
         output_activity = Parameter(None, read_only=True, getter=_CHM_output_activity_getter)

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -1106,6 +1106,23 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
         if self._target_included:
             self.input_ports[TARGET].internal_only = True
 
+    def _instantiate_attributes_before_function(self, function=None, context=None):
+        super()._instantiate_attributes_before_function(function=function, context=context)
+
+        # Set minus_phase activity, plus_phase, current_activity and initial_value
+        #    all  to zeros with size of Mechanism's array
+        # Should be OK to use attributes here because initialization should only occur during None context
+        self._set_multiple_parameter_values(
+            context,
+            initial_value=self.input_ports[RECURRENT].socket_template,
+            current_activity=self.input_ports[RECURRENT].socket_template,
+            minus_phase_activity=self.input_ports[RECURRENT].socket_template,
+            plus_phase_activity=self.input_ports[RECURRENT].socket_template,
+            execution_phase=None,
+        )
+        if self._target_included:
+            self.parameters.output_activity._set(self.input_ports[TARGET].socket_template, context)
+
     @tc.typecheck
     def _instantiate_recurrent_projection(self,
                                           mech: Mechanism,
@@ -1131,21 +1148,6 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
                  function_variable=None,
                  runtime_params=None,
                  ):
-
-        if self.initialization_status == ContextFlags.INITIALIZING:
-            # Set minus_phase activity, plus_phase, current_activity and initial_value
-            #    all  to zeros with size of Mechanism's array
-            # Should be OK to use attributes here because initialization should only occur during None context
-            self._set_multiple_parameter_values(
-                context,
-                initial_value=self.input_ports[RECURRENT].socket_template,
-                current_activity=self.input_ports[RECURRENT].socket_template,
-                minus_phase_activity=self.input_ports[RECURRENT].socket_template,
-                plus_phase_activity=self.input_ports[RECURRENT].socket_template,
-                execution_phase=None,
-            )
-            if self._target_included:
-                self.parameters.output_activity._set(self.input_ports[TARGET].socket_template, context)
 
         # Initialize execution_phase as minus_phase
         if self.parameters.execution_phase._get(context) is None:

--- a/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
@@ -254,7 +254,12 @@ class KohonenMechanism(TransferMechanism):
                     :type: ``list``
                     :read only: True
         """
-        learning_function = Parameter(Kohonen(distance_function=GAUSSIAN), stateful=False, loggable=False)
+        learning_function = Parameter(
+            Kohonen(distance_function=GAUSSIAN),
+            stateful=False,
+            loggable=False,
+            reference=True
+        )
         learning_rate = Parameter(None, modulable=True)
         enable_learning = True
         matrix = DEFAULT_MATRIX

--- a/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
@@ -568,13 +568,11 @@ class LCAMechanism(RecurrentTransferMechanism):
 
         # if not self.integrator_function:
         if self.initialization_status == ContextFlags.INITIALIZING:
-            self.integrator_function = LeakyCompetingIntegrator(
-                function_variable,
-                initializer=initial_value,
-                noise=noise,
-                time_step_size=time_step_size,
-                leak=leak,
-                owner=self)
+            self.integrator_function.parameters.initializer._set(initial_value, context)
+            self.integrator_function.parameters.previous_value._set(initial_value, context)
+            self.integrator_function.parameters.noise._set(noise, context)
+            self.integrator_function.parameters.time_step_size._set(time_step_size, context)
+            self.integrator_function.parameters.leak._set(leak, context)
 
         current_input = self.integrator_function._execute(
             function_variable,

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -972,6 +972,11 @@ class RecurrentTransferMechanism(TransferMechanism):
             self.recurrent_projection = self._instantiate_recurrent_projection(self,
                                                                                matrix=self.matrix,
                                                                                context=context)
+
+            # creating a recurrent_projection changes the default variable shape
+            # so we have to reshape any Paramter Functions
+            self._update_parameter_class_variables(context)
+
         self.aux_components.append(self.recurrent_projection)
 
         if self.learning_enabled:
@@ -1228,9 +1233,8 @@ class RecurrentTransferMechanism(TransferMechanism):
         return super()._get_variable_from_input(input, context)
 
     @handle_external_context(execution_id=NotImplemented)
-    def reset(self, *args, context=None):
-        if self.parameters.integrator_mode.get(context):
-            super().reset(*args, context=context)
+    def reset(self, *args, force=False, context=None):
+        super().reset(*args, force=force, context=context)
         self.parameters.value.clear_history(context)
 
     @property

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -624,7 +624,14 @@ class RecurrentTransferMechanism(TransferMechanism):
         noise = Parameter(0.0, modulable=True)
         smoothing_factor = Parameter(0.5, modulable=True)
         enable_learning = False
-        learning_function = Parameter(Hebbian, stateful=False, loggable=False)
+        # learning_function is a reference because it is used for
+        # an auxiliary learning mechanism
+        learning_function = Parameter(
+            Hebbian,
+            stateful=False,
+            loggable=False,
+            reference=True
+        )
         learning_rate = Parameter(None, setter=_recurrent_transfer_mechanism_learning_rate_setter)
         learning_condition = Parameter(None, stateful=False, loggable=False)
         has_recurrent_input_port = Parameter(None, stateful=False, loggable=False)

--- a/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
+++ b/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
@@ -260,7 +260,7 @@ class AutoAssociativeProjection(MappingProjection):
 
         auto = Parameter(1, getter=_auto_getter, setter=_auto_setter, modulable=True)
         hetero = Parameter(0, getter=_hetero_getter, setter=_hetero_setter, modulable=True)
-        matrix = Parameter(DEFAULT_MATRIX, function_parameter=True, getter=_matrix_getter, setter=_matrix_setter, modulable=True)
+        matrix = Parameter(DEFAULT_MATRIX, getter=_matrix_getter, setter=_matrix_setter, modulable=True)
 
     classPreferenceLevel = PreferenceLevel.TYPE
 

--- a/tests/functions/test_accumulator_integrator.py
+++ b/tests/functions/test_accumulator_integrator.py
@@ -152,7 +152,7 @@ class TestAccumulator():
         A()
         A()
         val = A()
-        assert np.allclose([[-0.43300219]], val)
+        assert np.allclose([[-0.34591555]], val)
 
     def test_accumulator_standalone_noise_function_in_array(self):
         A = AccumulatorIntegrator(noise=[10, NormalDist(standard_deviation=0.1), 20])

--- a/tests/functions/test_buffer.py
+++ b/tests/functions/test_buffer.py
@@ -82,8 +82,8 @@ class TestBuffer():
         B.execute([4, 5, 6])
         B.execute([7, 8, 9])
         val = B.execute([10,11,12])
-        assert np.allclose(deque(np.atleast_1d([[ 4.10105279, 5.34507377, 6.02430687],
-                                                [ 7.00103478, 8.09010473, 9.09586966],
+        assert np.allclose(deque(np.atleast_1d([[4.02430687, 4.91927251, 5.95087965],
+                                                [7.09586966, 7.91823773, 8.86077491],
                                                 [10, 11, 12]])), val)
         benchmark(B.execute, [1, 2, 3])
 

--- a/tests/functions/test_integrator.py
+++ b/tests/functions/test_integrator.py
@@ -29,11 +29,11 @@ def SimpleIntFun(init, value, iterations, noise, rate, offset, **kwargs):
                     4.2037768,  4.03845052, 4.39892272, 4.45597924, 3.99547688]
     elif isinstance(noise, pnl.DistributionFunction):
         if "initializer" in kwargs:
-            return [4.97918455, 5.93969152, 1.40175578, 2.44777247, 2.27219373,
-                    3.49115648, 0.74116762, 3.71299288, 3.21473103, 1.17786362]
+            return [6.07047464, 1.45183492, 2.13615798, 3.22296925, 3.29867927,
+                    0.9734048, 2.54011924, 3.21213761, 1.54651058, 2.7026355, ]
         else:
-            return [4.18745951, 5.4107966,  0.83371122, 1.52217583, 2.20115767,
-                    3.40402718, 0.72094922, 2.88037304, 2.43657428, 0.30785147]
+            return [5.2787496, 0.92294, 1.56811342, 2.29737262, 3.22764321,
+                    0.8862755, 2.51990084, 2.37951776, 0.76835383, 1.83262335]
     else:
         if "initializer" in kwargs:
             return [5.53160614, 4.86244369, 3.79932695, 5.06809088, 2.1305511,
@@ -53,11 +53,11 @@ def AdaptiveIntFun(init, value, iterations, noise, rate, offset, **kwargs):
                     3.18971771, 3.06427238, 3.33778941, 3.38108243, 3.03166509]
     elif isinstance(noise, pnl.DistributionFunction):
         if "initializer" in kwargs:
-            return [3.67089771, 4.18435033, 1.30397717, 1.80024477, 1.53349296,
-                    2.26605138, 0.90036311, 2.65296649, 1.92327214, 0.87106782]
+            return [4.18870661, 1.3561085, 1.69287182, 1.94643064, 2.12581409,
+                    1.05242466, 2.05628752, 1.90164378, 1.18394637, 1.39578569]
         else:
-            return [3.35596055, 3.97396333, 1.07801699, 1.43205537, 1.50523581,
-                    2.23139257, 0.89232051, 2.32176195, 1.61373227, 0.52498915]
+            return [3.87376946, 1.14572149, 1.46691163, 1.57824123, 2.09755694,
+                    1.01776584, 2.04824492, 1.57043925, 0.8744065, 1.04970702]
     else:
         if "initializer" in kwargs:
             return [3.91143701, 3.49857235, 2.67777415, 3.51140748, 1.59096419,
@@ -98,9 +98,9 @@ def LeakyFun(init, value, iterations, noise, **kwargs):
             return [2.93867224, 2.74475902, 2.74803958, 3.06104933, 2.23711905, 2.31689203, 2.19429898, 3.07659637, 3.04734388, 2.96259823]
     elif isinstance(noise, pnl.DistributionFunction):
         if "initializer" not in kwargs:
-            return [2.23227404, 2.6077243, 1.211716, 1.41726436, 1.60300815, 1.97791233, 1.16614943, 1.84495105, 1.6989461, 1.03445751]
+            return [2.55912037, 1.24455938, 1.43417309, 1.638423, 1.91298882, 1.22700281, 1.71226825, 1.67794471, 1.20395947, 1.48326449]
         else:
-            return [2.9628102, 3.09574331, 1.73585895, 2.27132579, 1.66855415, 2.0583078, 1.18480523, 2.61322145, 2.41696261, 1.83723032]
+            return [3.28965653, 1.73257839, 1.95831604, 2.49248443, 1.97853482, 1.30739828, 1.73092406, 2.4462151, 1.92197598, 2.28603731]
     else:
         if "initializer" not in kwargs:
             return [2.39694798, 2.27976578, 1.9349721, 2.21280371, 1.5655935, 2.11241762, 1.59283164, 2.46577518, 2.09617208, 1.82765063]
@@ -165,16 +165,16 @@ def test_integrator_function_no_default_variable_and_params_len_more_than_1():
 def test_integrator_function_default_variable_len_1_but_user_specified_and_params_len_more_than_1():
     with pytest.raises(FunctionError) as error_text:
         Functions.AdaptiveIntegrator(default_variable=[1], rate=[.1, .2, .3])
-    error_msg_a = 'The length (3) of the array specified for the rate parameter'
-    error_msg_b = 'must match the length (1) of the default input ([1])'
+    error_msg_a = 'The length of the array specified for the rate parameter'
+    error_msg_b = 'must match the length of the default input'
     assert error_msg_a in str(error_text.value)
     assert error_msg_b in str(error_text.value)
 
 def test_integrator_function_default_variable_and_params_len_more_than_1_error():
     with pytest.raises(FunctionError) as error_text:
         Functions.AdaptiveIntegrator(default_variable=[0,0], rate=[.1, .2, .3])
-    error_msg_a = 'The length (3) of the array specified for the rate parameter'
-    error_msg_b = 'must match the length (2) of the default input ([0 0])'
+    error_msg_a = 'The length of the array specified for the rate parameter'
+    error_msg_b = 'must match the length of the default input'
     assert error_msg_a in str(error_text.value)
     assert error_msg_b in str(error_text.value)
 

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -123,3 +123,27 @@ def test_transfer_with_costs_function():
     assert np.allclose(f.adjustment_cost, 4)
     assert np.allclose(f.duration_cost, 6)
     assert np.allclose(np.float(f.combined_costs), 12.718281828459045)
+
+
+@pytest.mark.parametrize(
+    'default_variable, func_name, expected_func_variable, expected_func_value',
+    [
+        ([1, 2, 3], 'transfer_fct', [1, 2, 3], [1, 2, 3])
+    ]
+)
+def test_transfer_with_costs_shapes(
+    default_variable,
+    func_name,
+    expected_func_variable,
+    expected_func_value
+):
+    twc = Functions.TransferWithCosts(default_variable=default_variable)
+
+    np.testing.assert_array_equal(
+        getattr(twc.parameters, func_name).get().defaults.variable,
+        expected_func_variable
+    )
+    np.testing.assert_array_equal(
+        getattr(twc.parameters, func_name).get().defaults.value,
+        expected_func_value
+    )

--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -1096,8 +1096,8 @@ class TestIntegratorNoise:
 
         val2 = float(I.execute(0))
 
-        np.testing.assert_allclose(val, 10.302846)
-        np.testing.assert_allclose(val2, 4.306823)
+        np.testing.assert_allclose(val, 9.306822898004032)
+        np.testing.assert_allclose(val2, 6.000180029830552)
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism
@@ -1112,7 +1112,7 @@ class TestIntegratorNoise:
 
         val = I.execute([10, 10, 10, 10])[0]
 
-        np.testing.assert_allclose(val, [8.607749, 10.660535, 11.108879,  9.084011])
+        np.testing.assert_allclose(val, [10.66053518, 11.10887925, 9.0840107, 10.30157835])
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism
@@ -1126,7 +1126,7 @@ class TestIntegratorNoise:
 
         val = float(I.execute(10))
 
-        np.testing.assert_allclose(val, 0.3028459185822786)
+        np.testing.assert_allclose(val, -0.6931771019959673)
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism
@@ -1140,7 +1140,7 @@ class TestIntegratorNoise:
         )
 
         val = I.execute([10, 10, 10, 10])[0]
-        np.testing.assert_allclose(val, [-1.39225086, 0.66053518, 1.10887925, -0.9159893])
+        np.testing.assert_allclose(val, [0.66053518, 1.10887925, -0.9159893, 0.30157835])
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism
@@ -1154,7 +1154,7 @@ class TestIntegratorNoise:
 
         val = float(I.execute(10))
 
-        np.testing.assert_allclose(val, 10.302846)
+        np.testing.assert_allclose(val, 9.306822898004032)
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism
@@ -1169,7 +1169,7 @@ class TestIntegratorNoise:
 
         val = I.execute([10, 10, 10, 10])[0]
 
-        np.testing.assert_allclose(val, [8.607749, 10.660535, 11.108879,  9.084011])
+        np.testing.assert_allclose(val, [10.66053518, 11.10887925, 9.0840107, 10.30157835])
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism

--- a/tests/mechanisms/test_mechanisms.py
+++ b/tests/mechanisms/test_mechanisms.py
@@ -42,6 +42,101 @@ class TestMechanism:
         assert M.function.defaults.value.shape == function_value.shape
 
 
+class TestMechanismFunctionParameters:
+    f = pnl.Linear()
+    i = pnl.SimpleIntegrator()
+    mech_1 = pnl.TransferMechanism(function=f, integrator_function=i)
+    mech_2 = pnl.TransferMechanism(function=f, integrator_function=i)
+    integrator_mechanism = pnl.IntegratorMechanism(function=i)
+
+    @pytest.mark.parametrize(
+        "f, g",
+        [
+            pytest.param(
+                mech_1.defaults.function,
+                mech_2.defaults.function,
+                id="function_defaults",
+            ),
+            pytest.param(
+                mech_1.defaults.function,
+                mech_1.parameters.function.get(),
+                id="function_default-and-value",
+            ),
+            pytest.param(
+                mech_1.defaults.function,
+                mech_2.parameters.function.get(),
+                id="function_default-and-other-value",
+            ),
+            pytest.param(
+                mech_1.defaults.integrator_function,
+                mech_2.defaults.integrator_function,
+                id="integrator_function_defaults",
+            ),
+            pytest.param(
+                mech_1.defaults.integrator_function,
+                mech_1.parameters.integrator_function.get(),
+                id="integrator_function_default-and-value",
+            ),
+            pytest.param(
+                mech_1.defaults.integrator_function,
+                mech_2.parameters.integrator_function.get(),
+                id="integrator_function_default-and-other-value",
+            ),
+        ],
+    )
+    def test_function_parameter_distinctness(self, f, g):
+        assert f is not g
+
+    @pytest.mark.parametrize(
+        "f, owner",
+        [
+            pytest.param(
+                mech_1.parameters.function.get(),
+                mech_1,
+                id='function'
+            ),
+            pytest.param(
+                integrator_mechanism.class_defaults.function,
+                integrator_mechanism.class_parameters.function,
+                id="class_default_function"
+            ),
+            pytest.param(
+                mech_1.defaults.function,
+                mech_1.parameters.function,
+                id="default_function"
+            ),
+            pytest.param(
+                mech_1.parameters.termination_measure.get(),
+                mech_1,
+                id='termination_measure'
+            ),
+            pytest.param(
+                mech_1.class_defaults.termination_measure,
+                mech_1.class_parameters.termination_measure,
+                id="class_default_termination_measure"
+            ),
+            pytest.param(
+                mech_1.defaults.termination_measure,
+                mech_1.parameters.termination_measure,
+                id="default_termination_measure"
+            ),
+        ]
+    )
+    def test_function_parameter_ownership(self, f, owner):
+        assert f.owner is owner
+
+    @pytest.mark.parametrize(
+        'param_name, function',
+        [
+            ('function', f),
+            ('integrator_function', i),
+        ]
+    )
+    def test_function_parameter_assignment(self, param_name, function):
+        # mech_1 should use the exact instances, mech_2 should have copies
+        assert getattr(self.mech_1.parameters, param_name).get() is function
+        assert getattr(self.mech_2.parameters, param_name).get() is not function
+
 class TestResetValues:
 
     def test_reset_state_integrator_mechanism(self):

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -21,6 +21,7 @@ from psyneulink.core.compositions.composition import Composition
 from psyneulink.core.globals.keywords import \
     INSTANTANEOUS_MODE_VALUE, INTEGRATOR_MODE_VALUE, RESET, COMBINE, RESULT, GREATER_THAN
 from psyneulink.core.globals.utilities import UtilitiesError, set_global_seed
+from psyneulink.core.globals.parameters import ParameterError
 from psyneulink.core.scheduling.condition import Never
 from psyneulink.core.scheduling.time import TimeScale
 
@@ -191,7 +192,7 @@ class TestTransferMechanismNoise:
         )
         T.reset_stateful_function_when = Never()
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[-0.71562799,  0.01034782,  0.90104733,  0.95869664]])
+        assert np.allclose(val, [[-1.56404341, -0.51529709, -2.55352727, 0.30284592]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -207,8 +208,7 @@ class TestTransferMechanismNoise:
         )
         T.reset_stateful_function_when = Never()
         val = T.execute([0, 0, 0, 0])
-        expected = [-1.5640434149388383, -3.013204030356897, -1.225036779097983,
-       1.3093711955796925]
+        expected = [0.6202001216069017, 0.840166034615641, 0.7279826246296707, -1.5678942459349325]
         assert np.allclose(np.asfarray(val[0]), expected)
 
     @pytest.mark.mechanism
@@ -290,7 +290,7 @@ class TestDistributionFunctions:
         )
 
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[-0.71562799,  0.01034782,  0.90104733,  0.95869664]])
+        assert np.allclose(val, [[-1.56404341, -0.51529709, -2.55352727, 0.30284592]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -322,7 +322,7 @@ class TestDistributionFunctions:
             integrator_mode=True,
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.87558564, 2.38719447, 0.7025651 , 0.33105989]])
+        assert np.allclose(val, [[0.54571315, 0.29964231, 0.71595475, 0.51908319]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -365,7 +365,7 @@ class TestDistributionFunctions:
             integrator_mode=True
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.58338204, 0.90811289, 0.50468686, 0.28183784]])
+        assert np.allclose(val, [[0.42057158, 0.25891675, 0.51127472, 0.40493414]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -380,7 +380,7 @@ class TestDistributionFunctions:
             integrator_mode=True
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.87558564, 2.38719447, 0.7025651 , 0.33105989]])
+        assert np.allclose(val, [[0.54571315, 0.29964231, 0.71595475, 0.51908319]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -395,7 +395,7 @@ class TestDistributionFunctions:
             integrator_mode=True
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.41203028, 0.40277101, 1.0678432 , 0.34512569]])
+        assert np.allclose(val, [[0.11902672, 0.73955962, 8.38161237, 0.49600183]])
 
 
 class TestTransferMechanismFunctions:
@@ -724,7 +724,7 @@ class TestTransferMechanismIntegratorFunctionParams:
 
     def test_transfer_mech_array_assignments_wrong_size_fct_rate(self):
 
-        with pytest.raises(TransferError) as error_text:
+        with pytest.raises(FunctionError) as error_text:
             T = TransferMechanism(
                     name='T',
                     default_variable=[0 for i in range(VECTOR_SIZE)],
@@ -732,8 +732,8 @@ class TestTransferMechanismIntegratorFunctionParams:
                     integrator_function=AdaptiveIntegrator(rate=[i / 10 for i in range(VECTOR_SIZE + 1)])
             )
         assert (
-            "integration_rate' arg for" in str(error_text.value)
-            and "must be either an int or float, or have the same shape as its variable" in str(error_text.value)
+            "The following parameters with len>1 specified" in str(error_text.value)
+            and "don't have the same length as its 'default_variable' (4): ['rate']." in str(error_text.value)
         )
 
     # INITIAL_VALUE / INITALIZER TESTS -------------------------------------------------------
@@ -862,31 +862,28 @@ class TestTransferMechanismIntegratorFunctionParams:
 
     def test_transfer_mech_array_assignment_wrong_size_integrator_fct_default_variable(self):
 
-        with pytest.raises(TransferError) as error_text:
+        with pytest.raises(ParameterError) as error_text:
             T = TransferMechanism(
                     name='T',
                     default_variable=[0 for i in range(VECTOR_SIZE)],
                     integrator_mode=True,
                     integrator_function=AdaptiveIntegrator(default_variable=[0 for i in range(VECTOR_SIZE + 1)])
             )
-        error_msg_a = 'The length (5) of the \'variable\' or one of the parameters specified for '
-        error_msg_b = 'the integrator_function of T doesn\'t match the size (4) of the '
-        error_msg_c = 'innermost dimension (axis 0) of its \'variable\' (i.e., the length of its items .'
-        assert (error_msg in str(error_text.value) for error_msg in {error_msg_a, error_msg_b, error_msg_c})
+        assert 'Variable shape incompatibility between (TransferMechanism T) and its integrator_function Parameter' in str(error_text.value)
 
     def test_transfer_mech_array_assignment_wrong_size_integrator_fct_param(self):
 
-        with pytest.raises(TransferError) as error_text:
+        with pytest.raises(FunctionError) as error_text:
             T = TransferMechanism(
                     name='T',
                     default_variable=[0 for i in range(VECTOR_SIZE)],
                     integrator_mode=True,
                     integrator_function=AdaptiveIntegrator(rate=[0 for i in range(VECTOR_SIZE + 1)])
             )
-        error_msg_a = 'The length (5) of the \'variable\' or one of the parameters specified for '
-        error_msg_b = 'the integrator_function of T doesn\'t match the size (4) of the '
-        error_msg_c = 'innermost dimension (axis 0) of its \'variable\' (i.e., the length of its items .'
-        assert (error_msg in str(error_text.value) for error_msg in {error_msg_a, error_msg_b, error_msg_c})
+        assert (
+            "The following parameters with len>1 specified" in str(error_text.value)
+            and "don't have the same length as its 'default_variable' (4): ['rate']." in str(error_text.value)
+        )
 
     # FIX: CAN'T RUN THIS YET:  CRASHES W/O ERROR MESSAGE SINCE DEFAULT_VARIABLE OF FCT DOESN'T MATCH ITS INITIALIZER
     # # def test_transfer_mech_array_assignments_wrong_size_fct_initlzr(self, benchmark, mode):
@@ -1017,7 +1014,7 @@ class TestTransferMechanismIntegratorFunctionParams:
     # def test_transfer_mech_array_assignments_wrong_size_fct_noise(self, benchmark, mode):
     def test_transfer_mech_array_assignments_wrong_size_fct_noise(self):
 
-        with pytest.raises(MechanismError) as error_text:
+        with pytest.raises(FunctionError) as error_text:
             T = TransferMechanism(
                     name='T',
                     default_variable=[0 for i in range(VECTOR_SIZE)],
@@ -1550,7 +1547,7 @@ class TestTransferMechanismMultipleInputPorts:
             default_variable=[[0.0, 0.0], [0.0, 0.0]]
         )
         val = T.execute([[1.0, 2.0], [3.0, 4.0]])
-        assert np.allclose(val, [[3.60569184,  3.6136458], [9.00036006, 14.09938081]])
+        assert np.allclose(val, [[1.6136458, 7.00036006], [12.09938081, 7.56874402]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism


### PR DESCRIPTION
Previously, only 'function' would have the correct shape. Now, all Functions that are Parameters can have their default variable and value set at instantiation time. Their owners' variable will be used, and passed through a _parse_<parameter name>_variable method if it exists on the owner.

mechanisms
----------
Use integrator_mode to determine integration status

Previously, this was done with checking for integrator_function being initialized, but this is now always the case, to ensure valid variable shape

Add argument 'force' to Mechanism.reset to ignore integrator_mode and proceed with resetting the integrator_function (it will always exist even when integration_mode is False)

RecurrentTransferMechanism.reset suppressed reset when integrator_mode was False, to prevent errors in Contrastive Hebbian. Replace this with a check in Contrastive Hebbian

tests
-----
Update numeric changes due to rng offset changes

Compared to devel, these tests changed as a result of the following numbers of calls to np.random methods during initialization:

| Test Name | numpy RNG method | offset |
| - | - | - |
test_transfer_mech_2d_variable_noise | np.random.normal | +1

Compared to devel, these tests changed as a result of the following numbers of calls to the random_state parameter of noise functions during initialization:

| Test Name | numpy RNG method | offset |
| - | - | - |
test_execute | random_state.normal | +1
test_accumulator_standalone_noise_function | random_state.normal | +1
test_integrator_simple_noise_fn | random_state.normal | +1
test_integrator_simple_noise_fn_var_list | random_state.normal | +1
test_integrator_accumulator_noise_fn | random_state.normal | +1
test_integrator_accumulator_noise_fn_var_list | random_state.normal | +1
test_integrator_adaptive_noise_fn | random_state.normal | +1
test_integrator_adaptive_noise_fn_var_list | random_state.normal | +1
test_buffer_standalone_noise_function | random_state.normal | +2

| Test Name | random_state Parameter RNG method | offset |
| - | - | - |
test_transfer_mech_array_var_normal_array_noise | random_state.normal | -1 (for each NormalDist instance)
test_transfer_mech_normal_noise | random_state.normal | -7
test_transfer_mech_exponential_noise | random_state.random | -7
test_transfer_mech_Uniform_noise | random_state.random | -7
test_transfer_mech_Gamma_noise | random_state.random | -7
test_transfer_mech_wald_noise | random_state.wald | -7
test_transfer_mech_array_var_normal_len_1_noise | random_state.normal | -7