### PR TITLE
travis: Use nproc to get the number of CPU cores instead of pytest-xdist 'auto'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ addons:
       - graphviz
 
 before_install:
+  - lscpu
   - |
     # Install venv on Linux using Ubuntu distributed python
     if [ "$TRAVIS_CPU_ARCH" != "amd64" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,9 +116,18 @@ install:
 
 script:
   - if [ "x$RUN_COV" != "x" ] ; then echo "Running with coverage"; export COV_ARGS="--cov=psyneulink"; else echo "Running without coverage"; export COV_ARGS=""; fi
+  # CPU count detection is a mess. pytest-xdist checks for physical cores
+  # (not threads). However, Travis exposes mixed configurations:
+  #   * amd64: 1s * 1c * 2t   = 1c/2t
+  #   * arm64: 1s * 32c * 1t  = 32c/32t
+  #   * ppc64le: 2s * 1c * 8t = 2c/16t
+  #   * s390x:  4drawers * 1book * 1s * 1c * 1t = 4c/4t
+  # 'nproc' should give the correct count, including threads.
+  # There's also a limit on available memory so the below maxproc numbers
+  # make sure we don't run out of memory.
   - if [ "$TRAVIS_CPU_ARCH" == "ppc64le" ] ; then export MAX_PROCESSES="--maxprocesses=6"; fi
   - if [ "$TRAVIS_CPU_ARCH" == "arm64" ] ; then export MAX_PROCESSES="--maxprocesses=16"; fi
-  - pytest -n auto -p no:logging --verbosity=0 $COV_ARGS $MAX_PROCESSES
+  - pytest -n `nproc` -p no:logging --verbosity=0 $COV_ARGS $MAX_PROCESSES
 
 after_script:
   - if [ "x$RUN_COV" != "x" ] ; then coveralls; fi


### PR DESCRIPTION
workaround for: https://github.com/pytest-dev/pytest-xdist/issues/602

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>