### PR TITLE
llvm: Use standard param/state structures for Ports and GridSearch

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1381,6 +1381,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             # Modulated parameters change shape to array
             if np.isscalar(param) and self._is_param_modulated(p):
                 return (param,)
+            elif p.name == 'num_estimates':
+                return 0 if param is None else param
             elif p.name == 'matrix': # Flatten matrix
                 return tuple(np.asfarray(param).flatten())
             return _convert(param)

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1246,11 +1246,11 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      "previous_w", "random_state", "is_finished_flag",
                      "num_executions_before_finished", "num_executions",
                      "execution_count", "value", "input_ports", "output_ports"}
-        blacklist = set() if hasattr(self, 'ports') else {"value"}
-        # 'objective_mechanism' parameter is just for reference
-        blacklist.add("objective_mechanism")
-        # 'agent_rep'is for reference to enclosing composition
-        blacklist.add("agent_rep")
+        blacklist = { # References to other components
+                     "objective_mechanism", "agent_rep"}
+        # Only mechanisms use "value" state
+        if not hasattr(self, 'ports'):
+            blacklist.add("value")
         def _is_compilation_state(p):
             val = p.get()   # memoize for this function
             return val is not None and p.name not in blacklist and \
@@ -1301,6 +1301,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      "input_labels_dict", "output_labels_dict",
                      "modulated_mechanisms", "grid",
                      "activation_derivative_fct", "input_specification",
+                     # Reference to other components
+                     "objective_mechanism", "agent_rep",
                      # Shape mismatch
                      "costs", "auto", "hetero",
                      # autodiff specific types
@@ -1310,10 +1312,6 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         # * integration rate -- shape mismatch with param port input
         if hasattr(self, 'ports'):
             blacklist.update(["matrix", "integration_rate"])
-        # 'objective_mechanism' parameter is just for reference
-        blacklist.add("objective_mechanism")
-        # 'agent_rep'is for reference to enclosing composition
-        blacklist.add("agent_rep")
         def _is_compilation_param(p):
             if p.name not in blacklist and not isinstance(p, ParameterAlias):
                 #FIXME: this should use defaults

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1247,7 +1247,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      "num_executions_before_finished", "num_executions",
                      "execution_count", "value", "input_ports", "output_ports"}
         blacklist = { # References to other components
-                     "objective_mechanism", "agent_rep"}
+                     "objective_mechanism", "agent_rep", "projections"}
         # Only mechanisms use "value" state
         if not hasattr(self, 'ports'):
             blacklist.add("value")
@@ -1302,7 +1302,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      "modulated_mechanisms", "grid",
                      "activation_derivative_fct", "input_specification",
                      # Reference to other components
-                     "objective_mechanism", "agent_rep",
+                     "objective_mechanism", "agent_rep", "projections",
                      # Shape mismatch
                      "costs", "auto", "hetero",
                      # autodiff specific types

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -1389,70 +1389,6 @@ class GridSearch(OptimizationFunction):
         # OptimizationControlMechanism
         return getattr(self.objective_function, '__self__', None)
 
-    def _get_param_ids(self):
-        ids = super()._get_param_ids()
-        if self._get_optimized_composition() is not None:
-            ids.append("objective_function")
-
-        return ids
-
-    def _get_param_struct_type(self, ctx):
-        param_struct = ctx.get_param_struct_type(super())
-
-        ocm = self._get_optimized_composition()
-        if ocm is not None:
-            # self.objective_function is a bound method of
-            # OptimizationControlMechanism
-            obj_func_params = ocm._get_evaluate_param_struct_type(ctx)
-            return pnlvm.ir.LiteralStructType([*param_struct,
-                                               obj_func_params])
-
-        return param_struct
-
-    def _get_param_initializer(self, context):
-        param_initializer = super()._get_param_initializer(context)
-
-        ocm = self._get_optimized_composition()
-        if ocm is not None:
-            # self.objective_function is a bound method of
-            # OptimizationControlMechanism
-            obj_func_param_init = ocm._get_evaluate_param_initializer(context)
-            return (*param_initializer, obj_func_param_init)
-
-        return param_initializer
-
-    def _get_state_ids(self):
-        ids = super()._get_state_ids()
-        if self._get_optimized_composition() is not None:
-            ids.append("objective_function")
-
-        return ids
-
-    def _get_state_struct_type(self, ctx):
-        state_struct = ctx.get_state_struct_type(super())
-
-        ocm = self._get_optimized_composition()
-        if ocm is not None:
-            # self.objective_function is a bound method of
-            # OptimizationControlMechanism
-            obj_func_state = ocm._get_evaluate_state_struct_type(ctx)
-            state_struct = pnlvm.ir.LiteralStructType([*state_struct,
-                                                       obj_func_state])
-
-        return state_struct
-
-    def _get_state_initializer(self, context):
-        state_initializer = super()._get_state_initializer(context)
-
-        ocm = self._get_optimized_composition()
-        if ocm is not None:
-            # self.objective_function is a bound method of
-            # OptimizationControlMechanism
-            obj_func_state_init = ocm._get_evaluate_state_initializer(context)
-            state_initializer = (*state_initializer, obj_func_state_init)
-
-        return state_initializer
-
     def _get_output_struct_type(self, ctx):
         val = self.defaults.value
         # compiled version should never return 'all values'
@@ -1548,24 +1484,25 @@ class GridSearch(OptimizationFunction):
         if ocm is not None:
             assert ocm.function is self
             obj_func = ctx.import_llvm_function(ocm, tags=tags.union({"evaluate"}))
-            sample_t = ocm._get_evaluate_alloc_struct_type(ctx)
-            value_t = ocm._get_evaluate_output_struct_type(ctx)
-            extra_args = [arg_in] + list(builder.function.args[-3:])
+            comp_args = builder.function.args[-3:]
+            obj_param_ptr = comp_args[0]
+            obj_state_ptr = comp_args[1]
+            extra_args = [arg_in, comp_args[2]]
         else:
             obj_func = ctx.import_llvm_function(self.objective_function)
-            sample_t = obj_func.args[2].type.pointee
-            value_t = obj_func.args[3].type.pointee
+            obj_state_ptr = pnlvm.helpers.get_state_ptr(builder, self, state,
+                                                        "objective_function")
+            obj_param_ptr = pnlvm.helpers.get_param_ptr(builder, self, params,
+                                                        "objective_function")
             extra_args = []
 
+        sample_t = obj_func.args[2].type.pointee
+        value_t = obj_func.args[3].type.pointee
         min_sample_ptr = builder.alloca(sample_t)
         min_value_ptr = builder.alloca(value_t)
         sample_ptr = builder.alloca(sample_t)
         value_ptr = builder.alloca(value_t)
 
-        obj_state_ptr = pnlvm.helpers.get_state_ptr(builder, self, state,
-                                                    self.parameters.objective_function.name)
-        obj_param_ptr = pnlvm.helpers.get_param_ptr(builder, self, params,
-                                                    self.parameters.objective_function.name)
         search_space_ptr = pnlvm.helpers.get_param_ptr(builder, self, params,
                                                        self.parameters.search_space.name)
 

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -1417,8 +1417,7 @@ class GridSearch(OptimizationFunction):
                 value_t.as_pointer(),
                 ctx.float_ty.as_pointer(),
                 ctx.int32_ty]
-        builder = ctx.create_llvm_function(args, self, tags=tags,
-                                           return_type=pnlvm.ir.VoidType())
+        builder = ctx.create_llvm_function(args, self, tags=tags)
 
         params, state, min_sample_ptr, samples_ptr, min_value_ptr, values_ptr, opt_count_ptr, count = builder.function.args
         for p in builder.function.args[:-1]:

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1017,26 +1017,6 @@ class OptimizationControlMechanism(ControlMechanism):
 
         return result
 
-    def _get_evaluate_param_struct_type(self, ctx):
-        num_estimates = ctx.int32_ty
-        intensity_cost = (ctx.get_param_struct_type(op.intensity_cost_function) for op in self.output_ports)
-        intensity_cost_struct = pnlvm.ir.LiteralStructType(intensity_cost)
-        return pnlvm.ir.LiteralStructType([intensity_cost_struct, num_estimates])
-
-    def _get_evaluate_param_initializer(self, context):
-        num_estimates = self.parameters.num_estimates.get(context) or 0
-        intensity_cost = tuple(op.intensity_cost_function._get_param_initializer(context) for op in self.output_ports)
-        return (intensity_cost, num_estimates)
-
-    def _get_evaluate_state_struct_type(self, ctx):
-        intensity_cost = (ctx.get_state_struct_type(op.intensity_cost_function) for op in self.output_ports)
-        intensity_cost_struct = pnlvm.ir.LiteralStructType(intensity_cost)
-        return pnlvm.ir.LiteralStructType([intensity_cost_struct])
-
-    def _get_evaluate_state_initializer(self, context):
-        intensity_cost = tuple(op.intensity_cost_function._get_state_initializer(context) for op in self.output_ports)
-        return (intensity_cost,)
-
     def _get_evaluate_input_struct_type(self, ctx):
         # We construct input from optimization function input
         return ctx.get_input_struct_type(self.function)
@@ -1051,8 +1031,8 @@ class OptimizationControlMechanism(ControlMechanism):
 
     def _gen_llvm_net_outcome_function(self, *, ctx, tags=frozenset()):
         assert "net_outcome" in tags
-        args = [self._get_evaluate_param_struct_type(ctx).as_pointer(),
-                self._get_evaluate_state_struct_type(ctx).as_pointer(),
+        args = [ctx.get_param_struct_type(self).as_pointer(),
+                ctx.get_state_struct_type(self).as_pointer(),
                 self._get_evaluate_alloc_struct_type(ctx).as_pointer(),
                 ctx.float_ty.as_pointer(),
                 ctx.float_ty.as_pointer()]
@@ -1063,6 +1043,11 @@ class OptimizationControlMechanism(ControlMechanism):
             p.attributes.add('nonnull')
         params, state, allocation_sample, objective_ptr, arg_out = llvm_func.args
 
+        op_params = pnlvm.helpers.get_param_ptr(builder, self, params,
+                                                "output_ports")
+        op_states = pnlvm.helpers.get_state_ptr(builder, self, state,
+                                                "output_ports", None)
+
         # calculate cost function
         total_cost = builder.alloca(ctx.float_ty)
         builder.store(ctx.float_ty(-0.0), total_cost)
@@ -1070,9 +1055,16 @@ class OptimizationControlMechanism(ControlMechanism):
             # FIXME: Add support for other cost types
             assert op.cost_options == CostFunctions.INTENSITY
 
+            op_i_params = builder.gep(op_params, [ctx.int32_ty(0),
+                                                  ctx.int32_ty(i)])
+            op_i_state = builder.gep(op_states, [ctx.int32_ty(0),
+                                                 ctx.int32_ty(i)])
+
             func = ctx.import_llvm_function(op.intensity_cost_function)
-            func_params = builder.gep(params, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(i)])
-            func_state = builder.gep(state, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(i)])
+            func_params = pnlvm.helpers.get_param_ptr(builder, op, op_i_params,
+                                                      "intensity_cost_function")
+            func_state = pnlvm.helpers.get_state_ptr(builder, op, op_i_state,
+                                                     "intensity_cost_function")
             func_out = builder.alloca(func.args[3].type.pointee)
             func_in = builder.alloca(func.args[2].type.pointee)
 
@@ -1106,13 +1098,11 @@ class OptimizationControlMechanism(ControlMechanism):
     def _gen_llvm_evaluate_function(self, *, ctx:pnlvm.LLVMBuilderContext,
                                              tags=frozenset()):
         assert "evaluate" in tags
-        args = [self._get_evaluate_param_struct_type(ctx).as_pointer(),
-                self._get_evaluate_state_struct_type(ctx).as_pointer(),
+        args = [ctx.get_param_struct_type(self.agent_rep).as_pointer(),
+                ctx.get_state_struct_type(self.agent_rep).as_pointer(),
                 self._get_evaluate_alloc_struct_type(ctx).as_pointer(),
                 self._get_evaluate_output_struct_type(ctx).as_pointer(),
                 self._get_evaluate_input_struct_type(ctx).as_pointer(),
-                ctx.get_param_struct_type(self.agent_rep).as_pointer(),
-                ctx.get_state_struct_type(self.agent_rep).as_pointer(),
                 ctx.get_data_struct_type(self.agent_rep).as_pointer()]
 
         builder = ctx.create_llvm_function(args, self, str(self) + "_evaluate")
@@ -1120,10 +1110,7 @@ class OptimizationControlMechanism(ControlMechanism):
         for p in llvm_func.args:
             p.attributes.add('nonnull')
 
-        params, state, allocation_sample, arg_out, arg_in, comp_params, base_comp_state, base_comp_data = llvm_func.args
-
-        sim_f = ctx.import_llvm_function(self.agent_rep,
-                                         tags=frozenset({"run", "simulation"}))
+        comp_params, base_comp_state, allocation_sample, arg_out, arg_in, base_comp_data = llvm_func.args
 
         # Create a simulation copy of composition state
         comp_state = builder.alloca(base_comp_state.type.pointee, name="state_copy")
@@ -1132,6 +1119,24 @@ class OptimizationControlMechanism(ControlMechanism):
         # Create a simulation copy of composition data
         comp_data = builder.alloca(base_comp_data.type.pointee, name="data_copy")
         builder.store(builder.load(base_comp_data), comp_data)
+
+        # Evaluate is called on composition controller
+        assert self.composition.controller is self
+        assert self.composition is self.agent_rep
+        nodes_states = pnlvm.helpers.get_state_ptr(builder, self.composition,
+                                                   comp_state, "nodes", None)
+        nodes_params = pnlvm.helpers.get_param_ptr(builder, self.composition,
+                                                   comp_params, "nodes")
+
+        controller_idx = self.composition._get_node_index(self)
+        controller_state = builder.gep(nodes_states, [ctx.int32_ty(0),
+                                                      ctx.int32_ty(controller_idx)])
+        controller_params = builder.gep(nodes_params, [ctx.int32_ty(0),
+                                                       ctx.int32_ty(controller_idx)])
+
+        # Get simulation function
+        sim_f = ctx.import_llvm_function(self.agent_rep,
+                                         tags=frozenset({"run", "simulation"}))
 
         # Apply allocation sample to simulation data
         assert len(self.output_ports) == len(allocation_sample.type.pointee)
@@ -1166,7 +1171,10 @@ class OptimizationControlMechanism(ControlMechanism):
 
 
         # Determine simulation counts
-        num_estimates_ptr = builder.gep(params, [ctx.int32_ty(0), ctx.int32_ty(1)])
+        num_estimates_ptr = pnlvm.helpers.get_param_ptr(builder, self,
+                                                        controller_params,
+                                                        "num_estimates")
+
         num_estimates = builder.load(num_estimates_ptr, "num_estimates")
 
         # if num_estimates is 0, run 1 trial
@@ -1199,8 +1207,9 @@ class OptimizationControlMechanism(ControlMechanism):
                                          ctx.int32_ty(0)], "obj_val_ptr")
 
         net_outcome_f = ctx.import_llvm_function(self, tags=tags.union({"net_outcome"}))
-        builder.call(net_outcome_f, [params, state, allocation_sample,
-                                     objective_val_ptr, arg_out])
+        builder.call(net_outcome_f, [controller_params, controller_state,
+                                     allocation_sample, objective_val_ptr,
+                                     arg_out])
 
         builder.ret_void()
 

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -620,9 +620,11 @@ import typecheck as tc
 import types
 import warnings
 
+from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.component import Component, ComponentError
 from psyneulink.core.components.functions.function import Function
 from psyneulink.core.components.functions.selectionfunctions import OneHot
+from psyneulink.core.components.functions.transferfunctions import CostFunctions
 from psyneulink.core.components.ports.port import Port_Base, _instantiate_port_list, port_type_keywords
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import \
@@ -1291,6 +1293,48 @@ class OutputPort(Port_Base):
                 'dtype': str(self.defaults.value.dtype)
             }
         }
+
+    def _gen_llvm_function(self, *, ctx:pnlvm.LLVMBuilderContext,
+                                    extra_args=[], tags:frozenset):
+        if "costs" in tags:
+            assert len(extra_args) == 0
+            return self._gen_llvm_costs(ctx=ctx, tags=tags)
+
+        return super()._gen_llvm_function(ctx=ctx, extra_args=extra_args, tags=tags)
+
+    def _gen_llvm_costs(self, *, ctx:pnlvm.LLVMBuilderContext, tags:frozenset):
+        args = [ctx.get_param_struct_type(self).as_pointer(),
+                ctx.get_state_struct_type(self).as_pointer(),
+                ctx.get_input_struct_type(self).as_pointer()]
+
+        assert "costs" in tags
+        builder = ctx.create_llvm_function(args, self, str(self) + "_costs",
+                                           tags=tags,
+                                           return_type=ctx.float_ty)
+
+        params, state, arg_in = builder.function.args
+
+        # FIXME: Add support for other cost types
+        assert self.cost_options == CostFunctions.INTENSITY
+
+        func = ctx.import_llvm_function(self.intensity_cost_function)
+        func_params = pnlvm.helpers.get_param_ptr(builder, self, params,
+                                                  "intensity_cost_function")
+        func_state = pnlvm.helpers.get_state_ptr(builder, self, state,
+                                                 "intensity_cost_function")
+        func_out = builder.alloca(func.args[3].type.pointee)
+        # Port input is always struct
+        func_in = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(0)])
+
+        builder.call(func, [func_params, func_state, func_in, func_out])
+
+
+        # Cost function output is 1 element array
+        ret_ptr = builder.gep(func_out, [ctx.int32_ty(0), ctx.int32_ty(0)])
+        ret_val = builder.load(ret_ptr)
+        builder.ret(ret_val)
+
+        return builder.function
 
 
 def _instantiate_output_ports(owner, output_ports=None, context=None):

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2271,7 +2271,8 @@ class Port_Base(Port):
         state_f = ctx.import_llvm_function(self.function)
 
         # Create a local copy of the function parameters
-        base_params = pnlvm.helpers.get_param_ptr(builder, self, params, self.parameters.function.name)
+        base_params = pnlvm.helpers.get_param_ptr(builder, self, params,
+                                                  "function")
         f_params = builder.alloca(state_f.args[0].type.pointee)
         builder.store(builder.load(base_params), f_params)
 
@@ -2326,7 +2327,7 @@ class Port_Base(Port):
             arg_out = builder.gep(arg_out, [ctx.int32_ty(0), ctx.int32_ty(0)])
         # Extract the data part of input
         f_input = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(0)])
-        f_state = pnlvm.helpers.get_state_ptr(builder, self, state, self.parameters.function.name)
+        f_state = pnlvm.helpers.get_state_ptr(builder, self, state, "function")
         builder.call(state_f, [f_params, f_state, f_input, arg_out])
         return builder
 

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2261,12 +2261,6 @@ class Port_Base(Port):
             input_types.append(ctx.get_output_struct_type(mod))
         return pnlvm.ir.LiteralStructType(input_types)
 
-    def _get_compilation_params(self):
-        return [self.parameters.function]
-
-    def _get_compilation_state(self):
-        return [self.parameters.function]
-
     def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:frozenset):
         state_f = ctx.import_llvm_function(self.function)
 

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -628,30 +628,26 @@ class CompExecution(CUDAExecution):
 
         bin_func = pnlvm.LLVMBinaryFunction.from_obj(ocm, tags=frozenset({"evaluate"}))
         self.__bin_func = bin_func
-        assert len(bin_func.byref_arg_types) == 8
+        assert len(bin_func.byref_arg_types) == 6
 
-        # There are 8 arguments to evaluate:
-        # param, state, allocations, results, output, input, comp_params, comp_state, comp_data
+        # There are 6 arguments to evaluate:
+        # comp_param, comp_state, allocations, results, output, input, comp_data
         # all but #2 and #3 are shared
-        ct_param = bin_func.byref_arg_types[0](*ocm._get_evaluate_param_initializer(context))
-        ct_state = bin_func.byref_arg_types[1](*ocm._get_evaluate_state_initializer(context))
+        ct_comp_param = bin_func.byref_arg_types[0](*ocm.agent_rep._get_param_initializer(context))
+        ct_comp_state = bin_func.byref_arg_types[1](*ocm.agent_rep._get_state_initializer(context))
         # Make sure the dtype matches _gen_llvm_evaluate_function
         allocations = np.asfarray(np.atleast_2d([*itertools.product(*search_space)]))
         ct_allocations = allocations.ctypes.data_as(ctypes.POINTER(bin_func.byref_arg_types[2] * len(allocations)))
         out_ty = bin_func.byref_arg_types[3] * len(allocations)
         ct_in = variable.ctypes.data_as(ctypes.POINTER(bin_func.byref_arg_types[4]))
 
-        ct_comp_param = bin_func.byref_arg_types[5](*ocm.agent_rep._get_param_initializer(context))
-        ct_comp_state = bin_func.byref_arg_types[6](*ocm.agent_rep._get_state_initializer(context))
-        ct_comp_data = bin_func.byref_arg_types[7](*ocm.agent_rep._get_data_initializer(context))
+        ct_comp_data = bin_func.byref_arg_types[5](*ocm.agent_rep._get_data_initializer(context))
 
-        cuda_args = (self.upload_ctype(ct_param, 'params'),
-                     self.upload_ctype(ct_state, 'state'),
+        cuda_args = (self.upload_ctype(ct_comp_param, 'params'),
+                     self.upload_ctype(ct_comp_state, 'state'),
                      self.upload_ctype(ct_allocations.contents, 'input'),
                      jit_engine.pycuda.driver.mem_alloc(ctypes.sizeof(out_ty)),
                      self.upload_ctype(ct_in.contents, 'input'),
-                     self.upload_ctype(ct_comp_param, 'params'),
-                     self.upload_ctype(ct_comp_state, 'state'),
                      self.upload_ctype(ct_comp_data, 'data'),
                     )
 


### PR DESCRIPTION
Convert allocation cost computation to OutputPort variant