### PR TITLE
Add FunctionParameter and SharedParameter subclasses

### DIFF
--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -67,7 +67,7 @@ from psyneulink.core.globals.keywords import \
     RATE, RECEIVER, RELU_FUNCTION, SCALE, SLOPE, SOFTMAX_FUNCTION, STANDARD_DEVIATION, SUM,\
     TRANSFER_FUNCTION_TYPE, TRANSFER_WITH_COSTS_FUNCTION, VARIANCE, VARIABLE, X_0, PREFERENCE_SET_NAME
 from psyneulink.core.globals.parameters import \
-    Parameter, get_validator_by_function
+    FunctionParameter, Parameter, get_validator_by_function
 from psyneulink.core.globals.utilities import parameter_spec, get_global_seed, safe_len
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.preferences.basepreferenceset import \
@@ -3190,134 +3190,6 @@ class CostFunctions(IntEnum):
     ALL           = INTENSITY | ADJUSTMENT | DURATION
     DEFAULTS      = INTENSITY
 
-# Getters and setters for transfer and cost function multiplicative and additive parameters ----------------------------
-
-def _transfer_fct_mult_param_getter(owning_component=None, context=None):
-    try:
-        return owning_component.parameters.transfer_fct.get().parameters.multiplicative_param.get(context)
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _transfer_fct_mult_param_setter(value, owning_component=None, context=None):
-    owning_component.parameters.transfer_fct.get().parameters.multiplicative_param._set(value, context)
-    return value
-
-def _transfer_fct_add_param_getter(owning_component=None, context=None):
-    try:
-        return owning_component.parameters.transfer_fct.get().parameters.additive_param.get(context)
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _transfer_fct_add_param_setter(value, owning_component=None, context=None):
-    try:
-        owning_component.parameters.transfer_fct.get().parameters.additive_param._set(value, context)
-        return value
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _intensity_cost_fct_mult_param_getter(owning_component=None, context=None):
-    try:
-        return owning_component.parameters.intensity_cost_fct.get().parameters.multiplicative_param.get(context)
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _intensity_cost_fct_mult_param_setter(value, owning_component=None, context=None):
-    try:
-        owning_component.parameters.intensity_cost_fct.get().parameters.multiplicative_param._set(value, context)
-        return value
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _intensity_cost_fct_add_param_getter(owning_component=None, context=None):
-    try:
-        return owning_component.parameters.intensity_cost_fct.get().parameters.additive_param.get(context)
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _intensity_cost_fct_add_param_setter(value, owning_component=None, context=None):
-    try:
-        owning_component.parameters.intensity_cost_fct.get().parameters.additive_param._set(value, context)
-        return value
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _adjustment_cost_fct_mult_param_getter(owning_component=None, context=None):
-    try:
-        return owning_component.parameters.adjustment_cost_fct.get().parameters.multiplicative_param.get(context)
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _adjustment_cost_fct_mult_param_setter(value, owning_component=None, context=None):
-    try:
-        owning_component.parameters.adjustment_cost_fct.get().parameters.multiplicative_param._set(value, context)
-        return value
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _adjustment_cost_fct_add_param_getter(owning_component=None, context=None):
-    try:
-        return owning_component.parameters.adjustment_cost_fct.get().parameters.additive_param.get(context)
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _adjustment_cost_fct_add_param_setter(value, owning_component=None, context=None):
-    try:
-        owning_component.parameters.adjustment_cost_fct.get().parameters.additive_param._set(value, context)
-        return value
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _duration_cost_fct_mult_param_getter(owning_component=None, context=None):
-    try:
-        return owning_component.parameters.duration_cost_fct.get().parameters.multiplicative_param.get(context)
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _duration_cost_fct_mult_param_setter(value, owning_component=None, context=None):
-    try:
-        owning_component.parameters.duration_cost_fct.get().parameters.multiplicative_param._set(value, context)
-        return value
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _duration_cost_fct_add_param_getter(owning_component=None, context=None):
-    try:
-        return owning_component.parameters.duration_cost_fct.get().parameters.additive_param.get(context)
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _duration_cost_fct_add_param_setter(value, owning_component=None, context=None):
-    try:
-        owning_component.parameters.duration_cost_fct.get().parameters.additive_param._set(value, context)
-        return value
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _combine_costs_fct_mult_param_getter(owning_component=None, context=None):
-    try:
-        return owning_component.parameters.combine_costs_fct.get().parameters.multiplicative_param.get(context)
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _combine_costs_fct_mult_param_setter(value, owning_component=None, context=None):
-    try:
-        owning_component.parameters.combine_costs_fct.get().parameters.multiplicative_param._set(value, context)
-        return value
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _combine_costs_fct_add_param_getter(owning_component=None, context=None):
-    try:
-        return owning_component.parameters.combine_costs_fct.get().parameters.additive_param.get(context)
-    except (TypeError, IndexError, AttributeError):
-        return None
-
-def _combine_costs_fct_add_param_setter(value, owning_component=None, context=None):
-    try:
-        owning_component.parameters.combine_costs_fct.get().parameters.additive_param._set(value, context)
-        return value
-    except (TypeError, IndexError, AttributeError):
-        return None
 
 TRANSFER_FCT = 'transfer_fct'
 INTENSITY_COST_FCT = 'intensity_cost_fct'
@@ -3728,14 +3600,18 @@ class TransferWithCosts(TransferFunction):
         # Create primary functions' modulation params for TransferWithCosts
         transfer_fct = Parameter(Linear, stateful=False)
         _validate_transfer_fct = get_validator_by_function(is_function_type)
-        transfer_fct_mult_param = Parameter(modulable=True, aliases=MULTIPLICATIVE_PARAM,
-                                            modulation_combination_function=PRODUCT,
-                                            getter=_transfer_fct_mult_param_getter,
-                                            setter=_transfer_fct_mult_param_setter)
-        transfer_fct_add_param = Parameter(modulable=True, aliases=ADDITIVE_PARAM,
-                                           modulation_combination_function=SUM,
-                                           getter=_transfer_fct_add_param_getter,
-                                           setter=_transfer_fct_add_param_setter)
+        transfer_fct_mult_param = FunctionParameter(
+            aliases=MULTIPLICATIVE_PARAM,
+            modulation_combination_function=PRODUCT,
+            function_name='transfer_fct',
+            function_parameter_name=MULTIPLICATIVE_PARAM,
+        )
+        transfer_fct_add_param = FunctionParameter(
+            aliases=ADDITIVE_PARAM,
+            modulation_combination_function=SUM,
+            function_name='transfer_fct',
+            function_parameter_name=ADDITIVE_PARAM,
+        )
 
         enabled_cost_functions = Parameter(
             CostFunctions.DEFAULTS,
@@ -3747,50 +3623,58 @@ class TransferWithCosts(TransferFunction):
         intensity_cost = None
         intensity_cost_fct = Parameter(Exponential, stateful=False)
         _validate_intensity_cost_fct = get_validator_by_function(is_function_type)
-        intensity_cost_fct_mult_param = Parameter(modulable=True,
-                                                  modulation_combination_function=PRODUCT,
-                                                  getter=_intensity_cost_fct_mult_param_getter,
-                                                  setter=_intensity_cost_fct_mult_param_setter)
-        intensity_cost_fct_add_param = Parameter(modulable=True,
-                                                 modulation_combination_function=SUM,
-                                                 getter=_intensity_cost_fct_add_param_getter,
-                                                 setter=_intensity_cost_fct_add_param_setter)
+        intensity_cost_fct_mult_param = FunctionParameter(
+            modulation_combination_function=PRODUCT,
+            function_name='intensity_cost_fct',
+            function_parameter_name=MULTIPLICATIVE_PARAM,
+        )
+        intensity_cost_fct_add_param = FunctionParameter(
+            modulation_combination_function=SUM,
+            function_name='intensity_cost_fct',
+            function_parameter_name=ADDITIVE_PARAM,
+        )
 
         adjustment_cost = None
         adjustment_cost_fct = Parameter(Linear, stateful=False)
         _validate_adjustment_cost_fct = get_validator_by_function(is_function_type)
-        adjustment_cost_fct_mult_param = Parameter(modulable=True,
-                                                   modulation_combination_function=PRODUCT,
-                                                   getter=_adjustment_cost_fct_mult_param_getter,
-                                                   setter=_adjustment_cost_fct_mult_param_setter)
-        adjustment_cost_fct_add_param = Parameter(modulable=True,
-                                                  modulation_combination_function=SUM,
-                                                  getter=_adjustment_cost_fct_add_param_getter,
-                                                  setter=_adjustment_cost_fct_add_param_setter)
+        adjustment_cost_fct_mult_param = FunctionParameter(
+            modulation_combination_function=PRODUCT,
+            function_name='adjustment_cost_fct',
+            function_parameter_name=MULTIPLICATIVE_PARAM,
+        )
+        adjustment_cost_fct_add_param = FunctionParameter(
+            modulation_combination_function=SUM,
+            function_name='adjustment_cost_fct',
+            function_parameter_name=ADDITIVE_PARAM,
+        )
 
         duration_cost = None
         duration_cost_fct = Parameter(SimpleIntegrator, stateful=False)
         _validate_duration_cost_fct = get_validator_by_function(is_function_type)
-        duration_cost_fct_mult_param = Parameter(modulable=True,
-                                                 modulation_combination_function=PRODUCT,
-                                                 getter=_duration_cost_fct_mult_param_getter,
-                                                 setter=_duration_cost_fct_mult_param_setter)
-        duration_cost_fct_add_param = Parameter(modulable=True,
-                                                modulation_combination_function=SUM,
-                                                getter=_duration_cost_fct_add_param_getter,
-                                                setter=_duration_cost_fct_add_param_setter)
+        duration_cost_fct_mult_param = FunctionParameter(
+            modulation_combination_function=PRODUCT,
+            function_name='duration_cost_fct',
+            function_parameter_name=MULTIPLICATIVE_PARAM,
+        )
+        duration_cost_fct_add_param = FunctionParameter(
+            modulation_combination_function=SUM,
+            function_name='duration_cost_fct',
+            function_parameter_name=ADDITIVE_PARAM,
+        )
 
         combined_costs = None
         combine_costs_fct = Parameter(LinearCombination, stateful=False)
         _validate_combine_costs_fct = get_validator_by_function(is_function_type)
-        combine_costs_fct_mult_param=Parameter(modulable=True,
-                                               modulation_combination_function=PRODUCT,
-                                               getter=_combine_costs_fct_mult_param_getter,
-                                               setter=_combine_costs_fct_mult_param_setter)
-        combine_costs_fct_add_param=Parameter(modulable=True,
-                                              modulation_combination_function=SUM,
-                                              getter=_combine_costs_fct_add_param_getter,
-                                              setter=_combine_costs_fct_add_param_setter)
+        combine_costs_fct_mult_param = FunctionParameter(
+            modulation_combination_function=PRODUCT,
+            function_name='combine_costs_fct',
+            function_parameter_name=MULTIPLICATIVE_PARAM,
+        )
+        combine_costs_fct_add_param = FunctionParameter(
+            modulation_combination_function=SUM,
+            function_name='combine_costs_fct',
+            function_parameter_name=ADDITIVE_PARAM,
+        )
 
     @tc.typecheck
     def __init__(self,

--- a/psyneulink/core/components/ports/parameterport.py
+++ b/psyneulink/core/components/ports/parameterport.py
@@ -810,7 +810,7 @@ def _instantiate_parameter_ports(owner, function=None, context=None):
         for p in function.parameters:
             if not skip_parameter_port(p):
                 try:
-                    value = owner.initial_function_parameters[p.name]
+                    value = owner.initial_shared_parameters['function'][p.name]
                 except (KeyError, TypeError):
                     if p.spec is not None:
                         value = p.spec

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -342,7 +342,7 @@ from psyneulink.core.globals.context import ContextFlags, handle_external_contex
 from psyneulink.core.globals.keywords import \
     CONTRASTIVE_HEBBIAN_MECHANISM, COUNT, FUNCTION, HARD_CLAMP, HOLLOW_MATRIX, MAX_ABS_DIFF, NAME, \
     SIZE, SOFT_CLAMP, TARGET, VARIABLE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, SharedParameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.utilities import is_numeric_or_none, parameter_spec
 from psyneulink.library.components.mechanisms.processing.transfer.recurrenttransfermechanism import \
@@ -930,11 +930,10 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
 
         minus_phase_termination_condition = Parameter(CONVERGENCE, stateful=False, loggable=False)
         plus_phase_termination_condition = Parameter(CONVERGENCE, stateful=False, loggable=False)
-        learning_function = Parameter(
+        learning_function = SharedParameter(
             ContrastiveHebbian,
-            stateful=False,
-            loggable=False,
-            reference=True
+            attribute_name='learning_mechanism',
+            shared_parameter_name='function',
         )
         max_passes = Parameter(1000, stateful=False)
 

--- a/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
@@ -466,7 +466,7 @@ class KohonenMechanism(TransferMechanism):
 
         self._learning_enabled = value
         # Enable learning for KohonenMechanism's learning_mechanism
-        if hasattr(self, 'learning_mechanism'):
+        if self.learning_mechanism is not None:
             self.learning_mechanism.learning_enabled = value
         # If KohonenMechanism has no LearningMechanism, warn and then ignore attempt to set learning_enabled
         elif value is True:

--- a/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
@@ -90,7 +90,7 @@ from psyneulink.core.globals.context import ContextFlags, handle_external_contex
 from psyneulink.core.globals.keywords import \
     DEFAULT_MATRIX, FUNCTION, GAUSSIAN, IDENTITY_MATRIX, INITIALIZING, KOHONEN_MECHANISM, \
     LEARNED_PROJECTIONS, LEARNING_SIGNAL, MATRIX, MAX_INDICATOR, NAME, OWNER_VALUE, OWNER_VARIABLE, RESULT, VARIABLE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, SharedParameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.utilities import is_numeric_or_none, parameter_spec
 from psyneulink.library.components.mechanisms.modulatory.learning.kohonenlearningmechanism import KohonenLearningMechanism
@@ -252,13 +252,11 @@ class KohonenMechanism(TransferMechanism):
                     :type: ``list``
                     :read only: True
         """
-        learning_function = Parameter(
+        learning_function = SharedParameter(
             Kohonen(distance_function=GAUSSIAN),
-            stateful=False,
-            loggable=False,
-            reference=True
+            attribute_name='learning_mechanism',
+            shared_parameter_name='function',
         )
-        learning_rate = Parameter(None, modulable=True)
         enable_learning = True
         matrix = DEFAULT_MATRIX
 

--- a/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
@@ -200,7 +200,7 @@ from psyneulink.core.components.mechanisms.processing.transfermechanism import _
 from psyneulink.core.globals.keywords import \
     CONVERGENCE, FUNCTION, GREATER_THAN_OR_EQUAL, INITIALIZER, LCA_MECHANISM, LEAK, LESS_THAN_OR_EQUAL, MATRIX, NAME, \
     NOISE, RATE, RESULT, TERMINATION_THRESHOLD, TERMINATION_MEASURE, TERMINATION_COMPARISION_OP, TIME_STEP_SIZE, VALUE, INVERSE_HOLLOW_MATRIX, AUTO
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import FunctionParameter, Parameter
 from psyneulink.core.globals.context import ContextFlags
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.library.components.mechanisms.processing.transfer.recurrenttransfermechanism import \
@@ -397,11 +397,16 @@ class LCAMechanism(RecurrentTransferMechanism):
             getter=_recurrent_transfer_mechanism_matrix_getter,
             setter=_recurrent_transfer_mechanism_matrix_setter
         )
-        leak = Parameter(0.5, modulable=True)
+        integration_rate = FunctionParameter(
+            0.5,
+            function_name='integrator_function',
+            function_parameter_name='rate',
+            aliases='leak'
+        )
         auto = Parameter(0.0, modulable=True, aliases='self_excitation')
         hetero = Parameter(-1.0, modulable=True)
         competition = Parameter(1.0, modulable=True)
-        time_step_size = Parameter(0.1, modulable=True)
+        time_step_size = FunctionParameter(0.1, function_name='integrator_function')
 
         initial_value = None
         integrator_mode = Parameter(True, setter=_integrator_mode_setter)

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -688,6 +688,7 @@ class RecurrentTransferMechanism(TransferMechanism):
         if matrix is AutoAssociativeProjection:
             matrix = HOLLOW_MATRIX
 
+        self.learning_mechanism = None
         self._learning_enabled = enable_learning
 
         super().__init__(
@@ -1063,7 +1064,7 @@ class RecurrentTransferMechanism(TransferMechanism):
 
         self._learning_enabled = value
         # Enable learning for RecurrentTransferMechanism's learning_mechanism
-        if hasattr(self, 'learning_mechanism'):
+        if self.learning_mechanism is not None:
             self.learning_mechanism.learning_enabled = value
         # If RecurrentTransferMechanism has no LearningMechanism, warn and then ignore attempt to set learning_enabled
         elif value is True:

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -207,7 +207,7 @@ from psyneulink.core.components.ports.port import _instantiate_port
 from psyneulink.core.globals.context import handle_external_context
 from psyneulink.core.globals.keywords import \
     AUTO, ENERGY, ENTROPY, HETERO, HOLLOW_MATRIX, INPUT_PORT, MATRIX, NAME, RECURRENT_TRANSFER_MECHANISM, RESULT
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, SharedParameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.registry import register_instance, remove_instance_from_registry
 from psyneulink.core.globals.socket import ConnectionInfo
@@ -286,12 +286,6 @@ def _recurrent_transfer_mechanism_matrix_setter(value, owning_component=None, co
         owning_component.parameters.auto._set(auto, context)
         owning_component.parameters.hetero._set(hetero, context)
 
-    return value
-
-
-def _recurrent_transfer_mechanism_learning_rate_setter(value, owning_component=None, context=None):
-    if hasattr(owning_component, "learning_mechanism") and owning_component.learning_mechanism:
-        owning_component.learning_mechanism.parameters.learning_rate._set(value, context)
     return value
 
 
@@ -619,19 +613,17 @@ class RecurrentTransferMechanism(TransferMechanism):
         auto = Parameter(1, modulable=True)
         hetero = Parameter(0, modulable=True)
         combination_function = LinearCombination
-        noise = Parameter(0.0, modulable=True)
         smoothing_factor = Parameter(0.5, modulable=True)
         enable_learning = False
         # learning_function is a reference because it is used for
         # an auxiliary learning mechanism
-        learning_function = Parameter(
+        learning_function = SharedParameter(
             Hebbian,
-            stateful=False,
-            loggable=False,
-            reference=True
+            attribute_name='learning_mechanism',
+            shared_parameter_name='function',
         )
-        learning_rate = Parameter(None, setter=_recurrent_transfer_mechanism_learning_rate_setter)
-        learning_condition = Parameter(None, stateful=False, loggable=False)
+        learning_rate = SharedParameter(None, attribute_name='learning_mechanism')
+        learning_condition = SharedParameter(None, attribute_name='learning_mechanism')
         has_recurrent_input_port = Parameter(False, stateful=False, loggable=False)
 
         output_ports = Parameter(
@@ -1180,24 +1172,30 @@ class RecurrentTransferMechanism(TransferMechanism):
 
         """
 
-        # This insures that these are validated if the method is called from the command line (i.e., by the user)
-        if learning_function:
-            self.learning_function = learning_function
-        if learning_rate:
-            self.learning_rate = learning_rate
-        if learning_condition:
-            self.learning_condition = learning_condition
+        if not isinstance(learning_condition, Condition):
+            if learning_condition == CONVERGENCE:
+                learning_condition = WhenFinished(self)
+            elif learning_condition == UPDATE:
+                learning_condition = None
 
-        if not isinstance(self.learning_condition, Condition):
-            if self.learning_condition == CONVERGENCE:
-                self.learning_condition = WhenFinished(self)
-            elif self.learning_condition == UPDATE:
-                self.learning_condition = None
+        try:
+            shared_params = self.initial_shared_parameters['learning_mechanism']
+
+            if learning_condition is None:
+                learning_condition = shared_params['learning_condition']
+
+            if learning_rate is None:
+                learning_rate = shared_params['learning_rate']
+
+            if learning_function is None:
+                learning_function = shared_params['learning_function']
+        except KeyError:
+            pass
 
         self.learning_mechanism = self._instantiate_learning_mechanism(activity_vector=self._learning_signal_source,
-                                                                       learning_function=self.learning_function,
-                                                                       learning_rate=self.learning_rate,
-                                                                       learning_condition=self.learning_condition,
+                                                                       learning_function=learning_function,
+                                                                       learning_rate=learning_rate,
+                                                                       learning_condition=learning_condition,
                                                                        matrix=self.recurrent_projection,
                                                                        context=context)
 

--- a/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
+++ b/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
@@ -112,7 +112,7 @@ from psyneulink.core.components.projections.projection import projection_keyword
 from psyneulink.core.components.shellclasses import Mechanism
 from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.globals.context import ContextFlags
-from psyneulink.core.globals.keywords import AUTO_ASSOCIATIVE_PROJECTION, DEFAULT_MATRIX, HOLLOW_MATRIX, MATRIX
+from psyneulink.core.globals.keywords import AUTO_ASSOCIATIVE_PROJECTION, DEFAULT_MATRIX, HOLLOW_MATRIX, MATRIX, FUNCTION, OWNER_MECH
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
@@ -293,6 +293,19 @@ class AutoAssociativeProjection(MappingProjection):
                          name=name,
                          prefs=prefs,
                          **kwargs)
+
+    # temporary override to make sure matrix/auto/hetero parameters
+    # get passed properly. should be replaced with a better organization
+    # of auto/hetero, in which the base parameters are stored either on
+    # AutoAssociativeProjection or on LinearMatrix itself
+    def _override_unspecified_shared_parameters(self, context):
+        super()._override_unspecified_shared_parameters(context)
+
+        if FUNCTION not in self.initial_shared_parameters:
+            try:
+                self.initial_shared_parameters[FUNCTION] = self.initial_shared_parameters[OWNER_MECH]
+            except KeyError:
+                pass
 
     # COMMENTED OUT BY KAM 1/9/2018 -- this method is not currently used; should be moved to Recurrent Transfer Mech
     #     if it is used in the future

--- a/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
+++ b/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
@@ -113,7 +113,7 @@ from psyneulink.core.components.shellclasses import Mechanism
 from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.globals.context import ContextFlags
 from psyneulink.core.globals.keywords import AUTO_ASSOCIATIVE_PROJECTION, DEFAULT_MATRIX, HOLLOW_MATRIX, MATRIX, FUNCTION, OWNER_MECH
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import SharedParameter, Parameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 
@@ -128,33 +128,6 @@ projection_keywords.update({AUTO_ASSOCIATIVE_PROJECTION})
 class AutoAssociativeError(Exception):
     def __init__(self, error_value):
         self.error_value = error_value
-
-
-def _matrix_getter(owning_component=None, context=None):
-    return owning_component.owner_mech.parameters.matrix._get(context)
-
-
-def _matrix_setter(value, owning_component=None, context=None):
-    owning_component.owner_mech.parameters.matrix._set(value, context)
-    return value
-
-
-def _auto_getter(owning_component=None, context=None):
-    return owning_component.owner_mech.parameters.auto._get(context)
-
-
-def _auto_setter(value, owning_component=None, context=None):
-    owning_component.owner_mech.parameters.auto._set(value, context)
-    return value
-
-
-def _hetero_getter(owning_component=None, context=None):
-    return owning_component.owner_mech.parameters.hetero._get(context)
-
-
-def _hetero_setter(value, owning_component=None, context=None):
-    owning_component.owner_mech.parameters.hetero._set(value, context)
-    return value
 
 
 class AutoAssociativeProjection(MappingProjection):
@@ -258,9 +231,9 @@ class AutoAssociativeProjection(MappingProjection):
         # function is always LinearMatrix that requires 1D input
         function = Parameter(LinearMatrix, stateful=False, loggable=False)
 
-        auto = Parameter(1, getter=_auto_getter, setter=_auto_setter, modulable=True)
-        hetero = Parameter(0, getter=_hetero_getter, setter=_hetero_setter, modulable=True)
-        matrix = Parameter(DEFAULT_MATRIX, getter=_matrix_getter, setter=_matrix_setter, modulable=True)
+        auto = SharedParameter(1, attribute_name=OWNER_MECH)
+        hetero = SharedParameter(0, attribute_name=OWNER_MECH)
+        matrix = SharedParameter(DEFAULT_MATRIX, attribute_name=OWNER_MECH)
 
     classPreferenceLevel = PreferenceLevel.TYPE
 

--- a/tests/misc/test_parameters.py
+++ b/tests/misc/test_parameters.py
@@ -240,3 +240,68 @@ def test_copy():
 def test_user_specified(cls_, kwargs, parameter, is_user_specified):
     c = cls_(**kwargs)
     assert getattr(c.parameters, parameter)._user_specified == is_user_specified
+
+
+class TestSharedParameters:
+
+    recurrent_mech = pnl.RecurrentTransferMechanism(default_variable=[0, 0], enable_learning=True)
+    recurrent_mech_no_learning = pnl.RecurrentTransferMechanism(default_variable=[0, 0])
+    transfer_with_costs = pnl.TransferWithCosts(default_variable=[0, 0])
+
+    test_values = [
+        (
+            recurrent_mech,
+            'learning_function',
+            recurrent_mech.learning_mechanism.parameters.function
+        ),
+        (
+            recurrent_mech,
+            'learning_rate',
+            recurrent_mech.learning_mechanism.parameters.learning_rate
+        ),
+        (
+            transfer_with_costs,
+            'transfer_fct_mult_param',
+            transfer_with_costs.transfer_fct.parameters.multiplicative_param
+        )
+    ]
+
+    @pytest.mark.parametrize(
+        'obj, parameter_name, source',
+        test_values + [
+            (recurrent_mech_no_learning, 'learning_function', None),
+        ]
+    )
+    def test_sources(self, obj, parameter_name, source):
+        assert getattr(obj.parameters, parameter_name).source is source
+
+    @pytest.mark.parametrize(
+        'obj, parameter_name, source',
+        test_values
+    )
+    def test_values(self, obj, parameter_name, source):
+        obj_param = getattr(obj.parameters, parameter_name)
+        eids = range(5)
+
+        for eid in eids:
+            obj.execute(np.array([eid, eid]), context=eid)
+
+        assert all([
+            obj_param.get(eid) is source.get(eid)
+            for eid in eids
+        ])
+
+    @pytest.mark.parametrize(
+        'obj, parameter_name, attr_name',
+        [
+            (transfer_with_costs, 'intensity_cost_fct_mult_param', 'modulable'),
+            (recurrent_mech, 'learning_function', 'stateful'),
+            (recurrent_mech, 'learning_function', 'loggable'),
+            (recurrent_mech.recurrent_projection, 'auto', 'modulable'),
+        ]
+    )
+    def test_param_attrs_match(self, obj, parameter_name, attr_name):
+        shared_param = getattr(obj.parameters, parameter_name)
+        source_param = shared_param.source
+
+        assert getattr(shared_param, attr_name) == getattr(source_param, attr_name)


### PR DESCRIPTION
parameters: add FunctionParameter and SharedParameter subclasses

- serve as a reference to a Parameter on one of the Component's attributes or
other Parameters
- values are shared between target Parameter and SharedParameter
- when included in constructor, automatically passed on instantiation to
relevant secondary Functions
    - other objects (e.g. RecurrentTransferMechanism.learning_mechanism) must still manually retrieve these parameter values as before