### PR TITLE
feat/sphinx/extension/technical_note

### DIFF
--- a/Scripts/Examples/LVOC Composition.py
+++ b/Scripts/Examples/LVOC Composition.py
@@ -15,7 +15,7 @@ lvoc = OptimizationControlMechanism(agent_rep=RegressionCFA,
 c.add_node(lvoc)
 input_dict = {m1: [[1], [1]], m2: [1]}
 
-c.show_graph(model_based_optimizer_color=True)
+c.show_graph(show_controller=True)
 
 # c.run(inputs=input_dict)
 

--- a/docs/source/AGTControlMechanism.rst
+++ b/docs/source/AGTControlMechanism.rst
@@ -3,4 +3,5 @@ AGTControlMechanism
 
 .. automodule:: psyneulink.library.components.mechanisms.modulatory.control.agt.agtcontrolmechanism
    :members:
+   :private-members:
    :exclude-members: random, LinearCombination, Linear, Parameters

--- a/docs/source/AutoAssociativeLearningMechanism.rst
+++ b/docs/source/AutoAssociativeLearningMechanism.rst
@@ -3,4 +3,5 @@ AutoAssociativeLearningMechanism
 
 .. automodule:: psyneulink.library.components.mechanisms.modulatory.learning.autoassociativelearningmechanism
    :members:
+   :private-members:
    :exclude-members: random, execute, Parameters

--- a/docs/source/AutoAssociativeProjection.rst
+++ b/docs/source/AutoAssociativeProjection.rst
@@ -3,4 +3,5 @@ AutoAssociativeProjection
 
 .. automodule:: psyneulink.library.components.projections.pathway.autoassociativeprojection
    :members:
+   :private-members:
    :exclude-members: random, execute, Parameters

--- a/docs/source/AutodiffComposition.rst
+++ b/docs/source/AutodiffComposition.rst
@@ -3,3 +3,4 @@ AutodiffComposition
 
 .. automodule:: psyneulink.library.compositions.autodiffcomposition
    :members:
+   :private-members:

--- a/docs/source/CombinationFunctions.rst
+++ b/docs/source/CombinationFunctions.rst
@@ -6,5 +6,6 @@ CombinationFunctions
 
 .. automodule:: psyneulink.core.components.functions.combinationfunctions
    :members: Concatenate, Rearrange, Reduce, LinearCombination, CombineMeans, PredictionErrorDeltaFunction
+   :private-members:
    :exclude-members: Parameters
 

--- a/docs/source/ComparatorMechanism.rst
+++ b/docs/source/ComparatorMechanism.rst
@@ -3,4 +3,5 @@ ComparatorMechanism
 
 .. automodule:: psyneulink.library.components.mechanisms.processing.objective.comparatormechanism
    :members:
+   :private-members:
    :exclude-members: random, validate_monitored_value, add_monitored_values, Parameters

--- a/docs/source/Component.rst
+++ b/docs/source/Component.rst
@@ -24,4 +24,5 @@ Component
 |
 .. automodule:: psyneulink.core.components.component
    :members:
+   :private-members:
    :exclude-members: Parameters, ComponentLog, COMPONENT_BASE_CLASS, LogLevel, ComponentError, DefaultsFlexibility, ResetMode

--- a/docs/source/Composition.rst
+++ b/docs/source/Composition.rst
@@ -22,4 +22,5 @@ Composition
 |
 .. automodule:: psyneulink.core.compositions.composition
    :members: Composition, NodeRole
+   :private-members:
    :exclude-members: Parameters, show_structure, CompositionError

--- a/docs/source/CompositionFunctionApproximator.rst
+++ b/docs/source/CompositionFunctionApproximator.rst
@@ -13,3 +13,4 @@ CompositionFunctionApproximator
 
 .. automodule:: psyneulink.core.compositions.compositionfunctionapproximator
    :members:
+   :private-members:

--- a/docs/source/CompositionInterfaceMechanism.rst
+++ b/docs/source/CompositionInterfaceMechanism.rst
@@ -3,4 +3,5 @@ CompositionInterfaceMechanism
 
 .. automodule:: psyneulink.library.components.mechanisms.processing.compositioninterfacemechanism
    :members:
+   :private-members:
    :exclude-members: random

--- a/docs/source/Condition.rst
+++ b/docs/source/Condition.rst
@@ -3,4 +3,5 @@ Condition
 
 .. automodule:: psyneulink.core.scheduling.condition
    :members:
+   :private-members:
    :exclude-members: random, Parameters

--- a/docs/source/Context.rst
+++ b/docs/source/Context.rst
@@ -3,4 +3,5 @@ Context
 
 .. automodule:: psyneulink.core.globals.context
    :members:
+   :private-members:
    :exclude-members: Parameters

--- a/docs/source/ContrastiveHebbianMechanism.rst
+++ b/docs/source/ContrastiveHebbianMechanism.rst
@@ -3,4 +3,5 @@ ContrastiveHebbianMechanism
 
 .. automodule:: psyneulink.library.components.mechanisms.processing.transfer.contrastivehebbianmechanism
    :members:
+   :private-members:
    :exclude-members: random, Parameters

--- a/docs/source/ControlMechanism.rst
+++ b/docs/source/ControlMechanism.rst
@@ -13,4 +13,5 @@ ControlMechanism
 
 .. automodule:: psyneulink.core.components.mechanisms.modulatory.control.controlmechanism
    :members:
+   :private-members:
    :exclude-members: Linear, random, Parameters, control_signals

--- a/docs/source/ControlProjection.rst
+++ b/docs/source/ControlProjection.rst
@@ -3,4 +3,5 @@ ControlProjection
 
 .. automodule:: psyneulink.core.components.projections.modulatory.controlprojection
    :members:
+   :private-members:
    :exclude-members: random, execute, Parameters

--- a/docs/source/ControlSignal.rst
+++ b/docs/source/ControlSignal.rst
@@ -3,4 +3,5 @@ ControlSignal
 
 .. automodule:: psyneulink.core.components.ports.modulatorysignals.controlsignal
    :members:
+   :private-members:
    :exclude-members: random, execute, Parameters

--- a/docs/source/DDM.rst
+++ b/docs/source/DDM.rst
@@ -3,4 +3,5 @@ DDM
 
 .. automodule:: psyneulink.library.components.mechanisms.processing.integrator.ddm
    :members:
+   :private-members:
    :exclude-members: random, Parameters

--- a/docs/source/Defaults.rst
+++ b/docs/source/Defaults.rst
@@ -3,6 +3,7 @@ Defaults
 
 .. automodule:: psyneulink.core.globals.defaults
    :members: defaultControlAllocation include-private
+   :private-members:
    :exclude-members: random
 
    :autodata: defaultControlAllocation, Parameters

--- a/docs/source/DistributionFunctions.rst
+++ b/docs/source/DistributionFunctions.rst
@@ -6,4 +6,5 @@ DistributionFunctions
 
 .. automodule:: psyneulink.core.components.functions.distributionfunctions
    :members:
+   :private-members:
    :exclude-members: Parameters

--- a/docs/source/EVCAuxiliary.rst
+++ b/docs/source/EVCAuxiliary.rst
@@ -6,4 +6,5 @@ EVCAuxiliary
 
 .. automodule:: psyneulink.library.components.mechanisms.modulatory.control.evc.evcauxiliary
    :members:
+   :private-members:
    :exclude-members: random, LinearCombination, EVCAuxiliaryFunction, Parameters

--- a/docs/source/EVCControlMechanism.rst
+++ b/docs/source/EVCControlMechanism.rst
@@ -3,4 +3,5 @@ EVCControlMechanism
 
 .. automodule:: psyneulink.library.components.mechanisms.modulatory.control.evc.evccontrolmechanism
    :members:
+   :private-members:
    :exclude-members: random, LinearCombination, Linear, Parameters

--- a/docs/source/EpisodicMemoryMechanism.rst
+++ b/docs/source/EpisodicMemoryMechanism.rst
@@ -3,4 +3,5 @@ EpisodicMemoryMechanism
 
 .. automodule:: psyneulink.library.components.mechanisms.processing.integrator.episodicmemorymechanism
    :members:
+   :private-members:
    :exclude-members: random, Parameters

--- a/docs/source/Function.rst
+++ b/docs/source/Function.rst
@@ -6,4 +6,5 @@ Function
 
 .. automodule:: psyneulink.core.components.functions.function
    :members: Function_Base, ArgumentTherapy
+   :private-members:
    :exclude-members: Parameters

--- a/docs/source/Functions.rst
+++ b/docs/source/Functions.rst
@@ -16,4 +16,5 @@ Functions
 
 .. automodule:: psyneulink.core.components.functions.function
    :members: Function_Base, ArgumentTherapy,
+   :private-members:
    :exclude-members: Parameters

--- a/docs/source/GatingMechanism.rst
+++ b/docs/source/GatingMechanism.rst
@@ -3,4 +3,5 @@ Gating Mechanism
 
 .. automodule:: psyneulink.core.components.mechanisms.modulatory.gating.gatingmechanism
    :members:
+   :private-members:
    :exclude-members: Linear, random, Parameters

--- a/docs/source/GatingProjection.rst
+++ b/docs/source/GatingProjection.rst
@@ -3,4 +3,5 @@ GatingProjection
 
 .. automodule:: psyneulink.core.components.projections.modulatory.gatingprojection
    :members:
+   :private-members:
    :exclude-members: random, execute, Parameters

--- a/docs/source/GatingSignal.rst
+++ b/docs/source/GatingSignal.rst
@@ -3,4 +3,5 @@ GatingSignal
 
 .. automodule:: psyneulink.core.components.ports.modulatorysignals.gatingsignal
    :members:
+   :private-members:
    :exclude-members: Linear, random, Parameters

--- a/docs/source/InputPort.rst
+++ b/docs/source/InputPort.rst
@@ -3,4 +3,5 @@ InputPort
 
 .. automodule:: psyneulink.core.components.ports.inputport
    :members:
+   :private-members:
    :exclude-members: Linear, random, Parameters

--- a/docs/source/IntegratorFunctions.rst
+++ b/docs/source/IntegratorFunctions.rst
@@ -6,4 +6,5 @@ IntegratorFunctions
 
 .. automodule:: psyneulink.core.components.functions.statefulfunctions.integratorfunctions
    :members:
+   :private-members:
    :exclude-members: Parameters

--- a/docs/source/IntegratorMechanism.rst
+++ b/docs/source/IntegratorMechanism.rst
@@ -3,4 +3,5 @@ IntegratorMechanism
 
 .. automodule:: psyneulink.core.components.mechanisms.processing.integratormechanism
    :members:
+   :private-members:
    :exclude-members: random, Parameters

--- a/docs/source/InterfaceFunctions.rst
+++ b/docs/source/InterfaceFunctions.rst
@@ -6,4 +6,5 @@ InterfaceFunctions
 
 .. automodule:: psyneulink.core.components.functions.interfacefunctions
    :members:
+   :private-members:
    :exclude-members: Parameters

--- a/docs/source/KWTAMechanism.rst
+++ b/docs/source/KWTAMechanism.rst
@@ -3,4 +3,5 @@ KWTAMechanism
 
 .. automodule:: psyneulink.library.components.mechanisms.processing.transfer.kWTAMechanism
    :members:
+   :private-members:
    :exclude-members: random, Parameters

--- a/docs/source/Keywords.rst
+++ b/docs/source/Keywords.rst
@@ -3,4 +3,5 @@ Keywords
 
 .. automodule:: psyneulink.core.globals.keywords
    :members: MechanismRoles, MatrixKeywords, DistanceMetrics
+   :private-members:
    :exclude-members: random, LinearCombination, Parameters

--- a/docs/source/KohonenMechanism.rst
+++ b/docs/source/KohonenMechanism.rst
@@ -3,4 +3,5 @@ KohonenMechanism
 
 .. automodule:: psyneulink.library.components.mechanisms.processing.transfer.kohonenmechanism
    :members:
+   :private-members:
    :exclude-members: random, Parameters

--- a/docs/source/LCAMechanism.rst
+++ b/docs/source/LCAMechanism.rst
@@ -3,4 +3,5 @@ LCAMechanism
 
 .. automodule:: psyneulink.library.components.mechanisms.processing.transfer.lcamechanism
    :members:
+   :private-members:
    :exclude-members: random, Parameters

--- a/docs/source/LCControlMechanism.rst
+++ b/docs/source/LCControlMechanism.rst
@@ -3,4 +3,5 @@ LCControlMechanism
 
 .. automodule:: psyneulink.library.components.mechanisms.modulatory.control.agt.lccontrolmechanism
    :members:
+   :private-members:
    :exclude-members: random, LinearCombination, Linear, Parameters

--- a/docs/source/LCMechanism.rst
+++ b/docs/source/LCMechanism.rst
@@ -3,4 +3,5 @@ LCMechanism
 
 .. automodule:: psyneulink.library.components.mechanisms.modulatory.control.lcmechanism
    :members:
+   :private-members:
    :exclude-members: random, LinearCombination, Linear, Parameters

--- a/docs/source/LeabraMechanism.rst
+++ b/docs/source/LeabraMechanism.rst
@@ -3,4 +3,5 @@ LeabraMechanism
 
 .. automodule:: psyneulink.library.components.mechanisms.processing.leabramechanism
    :members:
+   :private-members:
    :exclude-members: random, Parameters

--- a/docs/source/LearningFunctions.rst
+++ b/docs/source/LearningFunctions.rst
@@ -6,6 +6,7 @@ LearningFunctions
 
 .. automodule:: psyneulink.core.components.functions.learningfunctions
    :members: LearningFunction, Kohonen, Hebbian, ContrastiveHebbian, Reinforcement, BayesGLM, BackPropagation, TDLearning
+   :private-members:
    :exclude-members: Parameters
 
 

--- a/docs/source/LearningMechanism.rst
+++ b/docs/source/LearningMechanism.rst
@@ -3,4 +3,5 @@ Learning Mechanism
 
 .. automodule:: psyneulink.core.components.mechanisms.modulatory.learning.learningmechanism
    :members:
+   :private-members:
    :exclude-members: Linear, random, Parameters

--- a/docs/source/LearningProjection.rst
+++ b/docs/source/LearningProjection.rst
@@ -3,4 +3,5 @@ LearningProjection
 
 .. automodule:: psyneulink.core.components.projections.modulatory.learningprojection
    :members:
+   :private-members:
    :exclude-members: random, execute, Parameters

--- a/docs/source/LearningSignal.rst
+++ b/docs/source/LearningSignal.rst
@@ -3,4 +3,5 @@ LearningSignal
 
 .. automodule:: psyneulink.core.components.ports.modulatorysignals.learningsignal
    :members:
+   :private-members:
    :exclude-members: Linear, random, Parameters

--- a/docs/source/Log.rst
+++ b/docs/source/Log.rst
@@ -3,4 +3,5 @@ Log
 
 .. automodule:: psyneulink.core.globals.log
    :members:
+   :private-members:
    :exclude-members: random, delete_entry, save_log, reset_entries, suspend_entries, LogEntry, EntriesDict, ContextState, Parameters

--- a/docs/source/MappingProjection.rst
+++ b/docs/source/MappingProjection.rst
@@ -3,4 +3,5 @@ MappingProjection
 
 .. automodule:: psyneulink.core.components.projections.pathway.mappingprojection
    :members:
+   :private-members:
    :exclude-members: random, execute, Parameters

--- a/docs/source/MaskedMappingProjection.rst
+++ b/docs/source/MaskedMappingProjection.rst
@@ -3,4 +3,5 @@ MaskedMappingProjection
 
 .. automodule:: psyneulink.library.components.projections.pathway.maskedmappingprojection
    :members:
+   :private-members:
    :exclude-members: random, execute, Parameters

--- a/docs/source/Mechanism.rst
+++ b/docs/source/Mechanism.rst
@@ -18,5 +18,6 @@ Mechanism
 |
 .. automodule:: psyneulink.core.components.mechanisms.mechanism
    :members:
+   :private-members:
    :exclude-members: MechParamsDict, MechanismError, MonitoredOutputPortsOption, random, Parameters, _input_port_variables_getter
 

--- a/docs/source/MemoryFunctions.rst
+++ b/docs/source/MemoryFunctions.rst
@@ -6,4 +6,5 @@ MemoryFunctions
 
 .. automodule:: psyneulink.core.components.functions.statefulfunctions.memoryfunctions
    :members:
+   :private-members:
    :exclude-members: Parameters

--- a/docs/source/ModulatoryMechanism.rst
+++ b/docs/source/ModulatoryMechanism.rst
@@ -13,5 +13,6 @@ ModulatoryMechanism
 
 .. automodule:: psyneulink.core.components.mechanisms.modulatory.modulatorymechanism
    :members:
+   :private-members:
    :exclude-members: Linear, random, Parameters
 

--- a/docs/source/ModulatoryProjection.rst
+++ b/docs/source/ModulatoryProjection.rst
@@ -14,4 +14,5 @@ ModulatoryProjection
 
 .. automodule:: psyneulink.core.components.projections.modulatory.modulatoryprojection
    :members: ModulatoryProjection_Base
+   :private-members:
    :exclude-members: Linear, random, Parameters

--- a/docs/source/ModulatorySignal.rst
+++ b/docs/source/ModulatorySignal.rst
@@ -17,5 +17,6 @@ ModulatorySignal
 
 .. automodule:: psyneulink.core.components.ports.modulatorysignals.modulatorysignal
    :members:
+   :private-members:
    :exclude-members: random, update, Parameters
 

--- a/docs/source/ObjectiveFunctions.rst
+++ b/docs/source/ObjectiveFunctions.rst
@@ -6,4 +6,5 @@ ObjectiveFunctions
 
 .. automodule:: psyneulink.core.components.functions.objectivefunctions
    :members:
+   :private-members:
    :exclude-members: Parameters

--- a/docs/source/ObjectiveMechanism.rst
+++ b/docs/source/ObjectiveMechanism.rst
@@ -3,4 +3,5 @@ ObjectiveMechanism
 
 .. automodule:: psyneulink.core.components.mechanisms.processing.objectivemechanism
    :members:
+   :private-members:
    :exclude-members: random, validate_monitored_value, add_monitored_values, Parameters

--- a/docs/source/OptimizationControlMechanism.rst
+++ b/docs/source/OptimizationControlMechanism.rst
@@ -3,4 +3,5 @@ OptimizationControlMechanism
 
 .. automodule:: psyneulink.core.components.mechanisms.modulatory.control.optimizationcontrolmechanism
    :members:
+   :private-members:
    :exclude-members: Linear, random, Parameters

--- a/docs/source/OptimizationFunctions.rst
+++ b/docs/source/OptimizationFunctions.rst
@@ -6,6 +6,7 @@ OptimizationFunctions
 
 .. automodule:: psyneulink.core.components.functions.optimizationfunctions
    :members:  OptimizationFunction, GradientOptimization, GridSearch, GaussianProcess, SampleSpec, SampleIterator
+   :private-members:
    :exclude-members: Parameters
 
 

--- a/docs/source/OutputPort.rst
+++ b/docs/source/OutputPort.rst
@@ -3,4 +3,5 @@ OutputPort
 
 .. automodule:: psyneulink.core.components.ports.outputport
    :members:
+   :private-members:
    :exclude-members: Linear, random

--- a/docs/source/ParameterPort.rst
+++ b/docs/source/ParameterPort.rst
@@ -3,4 +3,5 @@ ParameterPort
 
 .. automodule:: psyneulink.core.components.ports.parameterport
    :members:
+   :private-members:
    :exclude-members: random, update, Parameters

--- a/docs/source/Parameters.rst
+++ b/docs/source/Parameters.rst
@@ -3,4 +3,5 @@ Parameters
 
 .. automodule:: psyneulink.core.globals.parameters
    :members:
+   :private-members:
    :exclude-members: get_validator_by_function

--- a/docs/source/Pathway.rst
+++ b/docs/source/Pathway.rst
@@ -3,3 +3,4 @@ Pathway
 
 .. automodule:: psyneulink.core.compositions.pathway
    :members: Pathway, PathwayRole
+   :private-members:

--- a/docs/source/PathwayProjection.rst
+++ b/docs/source/PathwayProjection.rst
@@ -12,4 +12,5 @@ PathwayProjection
 
 .. automodule:: psyneulink.core.components.projections.pathway.pathwayprojection
    :members:
+   :private-members:
    :exclude-members: PathwayProjection_Base, Linear, random, Parameters

--- a/docs/source/Port.rst
+++ b/docs/source/Port.rst
@@ -15,5 +15,6 @@ Port
 
 .. automodule:: psyneulink.core.components.ports.port
    :members:
+   :private-members:
    :exclude-members: random, update, Parameters
 

--- a/docs/source/PredictionErrorMechanism.rst
+++ b/docs/source/PredictionErrorMechanism.rst
@@ -3,4 +3,5 @@ PredictionErrorMechanism
 
 .. automodule:: psyneulink.library.components.mechanisms.processing.objective.predictionerrormechanism
    :members:
+   :private-members:
    :exclude-members: Parameters

--- a/docs/source/ProcessingMechanism.rst
+++ b/docs/source/ProcessingMechanism.rst
@@ -14,4 +14,5 @@ ProcessingMechanism
 
 .. automodule:: psyneulink.core.components.mechanisms.processing.processingmechanism
    :members:
+   :private-members:
    :exclude-members: ProcessingMechanism_Base, MechanismTuple, MechanismList, random, Parameters

--- a/docs/source/Projection.rst
+++ b/docs/source/Projection.rst
@@ -11,4 +11,5 @@ Projection
 
 .. automodule:: psyneulink.core.components.projections.projection
    :members:
+   :private-members:
    :exclude-members: _is_projection_spec, random, Parameters, ProjectionError, DuplicateProjectionError

--- a/docs/source/RecurrentTransferMechanism.rst
+++ b/docs/source/RecurrentTransferMechanism.rst
@@ -3,4 +3,5 @@ RecurrentTransferMechanism
 
 .. automodule:: psyneulink.library.components.mechanisms.processing.transfer.recurrenttransfermechanism
    :members:
+   :private-members:
    :exclude-members: random, Parameters

--- a/docs/source/RegressionCFA.rst
+++ b/docs/source/RegressionCFA.rst
@@ -6,3 +6,4 @@ RegressionCFA
 
 .. automodule:: psyneulink.library.compositions.regressioncfa
    :members:
+   :private-members:

--- a/docs/source/Scheduler.rst
+++ b/docs/source/Scheduler.rst
@@ -3,4 +3,5 @@ Scheduler
 
 .. automodule:: psyneulink.core.scheduling.scheduler
    :members:
+   :private-members:
    :exclude-members: random, Parameters

--- a/docs/source/SelectionFunctions.rst
+++ b/docs/source/SelectionFunctions.rst
@@ -6,4 +6,5 @@ SelectionFunctions
 
 .. automodule:: psyneulink.core.components.functions.selectionfunctions
    :members:
+   :private-members:
    :exclude-members: Parameters

--- a/docs/source/StatefulFunction.rst
+++ b/docs/source/StatefulFunction.rst
@@ -6,4 +6,5 @@ StatefulFunction
 
 .. automodule:: psyneulink.core.components.functions.statefulfunctions.statefulfunction
    :members:
+   :private-members:
    :exclude-members: Parameters

--- a/docs/source/Time.rst
+++ b/docs/source/Time.rst
@@ -3,4 +3,5 @@ Time
 
 .. automodule:: psyneulink.core.scheduling.time
    :members:
+   :private-members:
    :exclude-members: random, Parameters

--- a/docs/source/TransferFunctions.rst
+++ b/docs/source/TransferFunctions.rst
@@ -6,4 +6,5 @@ TransferFunctions
 
 .. automodule:: psyneulink.core.components.functions.transferfunctions
    :members: TransferFunction, Identity, Linear, Exponential, Logistic, Tanh, ReLU, Gaussian, GaussianDistort, SoftMax, LinearMatrix, TransferWithCosts, CostFunctions
+   :private-members:
    :exclude-members: Parameters

--- a/docs/source/TransferMechanism.rst
+++ b/docs/source/TransferMechanism.rst
@@ -3,4 +3,5 @@ TransferMechanism
 
 .. automodule:: psyneulink.core.components.mechanisms.processing.transfermechanism
    :members:
+   :private-members:
    :exclude-members: random, Parameters

--- a/docs/source/UserDefinedFunction.rst
+++ b/docs/source/UserDefinedFunction.rst
@@ -6,4 +6,5 @@ UserDefinedFunction
 
 .. automodule:: psyneulink.core.components.functions.userdefinedfunction
    :members: UserDefinedFunction
+   :private-members:
    :exclude-members: Parameters

--- a/docs/source/_ext/technical_note.py
+++ b/docs/source/_ext/technical_note.py
@@ -1,0 +1,54 @@
+# Princeton University licenses this file to You under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may obtain a copy of the License at:
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+# **************************************  TechnicalNote *************************************************
+
+"""
+This is a Sphinx extension that enables a custom RST directive. It is based on the standard docutils Container
+directive, though it does not inherit from that directive as there are key changes that made subclassing unsuitable.
+
+The purpose of this directive is to wrap arbitrary content in a technical-note html class, thus allowing for it to be
+hidden or shown by way of embedded javascript in the doc.
+
+"""
+
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+from sphinx.util.nodes import nested_parse_with_titles
+
+class TechnicalNote(Directive):
+    # optional_arguments = 1
+    final_argument_whitespace = True
+    option_spec = {'name': directives.unchanged}
+    has_content = True
+
+    def run(self):
+        self.assert_has_content()
+        text = '\n'.join(self.content)
+        try:
+            if self.arguments:
+                classes = directives.class_option(self.arguments[0])
+            else:
+                classes = []
+            classes.append('technical-note')
+        except ValueError:
+            raise self.error(
+                'Invalid class attribute value for "%s" directive: "%s".'
+                % (self.name, self.arguments[0]))
+        node = nodes.container(text)
+        node['classes'].extend(classes)
+        nested_parse_with_titles(self.state, self.content, node)
+        return [node]
+
+def setup(app):
+    app.add_directive("technical_note", TechnicalNote)
+
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,6 +22,9 @@ import sys
 sys.path.insert(0, os.path.abspath('../../'))
 # adding this path alone so that Run/Environment module can go in the dropdown underneath Scheduling
 sys.path.insert(0, os.path.abspath('../../psyneulink/globals/'))
+# adding this path to enable enable technical_note sphinx extension
+sys.path.insert(0, os.path.abspath('./_ext'))
+
 import psyneulink._version
 # -- General configuration ------------------------------------------------
 
@@ -36,7 +39,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'sphinx.ext.mathjax',
-    'sphinx_autodoc_typehints'
+    'sphinx_autodoc_typehints',
+    'technical_note'
     # 'sphinx.ext.imgmath'
 ]
 

--- a/docs/source/json.rst
+++ b/docs/source/json.rst
@@ -3,4 +3,5 @@ JSON
 
 .. automodule:: psyneulink.core.globals.json
    :members:
+   :private-members:
    :exclude-members: PNLJSONError

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2306,8 +2306,9 @@ class Mechanism_Base(Mechanism):
                 ):
         """Carry out a single `execution <Mechanism_Execution>` of the Mechanism.
 
-        .. technical_note:
+        .. technical_note::
             Execution sequence:
+
             * Handle initialization if `initialization_status <Compoonent.initialization_status> is
               *ContextFlags.INITIALIZING*
             * Assign any `Port-specific runtime params <_Mechanism_Runtime_Port_and_Projection_Param_Specification>`

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3213,57 +3213,58 @@ class Mechanism_Base(Mechanism):
             for use in a GraphViz node specification.
 
         Example HTML for structure:
+            .. parsed-literal::
 
-        <<table border="1" cellborder="0" cellspacing="0" bgcolor="tan">          <- MAIN TABLE
+                <<table border="1" cellborder="0" cellspacing="0" bgcolor="tan">          <- MAIN TABLE
 
-        <tr>                                                                      <- BEGIN OutputPorts
-            <td colspan="2"><table border="0" cellborder="0" BGCOLOR="bisque">    <- OutputPorts OUTER TABLE
-                <tr>
-                    <td colspan="1"><b>OutputPorts</b></td>                      <- OutputPorts HEADER
-                </tr>
-                <tr>
-                    <td><table border="0" cellborder="1">                         <- OutputPort CELLS TABLE
+                <tr>                                                                      <- BEGIN OutputPorts
+                    <td colspan="2"><table border="0" cellborder="0" BGCOLOR="bisque">    <- OutputPorts OUTER TABLE
                         <tr>
-                            <td port="OutputPortPort1">OutputPort 1<br/><i>function 1</i><br/><i>=value</i></td>
-                            <td port="OutputPortPort2">OutputPort 2<br/><i>function 2</i><br/><i>=value</i></td>
+                            <td colspan="1"><b>OutputPorts</b></td>                      <- OutputPorts HEADER
+                        </tr>
+                        <tr>
+                            <td><table border="0" cellborder="1">                         <- OutputPort CELLS TABLE
+                                <tr>
+                                    <td port="OutputPortPort1">OutputPort 1<br/><i>function 1</i><br/><i>=value</i></td>
+                                    <td port="OutputPortPort2">OutputPort 2<br/><i>function 2</i><br/><i>=value</i></td>
+                                </tr>
+                            </table></td>
                         </tr>
                     </table></td>
                 </tr>
-            </table></td>
-        </tr>
 
-        <tr>                                                                      <- BEGIN MECHANISM & ParameterPorts
-            <td port="Mech name"><b>Mech name</b><br/><i>Roles</i></td>           <- MECHANISM CELL (OUTERMOST TABLE)
-            <td><table border="0" cellborder="0" BGCOLOR="bisque">                <- ParameterPorts OUTER TABLE
-                <tr>
-                    <td><b>ParameterPorts</b></td>                               <- ParameterPorts HEADER
-                </tr>
-                <tr>
-                    <td><table border="0" cellborder="1">                         <- ParameterPort CELLS TABLE
-                        <tr><td port="ParamPort1">Param 1<br/><i>function 1</i><br/><i>= value</i></td></tr>
-                        <tr><td port="ParamPort1">Param 2<br/><i>function 2</i><br/><i>= value</i></td></tr>
-                    </table></td>
-                </tr>
-            </table></td>
-        </tr>
-
-        <tr>                                                                      <- BEGIN InputPorts
-            <td colspan="2"><table border="0" cellborder="0" BGCOLOR="bisque">    <- InputPortS OUTER TABLE
-                <tr>
-                    <td colspan="1"><b>InputPorts</b></td>                       <- InputPorts HEADER
-                </tr>
-                <tr>
-                    <td><table border="0" cellborder="1">                         <- InputPort CELLS TABLE
+                <tr>                                                                      <- BEGIN MECHANISM & ParameterPorts
+                    <td port="Mech name"><b>Mech name</b><br/><i>Roles</i></td>           <- MECHANISM CELL (OUTERMOST TABLE)
+                    <td><table border="0" cellborder="0" BGCOLOR="bisque">                <- ParameterPorts OUTER TABLE
                         <tr>
-                            <td port="InputPortPort1">InputPort 1<br/><i>function 1</i><br/><i>= value</i></td>
-                            <td port="InputPortPort2">InputPort 2<br/><i>function 2</i><br/><i>= value</i></td>
+                            <td><b>ParameterPorts</b></td>                               <- ParameterPorts HEADER
+                        </tr>
+                        <tr>
+                            <td><table border="0" cellborder="1">                         <- ParameterPort CELLS TABLE
+                                <tr><td port="ParamPort1">Param 1<br/><i>function 1</i><br/><i>= value</i></td></tr>
+                                <tr><td port="ParamPort1">Param 2<br/><i>function 2</i><br/><i>= value</i></td></tr>
+                            </table></td>
                         </tr>
                     </table></td>
                 </tr>
-            </table></td>
-        </tr>
 
-        </table>>
+                <tr>                                                                      <- BEGIN InputPorts
+                    <td colspan="2"><table border="0" cellborder="0" BGCOLOR="bisque">    <- InputPortS OUTER TABLE
+                        <tr>
+                            <td colspan="1"><b>InputPorts</b></td>                       <- InputPorts HEADER
+                        </tr>
+                        <tr>
+                            <td><table border="0" cellborder="1">                         <- InputPort CELLS TABLE
+                                <tr>
+                                    <td port="InputPortPort1">InputPort 1<br/><i>function 1</i><br/><i>= value</i></td>
+                                    <td port="InputPortPort2">InputPort 2<br/><i>function 2</i><br/><i>= value</i></td>
+                                </tr>
+                            </table></td>
+                        </tr>
+                    </table></td>
+                </tr>
+
+                </table>>
 
         """
 
@@ -3689,19 +3690,20 @@ class Mechanism_Base(Mechanism):
 
         Returns
         -------
-
-        dict in the form
-        {INPUT_PORTS:
-                {(int) port_index:
-                        {{label_1: value_1},
-                         {label_2: value_2}}
-                },
-        OUTPUT_PORTS:
-        {(int) port_index:
-                        {{label_1: value_1},
-                         {label_2: value_2}}
-                }
-        }
+            dict
+                .. parsed-literal::
+                    {
+                        INPUT_PORTS:
+                                {(int) port_index:
+                                        {{label_1: value_1},
+                                         {label_2: value_2}}
+                                },
+                        OUTPUT_PORTS:
+                                {(int) port_index:
+                                        {{label_1: value_1},
+                                         {label_2: value_2}}
+                                }
+                    }
 
         """
         input_labels = self._get_standardized_label_dict(INPUT)
@@ -3724,13 +3726,14 @@ class Mechanism_Base(Mechanism):
 
         Returns
         -------
-        dict in the form
-        {INPUT_PORTS/OUTPUT_PORTS:
-                {(int) port_index:
-                        {{label_1: value_1},
-                         {label_2: value_2}}
+        dict
+            .. parsed-literal::
+                {INPUT_PORTS/OUTPUT_PORTS:
+                        {(int) port_index:
+                                {{label_1: value_1},
+                                 {label_2: value_2}}
+                        }
                 }
-        }
         """
         if label_type == INPUT:
             label_dict = self.input_labels_dict

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -344,9 +344,9 @@ graph.
 
 .. _Composition_Graph_Projection_Vertices:
 .. technical_note::
-   Because Projections are not strictly edges, they are assigned to `vertices <Graph.vertices>` in the Composition's
-   `graph <Composition.graph>`, along with its Nodes.  The actual edges are implicit in the dependencies determined
-   by the Projections, and listed in the graph's `dependency_dict <Graph.dependency_dict>`.
+    Because Projections are not strictly edges, they are assigned to `vertices <Graph.vertices>` in the Composition's
+    `graph <Composition.graph>`, along with its Nodes.  The actual edges are implicit in the dependencies determined
+    by the Projections, and listed in the graph's `dependency_dict <Graph.dependency_dict>`.
 
 Although individual Projections are directed, pairs of Nodes can be connected with Projections in each direction
 (forming a local `cycle <Composition_Cycle>`), and the `AutoAssociativeProjection` class of Projection can even
@@ -355,10 +355,10 @@ connect a Node with itself.  Projections can also connect the Node(s) of a Compo
 
 .. _Composition_Projections_to_CIMs:
 .. technical_note::
-   Although Projections can be specified to and from Nodes within a nested Composition, these are actually implemented
-   as Projections to or from the nested Composition's `input_CIM <Composition.input_CIM>`,`parameter_CIM
-   <Composition.parameter_CIM>` or `output_CIM <Composition.output_CIM>`, respectively; those, in turn, send or receive
-   Projections to the specified Nodes within the nested Composition.
+    Although Projections can be specified to and from Nodes within a nested Composition, these are actually implemented
+    as Projections to or from the nested Composition's `input_CIM <Composition.input_CIM>`,`parameter_CIM
+    <Composition.parameter_CIM>` or `output_CIM <Composition.output_CIM>`, respectively; those, in turn, send or receive
+    Projections to the specified Nodes within the nested Composition.
 
 Subsets of Nodes connected by Projections are often defined as a `Pathway <Pathway>`, as decribed in the next section.
 
@@ -7916,9 +7916,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 of Mechanisms that have stateful functions. If a node's reset_stateful_function_when condition is set to
                 Never, but they are listed in the reset_stateful_functions_to dict, then they will be reset once at the
                 beginning of the run, using the provided values.
-                ..technical_note::
-                    These values are used to seed the stateful attributes of Mechanisms with StatefulFunctions, thus
-                    effectively starting Integration at a user-specified point for a call to run.
 
         reset_stateful_functions_when :  Condition : default Never()
             sets the reset_stateful_function_when condition for all nodes in the Composition that currently have their

--- a/psyneulink/core/compositions/showgraph.py
+++ b/psyneulink/core/compositions/showgraph.py
@@ -20,11 +20,11 @@ of the Composition and, optionally, any `nested Compositions <Composition_Nested
 <Composition_Nodes>` of the Composition is represented as a node in the graph, and `Projections <Projection>` between
 them as edges.
 
-.. technical_note:
-   Every Composition is assigned a `ShowGraph` object, that is implemented in the free-standing showgraph.py module.
-   The `show_graph <Compositoin.show_graph>` method of a Composition directly calls the `show_graph
-   <ShowGraph.show_graph>` method of its `ShowGraph` object, as do all links to documentation concerning
-   `show_graph`.
+.. technical_note::
+    Every Composition is assigned a `ShowGraph` object, that is implemented in the free-standing showgraph.py module.
+    The `show_graph <Compositoin.show_graph>` method of a Composition directly calls the `show_graph
+    <ShowGraph.show_graph>` method of its `ShowGraph` object, as do all links to documentation concerning
+    `show_graph`.
 
 By default, all nodes within a Composition, including any `Compositions nested <Composition_Nested>` within it, are
 shown, each displayed as an oval (if the node is a `Mechanism`) or a rectangle (if it is a nested Composition),


### PR DESCRIPTION
Added custom technical_note RST directive as a Sphinx extension. This wraps arbitrary content in a technical-note html class in the rendered doc, which is then used by the PNL sphinx theme to display or hide the content based on whether the user has or hasn't enabled dev mode.