### PR TITLE
llvm/cuda: Cleanup

### DIFF
--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -1639,7 +1639,7 @@ class GridSearch(OptimizationFunction):
         # Compiled evaluate expects the same variable as mech function
         new_variable = [np.asfarray(ip.parameters.value.get(context))
                         for ip in ocm.input_ports]
-        new_variable = np.atleast_2d(new_variable)
+        new_variable = np.array(new_variable, dtype=np.object)
         # Map allocations to values
         comp_exec = pnlvm.execution.CompExecution(ocm.agent_rep, [context.execution_id])
         ct_alloc, ct_values = comp_exec.cuda_evaluate(new_variable,

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -1579,7 +1579,7 @@ in order of their power, are:
 of the following modes in the **bin_execute** argument of a `Composition execution method
 <Composition_Execution_Methods>`:
 
-    * *PTX|PTXExec|PTXRun* -- equivalent to the LLVM counterparts but run in a single thread of a CUDA capable GPU.
+    * *PTXExec|PTXRun* -- equivalent to the LLVM counterparts but run in a single thread of a CUDA capable GPU.
 
 This requires that a working `pycuda package <https://documen.tician.de/pycuda/>`_ is
 `installed <https://wiki.tiker.net/PyCuda/Installation>`_, and that CUDA execution is explicitly enabled by setting

--- a/psyneulink/core/llvm/__init__.py
+++ b/psyneulink/core/llvm/__init__.py
@@ -89,9 +89,9 @@ class LLVMBinaryFunction:
         return self.__cuda_kernel
 
     def cuda_call(self, *args, threads=1, block_size=32):
+        grid = ((threads + block_size - 1) // block_size, 1)
         self._cuda_kernel(*args, np.int32(threads),
-                          block=(block_size, 1, 1),
-                          grid=((threads + block_size) // block_size, 1))
+                          block=(block_size, 1, 1), grid=grid)
 
     def cuda_wrap_call(self, *args, threads=1, block_size=32):
         wrap_args = (jit_engine.pycuda.driver.InOut(a) if isinstance(a, np.ndarray) else a for a in args)

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -540,7 +540,7 @@ class CompExecution(CUDAExecution):
 
         assert len(inputs) == len(self._execution_contexts)
         # Extract input for each trial and execution id
-        run_inputs = ((([x] for x in self._composition._build_variable_for_input_CIM({m:inp[m][i] for m in inp.keys()})) for i in range(num_input_sets)) for inp in inputs)
+        run_inputs = ((([x] for x in self._composition._build_variable_for_input_CIM({k:v[i] for k,v in inp.items()})) for i in range(num_input_sets)) for inp in inputs)
         return c_input(*_tupleize(run_inputs))
 
     def _get_generator_run_input_struct(self, inputs, runs):

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -1039,7 +1039,6 @@ class TestControlMechanisms:
                                       pytest.param('LLVM', marks=pytest.mark.llvm),
                                       pytest.param('LLVMExec', marks=pytest.mark.llvm),
                                       pytest.param('LLVMRun', marks=pytest.mark.llvm),
-                                      pytest.param('PTX', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                       pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                       pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])])
     def test_control_of_mech_port(self, mode):
@@ -1604,7 +1603,6 @@ class TestModelBasedOptimizationControlMechanisms:
                                       pytest.param('LLVM', marks=pytest.mark.llvm),
                                       pytest.param('LLVMExec', marks=pytest.mark.llvm),
                                       pytest.param('LLVMRun', marks=pytest.mark.llvm),
-                                      pytest.param('PTX', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                       pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                       pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])])
     def test_model_based_ocm_after(self, benchmark, mode):
@@ -1651,7 +1649,6 @@ class TestModelBasedOptimizationControlMechanisms:
                                       pytest.param('LLVM', marks=pytest.mark.llvm),
                                       pytest.param('LLVMExec', marks=pytest.mark.llvm),
                                       pytest.param('LLVMRun', marks=pytest.mark.llvm),
-                                      pytest.param('PTX', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                       pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                       pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])])
     def test_model_based_ocm_before(self, benchmark, mode):

--- a/tests/llvm/test_builtins_random.py
+++ b/tests/llvm/test_builtins_random.py
@@ -35,8 +35,8 @@ def test_random_int(benchmark, mode):
             return out.value
     elif mode == 'PTX':
         init_fun = pnlvm.LLVMBinaryFunction.get('__pnl_builtin_mt_rand_init')
-        state = init_fun.byref_arg_types[0]()
-        gpu_state = pnlvm.jit_engine.pycuda.driver.to_device(bytearray(state))
+        state_size = ctypes.sizeof(init_fun.byref_arg_types[0])
+        gpu_state = pnlvm.jit_engine.pycuda.driver.mem_alloc(state_size)
         init_fun.cuda_call(gpu_state, np.int32(SEED))
 
         gen_fun = pnlvm.LLVMBinaryFunction.get('__pnl_builtin_mt_rand_int32')
@@ -79,8 +79,8 @@ def test_random_float(benchmark, mode):
             return out.value
     elif mode == 'PTX':
         init_fun = pnlvm.LLVMBinaryFunction.get('__pnl_builtin_mt_rand_init')
-        state = init_fun.byref_arg_types[0]()
-        gpu_state = pnlvm.jit_engine.pycuda.driver.to_device(bytearray(state))
+        state_size = ctypes.sizeof(init_fun.byref_arg_types[0])
+        gpu_state = pnlvm.jit_engine.pycuda.driver.mem_alloc(state_size)
         init_fun.cuda_call(gpu_state, np.int32(SEED))
 
         gen_fun = pnlvm.LLVMBinaryFunction.get('__pnl_builtin_mt_rand_double')
@@ -118,8 +118,8 @@ def test_random_normal(benchmark, mode):
             return out.value
     elif mode == 'PTX':
         init_fun = pnlvm.LLVMBinaryFunction.get('__pnl_builtin_mt_rand_init')
-        state = init_fun.byref_arg_types[0]()
-        gpu_state = pnlvm.jit_engine.pycuda.driver.to_device(bytearray(state))
+        state_size = ctypes.sizeof(init_fun.byref_arg_types[0])
+        gpu_state = pnlvm.jit_engine.pycuda.driver.mem_alloc(state_size)
         init_fun.cuda_call(gpu_state, np.int32(SEED))
 
         gen_fun = pnlvm.LLVMBinaryFunction.get('__pnl_builtin_mt_rand_normal')

--- a/tests/llvm/test_builtins_random.py
+++ b/tests/llvm/test_builtins_random.py
@@ -37,7 +37,7 @@ def test_random_int(benchmark, mode):
         init_fun = pnlvm.LLVMBinaryFunction.get('__pnl_builtin_mt_rand_init')
         state = init_fun.byref_arg_types[0]()
         gpu_state = pnlvm.jit_engine.pycuda.driver.to_device(bytearray(state))
-        init_fun.cuda_call(gpu_state, np.int64(SEED))
+        init_fun.cuda_call(gpu_state, np.int32(SEED))
 
         gen_fun = pnlvm.LLVMBinaryFunction.get('__pnl_builtin_mt_rand_int32')
         out = np.asarray([0], dtype=np.int64)
@@ -81,7 +81,7 @@ def test_random_float(benchmark, mode):
         init_fun = pnlvm.LLVMBinaryFunction.get('__pnl_builtin_mt_rand_init')
         state = init_fun.byref_arg_types[0]()
         gpu_state = pnlvm.jit_engine.pycuda.driver.to_device(bytearray(state))
-        init_fun.cuda_call(gpu_state, np.int64(SEED))
+        init_fun.cuda_call(gpu_state, np.int32(SEED))
 
         gen_fun = pnlvm.LLVMBinaryFunction.get('__pnl_builtin_mt_rand_double')
         out = np.asfarray([0.0], dtype=np.float64)
@@ -120,7 +120,7 @@ def test_random_normal(benchmark, mode):
         init_fun = pnlvm.LLVMBinaryFunction.get('__pnl_builtin_mt_rand_init')
         state = init_fun.byref_arg_types[0]()
         gpu_state = pnlvm.jit_engine.pycuda.driver.to_device(bytearray(state))
-        init_fun.cuda_call(gpu_state, np.int64(SEED))
+        init_fun.cuda_call(gpu_state, np.int32(SEED))
 
         gen_fun = pnlvm.LLVMBinaryFunction.get('__pnl_builtin_mt_rand_normal')
         out = np.asfarray([0.0], dtype=np.float64)

--- a/tests/mechanisms/test_control_mechanism.py
+++ b/tests/mechanisms/test_control_mechanism.py
@@ -218,7 +218,6 @@ class TestLCControlMechanism:
                                       pytest.param('LLVM', marks=pytest.mark.llvm),
                                       pytest.param('LLVMExec', marks=pytest.mark.llvm),
                                       pytest.param('LLVMRun', marks=pytest.mark.llvm),
-                                      pytest.param('PTX', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                       pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                       pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])])
     def test_control_of_all_output_ports(self, mode):

--- a/tests/models/test_bi_percepts.py
+++ b/tests/models/test_bi_percepts.py
@@ -21,7 +21,6 @@ from itertools import product
     pytest.param('LLVM', marks=[pytest.mark.llvm]),
     pytest.param('LLVMExec', marks=[pytest.mark.llvm]),
     pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
-    pytest.param('PTX', marks=[pytest.mark.llvm, pytest.mark.cuda]),
     pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
     pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda]),
 ])
@@ -149,7 +148,6 @@ def test_simplified_necker_cube(benchmark, mode):
                                   pytest.param('LLVM', marks=[pytest.mark.llvm]),
                                   pytest.param('LLVMExec', marks=[pytest.mark.llvm]),
                                   pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
-                                  pytest.param('PTX', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                   pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                   pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                   ])

--- a/tests/models/test_greedy_agent.py
+++ b/tests/models/test_greedy_agent.py
@@ -20,7 +20,6 @@ from psyneulink.core.globals.keywords import VARIANCE, NORMED_L0_SIMILARITY
     pytest.param('LLVM', marks=[pytest.mark.llvm]),
     pytest.param('LLVMExec', marks=[pytest.mark.llvm]),
     pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
-    pytest.param('PTX', marks=[pytest.mark.llvm, pytest.mark.cuda]),
     pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
     pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])])
 def test_simplified_greedy_agent(benchmark, mode):
@@ -71,7 +70,6 @@ def test_simplified_greedy_agent(benchmark, mode):
     pytest.param('LLVM', marks=[pytest.mark.llvm]),
     pytest.param('LLVMExec', marks=[pytest.mark.llvm]),
     pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
-    pytest.param('PTX', marks=[pytest.mark.llvm, pytest.mark.cuda]),
     pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
     pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])])
 def test_simplified_greedy_agent_random(benchmark, mode):
@@ -124,7 +122,6 @@ def test_simplified_greedy_agent_random(benchmark, mode):
      pytest.param('LLVM', marks=[pytest.mark.llvm]),
      pytest.param('LLVMExec', marks=[pytest.mark.llvm]),
      pytest.param('LLVMRun', marks=[pytest.mark.llvm]),
-     pytest.param('PTX', marks=[pytest.mark.llvm, pytest.mark.cuda]),
      pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
      pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda]),
 ])


### PR DESCRIPTION
Drop references to per node PTX mode.
Fix builtin random tests failures since configurable cuda grid block size.
Improve generation of input structures.