### PR TITLE
llvm: Support more integer widths

### DIFF
--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3003,7 +3003,7 @@ class Mechanism_Base(Mechanism):
         for scale in [TimeScale.TIME_STEP, TimeScale.PASS, TimeScale.TRIAL, TimeScale.RUN]:
             num_exec_time_ptr = builder.gep(num_executions_ptr, [ctx.int32_ty(0), ctx.int32_ty(scale.value)])
             new_val = builder.load(num_exec_time_ptr)
-            new_val = builder.add(new_val, ctx.int32_ty(1))
+            new_val = builder.add(new_val, new_val.type(1))
             builder.store(new_val, num_exec_time_ptr)
 
         builder = self._gen_llvm_output_ports(ctx, builder, value, params, state, arg_in, arg_out)

--- a/psyneulink/core/llvm/__init__.py
+++ b/psyneulink/core/llvm/__init__.py
@@ -88,12 +88,12 @@ class LLVMBinaryFunction:
             self.__cuda_kernel = _ptx_engine.get_kernel(self.name)
         return self.__cuda_kernel
 
-    def cuda_call(self, *args, threads=1, block_size=32):
+    def cuda_call(self, *args, threads=1, block_size=128):
         grid = ((threads + block_size - 1) // block_size, 1)
         self._cuda_kernel(*args, np.int32(threads),
                           block=(block_size, 1, 1), grid=grid)
 
-    def cuda_wrap_call(self, *args, threads=1, block_size=32):
+    def cuda_wrap_call(self, *args, threads=1, block_size=128):
         wrap_args = (jit_engine.pycuda.driver.InOut(a) if isinstance(a, np.ndarray) else a for a in args)
         self.cuda_call(*wrap_args, threads=threads, block_size=block_size)
 

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -431,12 +431,16 @@ def _convert_llvm_ir_to_ctype(t: ir.Type):
     if type_t is ir.VoidType:
         return None
     elif type_t is ir.IntType:
-        if t.width == 32:
-            return ctypes.c_int
+        if t.width == 8:
+            return ctypes.c_int8
+        elif t.width == 16:
+            return ctypes.c_int16
+        elif t.width == 32:
+            return ctypes.c_int32
         elif t.width == 64:
-            return ctypes.c_longlong
+            return ctypes.c_int64
         else:
-            assert False, "Integer type too big!"
+            assert False, "Unknown integer type: {}".format(type_t)
     elif type_t is ir.DoubleType:
         return ctypes.c_double
     elif type_t is ir.FloatType:

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -916,7 +916,7 @@ def gen_composition_run(ctx, composition, *, tags:frozenset):
             node_state = builder.gep(state, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(idx)])
             num_executions_ptr = helpers.get_state_ptr(builder, node, node_state, "num_executions")
             num_exec_time_ptr = builder.gep(num_executions_ptr, [ctx.int32_ty(0), ctx.int32_ty(TimeScale.RUN.value)])
-            builder.store(ctx.int32_ty(0), num_exec_time_ptr)
+            builder.store(num_exec_time_ptr.type.pointee(0), num_exec_time_ptr)
 
         # Call execution
         exec_tags = tags.difference({"run"})

--- a/psyneulink/core/llvm/jit_engine.py
+++ b/psyneulink/core/llvm/jit_engine.py
@@ -24,6 +24,8 @@ try:
             if pycuda.driver.get_version()[0] > 5:
                 from pycuda import autoinit as pycuda_default
                 import pycuda.compiler
+                assert pycuda_default.context is not None
+                pycuda_default.context.set_cache_config(pycuda.driver.func_cache.PREFER_L1)
                 ptx_enabled = True
             else:
                 raise UserWarning("CUDA driver too old (need 6+): " + str(pycuda.driver.get_version()))
@@ -316,5 +318,5 @@ class ptx_jit_engine(jit_engine):
             wrapper_mod = _gen_cuda_kernel_wrapper_module(function)
             self.compile_modules([wrapper_mod], set())
             kernel = self._engine._find_kernel(name + "_cuda_kernel")
-
+        kernel.set_cache_config(pycuda.driver.func_cache.PREFER_L1)
         return kernel

--- a/tests/llvm/test_custom_func.py
+++ b/tests/llvm/test_custom_func.py
@@ -64,3 +64,45 @@ def test_fixed_dimensions__pnl_builtin_vxm(mode):
         binf2.cuda_wrap_call(vector, matrix, new_res)
 
     assert np.array_equal(orig_res, new_res)
+
+
+@pytest.mark.llvm
+@pytest.mark.parametrize('mode', ['CPU',
+                                  pytest.param('PTX', marks=pytest.mark.cuda)])
+@pytest.mark.parametrize('val', [np.int8(0x7e),
+                                 np.int16(0x7eec),
+                                 np.int32(0x7eedbeee),
+                                 np.int64(0x7eedcafedeadbeee)
+                                ], ids=lambda x: str(x.dtype))
+def test_integer_broadcast(mode, val):
+    custom_name = None
+    with pnlvm.LLVMBuilderContext() as ctx:
+        custom_name = ctx.get_unique_name("broadcast")
+        int_ty = ctx.convert_python_struct_to_llvm_ir(val)
+        int_array_ty = ir.ArrayType(int_ty, 8)
+        func_ty = ir.FunctionType(ir.VoidType(), (int_ty.as_pointer(),
+                                                  int_array_ty.as_pointer()))
+        function = ir.Function(ctx.module, func_ty, name=custom_name)
+
+        i, o = function.args
+        block = function.append_basic_block(name="entry")
+        builder = ir.IRBuilder(block)
+        ival = builder.load(i)
+        ival = builder.add(ival, ival.type(1))
+        with pnlvm.helpers.array_ptr_loop(builder, o, "broadcast") as (b, i):
+            out_ptr = builder.gep(o, [ctx.int32_ty(0), i])
+            builder.store(ival, out_ptr)
+        builder.ret_void()
+
+    binf = pnlvm.LLVMBinaryFunction.get(custom_name)
+    res = np.zeros(8, dtype=val.dtype)
+
+    if mode == 'CPU':
+        ct_res = np.ctypeslib.as_ctypes(res)
+        ct_in = np.ctypeslib.as_ctypes(val)
+
+        binf(ctypes.byref(ct_in), ctypes.byref(ct_res))
+    else:
+        binf.cuda_wrap_call(np.asarray(val), res)
+
+    assert all(res == np.broadcast_to(val + 1, 8))

--- a/tests/mechanisms/test_processing_mechanism.py
+++ b/tests/mechanisms/test_processing_mechanism.py
@@ -317,59 +317,43 @@ class TestLinearMatrixFunction:
 
 class TestProcessingMechanismStandardOutputPorts:
 
-    def test_mean(self):
-        PM1 = ProcessingMechanism(default_variable=[0,0,0], output_ports=[MEAN])
-        PM1.execute([1,2,4])
-        assert np.allclose(PM1.output_ports[0].value,[2.33333333])
+    @pytest.mark.benchmark
+    @pytest.mark.parametrize("op, expected", [(MAX_ONE_HOT, [0, 2, 0]),
+                                              (MAX_INDICATOR, [0, 1, 0]),
+                                              (MAX_ABS_INDICATOR, [0, 0, 1]),
+                                             ],
+                             ids=lambda x: x if isinstance(x, str) else "")
+    @pytest.mark.parametrize("mode", ["Python",
+                                      pytest.param("LLVM", marks=[pytest.mark.llvm]),
+                                      pytest.param("PTX", marks=[pytest.mark.llvm, pytest.mark.cuda]),
+                                     ])
+    def test_output_ports(self, mode, op, expected, benchmark):
+        benchmark.group = "Output Port Op: {}".format(op)
+        PM1 = ProcessingMechanism(default_variable=[0, 0, 0], output_ports=[op])
+        var = [1, 2, 4] if op in {MEAN, MEDIAN, STANDARD_DEVIATION, VARIANCE} else [1, 2, -4]
+        if mode == "Python":
+            ex = PM1.execute
+        elif mode == "LLVM":
+            ex = pnlvm.MechExecution(PM1).execute
+        elif mode == "PTX":
+            ex = pnlvm.MechExecution(PM1).cuda_execute
+        res = benchmark(ex, var)
+        res = PM1.output_ports[0].value if mode == "Python" else res
+        assert np.allclose(res, expected)
 
-    def test_median(self):
-        PM1 = ProcessingMechanism(default_variable=[0,0,0], output_ports=[MEDIAN])
-        PM1.execute([1,2,4])
-        assert np.allclose(PM1.output_ports[0].value,[2])
-
-    def test_std_dev(self):
-        PM1 = ProcessingMechanism(default_variable=[0,0,0], output_ports=[STANDARD_DEVIATION])
-        PM1.execute([1,2,4])
-        assert np.allclose(PM1.output_ports[0].value,[1.24721913])
-
-    def test_variance(self):
-        PM1 = ProcessingMechanism(default_variable=[0,0,0], output_ports=[VARIANCE])
-        PM1.execute([1,2,4])
-        assert np.allclose(PM1.output_ports[0].value,[1.55555556])
-
-    def test_max_val(self):
-        PM1 = ProcessingMechanism(default_variable=[0,0,0], output_ports=[MAX_VAL])
-        PM1.execute([1,2,-4])
-        # assert np.allclose(PM1.output_ports[0].value,[0,2,0])
-        assert np.allclose(PM1.output_ports[0].value,[2])
-
-    def test_max_abs_val(self):
-        PM1 = ProcessingMechanism(default_variable=[0,0,0], output_ports=[MAX_ABS_VAL])
-        PM1.execute([1,2,-4])
-        # assert np.allclose(PM1.output_ports[0].value,[0,0,-4])
-        assert np.allclose(PM1.output_ports[0].value,[4])
-
-    def test_max_one_hot(self):
-        PM1 = ProcessingMechanism(default_variable=[0,0,0], output_ports=[MAX_ONE_HOT])
-        PM1.execute([1,2,-4])
-        assert np.allclose(PM1.output_ports[0].value,[0,2,0])
-
-    def test_max_abs_one_hot(self):
-        PM1 = ProcessingMechanism(default_variable=[0,0,0], output_ports=[MAX_ABS_ONE_HOT])
-        PM1.execute([1,2,-4])
-        assert np.allclose(PM1.output_ports[0].value,[0,0,4])
-
-    def test_max_indicator(self):
-        PM1 = ProcessingMechanism(default_variable=[0,0,0], output_ports=[MAX_INDICATOR])
-        PM1.execute([1,2,-4])
-        assert np.allclose(PM1.output_ports[0].value,[0,1,0])
-
-    def test_max_abs_indicator(self):
-        PM1 = ProcessingMechanism(default_variable=[0,0,0], output_ports=[MAX_ABS_INDICATOR])
-        PM1.execute([1,2,-4])
-        assert np.allclose(PM1.output_ports[0].value,[0,0,1])
-
-    def test_prob(self):
-        PM1 = ProcessingMechanism(default_variable=[0,0,0], output_ports=[PROB])
-        PM1.execute([1,2,4])
-        assert np.allclose(PM1.output_ports[0].value,[0,0,4])
+    # FIXME: These variants don't compile (use UDFs)
+    @pytest.mark.parametrize("op, expected", [(MEAN, [2.33333333]),
+                                              (MEDIAN, [2]),
+                                              (STANDARD_DEVIATION, [1.24721913]),
+                                              (VARIANCE, [1.55555556]),
+                                              (MAX_VAL, [2]),
+                                              (MAX_ABS_VAL, [4]),
+                                              (MAX_ABS_ONE_HOT, [0, 0, 4]),
+                                              (PROB, [0, 2, 0]),
+                                             ],
+                             ids=lambda x: x if isinstance(x, str) else "")
+    def test_output_ports2(self, op, expected):
+        PM1 = ProcessingMechanism(default_variable=[0, 0, 0], output_ports=[op])
+        var = [1, 2, 4] if op in {MEAN, MEDIAN, STANDARD_DEVIATION, VARIANCE} else [1, 2, -4]
+        PM1.execute(var)
+        assert np.allclose(PM1.output_ports[0].value, expected)

--- a/tests/mechanisms/test_processing_mechanism.py
+++ b/tests/mechanisms/test_processing_mechanism.py
@@ -66,111 +66,44 @@ class TestProcessingMechanismFunctions:
         PM2.execute(1.0)
         assert np.allclose(PM2.value, 3.0)
 
-    def test_processing_mechanism_LinearCombination_function(self):
-
-        PM1 = ProcessingMechanism(function=LinearCombination)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_Reduce_function(self):
-        PM1 = ProcessingMechanism(function=Reduce)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_CombineMeans_function(self):
-        PM1 = ProcessingMechanism(function=CombineMeans)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_Exponential_function(self):
-        PM1 = ProcessingMechanism(function=Exponential)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_Logistic_function(self):
-        PM1 = ProcessingMechanism(function=Logistic)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_SoftMax_function(self):
-        PM1 = ProcessingMechanism(function=SoftMax(per_item=False))
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_SimpleIntegrator_function(self):
-        PM1 = ProcessingMechanism(function=SimpleIntegrator)
-        PM1.execute(1.0)
-
-    def test_processing_mechanism_AdaptiveIntegrator_function(self):
-        PM1 = ProcessingMechanism(function=AdaptiveIntegrator)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_DriftDiffusionIntegrator_function(self):
-        PM1 = ProcessingMechanism(function=DriftDiffusionIntegrator)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_OrnsteinUhlenbeckIntegrator_function(self):
-        PM1 = ProcessingMechanism(function=OrnsteinUhlenbeckIntegrator)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_AccumulatorIntegrator_function(self):
-        PM1 = ProcessingMechanism(function=AccumulatorIntegrator)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_FitzHughNagumoIntegrator_function(self):
-        PM1 = ProcessingMechanism(function=FitzHughNagumoIntegrator)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_DualAdaptiveIntegrator_function(self):
-        PM1 = ProcessingMechanism(function=DualAdaptiveIntegrator)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_BogaczEtAl_function(self):
-        PM1 = ProcessingMechanism(function=DriftDiffusionAnalytical)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
+    @pytest.mark.parametrize("function,expected", [(LinearCombination, [[1.]]),
+                                                   (Reduce, [[1.]]),
+                                                   (CombineMeans, [1.0]),
+                                                   (Exponential, [[2.71828183]]),
+                                                   (Logistic, [[0.73105858]]),
+                                                   (SoftMax, [[1,]]),
+                                                   (SimpleIntegrator, [[1.]]),
+                                                   (AdaptiveIntegrator, [[1.]]),
+                                                   (DriftDiffusionIntegrator, [[[1.]], [[1.]]]),
+                                                   (OrnsteinUhlenbeckIntegrator, [[[-1.]], [[1.]]]),
+                                                   (AccumulatorIntegrator, [[0.]]),
+                                                   (FitzHughNagumoIntegrator, [[[0.05127053]], [[0.00279552]], [[0.05]]]),
+                                                   (DualAdaptiveIntegrator, [[0.1517455]]),
+                                                   (DriftDiffusionAnalytical, [[1.19932930e+00],
+                                                                               [3.35350130e-04],
+                                                                               [1.19932930e+00],
+                                                                               [2.48491374e-01],
+                                                                               [1.48291009e+00],
+                                                                               [1.19932930e+00],
+                                                                               [2.48491374e-01],
+                                                                               [1.48291009e+00]]),
+                                                   (NormalDist, [[-0.51529709]]),
+                                                   (ExponentialDist, [[0.29964231]]),
+                                                   (UniformDist, [[0.25891675]]),
+                                                   (GammaDist, [[0.29964231]]),
+                                                   (WaldDist, [[0.73955962]]),
+                                                  ],
+                             ids=lambda x: getattr(x, "componentName", ""))
+    def test_processing_mechanism_function(self, function, expected):
+        PM = ProcessingMechanism(function=function)
+        res = PM.execute(1.0)
+        assert np.allclose(np.asfarray(res), expected)
 
     # COMMENTED OUT BECAUSE OF MATLAB ENGINE:
     # def test_processing_mechanism_NavarroAndFuss_function(self):
     #     PM1 = ProcessingMechanism(function=NavarroAndFuss)
     #     PM1.execute(1.0)
     #     # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_NormalDist_function(self):
-        PM1 = ProcessingMechanism(function=NormalDist)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_ExponentialDist_function(self):
-        PM1 = ProcessingMechanism(function=ExponentialDist)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_UniformDist_function(self):
-        PM1 = ProcessingMechanism(function=UniformDist)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_GammaDist_function(self):
-        PM1 = ProcessingMechanism(function=GammaDist)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_WaldDist_function(self):
-        PM1 = ProcessingMechanism(function=WaldDist)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
-
-    def test_processing_mechanism_Stability_function(self):
-        PM1 = ProcessingMechanism(function=Stability)
-        PM1.execute(1.0)
-        # assert np.allclose(PM1.value, 1.0)
 
     def test_processing_mechanism_Distance_function(self):
         PM1 = ProcessingMechanism(function=Distance,


### PR DESCRIPTION
Make IR generation for execution counts bitwidth agnostic.
Add minor CUDA tune ups.