### PR TITLE
llvm: Do not reuse node function name for node invocation wrapper

### DIFF
--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -468,7 +468,7 @@ def gen_node_wrapper(ctx, composition, node, *, tags:frozenset):
         cond_ty = cond_gen.get_condition_struct_type().as_pointer()
         args.append(cond_ty)
 
-    builder = ctx.create_llvm_function(args, node, node_function.name, tags=tags,
+    builder = ctx.create_llvm_function(args, node, tags=tags,
                                        return_type=node_function.type.pointee.return_type)
     llvm_func = builder.function
     for a in llvm_func.args:


### PR DESCRIPTION
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>