### PR TITLE
llvm: Refactor param/state struct generation

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1250,6 +1250,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         blacklist = {"function"} if hasattr(self, 'ports') else {"value"}
         # 'objective_mechanism' parameter is just for reference
         blacklist.add("objective_mechanism")
+        # 'agent_rep'is for reference to enclosing composition
+        blacklist.add("agent_rep")
         def _is_compilation_state(p):
             val = p.get()   # memoize for this function
             return val is not None and p.name not in blacklist and \
@@ -1315,6 +1317,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             blacklist.update(["function", "matrix", "integration_rate"])
         # 'objective_mechanism' parameter is just for reference
         blacklist.add("objective_mechanism")
+        # 'agent_rep'is for reference to enclosing composition
+        blacklist.add("agent_rep")
         def _is_compilation_param(p):
             if p.name not in blacklist and not isinstance(p, ParameterAlias):
                 #FIXME: this should use defaults

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1245,7 +1245,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         whitelist = {"previous_time", "previous_value", "previous_v",
                      "previous_w", "random_state", "is_finished_flag",
                      "num_executions_before_finished", "num_executions",
-                     "execution_count", "value"}
+                     "execution_count", "value", "input_ports", "output_ports"}
         blacklist = set() if hasattr(self, 'ports') else {"value"}
         # 'objective_mechanism' parameter is just for reference
         blacklist.add("objective_mechanism")
@@ -1279,6 +1279,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 val = tuple(getattr(x, Time._time_scale_attr_map[t]) for t in TimeScale)
             elif isinstance(x, Component):
                 return x._get_state_initializer(context)
+            elif isinstance(x, ContentAddressableList):
+                return tuple(p._get_state_initializer(context) for p in x)
             else:
                 val = pnlvm._tupleize(x)
 
@@ -1318,7 +1320,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 val = p.get()
                 # Check if the value type is valid for compilation
                 return not isinstance(val, (str, ComponentsMeta,
-                                            ContentAddressableList, type(max),
+                                            type(max),
                                             type(_is_compilation_param),
                                             type(self._get_compilation_params)))
             return False

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1246,8 +1246,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      "previous_w", "random_state", "is_finished_flag",
                      "num_executions_before_finished", "num_executions",
                      "execution_count", "value"}
-        # mechanism functions are handled separately
-        blacklist = {"function"} if hasattr(self, 'ports') else {"value"}
+        blacklist = set() if hasattr(self, 'ports') else {"value"}
         # 'objective_mechanism' parameter is just for reference
         blacklist.add("objective_mechanism")
         # 'agent_rep'is for reference to enclosing composition
@@ -1305,11 +1304,10 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      # autodiff specific types
                      "pytorch_representation", "optimizer"}
         # Mechanism's need few extra entires:
-        # * function -- might overload _get_{param,state}_struct_type
         # * matrix -- is never used directly, and is flatened below
         # * integration rate -- shape mismatch with param port input
         if hasattr(self, 'ports'):
-            blacklist.update(["function", "matrix", "integration_rate"])
+            blacklist.update(["matrix", "integration_rate"])
         # 'objective_mechanism' parameter is just for reference
         blacklist.add("objective_mechanism")
         # 'agent_rep'is for reference to enclosing composition

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1248,6 +1248,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      "execution_count", "value"}
         # mechanism functions are handled separately
         blacklist = {"function"} if hasattr(self, 'ports') else {"value"}
+        # 'objective_mechanism' parameter is just for reference
+        blacklist.add("objective_mechanism")
         def _is_compilation_state(p):
             val = p.get()   # memoize for this function
             return val is not None and p.name not in blacklist and \
@@ -1311,6 +1313,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         # * integration rate -- shape mismatch with param port input
         if hasattr(self, 'ports'):
             blacklist.update(["function", "matrix", "integration_rate"])
+        # 'objective_mechanism' parameter is just for reference
+        blacklist.add("objective_mechanism")
         def _is_compilation_param(p):
             if p.name not in blacklist and not isinstance(p, ParameterAlias):
                 #FIXME: this should use defaults

--- a/psyneulink/core/components/functions/objectivefunctions.py
+++ b/psyneulink/core/components/functions/objectivefunctions.py
@@ -969,8 +969,7 @@ class Distance(ObjectiveFunction):
     def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tags:frozenset):
         assert isinstance(arg_in.type.pointee, pnlvm.ir.ArrayType)
         assert isinstance(arg_in.type.pointee.element, pnlvm.ir.ArrayType)
-        # FIXME python version also ignores other vectors
-        assert arg_in.type.pointee.count >= 2
+        assert arg_in.type.pointee.count == 2
 
         v1 = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(0)])
         v2 = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(1), ctx.int32_ty(0)])

--- a/psyneulink/core/components/functions/objectivefunctions.py
+++ b/psyneulink/core/components/functions/objectivefunctions.py
@@ -1111,10 +1111,10 @@ class Distance(ObjectiveFunction):
             if self.metric == ENERGY:
                 norm_factor = norm_factor ** 2
             ret = builder.fdiv(ret, ctx.float_ty(norm_factor), name="normalized")
-        # Get rid of nesting
-        # TODO: fix this properly
-        while arg_out.type.pointee != ret.type:
-            arg_out = builder.gep(arg_out, [ctx.int32_ty(0), ctx.int32_ty(0)])
+        if arg_out.type.pointee != ret.type:
+            # Some instance use 2d output values
+            arg_out = builder.gep(arg_out, [ctx.int32_ty(0), ctx.int32_ty(0),
+                                            ctx.int32_ty(0)])
         builder.store(ret, arg_out)
 
         return builder

--- a/psyneulink/core/components/functions/objectivefunctions.py
+++ b/psyneulink/core/components/functions/objectivefunctions.py
@@ -1149,15 +1149,15 @@ class Distance(ObjectiveFunction):
 
         # Maximum of Hadamard (elementwise) difference of v1 and v2
         if self.metric == MAX_ABS_DIFF:
-            result = np.max(abs(v1 - v2))
+            result = np.max(np.fabs(v1 - v2))
 
         # Simple Hadamard (elementwise) difference of v1 and v2
         elif self.metric == DIFFERENCE:
-            result = np.sum(np.abs(v1 - v2))
+            result = np.sum(np.fabs(v1 - v2))
 
         # Similarity (used specifically for testing Compilation of Predator-Prey Model)
         elif self.metric == NORMED_L0_SIMILARITY:
-            result = 1 - np.sum(np.abs(v1 - v2)) / 4
+            result = 1.0 - np.sum(np.abs(v1 - v2)) / 4.0
 
         # Euclidean distance between v1 and v2
         elif self.metric == EUCLIDEAN:
@@ -1166,13 +1166,13 @@ class Distance(ObjectiveFunction):
         # Cosine similarity of v1 and v2
         elif self.metric == COSINE:
             # result = np.correlate(v1, v2)
-            result = 1 - np.abs(Distance.cosine(v1, v2))
+            result = 1.0 - np.fabs(Distance.cosine(v1, v2))
             return self.convert_output_type(result)
 
         # Correlation of v1 and v2
         elif self.metric == CORRELATION:
             # result = np.correlate(v1, v2)
-            result = 1 - np.abs(Distance.correlation(v1, v2))
+            result = 1.0 - np.fabs(Distance.correlation(v1, v2))
             return self.convert_output_type(result)
 
         # Cross-entropy of v1 and v2
@@ -1184,18 +1184,18 @@ class Distance(ObjectiveFunction):
             # MODIFIED CW 3/20/18: avoid divide by zero error by plugging in two zeros
             # FIX: unsure about desired behavior when v2 = 0 and v1 != 0
             # JDC: returns [inf]; leave, and let it generate a warning or error message for user
-            result = -np.sum(np.where(np.logical_and(v1 == 0, v2 == 0), 0, v1 * np.log(v2)))
+            result = -np.sum(np.where(np.logical_and(v1 == 0, v2 == 0), 0.0, v1 * np.log(v2)))
 
         # Energy
         elif self.metric == ENERGY:
-            result = -np.sum(v1 * v2) / 2
+            result = -np.sum(v1 * v2) / 2.0
 
         else:
             assert False, '{} not a recognized metric in {}'.format(self.metric, self.__class__.__name__)
 
         if self.normalize and self.metric not in {MAX_ABS_DIFF, CORRELATION}:
             if self.metric == ENERGY:
-                result /= len(v1) ** 2
+                result /= len(v1) ** 2.0
             else:
                 result /= len(v1)
 

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -1377,6 +1377,8 @@ class GridSearch(OptimizationFunction):
             if all(type(x) == np.ndarray for x in variable) and not all(len(x) == len(variable[0]) for x in variable):
                 variable = tuple(variable)
 
+            warnings.warn("Shape mismatch: {} variable expected: {} vs. got: {}".format(self, variable, self.defaults.variable))
+
         else:
             variable = self.defaults.variable
 

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2743,31 +2743,27 @@ class Mechanism_Base(Mechanism):
         return port_param_dicts
 
     def _get_param_ids(self):
-        #FIXME: ports and function should be part of generated params
-        return ["ports", "function"] + super()._get_param_ids()
+        # FIXME: ports should be part of generated params
+        return ["ports"] + super()._get_param_ids()
 
     def _get_param_struct_type(self, ctx):
         ports_params = (ctx.get_param_struct_type(s) for s in self.ports)
         ports_param_struct = pnlvm.ir.LiteralStructType(ports_params)
-        function_param_struct = ctx.get_param_struct_type(self.function)
         mech_param_struct = ctx.get_param_struct_type(super())
 
         return pnlvm.ir.LiteralStructType((ports_param_struct,
-                                           function_param_struct,
                                            *mech_param_struct))
 
     def _get_state_ids(self):
-        #FIXME: ports and function should be part of generated state
-        return ["ports", "function"] + super()._get_state_ids()
+        # FIXME: ports should be part of generated state
+        return ["ports"] + super()._get_state_ids()
 
     def _get_state_struct_type(self, ctx):
         ports_state = (ctx.get_state_struct_type(s) for s in self.ports)
         ports_state_struct = pnlvm.ir.LiteralStructType(ports_state)
-        function_state_struct = ctx.get_state_struct_type(self.function)
         mech_state_struct = ctx.get_state_struct_type(super())
 
         return pnlvm.ir.LiteralStructType((ports_state_struct,
-                                           function_state_struct,
                                            *mech_state_struct))
 
     def _get_output_struct_type(self, ctx):
@@ -2785,17 +2781,15 @@ class Mechanism_Base(Mechanism):
 
     def _get_param_initializer(self, context):
         port_param_init = tuple(s._get_param_initializer(context) for s in self.ports)
-        function_param_init = self.function._get_param_initializer(context)
         mech_param_init = super()._get_param_initializer(context)
 
-        return (port_param_init, function_param_init, *mech_param_init)
+        return (port_param_init, *mech_param_init)
 
     def _get_state_initializer(self, context):
         port_state_init = tuple(s._get_state_initializer(context) for s in self.ports)
-        function_state_init = self.function._get_state_initializer(context)
         mech_state_init = super()._get_state_initializer(context)
 
-        return (port_state_init, function_state_init, *mech_state_init)
+        return (port_state_init, *mech_state_init)
 
     def _gen_llvm_ports(self, ctx, builder, ports,
                         get_output_ptr, fill_input_data,

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2797,6 +2797,9 @@ class Mechanism_Base(Mechanism):
         # Avoid recreating combined list in every iteration
         # FIXME: This should be converted to more standard memoization approach
         all_ports = self.ports
+        ports_param = pnlvm.helpers.get_param_ptr(builder, self, mech_params, "ports")
+        ports_state = pnlvm.helpers.get_state_ptr(builder, self, mech_state, "ports")
+
         mod_afferents = self.mod_afferents
         for i, port in enumerate(ports):
             p_function = ctx.import_llvm_function(port)
@@ -2821,10 +2824,8 @@ class Mechanism_Base(Mechanism):
                 builder.store(afferent_val, mod_out_ptr)
 
             port_idx = all_ports.index(port)
-            ports_param = pnlvm.helpers.get_param_ptr(builder, self, mech_params, "ports")
             p_params = builder.gep(ports_param, [ctx.int32_ty(0),
                                                  ctx.int32_ty(port_idx)])
-            ports_state = pnlvm.helpers.get_state_ptr(builder, self, mech_state, "ports")
             p_state = builder.gep(ports_state, [ctx.int32_ty(0),
                                                 ctx.int32_ty(port_idx)])
 

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3003,7 +3003,7 @@ class Mechanism_Base(Mechanism):
             pnlvm.helpers.push_state_val(builder, self, state, "value", value)
         else:
             # FIXME: Does this need some sort of parsing?
-            warnings.warn("Shape mismatch: function result does not match mechanism value: {}".format(value.type.pointee, val_ptr.type.pointee))
+            warnings.warn("Shape mismatch: function result does not match mechanism value param: {} vs. {}".format(value.type.pointee, val_ptr.type.pointee))
 
         # is_finished should be checked after output ports ran
         is_finished_f = ctx.import_llvm_function(self, tags=tags.union({"is_finished"}))

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2298,7 +2298,7 @@ class Port_Base(Port):
                 # Directly store the value in the output array
                 if f_mod_ptr.type != arg_out.type:
                     assert len(f_mod_ptr.type.pointee) == 1
-                    warnings.warn("Shape mismatch Overriding modulation should match parameter port output: {} vs. {}".format(
+                    warnings.warn("Shape mismatch: Overriding modulation should match parameter port output: {} vs. {}".format(
                                   afferent.defaults.value, self.defaults.value))
                     f_mod_ptr = builder.gep(f_mod_ptr, [ctx.int32_ty(0), ctx.int32_ty(0)])
                 builder.store(builder.load(f_mod_ptr), arg_out)
@@ -2312,7 +2312,7 @@ class Port_Base(Port):
                                                               self.function,
                                                               f_params, name)
                 if f_mod_param_ptr.type != f_mod_ptr.type:
-                    warnings.warn("Shape mismatch between modulation and modulated parameter: {} vs. {}".format(
+                    warnings.warn("Shape mismatch: Modulation vs. modulated parameter: {} vs. {}".format(
                                   afferent.defaults.value,
                                   getattr(self.function.parameters, name).get(None)))
                     param_val = pnlvm.helpers.load_extract_scalar_array_one(builder, f_mod_ptr)

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -298,8 +298,11 @@ class LLVMBuilderContext:
             # FIXME: Consider enums of non-int type
             assert all(round(x.value) == x.value for x in type(t))
             return self.int32_ty
-        elif isinstance(t, (int, float, np.number)):
+        elif isinstance(t, (int, float, np.floating)):
             return self.float_ty
+        elif isinstance(t, np.integer):
+            # Python 'int' is handled above as it is the default type for '0'
+            return ir.IntType(t.nbytes * 8)
         elif isinstance(t, np.ndarray):
             return self.convert_python_struct_to_llvm_ir(t.tolist())
         elif isinstance(t, np.random.RandomState):

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1200,8 +1200,8 @@ class DDM(ProcessingMechanism):
 
     def _gen_llvm_is_finished_cond(self, ctx, builder, params, state):
         # Setup pointers to internal function
-        func_state_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, 'function')
-        func_param_ptr = pnlvm.helpers.get_state_ptr(builder, self, params, 'function')
+        func_state_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, "function")
+        func_param_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, "function")
 
         # Find the single numeric entry in previous_value
         try:


### PR DESCRIPTION
Compose the structures recursively to make better use of caches. This reduces the number of Python -> LLVM conversions by ~40%.
Compose initializers recursively, this should help reduce initialization time and memory usage.
Use LLVM integer types for numpy.integer dtype.