### PR TITLE
Simplify, improve instantiation of secondary Functions

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1165,8 +1165,6 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         # we must know the final variable shape before setting up parameter
         # Functions or they will mismatch
         self._instantiate_parameter_classes(context)
-        self._override_unspecified_shared_parameters(context)
-        self._validate_subfunctions()
 
         if reset_stateful_function_when is not None:
             self.reset_stateful_function_when = reset_stateful_function_when
@@ -2055,6 +2053,27 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             if p.stateful:
                 setattr(self, _get_parametervalue_attr(p), ParameterValue(self, p))
 
+    def _get_parsed_variable(self, parameter, variable=NotImplemented, context=None):
+        if variable is NotImplemented:
+            variable = copy.deepcopy(self.defaults.variable)
+
+        try:
+            parameter = getattr(self.parameters, parameter)
+        except TypeError:
+            pass
+
+        try:
+            parse_variable_method = getattr(
+                self,
+                f'_parse_{parameter.name}_variable'
+            )
+            return copy.deepcopy(
+                call_with_pruned_args(parse_variable_method, variable, context=context)
+            )
+        except AttributeError:
+            # no parsing method, assume same shape as owner
+            return variable
+
     def _instantiate_parameter_classes(self, context=None):
         """
             An optional method that will take any Parameter values in
@@ -2079,9 +2098,12 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 val = p._get(context)
                 if (
                     p.name != FUNCTION
+                    and is_instance_or_subclass(val, Function)
                     and not p.reference
                     and not isinstance(p, SharedParameter)
                 ):
+                    function_default_variable = self._get_parsed_variable(p, context=context)
+
                     if (
                         inspect.isclass(val)
                         and issubclass(val, Function)
@@ -2089,59 +2111,65 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                         # instantiate class val with all relevant shared parameters
                         # some shared parameters may not be arguments (e.g.
                         # transfer_fct additive_param when function is Identity)
+                        # NOTE: this may cause an issue if there is an
+                        # incompatibility between a shared parameter and
+                        # the default variable, by forcing variable to
+                        # be _user_specified, where instead the variable
+                        # would be coerced to match
                         val = call_with_pruned_args(
                             val,
+                            default_variable=function_default_variable,
                             **self.initial_shared_parameters[p.name]
                         )
 
                         val.owner = self
                         p._set(val, context)
 
-        self._update_parameter_class_variables(context)
+                        for sub_param_name in itertools.chain(self.initial_shared_parameters[p.name], ['variable']):
+                            try:
+                                sub_param = getattr(val.parameters, sub_param_name)
+                            except AttributeError:
+                                # TransferWithCosts has SharedParameters
+                                # referencing transfer_fct's
+                                # additive_param or
+                                # multiplicative_param, but Identity
+                                # does not have them
+                                continue
 
-    def _update_parameter_class_variables(self, context=None):
-        from psyneulink.core.components.shellclasses import Function
-        for p in self.parameters:
-            if p.getter is None:
-                val = p._get(context)
-                if (
-                    p.name != FUNCTION
-                    and not p.reference
-                    and isinstance(val, Function)
-                    and not isinstance(p, SharedParameter)
-                ):
-                    try:
-                        parse_variable_method = getattr(
-                            self,
-                            f'_parse_{p.name}_variable'
-                        )
-                        function_default_variable = copy.deepcopy(
-                            call_with_pruned_args(
-                                parse_variable_method,
-                                variable=self.defaults.variable,
-                                context=context
-                            ),
-                        )
-                    except AttributeError:
-                        # no parsing method, assume same shape as owner
-                        function_default_variable = copy.deepcopy(
-                            self.defaults.variable
-                        )
+                            try:
+                                orig_param_name = [x.name for x in self.parameters if isinstance(x, SharedParameter) and x.source is sub_param][0]
+                            except IndexError:
+                                orig_param_name = sub_param_name
+                            sub_param._user_specified = getattr(self.parameters, orig_param_name)._user_specified
 
-                    incompatible = False
+                    elif isinstance(val, Function):
+                        incompatible = False
+                        if function_default_variable.shape != val.defaults.variable.shape:
+                            incompatible = True
+                            if val._variable_shape_flexibility is DefaultsFlexibility.INCREASE_DIMENSION:
+                                increased_dim = np.asarray([val.defaults.variable])
 
-                    if function_default_variable.shape != val.defaults.variable.shape:
-                        incompatible = True
-                        if val._variable_shape_flexibility is DefaultsFlexibility.INCREASE_DIMENSION:
-                            increased_dim = np.asarray([val.defaults.variable])
-
-                            if increased_dim.shape == function_default_variable.shape:
-                                function_default_variable = increased_dim
+                                if increased_dim.shape == function_default_variable.shape:
+                                    function_default_variable = increased_dim
+                                    incompatible = False
+                            elif val._variable_shape_flexibility is DefaultsFlexibility.FLEXIBLE:
                                 incompatible = False
-                        elif val._variable_shape_flexibility is DefaultsFlexibility.FLEXIBLE:
-                            incompatible = False
 
-                    if not incompatible:
+                        if incompatible:
+                            def _create_justified_line(k, v, error_line_len=110):
+                                return f'{k}: {v.rjust(error_line_len - len(k))}'
+
+                            raise ParameterError(
+                                f'Variable shape incompatibility between {self} and its {p.name} Parameter'
+                                + _create_justified_line(
+                                    f'\n{self}.variable',
+                                    f'{function_default_variable}    (numpy.array shape: {np.asarray(function_default_variable).shape})'
+                                )
+                                + _create_justified_line(
+                                    f'\n{self}.{p.name}.variable',
+                                    f'{val.defaults.variable}    (numpy.array shape: {np.asarray(val.defaults.variable).shape})'
+                                )
+                            )
                         val._update_default_variable(
                             function_default_variable,
                             context
@@ -2152,6 +2180,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                                 function_default_variable,
                                 context
                             )
+
+        self._override_unspecified_shared_parameters(context)
 
     def _override_unspecified_shared_parameters(self, context):
         for param_name, param in self.parameters.values(show_all=True).items():
@@ -2609,48 +2639,6 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 raise ComponentError("Value of {} param for {} ({}) is not compatible with {}".
                                     format(param_name, self.name, param_value, type_name))
 
-    def _validate_subfunctions(self):
-        from psyneulink.core.components.shellclasses import Function
-
-        for p in self.parameters:
-            if (
-                p.name != FUNCTION  # has specialized validation
-                and isinstance(p.default_value, Function)
-                and not p.reference
-                and not isinstance(p, SharedParameter)
-            ):
-                # TODO: assert it's not stateful?
-                function_variable = p.default_value.defaults.variable
-                expected_function_variable = self.defaults.variable
-
-                try:
-                    parse_variable_method = getattr(
-                        self,
-                        f'_parse_{p.name}_variable'
-                    )
-                    expected_function_variable = parse_variable_method(
-                        expected_function_variable
-                    )
-
-                except AttributeError:
-                    pass
-
-                if not function_variable.shape == expected_function_variable.shape:
-                    def _create_justified_line(k, v, error_line_len=110):
-                        return f'{k}: {v.rjust(error_line_len - len(k))}'
-
-                    raise ParameterError(
-                        f'Variable shape incompatibility between {self} and its {p.name} Parameter'
-                        + _create_justified_line(
-                            f'\n{self}.variable',
-                            f'{expected_function_variable}    (numpy.array shape: {np.asarray(expected_function_variable).shape})'
-                        )
-                        + _create_justified_line(
-                            f'\n{self}.{p.name}.variable',
-                            f'{function_variable}    (numpy.array shape: {np.asarray(function_variable).shape})'
-                        )
-                    )
-
     def _get_param_value_for_modulatory_spec(self, param_name, param_value):
         from psyneulink.core.globals.keywords import MODULATORY_SPEC_KEYWORDS
         if isinstance(param_value, str):
@@ -2957,6 +2945,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             self.defaults.value = value
 
     def _update_default_variable(self, new_default_variable, context=None):
+        from psyneulink.core.components.shellclasses import Function
+
         self.defaults.variable = copy.deepcopy(new_default_variable)
 
         # exclude value from validation because it isn't updated until
@@ -2974,16 +2964,22 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         )
         self._instantiate_value(context)
 
-        function_variable = self._parse_function_variable(
-            new_default_variable,
-            context
-        )
-        try:
-            self.function._update_default_variable(function_variable, context)
-        except AttributeError:
-            pass
+        for p in self.parameters:
+            val = p._get(context)
+            if (
+                not p.reference
+                and isinstance(val, Function)
+                and not isinstance(p, SharedParameter)
+            ):
+                function_default_variable = self._get_parsed_variable(p, context=context)
 
-        # TODO: is it necessary to call _validate_value here?
+                try:
+                    val._update_default_variable(function_default_variable, context)
+                    p.default_value._update_default_variable(copy.deepcopy(function_default_variable), context)
+                except (AttributeError, TypeError):
+                    pass
+
+                # TODO: is it necessary to call _validate_value here?
 
     def initialize(self, context=None):
         raise ComponentError("{} class does not support initialize() method".format(self.__class__.__name__))

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -483,8 +483,10 @@ import copy
 import dill
 import functools
 import inspect
+import itertools
 import logging
 import numbers
+import toposort
 import types
 import warnings
 
@@ -2060,8 +2062,19 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         """
         from psyneulink.core.components.shellclasses import Function
 
+        parameter_function_ordering = list(toposort.toposort({
+            p.name: p.dependencies for p in self.parameters if p.dependencies is not None
+        }))
+        parameter_function_ordering = list(itertools.chain.from_iterable(parameter_function_ordering))
+
+        def ordering(p):
+            try:
+                return parameter_function_ordering.index(p.name)
+            except ValueError:
+                return -1
+
         # (this originally occurred in _validate_params)
-        for p in self.parameters:
+        for p in sorted(self.parameters, key=ordering):
             if p.getter is None:
                 val = p._get(context)
                 if (

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -272,7 +272,7 @@ class IntegratorFunction(StatefulFunction):  # ---------------------------------
         for param in request_set:
             value = request_set[param]
             # If param is in Parameter class for function and it is a function_arg:
-            if param in self.parameters.names() and getattr(self.parameters, param).function_arg:
+            if param in self.parameters.names() and getattr(self.parameters, param).function_arg and getattr(self.parameters, param)._user_specified:
                 if value is not None and isinstance(value, (list, np.ndarray)) and len(value)>1:
                     # Store ones with length > 1 in dict for evaluation below
                     params_to_check.update({param:value})

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2272,7 +2272,7 @@ class Mechanism_Base(Mechanism):
         # (1) reset it, (2) update value, (3) update output ports
         if isinstance(self.function, StatefulFunction):
             new_value = self.function.reset(*args, context=context)
-            self.parameters.value._set(np.atleast_2d(new_value), context=context)
+            self.parameters.value._set(convert_to_np_array(new_value, dimension=2), context=context)
             self._update_output_ports(context=context)
 
         # If the mechanism has an auxiliary integrator function:

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -431,7 +431,7 @@ FEATURES = 'features'
 
 
 def _parse_feature_values_from_variable(variable):
-    return np.array(np.array(variable[1:]).tolist())
+    return convert_to_np_array(np.array(variable[1:]).tolist())
 
 
 class OptimizationControlMechanismError(Exception):

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1067,6 +1067,7 @@ class TransferMechanism(ProcessingMechanism_Base):
         # )
         initial_value = None
         integrator_function = Parameter(AdaptiveIntegrator, stateful=False, loggable=False)
+        function = Parameter(Linear, stateful=False, loggable=False, dependencies='integrator_function')
         integrator_function_value = Parameter([[0]], read_only=True)
         has_integrated = Parameter(False, user=False)
         on_resume_integrator_mode = Parameter(INSTANTANEOUS_MODE_VALUE, stateful=False, loggable=False)

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -284,7 +284,7 @@ from psyneulink.core.rpc.graph_pb2 import Entry, ndArray
 from psyneulink.core.globals.context import Context, ContextError, ContextFlags, _get_time, handle_external_context
 from psyneulink.core.globals.context import time as time_object
 from psyneulink.core.globals.log import LogCondition, LogEntry, LogError
-from psyneulink.core.globals.utilities import call_with_pruned_args, copy_iterable_with_shared, get_alias_property_getter, get_alias_property_setter, get_deepcopy_with_shared, unproxy_weakproxy
+from psyneulink.core.globals.utilities import call_with_pruned_args, copy_iterable_with_shared, get_alias_property_getter, get_alias_property_setter, get_deepcopy_with_shared, unproxy_weakproxy, create_union_set
 
 __all__ = [
     'Defaults', 'get_validator_by_function', 'Parameter', 'ParameterAlias', 'ParameterError',
@@ -730,6 +730,13 @@ class Parameter(ParameterBase):
             _instantiate_parameter_classes or validated for variable
             shape
 
+        dependencies
+            for Functions; if not None, this contains a set of Parameter
+            names corresponding to Parameters whose values must be
+            instantiated before that of this Parameter
+
+            :default: None
+
     """
     # The values of these attributes will never be inherited from parent Parameters
     # KDM 7/12/18: consider inheriting ONLY default_value?
@@ -791,6 +798,7 @@ class Parameter(ParameterBase):
         parse_spec=False,
         valid_types=None,
         reference=False,
+        dependencies=None,
         _owner=None,
         _inherited=False,
         # this stores a reference to the Parameter object that is the
@@ -817,6 +825,9 @@ class Parameter(ParameterBase):
                 valid_types = tuple(valid_types)
             else:
                 valid_types = (valid_types, )
+
+        if dependencies is not None:
+            dependencies = create_union_set(dependencies)
 
         super().__init__(
             default_value=default_value,
@@ -847,6 +858,7 @@ class Parameter(ParameterBase):
             parse_spec=parse_spec,
             valid_types=valid_types,
             reference=reference,
+            dependencies=dependencies,
             _inherited=_inherited,
             _inherited_source=_inherited_source,
             _user_specified=_user_specified,

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1164,7 +1164,7 @@ class DDM(ProcessingMechanism):
         # (1) reset function, (2) update mechanism value, (3) update output ports
         if isinstance(self.function, IntegratorFunction):
             new_values = self.function.reset(*args, context=context)
-            self.parameters.value._set(np.array(new_values), context)
+            self.parameters.value._set(convert_to_np_array(new_values), context)
             self._update_output_ports(context=context)
 
     @handle_external_context()

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -1247,9 +1247,10 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
         return current_activity
         # return self.current_activity
 
-    def _parse_function_variable(self, variable, context=None):
-        function_variable = self.combination_function(variable=variable, context=context)
-        return super(RecurrentTransferMechanism, self)._parse_function_variable(function_variable, context=context)
+    # TODO: remove this override after making combination_function its
+    # own Component?
+    def _parse_integrator_function_variable(self, variable, context=None):
+        return self.combination_function(variable=variable, context=context)
 
     def _parse_phase_convergence_function_variable(self, variable):
         # determines shape only

--- a/psyneulink/library/components/mechanisms/processing/transfer/kwtamechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kwtamechanism.py
@@ -326,7 +326,7 @@ class KWTAMechanism(RecurrentTransferMechanism):
                     :default value: 0.0
                     :type: ``float``
         """
-        function = Parameter(Logistic, stateful=False, loggable=False)
+        function = Parameter(Logistic, stateful=False, loggable=False, dependencies='integrator_function')
         k_value = Parameter(0.5, modulable=True)
         threshold = Parameter(0.0, modulable=True)
         ratio = Parameter(0.5, modulable=True)

--- a/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
@@ -431,6 +431,9 @@ class LCAMechanism(RecurrentTransferMechanism):
 
             return None
 
+        def _validate_integration_rate(self, integration_rate):
+            pass
+
     standard_output_ports = RecurrentTransferMechanism.standard_output_ports.copy()
     standard_output_ports.extend([{NAME:MAX_VS_NEXT,
                                     FUNCTION:max_vs_next},

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -193,6 +193,7 @@ from collections.abc import Iterable
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.component import _get_parametervalue_attr
 from psyneulink.core.components.functions.function import Function, get_matrix, is_function_type
+from psyneulink.core.components.functions.statefulfunctions.integratorfunctions import AdaptiveIntegrator
 from psyneulink.core.components.functions.learningfunctions import Hebbian
 from psyneulink.core.components.functions.objectivefunctions import Stability
 from psyneulink.core.components.functions.combinationfunctions import LinearCombination
@@ -614,6 +615,7 @@ class RecurrentTransferMechanism(TransferMechanism):
         matrix = Parameter(HOLLOW_MATRIX, modulable=True, getter=_recurrent_transfer_mechanism_matrix_getter, setter=_recurrent_transfer_mechanism_matrix_setter)
         auto = Parameter(1, modulable=True)
         hetero = Parameter(0, modulable=True)
+        integrator_function = Parameter(AdaptiveIntegrator, stateful=False, loggable=False, dependencies='combination_function')
         combination_function = Parameter(LinearCombination, stateful=False, loggable=False)
         smoothing_factor = Parameter(0.5, modulable=True)
         enable_learning = False

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -968,7 +968,7 @@ class RecurrentTransferMechanism(TransferMechanism):
 
             # creating a recurrent_projection changes the default variable shape
             # so we have to reshape any Paramter Functions
-            self._update_parameter_class_variables(context)
+            self._update_default_variable(self.defaults.variable, context)
 
         self.aux_components.append(self.recurrent_projection)
 
@@ -1217,10 +1217,14 @@ class RecurrentTransferMechanism(TransferMechanism):
         return super()._execute(variable, context, runtime_params)
 
     def _parse_function_variable(self, variable, context=None):
+        variable = self._parse_integrator_function_variable(variable, context=context)
+        return super()._parse_function_variable(variable, context=context)
+
+    def _parse_integrator_function_variable(self, variable, context=None):
         if self.has_recurrent_input_port:
             variable = self.combination_function.execute(variable=variable, context=context)
 
-        return super()._parse_function_variable(variable, context=context)
+        return variable
 
     def _get_variable_from_input(self, input, context=None):
         if self.has_recurrent_input_port:

--- a/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
+++ b/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
@@ -271,14 +271,14 @@ class AutoAssociativeProjection(MappingProjection):
     # get passed properly. should be replaced with a better organization
     # of auto/hetero, in which the base parameters are stored either on
     # AutoAssociativeProjection or on LinearMatrix itself
-    def _override_unspecified_shared_parameters(self, context):
-        super()._override_unspecified_shared_parameters(context)
-
+    def _instantiate_parameter_classes(self, context):
         if FUNCTION not in self.initial_shared_parameters:
             try:
                 self.initial_shared_parameters[FUNCTION] = self.initial_shared_parameters[OWNER_MECH]
             except KeyError:
                 pass
+
+        super()._instantiate_parameter_classes(context)
 
     # COMMENTED OUT BY KAM 1/9/2018 -- this method is not currently used; should be moved to Recurrent Transfer Mech
     #     if it is used in the future

--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -265,8 +265,8 @@ class TestReset:
         # reset mechanism without value spec
         I.reset()
         assert np.allclose(I.function.value[0], 0.0)
-        assert np.allclose(I.value[0], 0.0)
-        assert np.allclose(I.output_ports[0].value, 0.0)
+        assert np.allclose(I.value[0][0], 0.0)
+        assert np.allclose(I.output_ports[0].value[0], 0.0)
 
     def test_Accumulator_valid(self):
         I = IntegratorMechanism(
@@ -1050,8 +1050,8 @@ class TestIntegratorNoise:
 
         val2 = float(I.execute(0))
 
-        np.testing.assert_allclose(val, 9.306822898004032)
-        np.testing.assert_allclose(val2, 6.000180029830552)
+        np.testing.assert_allclose(val, 11.00018002983055)
+        np.testing.assert_allclose(val2, 7.549690404329112)
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism
@@ -1066,7 +1066,7 @@ class TestIntegratorNoise:
 
         val = I.execute([10, 10, 10, 10])[0]
 
-        np.testing.assert_allclose(val, [10.66053518, 11.10887925, 9.0840107, 10.30157835])
+        np.testing.assert_allclose(val, [11.10887925, 9.0840107, 10.30157835, 10.65375815])
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism
@@ -1080,7 +1080,7 @@ class TestIntegratorNoise:
 
         val = float(I.execute(10))
 
-        np.testing.assert_allclose(val, -0.6931771019959673)
+        np.testing.assert_allclose(val, 1.00018)
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism
@@ -1094,7 +1094,7 @@ class TestIntegratorNoise:
         )
 
         val = I.execute([10, 10, 10, 10])[0]
-        np.testing.assert_allclose(val, [0.66053518, 1.10887925, -0.9159893, 0.30157835])
+        np.testing.assert_allclose(val, [1.10887925, -0.9159893, 0.30157835, 0.65375815])
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism
@@ -1108,7 +1108,7 @@ class TestIntegratorNoise:
 
         val = float(I.execute(10))
 
-        np.testing.assert_allclose(val, 9.306822898004032)
+        np.testing.assert_allclose(val, 11.00018002983055)
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism
@@ -1123,7 +1123,7 @@ class TestIntegratorNoise:
 
         val = I.execute([10, 10, 10, 10])[0]
 
-        np.testing.assert_allclose(val, [10.66053518, 11.10887925, 9.0840107, 10.30157835])
+        np.testing.assert_allclose(val, [11.10887925, 9.0840107, 10.30157835, 10.65375815])
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -194,7 +194,7 @@ class TestTransferMechanismNoise:
         )
         T.reset_stateful_function_when = Never()
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.90104733, 0.95869664, -0.81762271, -1.39225086]])
+        assert np.allclose(val, [[0.01034782, 0.90104733, 0.95869664, -0.81762271]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -293,7 +293,7 @@ class TestDistributionFunctions:
         )
 
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.90104733, 0.95869664, -0.81762271, -1.39225086]])
+        assert np.allclose(val, [[0.01034782, 0.90104733, 0.95869664, -0.81762271]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -325,7 +325,7 @@ class TestDistributionFunctions:
             integrator_mode=True,
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.7025651, 0.33105989, 1.40978493, 0.9633011]])
+        assert np.allclose(val, [[2.38719447, 0.7025651, 0.33105989, 1.40978493]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -368,7 +368,7 @@ class TestDistributionFunctions:
             integrator_mode=True
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.50468686, 0.28183784, 0.7558042, 0.618369]])
+        assert np.allclose(val, [[0.90811289, 0.50468686, 0.28183784, 0.7558042]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -383,7 +383,7 @@ class TestDistributionFunctions:
             integrator_mode=True
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.7025651, 0.33105989, 1.40978493, 0.9633011]])
+        assert np.allclose(val, [[2.38719447, 0.7025651, 0.33105989, 1.40978493]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -398,7 +398,7 @@ class TestDistributionFunctions:
             integrator_mode=True
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[1.0678432, 0.34512569, 1.07265769, 1.3550318]])
+        assert np.allclose(val, [[0.40277101, 1.0678432, 0.34512569, 1.07265769]])
 
 
 class TestTransferMechanismFunctions:
@@ -1190,7 +1190,7 @@ class TestTransferMechanismTimeConstant:
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
     def test_transfer_mech_integration_rate_2(self):
-        with pytest.raises(TransferError) as error_text:
+        with pytest.raises(ParameterError) as error_text:
             T = TransferMechanism(
                 name='T',
                 default_variable=[0, 0, 0, 0],
@@ -1200,7 +1200,7 @@ class TestTransferMechanismTimeConstant:
             )
             T.execute([1, 1, 1, 1])
         assert (
-            "Value(s) in \'integration_rate\' arg for" in str(error_text.value)
+            "'integration_rate'" in str(error_text.value)
             and "must be an int or float in the interval [0,1]" in str(error_text.value)
         )
 
@@ -1563,7 +1563,7 @@ class TestTransferMechanismMultipleInputPorts:
             default_variable=[[0.0, 0.0], [0.0, 0.0]]
         )
         val = T.execute([[1.0, 2.0], [3.0, 4.0]])
-        assert np.allclose(val, [[4.80209467, 6.91739329], [5.36475458, 6.21549828]])
+        assert np.allclose(val, [[3.02069564, 6.80209467], [8.91739329, 7.36475458]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism

--- a/tests/misc/test_parameters.py
+++ b/tests/misc/test_parameters.py
@@ -322,3 +322,16 @@ class TestSharedParameters:
         source_param = shared_param.source
 
         assert getattr(shared_param, attr_name) == getattr(source_param, attr_name)
+
+    def test_conflict_warning(self):
+        with pytest.warns(
+            UserWarning,
+            match=(
+                'Specification of the "integration_rate" parameter.*conflicts'
+                ' with specification of its shared parameter "rate"'
+            )
+        ):
+            pnl.TransferMechanism(
+                integration_rate=.1,
+                integrator_function=pnl.AdaptiveIntegrator(rate=.2)
+            )

--- a/tests/misc/test_parameters.py
+++ b/tests/misc/test_parameters.py
@@ -323,6 +323,19 @@ class TestSharedParameters:
 
         assert getattr(shared_param, attr_name) == getattr(source_param, attr_name)
 
+    @pytest.mark.parametrize(
+        'integrator_function, expected_rate',
+        [
+            (pnl.AdaptiveIntegrator, pnl.TransferMechanism.defaults.integration_rate),
+            (pnl.AdaptiveIntegrator(), pnl.TransferMechanism.defaults.integration_rate),
+            (pnl.AdaptiveIntegrator(rate=.75), .75)
+        ]
+    )
+    def test_override_tmech(self, integrator_function, expected_rate):
+        t = pnl.TransferMechanism(integrator_function=integrator_function)
+        assert t.integrator_function.defaults.rate == expected_rate
+        assert t.integration_rate.modulated == t.integration_rate.base == expected_rate
+
     def test_conflict_warning(self):
         with pytest.warns(
             UserWarning,


### PR DESCRIPTION
- add `dependencies` field to `Parameter`, which is one or a set of Parameter names of secondary Functions which must be instantiated before the current Parameter (ex: `RecurrentTransferMechanism.combination_function` must be instantiated before `RecurrentTransferMechanism.integrator_function`)

`default_variable` is now immediately specified on creation of secondary functions to identify and resolve conflicts with initializers and any other parameters

`default_variable` of secondary Functions' secondary Functions are also set correctly on instantiation and when updated with `_update_default_variable`

Compared to devel, these tests changed as a result of the following numbers of calls to the `random_state` parameter of noise functions during initialization:

| Test Name | random_state Parameter RNG method | offset |
| - | - | - |
test_integrator_simple_noise_fn | random_state.normal | +1
test_integrator_simple_noise_fn_var_list | random_state.normal | +1
test_integrator_accumulator_noise_fn | random_state.normal | +1
test_integrator_accumulator_noise_fn_var_list | random_state.normal | +1
test_integrator_adaptive_noise_fn | random_state.normal | +1
test_integrator_adaptive_noise_fn_var_list | random_state.normal | +1
test_transfer_mech_array_var_normal_len_1_noise | random_state.normal | -1
test_transfer_mech_normal_noise | random_state.normal | -1
test_transfer_mech_exponential_noise | random_state.random | -1
test_transfer_mech_Uniform_noise | random_state.random | -1
test_transfer_mech_Gamma_noise | random_state.random | -1
test_transfer_mech_wald_noise | random_state.wald | -1
test_transfer_mech_2d_variable_noise | random_state.normal | -1

