### PR TITLE
Remove inactive link from docs

### DIFF
--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -16,6 +16,10 @@ Contents
 * `GradientOptimization`
 * `GridSearch`
 * `GaussianProcess`
+COMMENT:
+uncomment this when ParamEstimationFunction is ready for users
+* `ParamEstimationFunction`
+COMMENT
 
 Overview
 --------

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -9,12 +9,13 @@
 #
 # ******************************************   OPTIMIZATION FUNCTIONS **************************************************
 """
+Contents
+--------
 
 * `OptimizationFunction`
 * `GradientOptimization`
 * `GridSearch`
 * `GaussianProcess`
-* `ParamEstimationFunction`
 
 Overview
 --------


### PR DESCRIPTION
 Remove link at top of `optimizationfunctions` module docstring for `ParamEstimationFunction`, which is currently hidden because it is still in development