### PR TITLE
llvm: Convert input types when invoking compiled functions

### DIFF
--- a/psyneulink/core/components/functions/objectivefunctions.py
+++ b/psyneulink/core/components/functions/objectivefunctions.py
@@ -1000,7 +1000,7 @@ class Distance(ObjectiveFunction):
         elif self.metric == MAX_ABS_DIFF:
             del kwargs['acc']
             max_diff_ptr = builder.alloca(ctx.float_ty)
-            builder.store(ctx.float_ty("NaN"), max_diff_ptr)
+            builder.store(ctx.float_ty(float("NaN")), max_diff_ptr)
             kwargs['max_diff_ptr'] = max_diff_ptr
             inner = functools.partial(self.__gen_llvm_max_diff, **kwargs)
         elif self.metric == CORRELATION:

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -1516,7 +1516,7 @@ class GridSearch(OptimizationFunction):
         # Use NaN here. fcmp_unordered below returns true if one of the
         # operands is a NaN. This makes sure we always set min_*
         # in the first iteration
-        builder.store(min_value_ptr.type.pointee("NaN"), min_value_ptr)
+        builder.store(min_value_ptr.type.pointee(float("NaN")), min_value_ptr)
 
         b = builder
         with contextlib.ExitStack() as stack:

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -2357,7 +2357,7 @@ class SoftMax(TransferFunction):
         builder.store(exp_sum_ptr.type.pointee(0), exp_sum_ptr)
 
         max_ptr = builder.alloca(ctx.float_ty)
-        builder.store(max_ptr.type.pointee('-inf'), max_ptr)
+        builder.store(max_ptr.type.pointee(float('-inf')), max_ptr)
 
         max_ind_ptr = builder.alloca(ctx.int32_ty)
         builder.store(max_ind_ptr.type.pointee(-1), max_ind_ptr)

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2783,10 +2783,17 @@ class Mechanism_Base(Mechanism):
     def _get_input_struct_type(self, ctx):
         # Extract the non-modulation portion of InputPort input struct
         input_type_list = [ctx.get_input_struct_type(port).elements[0] for port in self.input_ports]
+
+
         # Get modulatory inputs
-        mod_input_type_list = [ctx.get_output_struct_type(proj) for proj in self.mod_afferents]
-        if len(mod_input_type_list) > 0:
+        if len(self.mod_afferents) > 0:
+            mod_input_type_list = (ctx.get_output_struct_type(proj) for proj in self.mod_afferents)
             input_type_list.append(pnlvm.ir.LiteralStructType(mod_input_type_list))
+        # Prefer an array type if there is no modulation.
+        # This is used to keep ctypes inputs as arrays instead of structs.
+        elif all(t == input_type_list[0] for t in input_type_list):
+            return pnlvm.ir.ArrayType(input_type_list[0], len(input_type_list))
+
         return pnlvm.ir.LiteralStructType(input_type_list)
 
     def _get_param_initializer(self, context):

--- a/tests/functions/test_distance.py
+++ b/tests/functions/test_distance.py
@@ -7,7 +7,7 @@ import pytest
 
 SIZE=1000
 # Some metrics (CROSS_ENTROPY) don't like 0s
-test_var = [np.random.rand(SIZE) + Function.EPSILON, np.random.rand(SIZE) + Function.EPSILON]
+test_var = np.random.rand(2, SIZE) + Function.EPSILON
 v1 = test_var[0]
 v2 = test_var[1]
 norm = len(test_var[0])
@@ -18,25 +18,25 @@ def correlation(v1,v2):
     return np.sum(v1_norm * v2_norm) / np.sqrt(np.sum(v1_norm**2) * np.sum(v2_norm**2))
 
 test_data = [
-    (test_var, kw.MAX_ABS_DIFF, False, None, np.max(abs(v1 - v2))),
-    (test_var, kw.MAX_ABS_DIFF, True,  None, np.max(abs(v1 - v2))),
-    (test_var, kw.DIFFERENCE, False, None, np.sum(np.abs(v1 - v2))),
-    (test_var, kw.DIFFERENCE, True,  None, np.sum(np.abs(v1 - v2)) / norm),
-    (test_var, kw.COSINE, False, None, 1 - np.abs(np.sum(v1 * v2) / (
+    (kw.MAX_ABS_DIFF, False, None, np.max(abs(v1 - v2))),
+    (kw.MAX_ABS_DIFF, True,  None, np.max(abs(v1 - v2))),
+    (kw.DIFFERENCE, False, None, np.sum(np.abs(v1 - v2))),
+    (kw.DIFFERENCE, True,  None, np.sum(np.abs(v1 - v2)) / norm),
+    (kw.COSINE, False, None, 1 - np.abs(np.sum(v1 * v2) / (
                                              np.sqrt(np.sum(v1**2)) *
                                              np.sqrt(np.sum(v2**2))) )),
-    (test_var, kw.NORMED_L0_SIMILARITY, False, None, 1 - np.sum(np.abs(v1 - v2) / 4)),
-    (test_var, kw.NORMED_L0_SIMILARITY, True, None, (1 - np.sum(np.abs(v1 - v2) / 4)) / norm),
-    (test_var, kw.EUCLIDEAN, False, None, np.linalg.norm(v1 - v2)),
-    (test_var, kw.EUCLIDEAN, True,  None, np.linalg.norm(v1 - v2) / norm),
-    (test_var, kw.ANGLE, False, "Needs sci-py", 0),
-    (test_var, kw.ANGLE, True,  "Needs sci-py", 0 / norm),
-    (test_var, kw.CORRELATION, False, None, 1 - np.abs(correlation(v1,v2))),
-    (test_var, kw.CORRELATION, True,  None, 1 - np.abs(correlation(v1,v2))),
-    (test_var, kw.CROSS_ENTROPY, False, None, -np.sum(v1 * np.log(v2))),
-    (test_var, kw.CROSS_ENTROPY, True,  None, -np.sum(v1 * np.log(v2)) / norm),
-    (test_var, kw.ENERGY, False, None, -np.sum(v1 * v2) / 2),
-    (test_var, kw.ENERGY, True, None, (-np.sum(v1 * v2) / 2) / norm**2),
+    (kw.NORMED_L0_SIMILARITY, False, None, 1 - np.sum(np.abs(v1 - v2) / 4)),
+    (kw.NORMED_L0_SIMILARITY, True, None, (1 - np.sum(np.abs(v1 - v2) / 4)) / norm),
+    (kw.EUCLIDEAN, False, None, np.linalg.norm(v1 - v2)),
+    (kw.EUCLIDEAN, True,  None, np.linalg.norm(v1 - v2) / norm),
+    (kw.ANGLE, False, "Needs sci-py", 0),
+    (kw.ANGLE, True,  "Needs sci-py", 0 / norm),
+    (kw.CORRELATION, False, None, 1 - np.abs(correlation(v1,v2))),
+    (kw.CORRELATION, True,  None, 1 - np.abs(correlation(v1,v2))),
+    (kw.CROSS_ENTROPY, False, None, -np.sum(v1 * np.log(v2))),
+    (kw.CROSS_ENTROPY, True,  None, -np.sum(v1 * np.log(v2)) / norm),
+    (kw.ENERGY, False, None, -np.sum(v1 * v2) / 2),
+    (kw.ENERGY, True, None, (-np.sum(v1 * v2) / 2) / norm**2),
 ]
 
 # use list, naming function produces ugly names
@@ -65,7 +65,8 @@ names = [
 @pytest.mark.function
 @pytest.mark.distance_function
 @pytest.mark.benchmark
-@pytest.mark.parametrize("variable, metric, normalize, fail, expected", test_data, ids=names)
+@pytest.mark.parametrize("metric, normalize, fail, expected", test_data, ids=names)
+@pytest.mark.parametrize("variable", [test_var, test_var.astype(np.float32), test_var.tolist()], ids=["np.float", "np.float32", "list"])
 @pytest.mark.parametrize("mode", ['Python',
                                   pytest.param('LLVM', marks=pytest.mark.llvm),
                                   pytest.param('PTX', marks=[pytest.mark.llvm, pytest.mark.cuda])

--- a/tests/functions/test_stability.py
+++ b/tests/functions/test_stability.py
@@ -11,16 +11,16 @@ import pytest
 SIZE=10
 # Some metrics (CROSS_ENTROPY) don't like 0s
 test_var = np.random.rand(SIZE) + Function.EPSILON
-hollow_matrix= Function.get_matrix(kw.HOLLOW_MATRIX, SIZE, SIZE)
+hollow_matrix = Function.get_matrix(kw.HOLLOW_MATRIX, SIZE, SIZE)
 v1 = test_var
 v2 = np.dot(hollow_matrix * hollow_matrix, v1)
 norm = len(v1)
 
 test_data = [
-    (test_var, kw.ENTROPY, False, -np.sum(v1 * np.log(v2))),
-    (test_var, kw.ENTROPY, True, -np.sum(v1 * np.log(v2)) / norm),
-    (test_var, kw.ENERGY, False, -np.sum(v1 * v2) / 2),
-    (test_var, kw.ENERGY, True, (-np.sum(v1 * v2) / 2) / norm**2),
+    (kw.ENTROPY, False, -np.sum(v1 * np.log(v2))),
+    (kw.ENTROPY, True, -np.sum(v1 * np.log(v2)) / norm),
+    (kw.ENERGY, False, -np.sum(v1 * v2) / 2),
+    (kw.ENERGY, True, (-np.sum(v1 * v2) / 2) / norm**2),
 ]
 
 # use list, naming function produces ugly names
@@ -34,7 +34,8 @@ names = [
 @pytest.mark.function
 @pytest.mark.stability_function
 @pytest.mark.benchmark
-@pytest.mark.parametrize("variable, metric, normalize, expected", test_data, ids=names)
+@pytest.mark.parametrize("metric, normalize, expected", test_data, ids=names)
+@pytest.mark.parametrize("variable", [test_var, test_var.astype(np.float32)], ids=["float", "float32"] )
 @pytest.mark.parametrize('mode', ['Python',
                                   pytest.param('LLVM', marks=pytest.mark.llvm),
                                   pytest.param('PTX', marks=[pytest.mark.llvm, pytest.mark.cuda])])


### PR DESCRIPTION
Make code generation float precision agnostic.
The switch between fp64 and fp32 is not exposed because there's still large number of tests that fail.
Some tests fail because of reduced precision, others fail because they don't use `Execution` classes and don't implement input conversion.