### PR TITLE
Fix numpy 1.19 deprecations

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -976,7 +976,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 return variable
 
             try:
-                return np.asarray(variable)
+                return convert_to_np_array(variable)
             except ValueError:
                 return convert_all_elements_to_np_array(variable)
 
@@ -1507,7 +1507,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                     variable = []
                     for s in size:
                         variable.append(np.zeros(s))
-                    variable = np.array(variable)
+                    variable = convert_to_np_array(variable)
+                # TODO: fix bare except
                 except:
                     raise ComponentError("variable (possibly default_variable) was not specified, but PsyNeuLink "
                                          "was unable to infer variable from the size argument, {}. size should be"

--- a/psyneulink/core/components/functions/combinationfunctions.py
+++ b/psyneulink/core/components/functions/combinationfunctions.py
@@ -43,7 +43,7 @@ from psyneulink.core.globals.keywords import \
     DEFAULT_VARIABLE, EXPONENTS, LINEAR_COMBINATION_FUNCTION, MULTIPLICATIVE_PARAM, OFFSET, OPERATION, \
     PREDICTION_ERROR_DELTA_FUNCTION, PRODUCT, REARRANGE_FUNCTION, REDUCE_FUNCTION, SCALE, SUM, WEIGHTS, \
     PREFERENCE_SET_NAME
-from psyneulink.core.globals.utilities import is_numeric, np_array_less_than_2d, parameter_spec
+from psyneulink.core.globals.utilities import convert_to_np_array, is_numeric, np_array_less_than_2d, parameter_spec
 from psyneulink.core.globals.context import Context, ContextFlags
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.basepreferenceset import \
@@ -552,7 +552,7 @@ class Rearrange(CombinationFunction):  # ---------------------------------------
                     for index in item:
                         stack.append(variable[index])
                     result.append(np.hstack(tuple(stack)))
-                result = np.array(result) * scale + offset
+                result = convert_to_np_array(result) * scale + offset
             except IndexError:
                 assert False, f"PROGRAM ERROR: Bad index specified in {repr(ARRANGEMENT)} arg -- " \
                     f"should have been caught in _validate_params or _instantiate_attributes_before_function"

--- a/psyneulink/core/components/functions/distributionfunctions.py
+++ b/psyneulink/core/components/functions/distributionfunctions.py
@@ -35,7 +35,7 @@ from psyneulink.core.globals.keywords import \
     EXPONENTIAL_DIST_FUNCTION, GAMMA_DIST_FUNCTION, HIGH, LOW, MULTIPLICATIVE_PARAM, NOISE, NORMAL_DIST_FUNCTION, \
     SCALE, STANDARD_DEVIATION, THRESHOLD, UNIFORM_DIST_FUNCTION, WALD_DIST_FUNCTION
 from psyneulink.core.globals.context import ContextFlags
-from psyneulink.core.globals.utilities import parameter_spec, get_global_seed
+from psyneulink.core.globals.utilities import convert_to_np_array, parameter_spec, get_global_seed
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 
 from psyneulink.core.globals.parameters import Parameter
@@ -1265,9 +1265,15 @@ class DriftDiffusionAnalytical(DistributionFunction):  # -----------------------
                     exp_neg2_ztilde_atilde = np.exp(-2 * ztilde * atilde)
 
                     if self.shenhav_et_al_compat_mode:
-                        exp_neg2_x0tilde_atilde = np.nanmax([1e-12, exp_neg2_x0tilde_atilde])
-                        exp_2_ztilde_atilde = np.nanmin([1e12, exp_2_ztilde_atilde])
-                        exp_neg2_ztilde_atilde = np.nanmax([1e-12, exp_neg2_ztilde_atilde])
+                        exp_neg2_x0tilde_atilde = np.nanmax(
+                            convert_to_np_array([1e-12, exp_neg2_x0tilde_atilde])
+                        )
+                        exp_2_ztilde_atilde = np.nanmin(
+                            convert_to_np_array([1e12, exp_2_ztilde_atilde])
+                        )
+                        exp_neg2_ztilde_atilde = np.nanmax(
+                            convert_to_np_array([1e-12, exp_neg2_ztilde_atilde])
+                        )
 
                     rt = ztilde * np.tanh(ztilde * atilde) + \
                          ((2 * ztilde * (1 - exp_neg2_x0tilde_atilde)) / (

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -161,7 +161,7 @@ from psyneulink.core.globals.preferences.basepreferenceset import REPORT_OUTPUT_
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
 from psyneulink.core.globals.registry import register_category
 from psyneulink.core.globals.utilities import (
-    get_global_seed, object_has_single_value, parameter_spec, safe_len
+    convert_to_np_array, get_global_seed, object_has_single_value, parameter_spec, safe_len
 )
 
 __all__ = [
@@ -649,7 +649,7 @@ class Function_Base(Function):
             else:
                 output_type = self.output_type
 
-        value = np.asarray(value)
+        value = convert_to_np_array(value)
 
         # Type conversion (specified by output_type):
 
@@ -1006,7 +1006,7 @@ def get_matrix(specification, rows=1, cols=1, context=None):
 
     # Matrix provided (and validated in _validate_params); convert to array
     if isinstance(specification, (list, np.matrix)):
-        specification = np.array(specification)
+        return convert_to_np_array(specification)
 
     if isinstance(specification, np.ndarray):
         if specification.ndim == 2:

--- a/psyneulink/core/components/functions/interfacefunctions.py
+++ b/psyneulink/core/components/functions/interfacefunctions.py
@@ -27,6 +27,7 @@ from psyneulink.core.globals.keywords import \
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.basepreferenceset import \
     PreferenceEntry, PreferenceLevel, is_pref_set, REPORT_OUTPUT_PREF
+from psyneulink.core.globals.utilities import convert_to_np_array
 
 
 __all__ = ['InterfaceFunction', 'InterfacePortMap']
@@ -173,7 +174,10 @@ class InterfacePortMap(InterfaceFunction):
         if self.corresponding_input_port.owner.parameters.value._get(context) is not None:
 
             # If CIM's variable does not match its value, then a new pair of ports was added since the last execution
-            if not np.shape(self.corresponding_input_port.owner.get_input_values(context)) == np.shape(self.corresponding_input_port.owner.parameters.value._get(context)):
+            input_values = convert_to_np_array(
+                self.corresponding_input_port.owner.get_input_values(context)
+            )
+            if not np.shape(input_values) == np.shape(self.corresponding_input_port.owner.parameters.value._get(context)):
                 return self.corresponding_input_port.owner.defaults.variable[index]
 
             # If the variable is 1D (e.g. [0. , 0.], NOT [[0. , 0.]]), and the index is 0, then return whole variable

--- a/psyneulink/core/components/functions/learningfunctions.py
+++ b/psyneulink/core/components/functions/learningfunctions.py
@@ -585,7 +585,7 @@ class BayesGLM(LearningFunction):
 
 
         variable = self._check_args(
-            [np.atleast_2d(variable[0]), np.atleast_2d(variable[1])],
+            [convert_to_np_array(variable[0], dimension=2), convert_to_np_array(variable[1], dimension=2)],
             params,
             context,
         )

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -44,7 +44,7 @@ from psyneulink.core.globals.keywords import \
     INCREMENT, INITIALIZER, INPUT_PORTS, INTEGRATOR_FUNCTION, INTEGRATOR_FUNCTION_TYPE, \
     INTERACTIVE_ACTIVATION_INTEGRATOR_FUNCTION, LEAKY_COMPETING_INTEGRATOR_FUNCTION, \
     MULTIPLICATIVE_PARAM, NOISE, OFFSET, OPERATION, ORNSTEIN_UHLENBECK_INTEGRATOR_FUNCTION, OUTPUT_PORTS, PRODUCT, \
-    RATE, REST, SIMPLE_INTEGRATOR_FUNCTION, SUM, TIME_STEP_SIZE, THRESHOLD
+    RATE, REST, SIMPLE_INTEGRATOR_FUNCTION, SUM, TIME_STEP_SIZE, THRESHOLD, VARIABLE
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.utilities import parameter_spec, all_within_range, iscompatible, get_global_seed
 from psyneulink.core.globals.context import Context, ContextFlags, handle_external_context
@@ -1203,7 +1203,12 @@ class AdaptiveIntegrator(IntegratorFunction):  # -------------------------------
         previous_value = self.get_previous_value(context)
         # MODIFIED 6/14/19 END
 
-        value = self._EWMA_filter(previous_value, rate, variable) + noise
+        try:
+            value = self._EWMA_filter(previous_value, rate, variable) + noise
+        except TypeError:
+            # TODO: this should be standardized along with the other instances
+            # of this error
+            raise FunctionError("Unrecognized type for {} of {} ({})".format(VARIABLE, self.name, variable))
 
         adjusted_value = value + offset
 

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -38,7 +38,7 @@ from psyneulink.core.components.functions.objectivefunctions import Distance
 from psyneulink.core.globals.keywords import \
     ADDITIVE_PARAM, BUFFER_FUNCTION, MEMORY_FUNCTION, COSINE, ContentAddressableMemory_FUNCTION, \
     MIN_INDICATOR, MULTIPLICATIVE_PARAM, NEWEST, NOISE, OLDEST, OVERWRITE, RATE, RANDOM
-from psyneulink.core.globals.utilities import all_within_range, parameter_spec, get_global_seed
+from psyneulink.core.globals.utilities import all_within_range, convert_to_np_array, parameter_spec, get_global_seed
 from psyneulink.core.globals.context import Context, ContextFlags, handle_external_context
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
@@ -330,7 +330,7 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
 
         # Apply rate and/or noise, if they are specified, to all stored items
         if len(previous_value):
-            previous_value = previous_value * rate + noise
+            previous_value = convert_to_np_array(previous_value) * rate + noise
 
         previous_value = deque(previous_value, maxlen=self.parameters.history._get(context))
 
@@ -995,7 +995,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
                     warnings.warn(f"Attempt to initialize memory of {self.__class__.__name__} with an entry ({entry}) "
                                   f"that has the same key as a previous one, while 'duplicate_keys'==False; "
                                   f"that entry has been skipped")
-            return np.asarray(self._memory)
+            return convert_to_np_array(self._memory)
 
     def _instantiate_attributes_before_function(self, function=None, context=None):
         self.parameters.previous_value._set(
@@ -1125,7 +1125,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         # Return 3d array with keys and vals as lists
         # IMPLEMENTATION NOTE:  if try to create np.ndarray directly, and keys and vals have same length
         #                       end up with array of arrays, rather than array of lists
-        ret_val = np.array([list(memory[0]),[]])
+        ret_val = convert_to_np_array([list(memory[0]),[]])
         ret_val[1] = list(memory[1])
         return ret_val
 
@@ -1326,7 +1326,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
 
     def _parse_memories(self, memories, method, context=None):
         """Parse passing of single vs. multiple memories, validate memories, and return ndarray"""
-        memories = np.array(memories)
+        memories = convert_to_np_array(memories)
         if not 1 <= memories.ndim <= 3:
             raise FunctionError(f"'memories' arg for {method} method of {self.__class__.__name__} "
                                 f"must be a 2-item list or 2d array, or a list or 3d array containing those")

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2397,7 +2397,7 @@ class Mechanism_Base(Mechanism):
 
                         return return_value
                 else:
-                    converted_to_2d = np.atleast_2d(return_value)
+                    converted_to_2d = convert_to_np_array(return_value, dimension=2)
                 # If return_value is a list of heterogenous elements, return as is
                 #     (satisfies requirement that return_value be an array of possibly multidimensional values)
                 if converted_to_2d.dtype == object:
@@ -2411,7 +2411,7 @@ class Mechanism_Base(Mechanism):
                 return_value = super()._execute(variable=self.defaults.variable,
                                                 context=context,
                                                 runtime_params=runtime_params)
-                return np.atleast_2d(return_value)
+                return convert_to_np_array(return_value, dimension=2)
 
         # SET UP RUNTIME PARAMS if any
 
@@ -2491,7 +2491,7 @@ class Mechanism_Base(Mechanism):
                                 for item in value))):
                         pass
                 else:
-                    converted_to_2d = np.atleast_2d(value)
+                    converted_to_2d = convert_to_np_array(value, dimension=2)
                     # If return_value is a list of heterogenous elements, return as is
                     #     (satisfies requirement that return_value be an array of possibly multidimensional values)
                     if converted_to_2d.dtype == object:
@@ -2537,7 +2537,7 @@ class Mechanism_Base(Mechanism):
         return value
 
     def _get_variable_from_input(self, input, context=None):
-        input = np.atleast_2d(input)
+        input = convert_to_np_array(input, dimension=2)
         num_inputs = np.size(input, 0)
         num_input_ports = len(self.input_ports)
         if num_inputs != num_input_ports:
@@ -2559,7 +2559,7 @@ class Mechanism_Base(Mechanism):
                                      f"required length ({len(input_port.defaults.variable)}) for input "
                                      f"to {InputPort.__name__} {repr(input_port.name)} of {self.name}.")
 
-        return np.array(self.get_input_values(context))
+        return convert_to_np_array(self.get_input_values(context))
 
     def _update_input_ports(self, runtime_input_port_params=None, context=None):
         """Update value for each InputPort in self.input_ports:
@@ -2574,7 +2574,7 @@ class Mechanism_Base(Mechanism):
             port= self.input_ports[i]
             port._update(params=runtime_input_port_params,
                          context=context)
-        return np.array(self.get_input_values(context))
+        return convert_to_np_array(self.get_input_values(context))
 
     def _update_parameter_ports(self, runtime_parameter_port_params=None, context=None):
 
@@ -3569,7 +3569,7 @@ class Mechanism_Base(Mechanism):
                 else:
                     old_variable = self.defaults.variable
                 old_variable.extend(added_variable)
-                self.defaults.variable = np.array(old_variable)
+                self.defaults.variable = convert_to_np_array(old_variable)
             instantiated_input_ports = _instantiate_input_ports(self,
                                                                   input_ports,
                                                                   added_variable,
@@ -3993,7 +3993,7 @@ def _is_mechanism_spec(spec):
 from collections import UserList
 class MechanismList(UserList):
     """Provides access to Mechanisms and their attributes in a list Mechanisms of an owner.
-    
+
     Properties return dicts with item : attribute pairs.
     Recursively process any item that itself is a MechanismList (e.g., a `Nested Composition <Composition_Nested>`.
 

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -587,7 +587,7 @@ from psyneulink.core.globals.keywords import \
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
-from psyneulink.core.globals.utilities import ContentAddressableList, convert_to_list, copy_iterable_with_shared, is_iterable
+from psyneulink.core.globals.utilities import ContentAddressableList, convert_to_list, convert_to_np_array, copy_iterable_with_shared, is_iterable
 
 __all__ = [
     'CONTROL_ALLOCATION', 'GATING_ALLOCATION', 'ControlMechanism', 'ControlMechanismError', 'ControlMechanismRegistry',
@@ -674,9 +674,13 @@ def validate_monitored_port_spec(owner, spec_list):
 def _control_mechanism_costs_getter(owning_component=None, context=None):
     # NOTE: In cases where there is a reconfiguration_cost, that cost is not returned by this method
     try:
-        costs = [c.compute_costs(c.parameters.value._get(context), context=context)
-                 for c in owning_component.control_signals
-                 if hasattr(c, 'compute_costs')] # GatingSignals don't have cost fcts
+        costs = [
+            convert_to_np_array(
+                c.compute_costs(c.parameters.value._get(context), context=context)
+            )
+            for c in owning_component.control_signals
+            if hasattr(c, 'compute_costs')
+        ] # GatingSignals don't have cost fcts
         return costs
 
     except TypeError:
@@ -692,8 +696,10 @@ def _net_outcome_getter(owning_component=None, context=None):
     # NOTE: In cases where there is a reconfiguration_cost, that cost is not included in the net_outcome
     try:
         c = owning_component
-        return c.compute_net_outcome(c.parameters.outcome._get(context),
-                                     c.combine_costs(c.parameters.costs._get(context)))
+        return c.compute_net_outcome(
+            c.parameters.outcome._get(context),
+            c.combine_costs()
+        )
     except TypeError:
         return [0]
 

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -413,6 +413,7 @@ from psyneulink.core.globals.keywords import \
     DEFAULT_VARIABLE, EID_FROZEN, FUNCTION, INTERNAL_ONLY, NAME, \
     OPTIMIZATION_CONTROL_MECHANISM, OBJECTIVE_MECHANISM, OUTCOME, PRODUCT, PARAMS, \
     CONTROL, AUTO_ASSIGN_MATRIX
+from psyneulink.core.globals.utilities import convert_to_np_array
 from psyneulink.core.globals.parameters import Parameter, ParameterAlias
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.context import handle_external_context
@@ -873,7 +874,7 @@ class OptimizationControlMechanism(ControlMechanism):
             port = self.input_ports[i]
             port._update(params=runtime_params, context=context)
             port_values.append(port.parameters.value._get(context))
-        return np.array(port_values)
+        return convert_to_np_array(port_values)
         # # MODIFIED 5/8/20 NEW:
         # input_port_values = super()._update_input_ports(runtime_params, context)
         # port_values.append(input_port_values)

--- a/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
@@ -550,7 +550,7 @@ from psyneulink.core.globals.keywords import \
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
-from psyneulink.core.globals.utilities import ContentAddressableList, is_numeric, parameter_spec, convert_to_list
+from psyneulink.core.globals.utilities import ContentAddressableList, convert_to_np_array, is_numeric, parameter_spec, convert_to_list
 
 __all__ = [
     'ACTIVATION_INPUT', 'ACTIVATION_INPUT_INDEX', 'ACTIVATION_OUTPUT', 'ACTIVATION_OUTPUT_INDEX',
@@ -1352,9 +1352,13 @@ class LearningMechanism(ModulatoryMechanism_Base):
 
         # Compute learning_signal for each error_signal (and corresponding error-Matrix):
         for error_signal_input, error_matrix in zip(error_signal_inputs, error_matrices):
-            function_variable = np.array([variable[ACTIVATION_INPUT_INDEX],
-                                          variable[ACTIVATION_OUTPUT_INDEX],
-                                          error_signal_input])
+            function_variable = convert_to_np_array(
+                [
+                    variable[ACTIVATION_INPUT_INDEX],
+                    variable[ACTIVATION_OUTPUT_INDEX],
+                    error_signal_input
+                ]
+            )
             learning_signal, error_signal = super()._execute(variable=function_variable,
             # MODIFIED CROSS_PATHWAYS 7/22/19 END
                                                              context=context,

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1080,6 +1080,10 @@ class TransferMechanism(ProcessingMechanism_Base):
             structural=True,
         )
 
+        def _validate_variable(self, variable):
+            if 'U' in str(variable.dtype):
+                return 'may not contain non-numeric entries'
+
         def _validate_integrator_mode(self, integrator_mode):
             if not isinstance(integrator_mode, bool):
                 return 'may only be True or False.'

--- a/psyneulink/core/components/ports/inputport.py
+++ b/psyneulink/core/components/ports/inputport.py
@@ -516,7 +516,7 @@ from psyneulink.core.globals.keywords import \
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
-from psyneulink.core.globals.utilities import append_type_to_name, is_numeric, iscompatible, kwCompatibilityLength
+from psyneulink.core.globals.utilities import append_type_to_name, convert_to_np_array, is_numeric, iscompatible, kwCompatibilityLength
 
 __all__ = [
     'InputPort', 'InputPortError', 'port_type_keywords', 'SHADOW_INPUTS',
@@ -976,7 +976,7 @@ class InputPort(Port_Base):
         ]
 
         if len(path_proj_values) > 0:
-            return  np.asarray(path_proj_values)
+            return convert_to_np_array(path_proj_values)
         else:
             return None
 

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -638,7 +638,7 @@ from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import \
-    is_numeric, iscompatible, make_readonly_property, recursive_update, ContentAddressableList
+    convert_to_np_array, is_numeric, iscompatible, make_readonly_property, recursive_update, ContentAddressableList
 
 __all__ = [
     'OutputPort', 'OutputPortError', 'PRIMARY', 'SEQUENTIAL', 'StandardOutputPorts', 'StandardOutputPortsError',
@@ -1350,7 +1350,7 @@ def _instantiate_output_ports(owner, output_ports=None, context=None):
                     for item in owner_value))):
         pass
     else:
-        converted_to_2d = np.atleast_2d(owner.value)
+        converted_to_2d = convert_to_np_array(owner.value, dimension=2)
         # If owner_value is a list of heterogenous elements, use as is
         if converted_to_2d.dtype == object:
             owner_value = owner.defaults.value

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2627,7 +2627,8 @@ def _instantiate_port(port_type:_is_port_class,           # Port's type
             port_spec_dict[REFERENCE_VALUE] = port_spec_dict[VARIABLE]
 
     #  Convert reference_value to np.array to match port_variable (which, as output of function, will be an np.array)
-    port_spec_dict[REFERENCE_VALUE] = convert_to_np_array(port_spec_dict[REFERENCE_VALUE],1)
+    if port_spec_dict[REFERENCE_VALUE] is not None:
+        port_spec_dict[REFERENCE_VALUE] = convert_to_np_array(port_spec_dict[REFERENCE_VALUE], 1)
 
     # INSTANTIATE PORT:
 

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -2391,7 +2391,7 @@ from psyneulink.core.globals.log import CompositionLog, LogCondition
 from psyneulink.core.globals.parameters import Parameter, ParametersBase
 from psyneulink.core.globals.registry import register_category
 from psyneulink.core.globals.utilities import \
-    ContentAddressableList, call_with_pruned_args, convert_to_list, merge_dictionaries
+    ContentAddressableList, call_with_pruned_args, convert_to_list, convert_to_np_array, merge_dictionaries
 from psyneulink.core.scheduling.condition import All, Always, Condition, EveryNCalls, Never
 from psyneulink.core.scheduling.scheduler import Scheduler
 from psyneulink.core.scheduling.time import Time, TimeScale
@@ -3066,13 +3066,13 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     input_CIM_ports : dict
         a dictionary in which the key of each entry is the `InputPort` of an `INPUT` `Node <Composition_Nodes>` in
         the Composition, and its value is a list containing two items:
-        
+
         - the `InputPort` of the `input_CIM <Composition.input_CIM>` that receives the input destined for that `INPUT`
           Node -- either from the `input <Composition_Execution_Inputs>` specified for the Node in a call to one of the
           Composition's `execution methods <Composition_Execution_Methods>`, or from a `MappingProjection` from a
           Node in an `enclosing Composition <Composition_Nested>` that has specified the `INPUT` Node as its `receiver
           <Projection_Base.receiver>`;
-        
+
         - the `OutputPort` of the `input_CIM <Composition.input_CIM>` that sends a `MappingProjection` to the
           `InputPort` of the `INPUT` Node.
 
@@ -3116,10 +3116,10 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     output_CIM_ports : dict
         a dictionary in which the key of each entry is the `OutputPort` of an `OUTPUT` `Node <Composition_Nodes>` in
         the Composition, and its value is a list containing two items:
-        
+
         - the `InputPort` of the output_CIM that receives a `MappingProjection` from the `OutputPort` of the `OUTPUT`
           Node;
-        
+
         - the `OutputPort` of the `output_CIM <Composition.output_CIM>` that is either recorded in the `results
           <Composition.results>` attrribute of the Composition, or sends a `MappingProjection` to a Node in the
           `enclosing Composition <Composition_Nested>` that has specified the `OUTPUT` Node as its `sender
@@ -7197,7 +7197,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                                                 )
 
             # Get control signal costs
-            all_costs = self.controller.parameters.costs._get(context) + [reconfiguration_cost]
+            all_costs = convert_to_np_array(self.controller.parameters.costs._get(context) + [reconfiguration_cost])
             # Compute a total for the candidate control signal(s)
             total_cost = self.controller.combine_costs(all_costs)
         return total_cost
@@ -7564,7 +7564,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         match_type = self._input_matches_variable(input, node_variable)
         if match_type == 'homogeneous':
             # np.atleast_2d will catch any single-input ports specified without an outer list
-            _input = np.atleast_2d(input)
+            _input = convert_to_np_array(input, 2)
         elif match_type == 'heterogeneous':
             _input = input
         else:
@@ -9202,11 +9202,12 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         return All(*cond)
 
     def _input_matches_variable(self, input_value, var):
+        var_shape = convert_to_np_array(var).shape
         # input_value ports are uniform
-        if np.shape(np.atleast_2d(input_value)) == np.shape(var):
+        if convert_to_np_array(input_value, dimension=2).shape == var_shape:
             return "homogeneous"
         # input_value ports have different lengths
-        elif len(np.shape(var)) == 1 and isinstance(var[0], (list, np.ndarray)):
+        elif len(var_shape) == 1 and isinstance(var[0], (list, np.ndarray)):
             for i in range(len(input_value)):
                 if len(input_value[i]) != len(var[i]):
                     return False

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -847,41 +847,53 @@ def np_array_less_than_2d(array):
     else:
         return False
 
-def convert_to_np_array(value, dimension):
-    """Convert value to np.array if it is not already
-
-    Check whether value is already an np.ndarray and whether it has non-numeric elements
-
-    Return np.array of specified dimension
-
-    :param value:
-    :return:
+def convert_to_np_array(value, dimension=None):
     """
+        Converts value to np.ndarray if it is not already. Handles
+        creation of "ragged" arrays
+        (https://numpy.org/neps/nep-0034-infer-dtype-is-object.html)
+
+        Args:
+            value
+                item to convert to np.ndarray
+
+            dimension : 1, 2, None
+                minimum dimension of np.ndarray to convert to
+
+        Returns:
+            value : np.ndarray
+    """
+    def safe_create_np_array(value):
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error', category=np.VisibleDeprecationWarning)
+            # NOTE: this will raise a ValueError in the future.
+            # See https://numpy.org/neps/nep-0034-infer-dtype-is-object.html
+            try:
+                try:
+                    return np.asarray(value)
+                except np.VisibleDeprecationWarning:
+                    return np.asarray(value, dtype=object)
+            except ValueError as e:
+                msg = str(e)
+                if 'cannot guess the desired dtype from the input' in msg:
+                    return np.asarray(value, dtype=object)
+                # KDM 6/29/20: this case handles a previously noted case
+                # by KAM 6/28/18, #877:
+                # [[0.0], [0.0], np.array([[0.0, 0.0]])]
+                # but was only handled for dimension=1
+                elif 'could not broadcast' in msg:
+                    return convert_all_elements_to_np_array(value)
+                else:
+                    raise
+
     if value is None:
         return None
 
+    value = safe_create_np_array(value)
+
     if dimension == 1:
-        # KAM 6/28/18: added for cases when even np does not recognize the shape/dtype
-        # Needed this specifically for the following shape: variable = [[0.0], [0.0], np.array([[0.0, 0.0]])]
-        # Which is due to a custom OutputPort variable that includes an owner value, owner param, and owner input
-        # port variable. FIX: This branch of code may erroneously catch other shapes that could be handled by np
-
-        try:
-            value = np.atleast_1d(value)
-
-        # KAM 6/28/18: added exception for cases when even np does not recognize the shape/dtype
-        # Needed this specifically for the following shape: variable = [[0.0], [0.0], np.array([[0.0, 0.0]])]
-        # Due to a custom OutputPort variable (variable = [owner value[0], owner param, owner InputPort variable])
-        # FIX: (1) is this exception specific enough? (2) this is not actually converting to an np.array but in this
-        # case (as far as I know) we cannot convert to np -- should we warn other methods that this value is "not np"?
-        except ValueError:
-            return value
-
+        value = np.atleast_1d(value)
     elif dimension == 2:
-        from numpy import ndarray
-        # if isinstance(value, ndarray) and value.dtype==object and len(value) == 2:
-        value = np.array(value)
-        # if value.dtype==object and len(value) == 2:
         # Array is made up of non-uniform elements, so treat as 2d array and pass
         if (
             value.ndim > 0
@@ -891,8 +903,9 @@ def convert_to_np_array(value, dimension):
             pass
         else:
             value = np.atleast_2d(value)
-    else:
-        raise UtilitiesError("dimensions param ({0}) must be 1 or 2".format(dimension))
+    elif dimension is not None:
+        raise UtilitiesError("dimension param ({0}) must be None, 1, or 2".format(dimension))
+
     return value
 
 

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -883,7 +883,11 @@ def convert_to_np_array(value, dimension):
         value = np.array(value)
         # if value.dtype==object and len(value) == 2:
         # Array is made up of non-uniform elements, so treat as 2d array and pass
-        if value.dtype==object:
+        if (
+            value.ndim > 0
+            and value.dtype == object
+            and any([safe_len(x) > 1 for x in value])
+        ):
             pass
         else:
             value = np.atleast_2d(value)

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -886,9 +886,6 @@ def convert_to_np_array(value, dimension=None):
                 else:
                     raise
 
-    if value is None:
-        return None
-
     value = safe_create_np_array(value)
 
     if dimension == 1:

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -889,8 +889,6 @@ def convert_to_np_array(value, dimension):
             value = np.atleast_2d(value)
     else:
         raise UtilitiesError("dimensions param ({0}) must be 1 or 2".format(dimension))
-    if 'U' in repr(value.dtype):
-        raise UtilitiesError("{0} has non-numeric entries".format(value))
     return value
 
 

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -360,7 +360,6 @@ Class Reference
 """
 import logging
 import types
-
 from collections.abc import Iterable
 
 import numpy as np
@@ -383,7 +382,7 @@ from psyneulink.core.globals.keywords import \
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set, REPORT_OUTPUT_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
-from psyneulink.core.globals.utilities import is_numeric, is_same_function_spec, object_has_single_value, get_global_seed
+from psyneulink.core.globals.utilities import convert_to_np_array, is_numeric, is_same_function_spec, object_has_single_value, get_global_seed
 
 from psyneulink.core import llvm as pnlvm
 
@@ -1041,7 +1040,7 @@ class DDM(ProcessingMechanism):
             if self.initialization_status != ContextFlags.INITIALIZING:
                 logger.info('{0} {1} is at {2}'.format(type(self).__name__, self.name, result))
 
-            return np.array([result[0], [result[1]]])
+            return convert_to_np_array([result[0], [result[1]]])
 
         # EXECUTE ANALYTIC SOLUTION (TRIAL TIME SCALE) -----------------------------------------------------------
         else:
@@ -1120,7 +1119,7 @@ class DDM(ProcessingMechanism):
             prob_upper_thr = builder.fsub(prob_lower_thr.type(1),
                                           prob_lower_thr)
             builder.store(prob_upper_thr, dst)
-            
+
             # Load function threshold
             threshold_ptr = pnlvm.helpers.get_param_ptr(builder, self.function,
                                                         params, THRESHOLD)
@@ -1191,7 +1190,7 @@ class DDM(ProcessingMechanism):
             )
             return True
         return False
-    
+
     def _gen_llvm_is_finished_cond(self, ctx, builder, params, state, current):
         # Setup pointers to internal function
         func_state_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, 'function')

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -106,6 +106,7 @@ from psyneulink.core.globals.context import ContextFlags
 from psyneulink.core.globals.keywords import CONTEXT, NAME, OWNER_VALUE, SIZE, VARIABLE
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
+from psyneulink.core.globals.utilities import convert_to_np_array
 
 __all__ = ['EpisodicMemoryMechanism', 'CONTENT_INPUT', 'ASSOC_INPUT', 'CONTENT_OUTPUT', 'ASSOC_OUTPUT']
 
@@ -302,7 +303,7 @@ class EpisodicMemoryMechanism(ProcessingMechanism_Base):
 
         # If assoc has not been specified, add empty list to call to function (which expects two items in its variable)
         if len(variable) != 2:
-            return np.array([variable[0],[]])
+            return convert_to_np_array([variable[0],[]])
         else:
             return variable
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,9 @@ pytest_plugins = ['pytest_profiling', 'helpers_namespace', 'benchmark']
 
 xfail_strict = True
 
+filterwarnings =
+	error::numpy.VisibleDeprecationWarning
+
 [pycodestyle]
 # for code explanation see https://pep8.readthedocs.io/en/latest/intro.html#error-codes
 ignore = E111,E114,E115,E116,E117,E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E201,E202,E203,E211,E221,E225,E231,E241,E251,E252,E261,E262,E265,E266,E271,E301,E302,E303,E305,E306,E402,E501,E711,E712,E713,E714,E721,E722,E731,E741,W293,W391,W503,W504,W605

--- a/tests/functions/test_combination.py
+++ b/tests/functions/test_combination.py
@@ -44,10 +44,10 @@ class TestRearrange:
     @pytest.mark.combination_function
     def test_default_variable_has_non_numeric_index(self):
         # with pytest.raises(pnl.FunctionError) as error_text:
-        with pytest.raises(pnl.UtilitiesError) as error_text:
+        with pytest.raises(pnl.FunctionError) as error_text:
             pnl.Rearrange(default_variable=[[0],['a']], arrangement=[(1,2),0])
         # error_msg = "All elements of 'default_variable' for Rearrange must be scalar values."
-        error_msg = "[['0']\\n ['a']] has non-numeric entries"
+        error_msg = "must be scalar values"
         assert error_msg in str(error_text.value)
 
     @pytest.mark.function

--- a/tests/functions/test_memory.py
+++ b/tests/functions/test_memory.py
@@ -129,7 +129,7 @@ def test_ContentAddressableMemory_with_initializer_and_key_size_same_as_val_size
             assoc_size=3,
             function = ContentAddressableMemory(
                     seed=2,
-                    initializer=np.array([stimuli['F'], stimuli['F']]),
+                    initializer=np.array([stimuli['F'], stimuli['F']], dtype=object),
                     duplicate_keys=True,
                     equidistant_keys_select=RANDOM)
     )
@@ -137,7 +137,7 @@ def test_ContentAddressableMemory_with_initializer_and_key_size_same_as_val_size
     retrieved_keys=[]
     for key in sorted(stimuli.keys()):
         retrieved = [i for i in em.execute(stimuli[key])]
-        retrieved_key = [k for k,v in stimuli.items() if np.array_equal(v, retrieved)] or [None]
+        retrieved_key = [k for k,v in stimuli.items() if v == retrieved] or [None]
         retrieved_keys.append(retrieved_key)
     assert retrieved_keys == [['F'], ['A'], ['A'], ['C'], ['B'], ['F']]
 
@@ -146,19 +146,19 @@ def test_ContentAddressableMemory_with_initializer_and_key_size_same_as_val_size
     retrieved_keys=[]
     for key in sorted(stimuli.keys()):
         retrieved = [i for i in em.execute(stimuli[key])]
-        retrieved_key = [k for k,v in stimuli.items() if np.array_equal(v, retrieved)] or [None]
+        retrieved_key = [k for k,v in stimuli.items() if v == retrieved] or [None]
         retrieved_keys.append(retrieved_key)
     assert retrieved_keys == [['A'], ['A'], ['A'], ['A'], ['B'], ['F']]
 
     stim = 'C'
     em.function.equidistant_keys_select = OLDEST
     retrieved = [i for i in em.function.get_memory(stimuli[stim][0])]
-    retrieved_key = [k for k,v in stimuli.items() if np.array_equal(v, retrieved)] or [None]
+    retrieved_key = [k for k,v in stimuli.items() if v == retrieved] or [None]
     assert retrieved_key == ['A']
 
     em.function.equidistant_keys_select = NEWEST
     retrieved = [i for i in em.function.get_memory(stimuli[stim][0])]
-    retrieved_key = [k for k,v in stimuli.items() if np.array_equal(v, retrieved)] or [None]
+    retrieved_key = [k for k,v in stimuli.items() if v == retrieved] or [None]
     assert retrieved_key == ['D']
 
     # Test that after allowing dups, warning is issued and memory with zeros is returned
@@ -188,27 +188,28 @@ def test_ContentAddressableMemory_with_initializer_and_key_size_diff_from_val_si
             content_size=3,
             assoc_size=4,
             function = ContentAddressableMemory(
-                    initializer=np.array([stimuli['F'], stimuli['F']]),
+                    initializer=np.array([stimuli['F'], stimuli['F']], dtype=object),
                     duplicate_keys=True,
                     equidistant_keys_select=RANDOM)
     )
 
     retrieved_keys=[]
     for key in sorted(stimuli.keys()):
+        print(key)
         retrieved = [i for i in em.execute(stimuli[key])]
-        retrieved_key = [k for k,v in stimuli.items() if np.array_equal(v, retrieved)] or [None]
+        retrieved_key = [k for k,v in stimuli.items() if v == retrieved] or [None]
         retrieved_keys.append(retrieved_key)
     assert retrieved_keys == [['F'], ['A'], ['A'], ['A'], ['B'], ['F']]
 
     stim = 'C'
     em.function.equidistant_keys_select = OLDEST
     retrieved = [i for i in em.function.get_memory(stimuli[stim][0])]
-    retrieved_key = [k for k,v in stimuli.items() if np.array_equal(v, retrieved)] or [None]
+    retrieved_key = [k for k,v in stimuli.items() if v == retrieved] or [None]
     assert retrieved_key == ['A']
 
     em.function.equidistant_keys_select = NEWEST
     retrieved = [i for i in em.function.get_memory(stimuli[stim][0])]
-    retrieved_key = [k for k,v in stimuli.items() if np.array_equal(v, retrieved)] or [None]
+    retrieved_key = [k for k,v in stimuli.items() if v == retrieved] or [None]
     assert retrieved_key == ['D']
 
     # Test that after allowing dups, warning is issued and memory with zeros is returned
@@ -245,19 +246,19 @@ def test_ContentAddressableMemory_without_initializer_and_key_size_same_as_val_s
     retrieved_keys=[]
     for key in sorted(stimuli.keys()):
         retrieved = [i for i in em.execute(stimuli[key])]
-        retrieved_key = [k for k,v in stimuli.items() if np.array_equal(v, retrieved)] or [None]
+        retrieved_key = [k for k,v in stimuli.items() if v == retrieved] or [None]
         retrieved_keys.append(retrieved_key)
     assert retrieved_keys == [[None], ['A'], ['A'], ['C'], ['B'], ['D']]
 
     stim = 'C'
     em.function.equidistant_keys_select = OLDEST
     retrieved = [i for i in em.function.get_memory(stimuli[stim][0])]
-    retrieved_key = [k for k,v in stimuli.items() if np.array_equal(v, retrieved)] or [None]
+    retrieved_key = [k for k,v in stimuli.items() if v == retrieved] or [None]
     assert retrieved_key == ['A']
 
     em.function.equidistant_keys_select = NEWEST
     retrieved = [i for i in em.function.get_memory(stimuli[stim][0])]
-    retrieved_key = [k for k,v in stimuli.items() if np.array_equal(v, retrieved)] or [None]
+    retrieved_key = [k for k,v in stimuli.items() if v == retrieved] or [None]
     assert retrieved_key == ['D']
 
     # Test that after allowing dups, warning is issued and memory with zeros is returned
@@ -294,19 +295,19 @@ def test_ContentAddressableMemory_without_initializer_and_key_size_diff_from_val
     retrieved_keys=[]
     for key in sorted(stimuli.keys()):
         retrieved = [i for i in em.execute(stimuli[key])]
-        retrieved_key = [k for k,v in stimuli.items() if np.array_equal(v, retrieved)] or [None]
+        retrieved_key = [k for k,v in stimuli.items() if v == retrieved] or [None]
         retrieved_keys.append(retrieved_key)
     assert retrieved_keys == [[None], ['A'], ['A'], ['C'], ['B'], ['D']]
 
     stim = 'C'
     em.function.equidistant_keys_select = OLDEST
     retrieved = [i for i in em.function.get_memory(stimuli[stim][0])]
-    retrieved_key = [k for k,v in stimuli.items() if np.array_equal(v, retrieved)] or [None]
+    retrieved_key = [k for k,v in stimuli.items() if v == retrieved] or [None]
     assert retrieved_key == ['A']
 
     em.function.equidistant_keys_select = NEWEST
     retrieved = [i for i in em.function.get_memory(stimuli[stim][0])]
-    retrieved_key = [k for k,v in stimuli.items() if np.array_equal(v, retrieved)] or [None]
+    retrieved_key = [k for k,v in stimuli.items() if v == retrieved] or [None]
     assert retrieved_key == ['D']
 
     # Test that after allowing dups, warning is issued and memory with zeros is returned
@@ -337,7 +338,7 @@ def test_ContentAddressableMemory_without_assoc():
             name='EPISODIC MEMORY MECH',
             content_size=3,
             function = ContentAddressableMemory(
-                    # initializer=np.array([stimuli['F'], stimuli['F']]),
+                    # initializer=np.array([stimuli['F'], stimuli['F']], dtype=object),
                     duplicate_keys=True,
                     equidistant_keys_select=RANDOM,
                     retrieval_prob = 1.0
@@ -347,14 +348,14 @@ def test_ContentAddressableMemory_without_assoc():
     for key in sorted(stimuli.keys()):
         print(f'\nCurrent memory: \n{em.memory}\n')
         retrieved = [i for i in em.execute(stimuli[key])]
-        retrieved_key = [k for k,v in stimuli.items() if np.array_equal(v, retrieved)] or [None]
+        retrieved_key = [k for k,v in stimuli.items() if v == retrieved] or [None]
         print(f'\nExecuted with stimulus {key}: {stimuli[key]};'
               f'\nRetrieved memory {retrieved_key[0]}: \n\t{retrieved}')
 
     retrieved_keys=[]
     for key in sorted(stimuli.keys()):
         retrieved = [i for i in em.execute(stimuli[key])]
-        retrieved_key = [k for k,v in stimuli.items() if np.array_equal(v, retrieved)] or [None]
+        retrieved_key = [k for k,v in stimuli.items() if v == retrieved] or [None]
         retrieved_keys.append(retrieved_key)
 
     assert retrieved_keys == [['A', 'C', 'D'], ['B'], ['A', 'C', 'D'], ['A', 'C', 'D'], ['E'], ['F']]
@@ -428,7 +429,7 @@ def test_ContentAddressableMemory_add_and_delete_from_memory():
             assert np.allclose(i,j)
 
     # Test adding memory with different size value as np.array
-    em.add_to_memory(np.array([[1,2,3],[200,201,202,203]]))
+    em.add_to_memory(np.array([[1,2,3],[200,201,202,203]], dtype=object))
     expected_memory = [[[ 7,  8,  9],[10, 11, 12]],
                        [[10, 20, 30],[40, 50, 60]],
                        [[11, 21, 31],[41, 51, 61]],
@@ -440,7 +441,7 @@ def test_ContentAddressableMemory_add_and_delete_from_memory():
 
     # Test error for illegal key:
     with pytest.raises(FunctionError) as error_text:
-        em.add_to_memory(np.array([[1,2],[200,201,202,203]]))
+        em.add_to_memory(np.array([[1,2],[200,201,202,203]], dtype=object))
     assert "Length of 'key'" in str(error_text.value) and "must be same as others in the dict" in str(error_text.value)
 
 

--- a/tests/log/test_log.py
+++ b/tests/log/test_log.py
@@ -232,14 +232,16 @@ class TestLog:
 
         result = T_1.log.nparray(entries=['mod_noise', 'RESULT'], header=False, owner_name=True)
         assert result[0] == PS.default_execution_id
-        np.testing.assert_array_equal(result[1][0],
-                                      np.array([[[0], [1], [2]],
-                                                [[ 0.], [ 0.], [ 0.]],
-                                                [[ 0.], [ 0.], [ 0.]],
-                                                [[ 0.], [ 0.], [ 0.]],
-                                                [[ 0.0], [ 0.0],[ 0.0]],
-                                                [[ 0.,  0.], [ 1.,  2.],[ 3., 4.]],
-                                                ]))
+
+        expected = [
+            [[0], [1], [2]],
+            [[0.], [0.], [0.]],
+            [[0.], [0.], [0.]],
+            [[0.], [0.], [0.]],
+            [[0.0], [0.0], [0.0]],
+            [[0., 0.], [1., 2.], [3., 4.]],
+        ]
+        assert result[1][0] == expected
 
     def test_log_initialization(self):
         T = pnl.TransferMechanism(

--- a/tests/mechanisms/test_input_state_spec.py
+++ b/tests/mechanisms/test_input_state_spec.py
@@ -37,7 +37,7 @@ class TestInputPortSpec:
             default_variable=[[0, 0], [0]],
             input_ports=[[32, 24], 'HELLO']
         )
-        assert T.defaults.variable.shape == np.array([[0, 0], [0]]).shape
+        assert T.defaults.variable.shape == np.array([[0, 0], [0]], dtype=object).shape
         assert len(T.input_ports) == 2
         assert T.input_ports[1].name == 'HELLO'
         # # PROBLEM WITH input FOR RUN:
@@ -53,7 +53,7 @@ class TestInputPortSpec:
     #         default_variable=[[0], [0]],
     #         input_ports=[[32, 24], 'HELLO']
     #     )
-    #     assert T.defaults.variable.shape == np.array([[0, 0], [0]]).shape
+    #     assert T.defaults.variable.shape == np.array([[0, 0], [0]], dtype=object).shape
     #     assert len(T.input_ports) == 2
     #     assert T.input_ports[1].name == 'HELLO'
 
@@ -145,7 +145,7 @@ class TestInputPortSpec:
             input_ports=[[32], 'HELLO'],
             params={INPUT_PORTS: [[32, 24], 'HELLO']}
         )
-        assert T.defaults.variable.shape == np.array([[0, 0], [0]]).shape
+        assert T.defaults.variable.shape == np.array([[0, 0], [0]], dtype=object).shape
         assert len(T.input_ports) == 2
         assert T.input_ports[1].name == 'HELLO'
         # # PROBLEM WITH input FOR RUN:
@@ -162,7 +162,7 @@ class TestInputPortSpec:
         #                INSTEAD, SEEM TO IGNORE InputPort SPECIFICATIONS AND JUST USE DEFAULT_VARIABLE
         #                NOTE:  WORKS FOR ObjectiveMechanism, BUT NOT TransferMechanism
         T = TransferMechanism(input_ports=[[32, 24], 'HELLO'])
-        assert T.defaults.variable.shape == np.array([[0, 0], [0]]).shape
+        assert T.defaults.variable.shape == np.array([[0, 0], [0]], dtype=object).shape
         assert len(T.input_ports) == 2
         assert T.input_ports[1].name == 'HELLO'
 
@@ -177,7 +177,7 @@ class TestInputPortSpec:
         #                INSTEAD, SEEM TO IGNORE InputPort SPECIFICATIONS AND JUST USE DEFAULT_VARIABLE
         #                NOTE:  WORKS FOR ObjectiveMechanism, BUT NOT TransferMechanism
         T = TransferMechanism(params={INPUT_PORTS: [[32, 24], 'HELLO']})
-        assert T.defaults.variable.shape == np.array([[0, 0], [0]]).shape
+        assert T.defaults.variable.shape == np.array([[0, 0], [0]], dtype=object).shape
         assert len(T.input_ports) == 2
         assert T.input_ports[1].name == 'HELLO'
 
@@ -453,7 +453,7 @@ class TestInputPortSpec:
                 {NAME: 'SECOND', VARIABLE: [0]}
             ]
         )
-        assert T.defaults.variable.shape == np.array([[0, 0], [0]]).shape
+        assert T.defaults.variable.shape == np.array([[0, 0], [0]], dtype=object).shape
         assert len(T.input_ports) == 2
 
     # ------------------------------------------------------------------------------------------------
@@ -511,7 +511,7 @@ class TestInputPortSpec:
             input_ports=[[0], [0]],
             params={INPUT_PORTS: [[0, 0], [0]]}
         )
-        assert T.defaults.variable.shape == np.array([[0, 0], [0]]).shape
+        assert T.defaults.variable.shape == np.array([[0, 0], [0]], dtype=object).shape
         assert len(T.input_ports) == 2
 
     # ------------------------------------------------------------------------------------------------

--- a/tests/mechanisms/test_kwta.py
+++ b/tests/mechanisms/test_kwta.py
@@ -7,7 +7,7 @@ from psyneulink.core.components.functions.transferfunctions import Linear, Logis
 from psyneulink.core.components.mechanisms.mechanism import MechanismError
 from psyneulink.core.globals.keywords import MATRIX_KEYWORD_VALUES, RANDOM_CONNECTIVITY_MATRIX
 from psyneulink.core.globals.preferences.basepreferenceset import REPORT_OUTPUT_PREF, VERBOSE_PREF
-from psyneulink.core.globals.utilities import UtilitiesError
+from psyneulink.core.globals.parameters import ParameterError
 from psyneulink.library.components.mechanisms.processing.transfer.kwtamechanism import KWTAError, KWTAMechanism
 
 class TestKWTAInputs:
@@ -60,13 +60,13 @@ class TestKWTAInputs:
         assert("which is not supported for KWTA" in str(error_text.value))
 
     def test_kwta_var_list_of_strings(self):
-        with pytest.raises(UtilitiesError) as error_text:
+        with pytest.raises(ParameterError) as error_text:
             K = KWTAMechanism(
                 name='K',
                 default_variable=['a', 'b', 'c', 'd'],
                 integrator_mode=True
             )
-        assert("has non-numeric entries" in str(error_text.value))
+        assert("non-numeric entries" in str(error_text.value))
 
     def test_recurrent_mech_inputs_mismatched_with_default_longer(self):
         with pytest.raises(MechanismError) as error_text:

--- a/tests/mechanisms/test_recurrent_transfer_mechanism.py
+++ b/tests/mechanisms/test_recurrent_transfer_mechanism.py
@@ -16,6 +16,7 @@ from psyneulink.core.components.mechanisms.processing.transfermechanism import T
 from psyneulink.core.globals.keywords import MATRIX_KEYWORD_VALUES, RANDOM_CONNECTIVITY_MATRIX, RESULT
 from psyneulink.core.globals.preferences.basepreferenceset import REPORT_OUTPUT_PREF, VERBOSE_PREF
 from psyneulink.core.globals.utilities import UtilitiesError
+from psyneulink.core.globals.parameters import ParameterError
 from psyneulink.core.scheduling.condition import Never
 from psyneulink.library.components.mechanisms.processing.transfer.recurrenttransfermechanism import \
     RecurrentTransferError, RecurrentTransferMechanism
@@ -218,23 +219,23 @@ class TestRecurrentTransferMechanismInputs:
         np.testing.assert_allclose(val, [[10.]])
 
     def test_recurrent_mech_inputs_list_of_strings(self):
-        with pytest.raises(UtilitiesError) as error_text:
+        with pytest.raises(FunctionError) as error_text:
             R = RecurrentTransferMechanism(
                 name='R',
                 default_variable=[0, 0, 0, 0],
                 integrator_mode=True
             )
             R.execute(["one", "two", "three", "four"])
-        assert "has non-numeric entries" in str(error_text.value)
+        assert "Unrecognized type" in str(error_text.value)
 
     def test_recurrent_mech_var_list_of_strings(self):
-        with pytest.raises(UtilitiesError) as error_text:
+        with pytest.raises(ParameterError) as error_text:
             R = RecurrentTransferMechanism(
                 name='R',
                 default_variable=['a', 'b', 'c', 'd'],
                 integrator_mode=True
             )
-        assert "has non-numeric entries" in str(error_text.value)
+        assert "non-numeric entries" in str(error_text.value)
 
     def test_recurrent_mech_inputs_mismatched_with_default_longer(self):
         with pytest.raises(MechanismError) as error_text:

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -111,14 +111,14 @@ class TestTransferMechanismInputs:
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
     def test_transfer_mech_inputs_list_of_strings(self):
-        with pytest.raises(UtilitiesError) as error_text:
+        with pytest.raises(FunctionError) as error_text:
             T = TransferMechanism(
                 name='T',
                 default_variable=[0, 0, 0, 0],
                 integrator_mode=True
             )
             T.execute(["one", "two", "three", "four"])
-        assert "has non-numeric entries" in str(error_text.value)
+        assert "Unrecognized type" in str(error_text.value)
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism

--- a/tests/misc/test_utilities.py
+++ b/tests/misc/test_utilities.py
@@ -8,7 +8,7 @@ from psyneulink.core.globals.utilities import convert_all_elements_to_np_array, 
 @pytest.mark.parametrize(
     'arr, expected',
     [
-        ([[0], [0, 0]], np.array([np.array([0]), np.array([0, 0])])),
+        ([[0], [0, 0]], np.array([np.array([0]), np.array([0, 0])], dtype=object)),
         # should test these but numpy cannot easily create an array from them
         # [np.ones((2,2)), np.zeros((2,1))]
         # [np.array([[0]]), np.array([[[ 1.,  1.,  1.], [ 1.,  1.,  1.]]])]


### PR DESCRIPTION
Handle numpy.VisibleDeprecationWarning and future ValueError produced by creating a numpy.ndarray with elements of varying shape or type, which was introduced by https://github.com/numpy/numpy/pull/15119
    
https://numpy.org/neps/nep-0034-infer-dtype-is-object.html
