### PR TITLE
Add NodeRole.CONTROLLER for Composition.controller

### DIFF
--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -3917,7 +3917,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             raise CompositionError('Invalid NodeRole: {0}'.format(role))
 
         try:
-            return [node for node in self.nodes if role in self.nodes_to_roles[node]]
+            return [node for node in self.nodes_to_roles if role in self.nodes_to_roles[node]]
 
         except KeyError as e:
             raise CompositionError('Node missing from {0}.nodes_to_roles: {1}'.format(self, e))

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -2921,20 +2921,21 @@ class NodeRole(enum.Enum):
         This role cannot be modified programmatically.
 
     """
-    ORIGIN = 0
-    INPUT = 1
-    SINGLETON = 2
-    INTERNAL = 3
-    CYCLE = 4
-    FEEDBACK_SENDER = 5
-    FEEDBACK_RECEIVER = 6
-    CONTROL_OBJECTIVE = 7
-    CONTROLLER_OBJECTIVE = 8
-    LEARNING = 9
-    TARGET = 10
-    LEARNING_OBJECTIVE = 11
-    OUTPUT = 12
-    TERMINAL = 13
+    ORIGIN = enum.auto()
+    INPUT = enum.auto()
+    SINGLETON = enum.auto()
+    INTERNAL = enum.auto()
+    CYCLE = enum.auto()
+    FEEDBACK_SENDER = enum.auto()
+    FEEDBACK_RECEIVER = enum.auto()
+    CONTROL_OBJECTIVE = enum.auto()
+    CONTROLLER_OBJECTIVE = enum.auto()
+    LEARNING = enum.auto()
+    TARGET = enum.auto()
+    LEARNING_OBJECTIVE = enum.auto()
+    OUTPUT = enum.auto()
+    TERMINAL = enum.auto()
+
 
 class Composition(Composition_Base, metaclass=ComponentsMeta):
     """

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -2871,6 +2871,10 @@ class NodeRole(enum.Enum):
         A `Node <Composition_Nodes>` that is an `ObjectiveMechanism` associated with a `ControlMechanism` other
         than the Composition's `controller <Composition.controller>` (if it has one).
 
+    CONTROLLER
+        A `Node <Composition_Nodes>` that is the `controller <Composition.controller>` of a Composition.
+        This role cannot be modified programmatically.
+
     CONTROLLER_OBJECTIVE
         A `Node <Composition_Nodes>` that is an `ObjectiveMechanism` associated with a Composition's `controller
         <Composition.controller>`.
@@ -6909,6 +6913,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         It also assigns a `ControlSignal` for any `Parameter` of a `Mechanism` `specified for control
         <ParameterPort_Value_Specification>`, and a `ControlProjection` to its correponding `ParameterPort`.
+
+        The ControlMechanism is assigned the `NodeRole` `CONTROLLER`.
 
         """
 

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -2340,7 +2340,6 @@ import typecheck as tc
 from PIL import Image
 from copy import deepcopy, copy
 from inspect import isgenerator, isgeneratorfunction
-from enum import Enum
 
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.compositions.showgraph import ShowGraph, INITIAL_FRAME, SHOW_CIM, EXECUTION_SET
@@ -2823,7 +2822,7 @@ class Graph(object):
         return dict((v.component,set(d.component for d in v.parents)) for v in self.vertices)
 
 
-class NodeRole(Enum):
+class NodeRole(enum.Enum):
     """Roles assigned to `Nodes <Composition_Nodes>` of a `Composition`.
 
     Attributes
@@ -2984,7 +2983,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         Composition is executed.  Set to True by default if **controller** specified;  if set to False,
         the `controller <Composition.controller>` is ignored when the Composition is executed.
 
-    controller_mode: Enum[BEOFRE|AFTER] : default AFTER
+    controller_mode: enum.Enum[BEOFRE|AFTER] : default AFTER
         specifies whether the controller is executed before or after the rest of the Composition
         in each trial.  Must be either the keyword *BEFORE* or *AFTER*.
 
@@ -7914,7 +7913,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         skip_initialization : bool : default False
 
-        clamp_input : Enum[SOFT_CLAMP|HARD_CLAMP|PULSE_CLAMP|NO_CLAMP] : default SOFT_CLAMP
+        clamp_input : enum.Enum[SOFT_CLAMP|HARD_CLAMP|PULSE_CLAMP|NO_CLAMP] : default SOFT_CLAMP
             specifies how inputs are handled for the Composition's `INPUT` `Nodes <Composition_Nodes>`.
 
             COMMENT:
@@ -8010,7 +8009,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             the scheduler object that owns the conditions that will instruct the execution of the Composition.
             If not specified, the Composition will use its automatically generated scheduler.
 
-        bin_execute : bool or Enum[LLVM|LLVMexec|LLVMRun|Python|PTXExec|PTXRun] : default Python
+        bin_execute : bool or enum.Enum[LLVM|LLVMexec|LLVMRun|Python|PTXExec|PTXRun] : default Python
             specifies whether to run using the Python interpreter or a `compiled mode <Composition_Compilation>`.
             False is the same as ``Python``;  True tries LLVM compilation modes, in order of power, progressively
             reverting to less powerful modes (in the order of the options listed), and to Python if no compilation
@@ -8565,7 +8564,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 called after each `PASS` is executed
                 passed the current *context* (but it is not necessary for your callable to take).
 
-            bin_execute : bool or Enum[LLVM|LLVMexec|Python|PTXExec] : default Python
+            bin_execute : bool or enum.Enum[LLVM|LLVMexec|Python|PTXExec] : default Python
                 specifies whether to run using the Python interpreter or a `compiled mode <Composition_Compilation>`.
                 see **bin_execute** argument of `run <Composition.run>` method for additional details.
 

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -2929,6 +2929,7 @@ class NodeRole(enum.Enum):
     FEEDBACK_SENDER = enum.auto()
     FEEDBACK_RECEIVER = enum.auto()
     CONTROL_OBJECTIVE = enum.auto()
+    CONTROLLER = enum.auto()
     CONTROLLER_OBJECTIVE = enum.auto()
     LEARNING = enum.auto()
     TARGET = enum.auto()
@@ -4275,6 +4276,11 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             for node, role in self.excluded_node_roles:
                 if role in self.get_roles_by_node(node):
                     self._remove_node_role(node, role)
+
+        # Manual override to avoid INPUT/OUTPUT setting, which would cause
+        # CIMs to be created, which is not correct for controllers
+        if self.controller is not None:
+            self.nodes_to_roles[self.controller] = {NodeRole.CONTROLLER}
 
     def _set_node_roles(self, node, roles):
         self._clear_node_roles(node)

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -6779,6 +6779,33 @@ class TestNodeRoles:
         # Validate that TERMINAL is LearningMechanism that Projects to first MappingProjection in learning_pathway
         (comp.get_nodes_by_role(NodeRole.TERMINAL))[0].efferents[0].receiver.owner.sender.owner == A
 
+    def test_controller_role(self):
+        comp = Composition()
+        A = ProcessingMechanism(name='A')
+        B = ProcessingMechanism(name='B')
+        comp.add_linear_processing_pathway([A, B])
+        comp.add_controller(
+            controller=pnl.OptimizationControlMechanism(
+                agent_rep=comp,
+                features=[A.input_port],
+                objective_mechanism=pnl.ObjectiveMechanism(
+                    function=pnl.LinearCombination(
+                        operation=pnl.PRODUCT),
+                    monitor=[A]
+                ),
+                function=pnl.GridSearch(),
+                control_signals=[
+                    {
+                        PROJECTIONS: ("slope", B),
+                        ALLOCATION_SAMPLES: np.arange(0.1, 1.01, 0.3)
+                    }
+                ]
+            )
+        )
+
+        assert comp.get_nodes_by_role(NodeRole.CONTROLLER) == [comp.controller]
+        assert comp.nodes_to_roles[comp.controller] == {NodeRole.CONTROLLER}
+
 
 class TestMisc:
 


### PR DESCRIPTION
`NodeRole.CONTROLLER` is assigned as a special case if a Composition has a controller. The controller is not in `Composition.nodes` and has no other roles.