### PR TITLE
ParameterAlias: ensure ParameterAlias returned when copied

### DIFF
--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1053,7 +1053,7 @@ class TransferMechanism(ProcessingMechanism_Base):
                     :type:
         """
         integrator_mode = Parameter(False, setter=_integrator_mode_setter)
-        integration_rate = Parameter(0.5, modulable=True)
+        integration_rate = FunctionParameter(0.5, modulable=True, function_name='integrator_function', function_parameter_name='rate')
         initial_value = None
         integrator_function = Parameter(AdaptiveIntegrator, stateful=False, loggable=False)
         integrator_function_value = Parameter([[0]], read_only=True)

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -636,7 +636,7 @@ from psyneulink.core.globals.keywords import \
     INITIALIZER, INSTANTANEOUS_MODE_VALUE, LESS_THAN_OR_EQUAL, MAX_ABS_DIFF, \
     NAME, NOISE, NUM_EXECUTIONS_BEFORE_FINISHED, OWNER_VALUE, RATE, RESET, RESULT, RESULTS, \
     SELECTION_FUNCTION_TYPE, TRANSFER_FUNCTION_TYPE, TRANSFER_MECHANISM, VARIABLE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, FunctionParameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import \
@@ -1078,6 +1078,8 @@ class TransferMechanism(ProcessingMechanism_Base):
             read_only=True,
             structural=True,
         )
+
+        my_offset = FunctionParameter(function_parameter_name='offset', function_name='integrator_function', modulable=True)
 
         def _validate_variable(self, variable):
             if 'U' in str(variable.dtype):

--- a/psyneulink/core/components/ports/parameterport.py
+++ b/psyneulink/core/components/ports/parameterport.py
@@ -810,7 +810,7 @@ def _instantiate_parameter_ports(owner, function=None, context=None):
         for p in function.parameters:
             if not skip_parameter_port(p):
                 try:
-                    value = owner.initial_function_parameters[p.name]
+                    value = owner.initial_function_parameters['function'][p.name]
                 except (KeyError, TypeError):
                     if p.spec is not None:
                         value = p.spec

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -687,7 +687,7 @@ class Parameter(types.SimpleNamespace):
     """
     # The values of these attributes will never be inherited from parent Parameters
     # KDM 7/12/18: consider inheriting ONLY default_value?
-    _uninherited_attrs = {'name', 'values', 'history', 'log'}
+    _uninherited_attrs = {'name', 'values', 'history', 'log', '_function_parameter_name'}
 
     # for user convenience - these attributes will be hidden from the repr
     # display if the function is True based on the value of the attribute
@@ -751,6 +751,7 @@ class Parameter(types.SimpleNamespace):
         # attributes will be taken from
         _inherited_source=None,
         _user_specified=False,
+        **kwargs
     ):
         if isinstance(aliases, str):
             aliases = [aliases]
@@ -802,6 +803,7 @@ class Parameter(types.SimpleNamespace):
             _inherited=_inherited,
             _inherited_source=_inherited_source,
             _user_specified=_user_specified,
+            **kwargs
         )
 
         self._owner = _owner
@@ -937,6 +939,8 @@ class Parameter(types.SimpleNamespace):
                         self._inherited_attrs_cache[attr] = getattr(self, attr)
                         try:
                             delattr(self, attr)
+                            if 'function' in attr:
+                                print('deleted', attr)
                         except AttributeError:
                             # attribute is a property
                             pass
@@ -1466,6 +1470,7 @@ class FunctionParameter(Parameter):
 
     def __init__(
         self,
+        default_value=None,
         function_parameter_name=None,
         function_name='function',
         getter=None,
@@ -1490,15 +1495,21 @@ class FunctionParameter(Parameter):
 
                 return value
 
-        self._function_parameter_name = function_parameter_name
-        self.function_name = function_name
+        # self.function_name = function_name
+        # self._function_parameter_name = function_parameter_name
+        import traceback
+        print(traceback.print_stack())
+        print(function_parameter_name)
 
         super().__init__(
-            function_parameter=True,
+            default_value=default_value,
             getter=getter,
             setter=setter,
+            function_name=function_name,
+            _function_parameter_name=function_parameter_name,
             **kwargs
         )
+        print(self)
 
     @property
     def function_parameter_name(self):

--- a/tests/misc/test_parameters.py
+++ b/tests/misc/test_parameters.py
@@ -1,3 +1,4 @@
+import copy
 import numpy as np
 import psyneulink as pnl
 import pytest
@@ -217,3 +218,11 @@ def test_dot_notation():
     assert t.parameters.value.get(c) == 5
     assert t.parameters.value.get(d) == 10
     assert t.parameters.value.get('custom execution id') == 20
+
+
+def test_copy():
+    f = pnl.Linear()
+    g = copy.deepcopy(f)
+
+    assert isinstance(g.parameters.additive_param, pnl.ParameterAlias)
+    assert g.parameters.additive_param.source is g.parameters.intercept


### PR DESCRIPTION
Previously, a ParameterAlias would become a new Parameter copy of its source when deepcopied