### PR TITLE
tests: Add DDM/LCA equivalence tests

### DIFF
--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -793,3 +793,20 @@ def test_sequence_of_DDM_mechs_in_Composition_Pathway():
         # if you do not specify, assert_allcose will use a relative tolerance of 1e-07,
         # which WILL FAIL unless you gather higher precision values to use as reference
         np.testing.assert_allclose(val, expected, atol=1e-08, err_msg='Failed on expected_output[{0}]'.format(i))
+
+
+@pytest.mark.mechanism
+@pytest.mark.ddm_mechanism
+@pytest.mark.parametrize('mode', ['Python',
+                                  pytest.param('LLVM', marks=pytest.mark.llvm),
+                                  pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                  pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                  pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
+                                  pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])])
+def test_DDMMechanism_LCA_equivalent(mode):
+    ddm = DDM(default_variable=[0], function=DriftDiffusionIntegrator(rate=1, time_step_size=0.1))
+    comp2 = Composition()
+    comp2.add_node(ddm)
+    result2 = comp2.run(inputs={ddm:[1]}, bin_execute=mode)
+    assert np.allclose(np.asfarray(result2[0]), [0.1])
+    assert np.allclose(np.asfarray(result2[1]), [0.1])

--- a/tests/mechanisms/test_lca.py
+++ b/tests/mechanisms/test_lca.py
@@ -285,6 +285,23 @@ class TestLCA:
     #     result = comp.run(inputs={lca:[1,0]})
     #     assert np.allclose(result, [[0.71463572, 0.28536428]])
 
+    @pytest.mark.mechanism
+    @pytest.mark.lca_mechanism
+    @pytest.mark.parametrize('mode', ['Python',
+                                      pytest.param('LLVM', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                      pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
+                                      pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda])])
+    def test_LCAMechanism_DDM_equivalent(self, mode):
+        lca = LCAMechanism(size=2, leak=0., threshold=1, auto=0, hetero=0,
+                           initial_value=[0, 0], execute_until_finished=False)
+        comp1 = Composition()
+        comp1.add_node(lca)
+        result1 = comp1.run(inputs={lca:[1, -1]}, bin_execute=mode)
+        assert np.allclose(result1, [[0.52497918747894, 0.47502081252106]],)
+
+
 class TestLCAReset:
 
     def test_reset_run(self):


### PR DESCRIPTION
parameters are configured in a way that LCA == DDM followed by Logistic