### PR TITLE
Cleanup imports

### DIFF
--- a/Scripts/Debug/bryant_lca_with_termination.py
+++ b/Scripts/Debug/bryant_lca_with_termination.py
@@ -1,6 +1,4 @@
 import psyneulink as pnl
-import numpy as np
-import pytest
 
 cueInterval = pnl.TransferMechanism(default_variable=[[0.0]],
                                     size=1,

--- a/Scripts/Debug/predator_prey_opt/predator_prey_dmt.py
+++ b/Scripts/Debug/predator_prey_opt/predator_prey_dmt.py
@@ -1,4 +1,3 @@
-import sys
 import os
 import timeit
 import numpy as np

--- a/Scripts/Examples/Rumelhart Semantic Network.py
+++ b/Scripts/Examples/Rumelhart Semantic Network.py
@@ -1,6 +1,4 @@
 from psyneulink import *
-import numpy as np
-import typecheck as tc
 
 # This script implements the following network, first described in Rumelhart and Todd
 # (Rumelhart, D. E., & Todd, P. M. (1993). Learning and connectionist representations. Attention and performance XIV:

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -483,18 +483,14 @@ import dill
 import inspect
 import logging
 import numbers
-import re
 import types
 import warnings
-import weakref
 
 from abc import ABCMeta
 from collections.abc import Iterable
-from collections import OrderedDict, UserDict
 from enum import Enum, IntEnum
 
 import numpy as np
-import typecheck as tc
 
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.globals.context import \
@@ -2438,7 +2434,6 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
 
                 elif target_set is not None:
                     # Copy any iterables so that deletions can be made to assignments belonging to the instance
-                    from collections.abc import Iterable
                     if not isinstance(param_value, Iterable) or isinstance(param_value, str):
                         target_set[param_name] = param_value
                     else:

--- a/psyneulink/core/components/functions/distributionfunctions.py
+++ b/psyneulink/core/components/functions/distributionfunctions.py
@@ -23,7 +23,6 @@ Overview
 Functions that return one or more samples from a distribution.
 
 """
-from enum import IntEnum
 
 import numpy as np
 import typecheck as tc

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -308,10 +308,6 @@ def _output_type_setter(value, owning_component):
     # https://github.com/PrincetonUniversity/PsyNeuLink/issues/895 is solved
     # properly(meaning Mechanism values may be something other than 2D np array)
     try:
-        # import here because if this package is not installed, we can assume
-        # the user is probably not dealing with compilation so no need to warn
-        # unecessarily
-        import llvmlite
         if (
             isinstance(owning_component.owner, Mechanism)
             and (

--- a/psyneulink/core/components/functions/objectivefunctions.py
+++ b/psyneulink/core/components/functions/objectivefunctions.py
@@ -20,7 +20,6 @@ Functions that return a scalar evaluation of their input.
 """
 
 import functools
-import itertools
 
 import numpy as np
 import typecheck as tc

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -2344,8 +2344,7 @@ class ParamEstimationFunction(OptimizationFunction):
         # https://github.com/scikit-optimize/scikit-optimize/issues/637
         # Lets import and set the backend to PS to be safe. We aren't plotting anyway
         # I guess. Only do this on Mac OS X
-        from sys import platform
-        if platform == "darwin":
+        if sys.platform == "darwin":
             import matplotlib
             matplotlib.use('PS')
 

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -25,8 +25,6 @@ Functions that integrate current value of input with previous value.
 
 """
 
-import itertools
-import numbers
 import warnings
 
 import numpy as np

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -22,7 +22,7 @@ Functions that store and can return a record of their input.
 
 """
 
-from collections import deque, OrderedDict
+from collections import deque
 
 import numpy as np
 import typecheck as tc

--- a/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
+++ b/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
@@ -16,13 +16,12 @@
 
 """
 
-import numpy as np
+import abc
 import typecheck as tc
-import itertools
 import warnings
 import numbers
 
-import abc
+import numpy as np
 
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.component import DefaultsFlexibility

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -41,12 +41,13 @@ All TransferFunctions have the following attributes:
 """
 
 import numbers
-from enum import IntEnum
-
 import numpy as np
 import typecheck as tc
 import types
 import warnings
+
+from enum import IntEnum
+from math import e, pi, sqrt
 
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.component import parameter_keywords
@@ -707,7 +708,6 @@ class Exponential(TransferFunction):  # ----------------------------------------
 
         # The following doesn't work with autograd (https://github.com/HIPS/autograd/issues/416)
         # result = scale * np.exp(rate * variable + bias) + offset
-        from math import e
         result = scale * e**(rate * variable + bias) + offset
         return self.convert_output_type(result)
 
@@ -731,7 +731,6 @@ class Exponential(TransferFunction):  # ----------------------------------------
 
 
         """
-        from math import e
         rate = self._get_current_function_param(RATE, context)
         scale = self._get_current_function_param(SCALE, context)
         bias = self._get_current_function_param(BIAS, context)
@@ -997,7 +996,6 @@ class Logistic(TransferFunction):  # -------------------------------------------
 
         # The following doesn't work with autograd (https://github.com/HIPS/autograd/issues/416)
         # result = 1. / (1 + np.exp(-gain * (variable - bias) + offset))
-        from math import e
         result = scale * (1. / (1 + e**(-gain * (variable + bias - x_0) + offset)))
 
         return self.convert_output_type(result)
@@ -1318,7 +1316,6 @@ class Tanh(TransferFunction):  # -----------------------------------------------
         # The following probably doesn't work with autograd (https://github.com/HIPS/autograd/issues/416)
         #   (since np.exp doesn't work)
         # result = 1. / (1 + np.tanh(-gain * (variable - bias) + offset))
-        from math import e
         exponent = -2 * (gain * (variable + bias - x_0) + offset)
         result = scale * (1 - e**exponent)/ (1 + e**exponent)
 
@@ -1351,7 +1348,6 @@ class Tanh(TransferFunction):  # -----------------------------------------------
 
         exponent = -2 * (gain * (input + bias - x_0) + offset)
         mult = -2 * gain * scale
-        from math import e
         numerator = -2 * e**(exponent)
         denominator = (1 + e**(exponent))**2
 
@@ -1771,7 +1767,6 @@ class Gaussian(TransferFunction):  # -------------------------------------------
         exp = builder.fdiv(exp_num, exp_denom)
         numerator = builder.call(exp_f, [exp])
 
-        from math import pi
         denom = builder.fmul(standard_deviation.type(2 * pi), standard_deviation)
         denom = builder.call(sqrt_f, [denom])
         val = builder.fdiv(numerator, denom)
@@ -1811,7 +1806,6 @@ class Gaussian(TransferFunction):  # -------------------------------------------
         scale = self._get_current_function_param(SCALE, context)
         offset = self._get_current_function_param(OFFSET, context)
 
-        from math import e, pi, sqrt
         gaussian = e**(-(variable - bias)**2 / (2 * standard_deviation**2)) / sqrt(2 * pi * standard_deviation)
         result = scale * gaussian + offset
 
@@ -1841,7 +1835,6 @@ class Gaussian(TransferFunction):  # -------------------------------------------
         sigma = self._get_current_function_param(STANDARD_DEVIATION, context)
         bias = self._get_current_function_param(BIAS, context)
 
-        from math import e, pi, sqrt
         adjusted_input = input - bias
         result = (-adjusted_input * e**(-(adjusted_input**2 / (2 * sigma**2)))) / sqrt(2 * pi * sigma**3)
 

--- a/psyneulink/core/components/functions/userdefinedfunction.py
+++ b/psyneulink/core/components/functions/userdefinedfunction.py
@@ -13,6 +13,8 @@ import ctypes
 import numpy as np
 import typecheck as tc
 
+from inspect import signature, _empty
+
 from psyneulink.core.components.component import ComponentError
 from psyneulink.core.components.functions.function import FunctionError, Function_Base
 from psyneulink.core.globals.context import ContextFlags
@@ -394,7 +396,6 @@ class UserDefinedFunction(Function_Base):
                 - dict with all others (to be assigned as params of UDF)
                 - dict with default values (from function definition, else set to None)
             """
-            from inspect import signature, _empty
             try:
                 arg_names = custom_function.__code__.co_varnames
             except AttributeError:

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -1071,6 +1071,7 @@ import abc
 import inspect
 import itertools
 import logging
+import re
 import types
 import warnings
 
@@ -3083,7 +3084,6 @@ class Mechanism_Base(Mechanism):
             output = self.output_port.parameters.value._get(context)
         params = params or self.parameters.values()
 
-        import re
         if 'mechanism' in self.name or 'Mechanism' in self.name:
             mechanism_string = ' '
         else:

--- a/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
@@ -363,10 +363,8 @@ Class Reference
 
 """
 
-import itertools
 import warnings
 import typecheck as tc
-import numpy as np
 
 from collections.abc import Iterable
 from collections import namedtuple

--- a/psyneulink/core/components/ports/inputport.py
+++ b/psyneulink/core/components/ports/inputport.py
@@ -1296,7 +1296,6 @@ class InputPort(Port_Base):
         can't be called by _parse_port_spec since the InputPort itself may not yet have been instantiated.
 
         """
-        import inspect
 
         if (
                 (

--- a/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
@@ -397,12 +397,6 @@ Class Reference
 
 """
 
-import inspect
-import itertools
-import warnings
-
-from enum import IntEnum
-
 import numpy as np
 import typecheck as tc
 

--- a/psyneulink/core/components/ports/modulatorysignals/modulatorysignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/modulatorysignal.py
@@ -407,8 +407,6 @@ Class Reference
 ---------------
 """
 
-import itertools
-
 from psyneulink.core.components.component import component_keywords
 from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.globals.context import ContextFlags

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -615,12 +615,10 @@ Class Reference
 """
 
 import copy
-import inspect
 import numpy as np
 import typecheck as tc
 import types
 import warnings
-from collections import OrderedDict
 
 from psyneulink.core.components.component import Component, ComponentError
 from psyneulink.core.components.functions.function import Function

--- a/psyneulink/core/components/ports/parameterport.py
+++ b/psyneulink/core/components/ports/parameterport.py
@@ -359,6 +359,7 @@ Class Reference
 
 """
 
+from copy import deepcopy
 import inspect
 import itertools
 import types
@@ -1002,7 +1003,6 @@ def _instantiate_parameter_port(owner, param_name, param_value, context, functio
         ):
             reference_value = function_param_value
         else:
-            from copy import deepcopy
             reference_value = deepcopy(function_param_value)
 
         # Assign parameterPort for function_param to the component

--- a/psyneulink/core/components/ports/parameterport.py
+++ b/psyneulink/core/components/ports/parameterport.py
@@ -361,7 +361,6 @@ Class Reference
 
 from copy import deepcopy
 import inspect
-import itertools
 import types
 import warnings
 

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -772,7 +772,6 @@ import warnings
 
 from collections.abc import Iterable
 from collections import defaultdict
-from copy import deepcopy
 
 import numpy as np
 import typecheck as tc

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -763,10 +763,10 @@ Class Reference
 """
 
 import abc
-import abc
 import inspect
 import itertools
 import numbers
+import sys
 import types
 import warnings
 
@@ -2674,7 +2674,6 @@ def _parse_port_type(owner, port_spec):
 
         # Port keyword
         if port_spec in port_type_keywords:
-            import sys
             return getattr(sys.modules['PsyNeuLink.Components.Ports.' + port_spec], port_spec)
 
         # Try as name of Port

--- a/psyneulink/core/components/projections/pathway/mappingprojection.py
+++ b/psyneulink/core/components/projections/pathway/mappingprojection.py
@@ -284,10 +284,8 @@ Class Reference
 
 """
 import copy
-import inspect
 
 import numpy as np
-import typecheck as tc
 
 from psyneulink.core.components.component import parameter_keywords
 from psyneulink.core.components.functions.statefulfunctions.integratorfunctions import AccumulatorIntegrator
@@ -444,7 +442,6 @@ class MappingProjection(PathwayProjection_Base):
 
     projection_sender = OutputPort
 
-    # @tc.typecheck
     def __init__(self,
                  sender=None,
                  receiver=None,

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -396,6 +396,7 @@ import abc
 import inspect
 import itertools
 import warnings
+from collections import namedtuple, defaultdict
 
 import numpy as np
 import typecheck as tc
@@ -458,7 +459,6 @@ def projection_param_keywords():
     return set(projection_param_keyword_mapping().values())
 
 
-from collections import namedtuple
 ProjectionTuple = namedtuple("ProjectionTuple", "port, weight, exponent, projection")
 
 
@@ -1196,7 +1196,6 @@ def _parse_projection_spec(projection_spec,
     if bad_arg:
         raise ProjectionError("Illegal argument in call to _parse_port_spec: {}".format(bad_arg))
 
-    from collections import defaultdict
     proj_spec_dict = defaultdict(lambda :None)
     proj_spec_dict.update(kwargs)
 

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -9758,6 +9758,5 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
 def get_compositions():
     """Return list of Compositions in caller's namespace."""
-    import inspect
     frame = inspect.currentframe()
     return [c for c in frame.f_back.f_locals.values() if isinstance(c, Composition)]

--- a/psyneulink/core/globals/log.py
+++ b/psyneulink/core/globals/log.py
@@ -1154,7 +1154,6 @@ class Log:
                 warnings.warn("{0} is not an entry in the Log for {1}".
                       format(entry_name, self.owner.name))
             else:
-                import numpy as np
                 multiple_eids = len(datum)>1
                 for eid in datum:
                     if multiple_eids:

--- a/psyneulink/core/globals/log.py
+++ b/psyneulink/core/globals/log.py
@@ -381,7 +381,6 @@ Class Reference
 
 """
 import enum
-import inspect
 import warnings
 
 from collections import OrderedDict, namedtuple

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -244,7 +244,6 @@ import copy
 import logging
 import types
 import typing
-import warnings
 import weakref
 
 from psyneulink.core.globals.keywords import MULTIPLICATIVE

--- a/psyneulink/core/globals/registry.py
+++ b/psyneulink/core/globals/registry.py
@@ -8,6 +8,7 @@
 #
 # ***********************************************  Registry ************************************************************
 
+import inspect
 import re
 
 from collections import defaultdict, namedtuple
@@ -121,7 +122,6 @@ def register_category(entry,
     """
 
     # IMPLEMENTATION NOTE:  Move to Port when that is implemented as ABC
-    import inspect
     from psyneulink.core.components.shellclasses import Port
     if inspect.isclass(entry) and issubclass(entry, Port):
         try:

--- a/psyneulink/core/globals/sampleiterator.py
+++ b/psyneulink/core/globals/sampleiterator.py
@@ -352,7 +352,6 @@ class SampleIterator(Iterator):
                 self.generator = None                    # ??
 
                 def generate_current_value():   # return next value in range
-                    from decimal import Decimal, getcontext
                     # Save global precision for later restoration
                     _global_precision = getcontext().prec
                     # Set SampleSpec precision

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -91,6 +91,7 @@ CONTENTS
 
 """
 
+import collections
 import copy
 import inspect
 import logging
@@ -102,10 +103,11 @@ import warnings
 import weakref
 import types
 import typing
+import typecheck as tc
 
 from enum import Enum, EnumMeta, IntEnum
+from collections.abc import Mapping
 
-import collections
 import numpy as np
 
 from psyneulink.core.globals.keywords import \
@@ -581,7 +583,6 @@ def powerset(iterable):
     s = list(iterable)
     return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
 
-import typecheck as tc
 @tc.typecheck
 def tensor_power(items, levels:tc.optional(range)=None, flat=False):
     """return tensor product for all members of powerset of items
@@ -635,7 +636,6 @@ def get_args(frame):
     return dict((key, value) for key, value in values.items() if key in args)
 
 
-from collections.abc import Mapping
 def recursive_update(d, u, non_destructive=False):
     """Recursively update entries of dictionary d with dictionary u
     From: https://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth
@@ -1519,12 +1519,9 @@ def safe_equals(x, y):
             return np.array_equal(x, y)
 
 
-import typecheck as tc
 @tc.typecheck
 def _get_arg_from_stack(arg_name:str):
     # Get arg from the stack
-
-    import inspect
 
     curr_frame = inspect.currentframe()
     prev_frame = inspect.getouterframes(curr_frame, 2)

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -15,6 +15,7 @@ import copy
 import ctypes
 import numpy as np
 from inspect import isgenerator
+import itertools
 import sys
 
 
@@ -624,7 +625,6 @@ class CompExecution(CUDAExecution):
         ocm = self._composition.controller
         assert len(self._execution_contexts) == 1
         context = self._execution_contexts[0]
-        import itertools
 
         bin_func = pnlvm.LLVMBinaryFunction.from_obj(ocm, tags=frozenset({"evaluate"}))
         self.__bin_func = bin_func

--- a/psyneulink/core/scheduling/scheduler.py
+++ b/psyneulink/core/scheduling/scheduler.py
@@ -275,13 +275,11 @@ Class Reference
 
 """
 
-import collections
 import copy
 import datetime
 import logging
-import warnings
 
-from toposort import toposort, toposort_flatten
+from toposort import toposort
 
 from psyneulink.core.globals.context import Context, handle_external_context
 from psyneulink.core.globals.json import JSONDumpable

--- a/psyneulink/library/components/projections/pathway/maskedmappingprojection.py
+++ b/psyneulink/library/components/projections/pathway/maskedmappingprojection.py
@@ -64,7 +64,6 @@ Class Reference
 ---------------
 
 """
-import numbers
 
 import numpy as np
 import typecheck as tc

--- a/psyneulink/library/compositions/__init__.py
+++ b/psyneulink/library/compositions/__init__.py
@@ -7,9 +7,7 @@ try:
     import torch
 
     from .autodiffcomposition import *
-    from .pytorchmodelcreator import *
 
     __all__.extend(autodiffcomposition.__all__)
-    __all__.extend(pytorchmodelcreator.__all__)
 except ImportError:
     pass

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -127,6 +127,19 @@ Class Reference
 ---------------
 
 """
+import numpy as np
+
+import logging
+try:
+    import torch
+    from torch import nn
+    import torch.optim as optim
+    torch_available = True
+except ImportError:
+    torch_available = False
+else:
+    from psyneulink.library.compositions.pytorchmodelcreator import PytorchModelCreator
+
 
 from psyneulink.core.components.functions.transferfunctions import Linear, Logistic, ReLU
 from psyneulink.core.components.mechanisms.processing.compositioninterfacemechanism import CompositionInterfaceMechanism
@@ -140,23 +153,7 @@ from psyneulink.core.scheduling.scheduler import Scheduler
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.scheduling.time import TimeScale
 from psyneulink.core import llvm as pnlvm
-import copy
-import numpy as np
-import ctypes
-from collections.abc import Iterable
-from toposort import toposort
-from inspect import isgenerator
 
-import logging
-try:
-    import torch
-    from torch import nn
-    import torch.optim as optim
-    torch_available = True
-except ImportError:
-    torch_available = False
-else:
-    from psyneulink.library.compositions.pytorchmodelcreator import PytorchModelCreator
 
 logger = logging.getLogger(__name__)
 

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -8,7 +8,6 @@
 
 # ********************************************* AutodiffComposition *************************************************
 import numpy as np
-import collections.abc
 
 from psyneulink.core.compositions.composition import Composition
 from psyneulink.core.globals.keywords import OBJECTIVE_MECHANISM, TRAINING_SET

--- a/psyneulink/library/compositions/gymforagercfa.py
+++ b/psyneulink/library/compositions/gymforagercfa.py
@@ -75,14 +75,10 @@ Class Reference
 
 """
 
-import itertools
 import numpy as np
 import typecheck as tc
 
 import gym_forager
-
-from enum import Enum
-from itertools import product
 
 from psyneulink.library.compositions.regressioncfa import RegressionCFA
 from psyneulink.core.components.functions.learningfunctions import BayesGLM

--- a/psyneulink/library/compositions/pytorchmodelcreator.py
+++ b/psyneulink/library/compositions/pytorchmodelcreator.py
@@ -1,4 +1,3 @@
-from psyneulink.core.scheduling.time import TimeScale
 from psyneulink.core.compositions.composition import NodeRole
 from psyneulink.core.components.functions.transferfunctions import Linear, Logistic, ReLU
 from psyneulink.core.globals.context import ContextFlags, handle_external_context

--- a/psyneulink/library/compositions/regressioncfa.py
+++ b/psyneulink/library/compositions/regressioncfa.py
@@ -71,7 +71,6 @@ Class Reference
 ---------------
 
 """
-import itertools
 import numpy as np
 import typecheck as tc
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -101,9 +101,6 @@ exclude_lines =
     if 0:
     if __name__ == .__main__.:
 
-# Omit models that are not tested
-omit = psyneulink/library/models/*
-
 [versioneer]
 VCS = git
 style = pep440


### PR DESCRIPTION
Prefer top-level global imports to local ones.
Do not expose pytorchmodelcreator.
Include `psyneulink/library/models` in code coverage reports