### PR TITLE
Remove internal use of dot notation for stateful parameters

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1786,7 +1786,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             for param_name in runtime_params:
                 if not isinstance(param_name, str):
                     generate_error(param_name)
-                elif hasattr(self, param_name):
+                elif param_name in self.parameters:
                     if param_name in {FUNCTION, INPUT_PORTS, OUTPUT_PORTS}:
                         generate_error(param_name)
                     if context.execution_id not in self._runtime_params_reset:
@@ -1797,7 +1797,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 # Any remaining params should either belong to the Component's function
                 #    or, if the Component is a Function, to it or its owner
                 elif ( # If Component is not a function, and its function doesn't have the parameter or
-                        (not is_function_type(self) and not hasattr(self.function, param_name))
+                        (not is_function_type(self) and param_name not in self.function.parameters)
                        # the Component is a standalone function:
                        or (is_function_type(self) and not self.owner)):
                     generate_error(param_name)
@@ -2856,8 +2856,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         # KAM added 6/14/18 for functions that do not pass their has_initializers status up to their owner via property
         # FIX: need comprehensive solution for has_initializers; need to determine whether ports affect mechanism's
         # has_initializers status
-        if self.function.has_initializers:
-            self.has_initializers = True
+        if self.function.parameters.has_initializers._get(context):
+            self.parameters.has_initializers._set(True, context)
 
         self._parse_param_port_sources()
 

--- a/psyneulink/core/components/functions/objectivefunctions.py
+++ b/psyneulink/core/components/functions/objectivefunctions.py
@@ -66,7 +66,7 @@ class ObjectiveFunction(Function_Base):
                     :default value: False
                     :type: ``bool``
         """
-        normalize = False
+        normalize = Parameter(False, stateful=False)
         metric = Parameter(None, stateful=False)
 
 
@@ -205,7 +205,7 @@ class Stability(ObjectiveFunction):
         metric = Parameter(ENERGY, stateful=False)
         metric_fct = Parameter(None, stateful=False, loggable=False)
         transfer_fct = Parameter(None, stateful=False, loggable=False)
-        normalize = False
+        normalize = Parameter(False, stateful=False)
 
     @tc.typecheck
     def __init__(self,

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -607,7 +607,7 @@ class AccumulatorIntegrator(IntegratorFunction):  # ----------------------------
         runtime_params = params
         if runtime_params:
             for param_name in runtime_params:
-                if hasattr(self, param_name):
+                if param_name in self.parameters:
                     if param_name in {FUNCTION, INPUT_PORTS, OUTPUT_PORTS}:
                         continue
                     if context.execution_id not in self._runtime_params_reset:

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -2682,7 +2682,10 @@ class LinearMatrix(TransferFunction):  # ---------------------------------------
             prefs=prefs,
         )
 
-        self.matrix = self.instantiate_matrix(self.matrix)
+        self.parameters.matrix.set(
+            self.instantiate_matrix(self.parameters.matrix.get()),
+            skip_log=True,
+        )
 
     # def _validate_variable(self, variable, context=None):
     #     """Insure that variable passed to LinearMatrix is a max 2D array
@@ -2921,10 +2924,12 @@ class LinearMatrix(TransferFunction):  # ---------------------------------------
         if isinstance(self.owner, Projection):
             self.receiver = self.defaults.variable
 
-        if self.matrix is None and not hasattr(self.owner, "receiver"):
+        matrix = self.parameters.matrix._get(context)
+
+        if matrix is None and not hasattr(self.owner, "receiver"):
             variable_length = np.size(np.atleast_2d(self.defaults.variable), 1)
-            self.matrix = np.identity(variable_length)
-        self.matrix = self.instantiate_matrix(self.matrix)
+            matrix = np.identity(variable_length)
+        self.parameters.matrix._set(self.instantiate_matrix(matrix), context)
 
     def instantiate_matrix(self, specification, context=None):
         """Implements matrix indicated by specification

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -1066,6 +1066,7 @@ Class Reference
 """
 
 import abc
+import copy
 import inspect
 import itertools
 import logging
@@ -1861,7 +1862,7 @@ class Mechanism_Base(Mechanism):
                         mech_variable_item = args[VARIABLE]
                 else:
                     try:
-                        mech_variable_item = parsed_input_port_spec.value
+                        mech_variable_item = parsed_input_port_spec.defaults.value
                     except AttributeError:
                         mech_variable_item = parsed_input_port_spec.defaults.mech_variable_item
             else:
@@ -2083,37 +2084,57 @@ class Mechanism_Base(Mechanism):
 
         super()._instantiate_function(function=function, function_params=function_params, context=context)
 
-        if self.input_ports and any(input_port.weight is not None for input_port in self.input_ports):
+        if (
+            self.input_ports
+            and any(
+                input_port.parameters.weight._get(context) is not None
+                for input_port in self.input_ports
+            )
+            and 'weights' in self.function.parameters
+        ):
 
             # Construct defaults:
             #    from function.weights if specified else 1's
             try:
-                default_weights = self.function.weights
+                default_weights = self.function.defaults.weights
             except AttributeError:
                 default_weights = None
             if default_weights is None:
                 default_weights = default_weights or [1.0] * len(self.input_ports)
 
             # Assign any weights specified in input_port spec
-            weights = [[input_port.weight if input_port.weight is not None else default_weight]
+            weights = [[input_port.defaults.weight if input_port.defaults.weight is not None else default_weight]
                        for input_port, default_weight in zip(self.input_ports, default_weights)]
-            self.function._weights = weights
+            self.function.parameters.weights._set(weights, context)
 
-        if self.input_ports and any(input_port.exponent is not None for input_port in self.input_ports):
+        if (
+            self.input_ports
+            and any(
+                input_port.parameters.exponent._get(context) is not None
+                for input_port in self.input_ports
+            )
+            and 'exponents' in self.function.parameters
+        ):
 
             # Construct defaults:
             #    from function.weights if specified else 1's
             try:
-                default_exponents = self.function.exponents
+                default_exponents = self.function.defaults.exponents
             except AttributeError:
                 default_exponents = None
             if default_exponents is None:
                 default_exponents = default_exponents or [1.0] * len(self.input_ports)
 
             # Assign any exponents specified in input_port spec
-            exponents = [[input_port.exponent if input_port.exponent is not None else default_exponent]
-                       for input_port, default_exponent in zip(self.input_ports, default_exponents)]
-            self.function._exponents = exponents
+            exponents = [
+                [
+                    input_port.parameters.exponent._get(context)
+                    if input_port.parameters.exponent._get(context) is not None
+                    else default_exponent
+                ]
+                for input_port, default_exponent in zip(self.input_ports, default_exponents)
+            ]
+            self.function.parameters.exponents._set(exponents, context)
 
         # this may be removed when the restriction making all Mechanism values 2D np arrays is lifted
         # ignore warnings of certain Functions that disable conversion
@@ -3607,7 +3628,10 @@ class Mechanism_Base(Mechanism):
             instantiated_output_ports = _instantiate_output_ports(self, output_ports, context=context)
 
         if update_variable:
-            self._update_default_variable(self.input_values, context)
+            self._update_default_variable(
+                [copy.deepcopy(port.defaults.value) for port in self.input_ports],
+                context
+            )
 
         return {INPUT_PORTS: instantiated_input_ports,
                 OUTPUT_PORTS: instantiated_output_ports}
@@ -3683,12 +3707,10 @@ class Mechanism_Base(Mechanism):
                                               component=port)
 
             elif port in self.output_ports:
-                if isinstance(port, OutputPort):
-                    index = self.output_ports.index(port)
-                else:
-                    index = self.output_ports.index(self.output_ports[port])
                 delete_port_Projections(port.efferents.copy(), port)
-                del self.output_values[index]
+                # NOTE: removed below del because output_values is
+                # generated on the fly. These comments can be removed
+                # del self.output_values[index]
                 del self.output_ports[port]
                 # If port is subclass of OutputPort:
                 #    check if regsistry has category for that class, and if so, use that

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -1532,10 +1532,10 @@ class ControlMechanism(ModulatoryMechanism_Base):
 
         control_signal = _instantiate_port(port_type=ControlSignal,
                                                owner=self,
-                                               variable=self.default_allocation           # User specified value
+                                               variable=self.defaults.default_allocation           # User specified value
                                                         or allocation_parameter_default,  # Parameter default
                                                reference_value=allocation_parameter_default,
-                                               modulation=self.modulation,
+                                               modulation=self.defaults.modulation,
                                                port_spec=control_signal_spec,
                                                context=context)
         if not type(control_signal) in convert_to_list(self.outputPortTypes):

--- a/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
@@ -500,7 +500,7 @@ class GatingMechanism(ControlMechanism):
                                                variable=self.default_allocation           # User specified value
                                                         or allocation_parameter_default,  # Parameter default
                                                reference_value=allocation_parameter_default,
-                                               modulation=self.modulation,
+                                               modulation=self.defaults.modulation,
                                                port_spec=gating_signal_spec,
                                                context=context)
         if not type(gating_signal) in convert_to_list(self.outputPortTypes):

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -847,12 +847,13 @@ class OptimizationControlMechanism(ControlMechanism):
 
         super()._instantiate_attributes_after_function(context=context)
         # Assign parameters to function (OptimizationFunction) that rely on OptimizationControlMechanism
-        self.function.reset({DEFAULT_VARIABLE: self.control_allocation,
-                                    OBJECTIVE_FUNCTION: self.evaluation_function,
-                                    # SEARCH_FUNCTION: self.search_function,
-                                    # SEARCH_TERMINATION_FUNCTION: self.search_termination_function,
-                                    SEARCH_SPACE: self.control_allocation_search_space
-                                    })
+        self.function.reset({
+            DEFAULT_VARIABLE: self.parameters.control_allocation._get(context),
+            OBJECTIVE_FUNCTION: self.evaluation_function,
+            # SEARCH_FUNCTION: self.search_function,
+            # SEARCH_TERMINATION_FUNCTION: self.search_termination_function,
+            SEARCH_SPACE: self.parameters.control_allocation_search_space._get(context)
+        })
 
         if isinstance(self.agent_rep, type):
             self.agent_rep = self.agent_rep()

--- a/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
@@ -1232,7 +1232,7 @@ class LearningMechanism(ModulatoryMechanism_Base):
                                                  variable=(OWNER_VALUE,0),
                                                  params=params,
                                                  reference_value=self.parameters.learning_signal._get(context),
-                                                 modulation=self.modulation,
+                                                 modulation=self.defaults.modulation,
                                                  # port_spec=self.learning_signal)
                                                  port_spec=learning_signal,
                                                  context=context)

--- a/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
@@ -761,15 +761,21 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
         DEFAULT_WEIGHT = 1
         DEFAULT_EXPONENT = 1
 
-        weights = [input_port.weight for input_port in self.input_ports]
-        exponents = [input_port.exponent for input_port in self.input_ports]
+        weights = [input_port.defaults.weight for input_port in self.input_ports]
+        exponents = [input_port.defaults.exponent for input_port in self.input_ports]
 
-        if hasattr(self.function, WEIGHTS):
+        if WEIGHTS in self.function.parameters:
             if any(weight is not None for weight in weights):
-                self.function.weights = [[weight or DEFAULT_WEIGHT] for weight in weights]
-        if hasattr(self.function, EXPONENTS):
+                self.function.parameters.weights._set(
+                    [[weight or DEFAULT_WEIGHT] for weight in weights],
+                    context
+                )
+        if EXPONENTS in self.function.parameters:
             if any(exponent is not None for exponent in exponents):
-                self.function.exponents = [[exponent or DEFAULT_EXPONENT] for exponent in exponents]
+                self.function.parameters.exponents._set(
+                    [[exponent or DEFAULT_EXPONENT] for exponent in exponents],
+                    context
+                )
         assert True
 
     # # MODIFIED 6/8/19 NEW: [JDC]
@@ -800,14 +806,14 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
 
     @property
     def monitor_weights_and_exponents(self):
-        if hasattr(self.function, WEIGHTS) and self.function.weights is not None:
-            weights = self.function.weights
+        if hasattr(self.function, WEIGHTS) and self.function.weights.base is not None:
+            weights = self.function.weights.base
         else:
-            weights = [input_port.weight for input_port in self.input_ports]
-        if hasattr(self.function, EXPONENTS) and self.function.exponents is not None:
-            exponents = self.function.exponents
+            weights = [input_port.weight.base for input_port in self.input_ports]
+        if hasattr(self.function, EXPONENTS) and self.function.exponents.base is not None:
+            exponents = self.function.exponents.base
         else:
-            exponents = [input_port.exponent for input_port in self.input_ports]
+            exponents = [input_port.exponent.base for input_port in self.input_ports]
         return [(w,e) for w, e in zip(weights,exponents)]
 
     @monitor_weights_and_exponents.setter

--- a/psyneulink/core/components/ports/inputport.py
+++ b/psyneulink/core/components/ports/inputport.py
@@ -1373,7 +1373,7 @@ def _instantiate_input_ports(owner, input_ports=None, reference_value=None, cont
     variable_item_is_OK = False
     for i, input_port in enumerate(owner.input_ports):
         try:
-            variable_item_is_OK = iscompatible(owner.defaults.variable[i], input_port.value)
+            variable_item_is_OK = iscompatible(owner.defaults.variable[i], input_port.defaults.value)
             if not variable_item_is_OK:
                 break
         except IndexError:
@@ -1382,7 +1382,7 @@ def _instantiate_input_ports(owner, input_ports=None, reference_value=None, cont
 
     if not variable_item_is_OK:
         old_variable = owner.defaults.variable
-        owner.defaults.variable = owner._handle_default_variable(default_variable=[port.value
+        owner.defaults.variable = owner._handle_default_variable(default_variable=[port.defaults.value
                                                                                    for port in owner.input_ports])
 
         if owner.verbosePref:

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -1201,7 +1201,7 @@ class OutputPort(Port_Base):
         is_PARAMS_DICT = False
         if fct_variable is None:
             try:
-                if owner.value is not None:
+                if owner.defaults.value is not None:
                     fct_variable = owner.defaults.value[0]
                 # Get owner's value by calling its function
                 else:
@@ -1394,7 +1394,7 @@ def _instantiate_output_ports(owner, output_ports=None, context=None):
                     for item in owner_value))):
         pass
     else:
-        converted_to_2d = convert_to_np_array(owner.value, dimension=2)
+        converted_to_2d = convert_to_np_array(owner.defaults.value, dimension=2)
         # If owner_value is a list of heterogenous elements, use as is
         if converted_to_2d.dtype == object:
             owner_value = owner.defaults.value
@@ -1427,11 +1427,11 @@ def _instantiate_output_ports(owner, output_ports=None, context=None):
                     except AttributeError:
                         index = output_port.index
                         output_port_value = owner_value[index]
-                elif output_port.value is None:
+                elif output_port.defaults.value is None:
                     output_port_value = output_port.function()
 
                 else:
-                    output_port_value = output_port.value
+                    output_port_value = output_port.defaults.value
 
             else:
                 # parse output_port

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2602,9 +2602,9 @@ def _instantiate_port(port_type:_is_port_class,           # Port's type
         # FIX: THIS SHOULD ONLY APPLY TO InputPort AND ParameterPort; WHAT ABOUT OutputPort?
         # Port's assigned value is incompatible with its reference_value (presumably its owner Mechanism's variable)
         reference_value = reference_value if reference_value is not None else port.reference_value
-        if not iscompatible(port.value, reference_value):
+        if not iscompatible(port.defaults.value, reference_value):
             raise PortError("{}'s value attribute ({}) is incompatible with the {} ({}) of its owner ({})".
-                             format(port.name, port.value, REFERENCE_VALUE, reference_value, owner.name))
+                             format(port.name, port.defaults.value, REFERENCE_VALUE, reference_value, owner.name))
 
         # Port has already been assigned to an owner
         if port.owner is not None and port.owner is not owner:

--- a/psyneulink/core/components/projections/modulatory/learningprojection.py
+++ b/psyneulink/core/components/projections/modulatory/learningprojection.py
@@ -474,8 +474,8 @@ class LearningProjection(ModulatoryProjection_Base):
 
         # replaces similar code in _instantiate_sender
         try:
-            if sender.owner.learning_rate is not None:
-                learning_rate = sender.owner.learning_rate
+            if sender.owner.defaults.learning_rate is not None:
+                learning_rate = sender.owner.defaults.learning_rate
         except AttributeError:
             pass
 

--- a/psyneulink/core/components/projections/pathway/mappingprojection.py
+++ b/psyneulink/core/components/projections/pathway/mappingprojection.py
@@ -606,7 +606,10 @@ class MappingProjection(PathwayProjection_Base):
                                  receiver_len,
                                  self.receiver.owner.name))
 
-                self.matrix = get_matrix(matrix_spec, mapping_input_len, receiver_len, context=context)
+                self.parameters.matrix._set(
+                    get_matrix(matrix_spec, mapping_input_len, receiver_len, context=context),
+                    context
+                )
 
                 # Since matrix shape has changed, output of self.function may have changed, so update value
                 self._instantiate_value(context=context)

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -368,7 +368,7 @@ class CompExecution(CUDAExecution):
                 if attribute == 'matrix':
                     # special case since we have to unflatten matrix
                     # FIXME: this seems to break something when generalized for all attributes
-                    value = np.array(value).reshape(component.matrix.shape)
+                    value = np.array(value).reshape(component.parameters.matrix._get(context).shape)
                     to_set._set(value, context=context)
 
     @property

--- a/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
@@ -662,7 +662,7 @@ class LCControlMechanism(ControlMechanism):
         base_level_gain = Parameter(0.5, modulable=True)
         scaling_factor_gain = Parameter(3.0, modulable=True)
 
-        modulated_mechanisms = None
+        modulated_mechanisms = Parameter(None, stateful=False, loggable=False)
 
     @tc.typecheck
     def __init__(self,

--- a/psyneulink/library/components/mechanisms/modulatory/learning/autoassociativelearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/learning/autoassociativelearningmechanism.py
@@ -361,20 +361,6 @@ class AutoAssociativeLearningMechanism(LearningMechanism):
     def _parse_function_variable(self, variable, context=None):
         return variable
 
-    def _instantiate_attributes_after_function(self, context=None):
-        super(AutoAssociativeLearningMechanism, self)._instantiate_attributes_after_function(context=context)
-        # KAM 2/27/19 added the line below to set the learning rate of the hebbian learning function to the learning
-        # rate value passed into RecurrentTransfermechanism
-        if self.learning_rate:
-            self.function.learning_rate = self.learning_rate
-
-    def _instantiate_attributes_after_function(self, context=None):
-        super(AutoAssociativeLearningMechanism, self)._instantiate_attributes_after_function(context=context)
-        # KAM 2/27/19 added the line below to set the learning rate of the hebbian learning function to the learning
-        # rate value passed into RecurrentTransfermechanism
-        if self.learning_rate:
-            self.function.learning_rate = self.learning_rate
-
     def _validate_variable(self, variable, context=None):
         """Validate that variable has only one item: activation_input.
         """

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -1235,10 +1235,10 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
                 #    both the integrator_function's previous_value
                 #    and the Mechanism's current activity (which is returned as its input)
                 if not self.continuous and self.parameters.integrator_mode._get(context):
-                    self.reset(self.initial_value, context=context)
+                    self.reset(self.parameters.initial_value._get(context), context=context)
                     self.parameters.current_activity._set(self.parameters.initial_value._get(context), context)
-                self.parameters.current_termination_threshold._set(self.plus_phase_termination_threshold, context)
-                self.parameters.current_termination_condition._set(self.plus_phase_termination_condition, context)
+                self.parameters.current_termination_threshold._set(self.parameters.plus_phase_termination_threshold._get(context), context)
+                self.parameters.current_termination_condition._set(self.parameters.plus_phase_termination_condition._get(context), context)
 
             # Switch execution_phase
             self.parameters.execution_phase._set(not self.parameters.execution_phase._get(context), context)
@@ -1299,20 +1299,21 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
 
     @handle_external_context()
     def is_converged(self, value=NotImplemented, context=None):
+        phase_convergence_threshold = self.parameters.phase_convergence_threshold._get(context)
         # Check for convergence
         if (
-            self.phase_convergence_threshold is not None
+            phase_convergence_threshold is not None
             and self.parameters.value.get_previous(context) is not None
             and self.initialization_status != ContextFlags.INITIALIZING
         ):
-            if self.delta(value, context) <= self.phase_convergence_threshold:
+            if self.delta(value, context) <= phase_convergence_threshold:
                 return True
             elif self.get_current_execution_time(context).pass_ >= self.max_passes:
                 phase_str = repr('PLUS_PHASE') if self.parameters.execution_phase._get(context) == PLUS_PHASE \
                     else repr('MINUS_PHASE')
                 raise ContrastiveHebbianError(f"Maximum number of executions ({self.max_passes}) has occurred "
                                               f"before reaching convergence_threshold "
-                                              f"({self.phase_convergence_threshold}) for {self.name} in "
+                                              f"({phase_convergence_threshold}) for {self.name} in "
                                               f"{phase_str} of trial {self.get_current_execution_time(context).trial} "
                                               f"of run {self.get_current_execution_time(context).run}.")
             else:

--- a/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
@@ -397,7 +397,7 @@ class KohonenMechanism(TransferMechanism):
                 self._learning_enable_deferred = True
                 return
 
-        self.matrix = self.learned_projection.parameter_ports[MATRIX]
+        self.parameters.matrix._set(self.learned_projection.parameter_ports[MATRIX], context)
 
         self.learning_mechanism = self._instantiate_learning_mechanism(learning_function=self.learning_function,
                                                                        learning_rate=self.learning_rate,

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -180,6 +180,7 @@ Class Reference
 
 """
 
+import copy
 import itertools
 import numbers
 import numpy as np
@@ -612,7 +613,7 @@ class RecurrentTransferMechanism(TransferMechanism):
         matrix = Parameter(HOLLOW_MATRIX, modulable=True, getter=_recurrent_transfer_mechanism_matrix_getter, setter=_recurrent_transfer_mechanism_matrix_setter)
         auto = Parameter(1, modulable=True)
         hetero = Parameter(0, modulable=True)
-        combination_function = LinearCombination
+        combination_function = Parameter(LinearCombination, stateful=False, loggable=False)
         smoothing_factor = Parameter(0.5, modulable=True)
         enable_learning = False
         # learning_function is a reference because it is used for
@@ -851,7 +852,7 @@ class RecurrentTransferMechanism(TransferMechanism):
             raise RecurrentTransferError("Matrix parameter ({}) for {} failed to produce a suitable matrix: "
                                          "if the matrix parameter does not produce a suitable matrix, the "
                                          "'auto' and 'hetero' parameters must be specified; currently, either"
-                                         "auto or hetero parameter is missing.".format(self.matrix, self))
+                                         "auto or hetero parameter is missing.".format(self.parameters.matrix._get(context), self))
 
         if AUTO not in param_keys and HETERO in param_keys:
             d = np.diagonal(matrix).copy()
@@ -862,7 +863,7 @@ class RecurrentTransferMechanism(TransferMechanism):
                                        reference_value_name=AUTO,
                                        params=None,
                                        context=context)
-            self.auto = d
+            self.parameters.auto._set(d, context)
             if port is not None:
                 self._parameter_ports[AUTO] = port
                 port.source = self.parameters.auto
@@ -873,7 +874,7 @@ class RecurrentTransferMechanism(TransferMechanism):
 
             m = matrix.copy()
             np.fill_diagonal(m, 0.0)
-            self.hetero = m
+            self.parameters.hetero._set(m, context)
             port = _instantiate_port(owner=self,
                                        port_type=ParameterPort,
                                        name=HETERO,
@@ -938,9 +939,9 @@ class RecurrentTransferMechanism(TransferMechanism):
             else:
                 self.combination_function = comb_fct
 
-        if self.auto is None and self.hetero is None:
-            self.matrix = matrix
-            if self.matrix is None:
+        if self.parameters.auto._get(context) is None and self.parameters.hetero._get(context) is None:
+            self.parameters.matrix._set(matrix, context)
+            if self.parameters.matrix._get(context) is None:
                 raise RecurrentTransferError("PROGRAM ERROR: Failed to instantiate \'matrix\' param for {}".
                                              format(self.__class__.__name__))
 
@@ -951,14 +952,15 @@ class RecurrentTransferMechanism(TransferMechanism):
 
         super()._instantiate_attributes_after_function(context=context)
 
+        matrix = self.parameters.matrix._get(context)
         # (7/19/17 CW) this line of code is now questionable, given the changes to matrix and the recurrent projection
-        if isinstance(self.matrix, AutoAssociativeProjection):
-            self.recurrent_projection = self.matrix
+        if isinstance(matrix, AutoAssociativeProjection):
+            self.recurrent_projection = matrix
 
         # IMPLEMENTATION NOTE:  THESE SHOULD BE MOVED TO COMPOSITION WHEN THAT IS IMPLEMENTED
         else:
             self.recurrent_projection = self._instantiate_recurrent_projection(self,
-                                                                               matrix=self.matrix,
+                                                                               matrix=matrix,
                                                                                context=context)
 
             # creating a recurrent_projection changes the default variable shape
@@ -1113,7 +1115,7 @@ class RecurrentTransferMechanism(TransferMechanism):
                                         matrix,
                                         context=None):
 
-        learning_mechanism = AutoAssociativeLearningMechanism(default_variable=[activity_vector.value],
+        learning_mechanism = AutoAssociativeLearningMechanism(default_variable=copy.deepcopy([activity_vector.defaults.value]),
                                                               # learning_signals=[self.recurrent_projection],
                                                               function=learning_function,
                                                               learning_rate=learning_rate,


### PR DESCRIPTION
Dot notation may work coincidentally, but may subtly return values for the wrong context. `defaults` or `get`/`_get` should be used instead.