### PR TITLE
Context: generate an execution_id on creation if unspecified

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1089,6 +1089,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         context = Context(
             source=ContextFlags.COMPONENT,
             execution_phase=ContextFlags.IDLE,
+            execution_id=None,
         )
 
         try:
@@ -2781,7 +2782,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 self.defaults.variable,
                 # we can't just pass context here, because this specifically tries to bypass a
                 # branch in TransferMechanism._parse_function_variable
-                context=Context(source=ContextFlags.INSTANTIATE)
+                context=Context(source=ContextFlags.INSTANTIATE, execution_id=context.execution_id)
             )
         )
 
@@ -3639,7 +3640,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         try:
             return self._most_recent_context
         except AttributeError:
-            self._most_recent_context = Context(source=ContextFlags.COMMAND_LINE)
+            self._most_recent_context = Context(source=ContextFlags.COMMAND_LINE, execution_id=None)
             return self._most_recent_context
 
     @most_recent_context.setter

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2990,7 +2990,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         """
         pass
 
-    @handle_external_context(execution_id=NotImplemented)
+    @handle_external_context(fallback_most_recent=True)
     def reset(self, *args, context=None):
         """
             If the component's execute method involves execution of an `IntegratorFunction` Function, this method
@@ -3000,8 +3000,6 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         """
         from psyneulink.core.components.functions.statefulfunctions.integratorfunctions import IntegratorFunction
         if isinstance(self.function, IntegratorFunction):
-            if context is NotImplemented:
-                context = self.most_recent_context
             new_value = self.function.reset(*args, context=context)
             self.parameters.value.set(np.atleast_2d(new_value), context, override=True)
         else:

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -633,7 +633,7 @@ class Function_Base(Function):
         # temporary method until previous values are integrated for all parameters
         value = self.parameters.previous_value._get(context)
         if value is None:
-            value = self.parameters.previous_value._get(Context())
+            value = self.parameters.previous_value._get(Context(execution_id=context.execution_id))
 
         return value
 

--- a/psyneulink/core/components/functions/learningfunctions.py
+++ b/psyneulink/core/components/functions/learningfunctions.py
@@ -521,7 +521,7 @@ class BayesGLM(LearningFunction):
         self.gamma_shape_n = self.gamma_shape_0
         self.gamma_size_n = self.gamma_size_0
 
-    @handle_external_context(execution_id=NotImplemented)
+    @handle_external_context(fallback_most_recent=True)
     def reset(self, *args, context=None):
         # If variable passed during execution does not match default assigned during initialization,
         #    reassign default and re-initialize priors

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -430,7 +430,7 @@ class OptimizationFunction(Function_Base):
                 if 'required positional arguments' not in str(e):
                     raise
 
-    @handle_external_context(execution_id=NotImplemented)
+    @handle_external_context(fallback_most_recent=True)
     def reset(self, *args, context=None):
         """Reset parameters of the OptimizationFunction
 
@@ -443,8 +443,6 @@ class OptimizationFunction(Function_Base):
             * `search_function <OptimizationFunction.search_function>`
             * `search_termination_function <OptimizationFunction.search_termination_function>`
         """
-        if context.execution_id is NotImplemented:
-            context.execution_id = self.most_recent_context.execution_id
         self._validate_params(request_set=args[0])
 
         if DEFAULT_VARIABLE in args[0]:
@@ -924,7 +922,7 @@ class GradientOptimization(OptimizationFunction):
                     raise OptimizationFunctionError(f"All items in {repr(SEARCH_SPACE)} arg for {self.name}{owner_str} "
                                                     f"must be or resolve to a 2-item list or tuple; this doesn't: {s}.")
 
-    @handle_external_context(execution_id=NotImplemented)
+    @handle_external_context(fallback_most_recent=True)
     def reset(self, *args, context=None):
         super().reset(*args)
 
@@ -1328,11 +1326,9 @@ class GridSearch(OptimizationFunction):
             #                                            self.__class__.__name__,
             #                                            ))
 
-    @handle_external_context(execution_id=NotImplemented)
+    @handle_external_context(fallback_most_recent=True)
     def reset(self, *args, context=None):
         """Assign size of `search_space <GridSearch.search_space>"""
-        if context.execution_id is NotImplemented:
-            context.execution_id = self.most_recent_context.execution_id
         super(GridSearch, self).reset(*args, context=context)
         sample_iterators = args[0]['search_space']
         owner_str = ''

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -1744,7 +1744,7 @@ class DualAdaptiveIntegrator(IntegratorFunction):  # ---------------------------
 
         return value + offset
 
-    @handle_external_context(execution_id=NotImplemented)
+    @handle_external_context(fallback_most_recent=True)
     def reset(self, short=None, long=None, context=NotImplemented):
         """
         Effectively begins accumulation over again at the specified utilities.
@@ -1761,9 +1761,6 @@ class DualAdaptiveIntegrator(IntegratorFunction):  # ---------------------------
         <DualAdaptiveIntegrator.initial_short_term_avg>` and `initial_long_term_avg
         <DualAdaptiveIntegrator.initial_long_term_avg>` are used.
         """
-        if context.execution_id is NotImplemented:
-            context.execution_id = self.most_recent_context.execution_id
-
         if short is None:
             short = self._get_current_parameter_value("initial_short_term_avg", context)
         if long is None:

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -726,8 +726,8 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         )
 
         if self.previous_value.size != 0:
-            self.parameters.key_size._set(len(self.previous_value[KEYS][0]), Context())
-            self.parameters.val_size._set(len(self.previous_value[VALS][0]), Context())
+            self.parameters.key_size._set(len(self.previous_value[KEYS][0]), Context(execution_id=None))
+            self.parameters.val_size._set(len(self.previous_value[VALS][0]), Context(execution_id=None))
 
     def _parse_distance_function_variable(self, variable):
         # actual used variable in execution (get_memory) checks distance

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -252,7 +252,7 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
             context
         )
 
-    @handle_external_context(execution_id=NotImplemented)
+    @handle_external_context(fallback_most_recent=True)
     def reset(self, *args, context=None):
         """
 
@@ -265,9 +265,6 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
         `value <Buffer.value>` takes on the same value as  `previous_value <Buffer.previous_value>`.
 
         """
-        if context.execution_id is NotImplemented:
-            context.execution_id = self.most_recent_context.execution_id
-
         # no arguments were passed in -- use current values of initializer attributes
         if len(args) == 0 or args is None:
             reinitialization_value = self._get_current_parameter_value("initializer", context)
@@ -1021,7 +1018,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         if isinstance(self.selection_function, type):
             self.selection_function = self.selection_function(context=context)
 
-    @handle_external_context(execution_id=NotImplemented)
+    @handle_external_context(fallback_most_recent=True)
     def reset(self, *args, context=None):
         """
         reset(<new_dictionary> default={})
@@ -1036,9 +1033,6 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         `value <ContentAddressableMemory.value>` takes on the same value as
         `previous_value <ContentAddressableMemory.previous_value>`.
         """
-        if context.execution_id is NotImplemented:
-            context.execution_id = self.most_recent_context.execution_id
-
         # no arguments were passed in -- use current values of initializer attributes
         if len(args) == 0 or args is None:
             reinitialization_value = self._get_current_parameter_value("initializer", context)

--- a/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
+++ b/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
@@ -478,7 +478,7 @@ class StatefulFunction(Function_Base): #  --------------------------------------
 
         super()._update_default_variable(new_default_variable, context=context)
 
-    @handle_external_context(execution_id=NotImplemented)
+    @handle_external_context(fallback_most_recent=True)
     def reset(self, *args, context=None):
         """
             Resets `value <StatefulFunction.previous_value>`  and `previous_value <StatefulFunction.previous_value>`
@@ -504,10 +504,6 @@ class StatefulFunction(Function_Base): #  --------------------------------------
             reinitialization steps.
 
         """
-
-        if context.execution_id is NotImplemented:
-            context.execution_id = self.most_recent_context.execution_id
-
         reinitialization_values = []
 
         # no arguments were passed in -- use current values of initializer attributes

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2213,7 +2213,7 @@ class Mechanism_Base(Mechanism):
         """Stub that can be overidden by subclasses that need to know when a projection is added to the Mechanism"""
         pass
 
-    @handle_external_context(execution_id=NotImplemented)
+    @handle_external_context(fallback_most_recent=True)
     def reset(self, *args, force=False, context=None):
         """Reset `value <Mechanism_Base.value>` if Mechanisms is stateful.
 
@@ -2264,9 +2264,6 @@ class Mechanism_Base(Mechanism):
         """
         from psyneulink.core.components.functions.statefulfunctions.statefulfunction import StatefulFunction
         from psyneulink.core.components.functions.statefulfunctions.integratorfunctions import IntegratorFunction
-
-        if context.execution_id is NotImplemented:
-            context.execution_id = self.most_recent_context.execution_id
 
         # If the primary function of the mechanism is stateful:
         # (1) reset it, (2) update value, (3) update output ports

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3589,7 +3589,10 @@ class Mechanism_Base(Mechanism):
         from psyneulink.core.components.ports.inputport import InputPort, _instantiate_input_ports
         from psyneulink.core.components.ports.outputport import OutputPort, _instantiate_output_ports
 
-        context = Context(source=ContextFlags.METHOD)
+        # not transferring execution_id here because later function calls
+        # need execution_id=None to succeed.
+        # TODO: remove context passing for init methods if they don't need it
+        context = Context(source=ContextFlags.METHOD, execution_id=None)
 
         # Put in list to standardize treatment below
         if not isinstance(ports, list):

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1309,7 +1309,7 @@ class OptimizationControlMechanism(ControlMechanism):
 
         if features:
             features = self._parse_feature_specs(features=features,
-                                                 context=Context(source=ContextFlags.COMMAND_LINE))
+                                                 context=Context(source=ContextFlags.COMMAND_LINE, execution_id=None))
         self.add_ports(InputPort, features)
 
     @tc.typecheck

--- a/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
@@ -375,7 +375,7 @@ from psyneulink.core.components.mechanisms.processing.processingmechanism import
 from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.components.ports.inputport import InputPort, INPUT_PORT
 from psyneulink.core.components.ports.port import _parse_port_spec
-from psyneulink.core.globals.context import ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import \
     CONTROL, EXPONENT, EXPONENTS, FUNCTION, LEARNING, MATRIX, NAME, OBJECTIVE_MECHANISM, OUTCOME, OWNER_VALUE, \
     PARAMS, PREFERENCE_SET_NAME, PROJECTION, PROJECTIONS, PORT_TYPE, VARIABLE, WEIGHT, WEIGHTS
@@ -666,6 +666,7 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
             port.name = "Value of {} [{}]".format(proj.sender.owner.name, proj.sender.name)
             register_instance(port, port.name, InputPort, self._portRegistry, INPUT_PORT)
 
+    @handle_external_context(source=ContextFlags.METHOD)
     def add_to_monitor(self, monitor_specs, context=None):
         """Instantiate `OutputPorts <OutputPort>` to be monitored by the ObjectiveMechanism.
 
@@ -729,11 +730,6 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
             # Otherwise, use its sender's (OutputPort) value
             else:
                 reference_value.append(projection_tuple.port.value)
-
-        if not context:
-            from psyneulink.core.globals.context import Context
-            context = Context()
-        context.source = ContextFlags.METHOD
 
         input_ports = self._instantiate_input_ports(monitor_specs=monitor_specs,
                                                       reference_value=reference_value,

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1743,7 +1743,7 @@ class TransferMechanism(ProcessingMechanism_Base):
 
         return value
 
-    @handle_external_context(execution_id=NotImplemented)
+    @handle_external_context(fallback_most_recent=True)
     def reset(self, *args, force=False, context=None):
         super().reset(*args, force=force, context=context)
         self.parameters.value.clear_history(context)

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2334,7 +2334,7 @@ class Port_Base(Port):
         Used primarily during validation, when the function may not have been fully instantiated yet
         (e.g., InputPort must sometimes embed its variable in a list-- see InputPort._get_port_function_value).
         """
-        return function.execute(variable, context=Context(source=ContextFlags.UNSET))
+        return function.execute(variable, context=Context(source=ContextFlags.UNSET, execution_id=None))
 
     @property
     def _dependent_components(self):

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -9341,11 +9341,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     def _update_learning_parameters(self, context):
         pass
 
-    @handle_external_context(execution_id=NotImplemented)
+    @handle_external_context(fallback_most_recent=True)
     def reset(self, values=None, include_unspecified_nodes=True, context=NotImplemented):
-        if context is NotImplemented:
-            context = self.most_recent_context
-
         if not values:
             values = {}
 

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -3315,7 +3315,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         self._initialize_parameters(
             **param_defaults,
             retain_old_simulation_data=retain_old_simulation_data,
-            context=Context(source=ContextFlags.COMPOSITION)
+            context=Context(source=ContextFlags.COMPOSITION, execution_id=None)
         )
 
         # Compiled resources
@@ -3361,10 +3361,10 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             projections = convert_to_list(projections)
             self.add_projections(projections)
 
-        self.add_pathways(pathways, context=Context(source=ContextFlags.CONSTRUCTOR))
+        self.add_pathways(pathways, context=Context(source=ContextFlags.CONSTRUCTOR, execution_id=None))
 
         # Call with context = COMPOSITION to avoid calling _check_initialization_status again
-        self._analyze_graph(context=Context(source=ContextFlags.COMPOSITION))
+        self._analyze_graph(context=Context(source=ContextFlags.COMPOSITION, execution_id=None))
 
         show_graph_attributes = show_graph_attributes or {}
         self._show_graph = ShowGraph(self, **show_graph_attributes)
@@ -3591,7 +3591,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             for spec in hanging_control_specs:
                 control_signal = self.controller._instantiate_control_signal(control_signal=spec,
                                                                              context=Context(
-                                                                                 source=ContextFlags.COMPOSITION))
+                                                                                 source=ContextFlags.COMPOSITION, execution_id=None))
                 self.controller.control.append(control_signal)
                 self.controller._activate_projections_for_compositions(self)
         return []
@@ -5555,10 +5555,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # Otherwise, refer to call from this method
         else:
             pathway_arg_str = f"'pathway' arg for add_linear_procesing_pathway method of {self.name}"
-            # FIX 4/4/20 [JDC]: Reset to None for now to replicate prior behavior,
-            #                   but need to implement proper behavior wrt call to analyze_graph()
-            #                   _check_initalization_state()
-            context = None
 
         # First, deal with Pathway() or tuple specifications
         if isinstance(pathway, Pathway):
@@ -5589,6 +5585,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             # Use add_nodes so that node spec can also be a tuple with required_roles
             self.add_nodes(nodes=[pathway[0]],
                            context=Context(source=ContextFlags.METHOD,
+                                           execution_id=context.execution_id,
                                            string=pathway_arg_str))
             nodes.append(pathway[0])
         else:
@@ -5602,6 +5599,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             if _is_node_spec(pathway[c]):
                 self.add_nodes(nodes=[pathway[c]],
                                context=Context(source=ContextFlags.METHOD,
+                                               execution_id=context.execution_id,
                                                string=pathway_arg_str))
                 nodes.append(pathway[c])
 
@@ -5776,10 +5774,14 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         pathway = Pathway(pathway=explicit_pathway,
                           composition=self,
                           name=pathway_name,
-                          context=Context(source=ContextFlags.METHOD))
+                          context=Context(source=ContextFlags.METHOD, execution_id=context.execution_id))
         self.pathways.append(pathway)
 
-        self._analyze_graph(context=context)
+        # FIX 4/4/20 [JDC]: Reset to None for now to replicate prior behavior,
+        #                   but need to implement proper behavior wrt call to analyze_graph()
+        #                   _check_initalization_state()
+        # 10/22/20 [KDM]: Pass no context instead of setting to None
+        self._analyze_graph()
 
         return pathway
 
@@ -6034,7 +6036,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # Otherwise, refer to call from this method
         else:
             pathway_arg_str = f"'pathway' arg for add_linear_procesing_pathway method of {self.name}"
-        context = Context(source=ContextFlags.METHOD, string=pathway_arg_str)
+        context = Context(source=ContextFlags.METHOD, string=pathway_arg_str, execution_id=context.execution_id)
 
         # Deal with Pathway() specifications
         if isinstance(pathway, Pathway):
@@ -6511,6 +6513,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         #    _check_for_projection_assignments() in order to ignore checks for require_projection_in_composition
         pathway_arg_str = f"'pathway' arg for add_backpropagation_learning_pathway method of {self.name}"
         learning_pathway = self.add_linear_processing_pathway(pathway, name, Context(source=ContextFlags.INITIALIZING,
+                                                                                     execution_id=context.execution_id,
                                                                                      string=pathway_arg_str))
         processing_pathway = learning_pathway.pathway
 
@@ -6618,7 +6621,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             self._terminal_backprop_sequences[output_source] = {LEARNING_MECHANISM: learning_mechanism,
                                                                 TARGET_MECHANISM: target,
                                                                 OBJECTIVE_MECHANISM: comparator}
-            self._add_required_node_role(processing_pathway[-1], NodeRole.OUTPUT, Context(source=ContextFlags.METHOD))
+            self._add_required_node_role(processing_pathway[-1], NodeRole.OUTPUT, Context(source=ContextFlags.METHOD, execution_id=context.execution_id))
 
             sequence_end = path_length - 3
 
@@ -6893,8 +6896,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                         error_signal_input_port = learning_mech.add_ports(
                             InputPort(projections=error_source.output_ports[ERROR_SIGNAL],
                                       name=ERROR_SIGNAL,
-                                      context=Context(source=ContextFlags.METHOD)),
-                            context=Context(source=ContextFlags.METHOD))[0]
+                                      context=Context(source=ContextFlags.METHOD, execution_id=None)),
+                            context=Context(source=ContextFlags.METHOD, execution_id=None))[0]
                     # Create Projection here so that don't have to worry about determining correct
                     #    error_signal_input_port of learning_mech in _create_non_terminal_backprop_learning_components
                     try:
@@ -6938,8 +6941,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                     error_signal_input_port = learning_mech.add_ports(
                                                         InputPort(projections=error_source.output_ports[ERROR_SIGNAL],
                                                                   name=ERROR_SIGNAL,
-                                                                  context=Context(source=ContextFlags.METHOD)),
-                                                        context=Context(source=ContextFlags.METHOD))
+                                                                  context=Context(source=ContextFlags.METHOD, execution_id=None)),
+                                                        context=Context(source=ContextFlags.METHOD, execution_id=None))
                 # DOES THE ABOVE GENERATE A PROJECTION?  IF SO, JUST GET AND RETURN THAT;  ELSE DO THE FOLLOWING:
                 error_projections.append(MappingProjection(sender=error_source.output_ports[ERROR_SIGNAL],
                                                            receiver=error_signal_input_port))
@@ -6969,8 +6972,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 error_signal_input_port = dependent_learning_mech.add_ports(
                                                     InputPort(projections=error_source.output_ports[ERROR_SIGNAL],
                                                               name=ERROR_SIGNAL,
-                                                              context=Context(source=ContextFlags.METHOD)),
-                                                    context=Context(source=ContextFlags.METHOD))
+                                                              context=Context(source=ContextFlags.METHOD, execution_id=None)),
+                                                    context=Context(source=ContextFlags.METHOD, execution_id=None))
                 projections.append(error_signal_input_port[0].path_afferents[0])
                 # projections.append(MappingProjection(sender=error_source.output_ports[ERROR_SIGNAL],
                 #                                      receiver=error_signal_input_port[0]))
@@ -7025,7 +7028,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         #        (e.g., was constructed in the controller argument of the Composition), in which case assign it here.
         if controller.initialization_status == ContextFlags.DEFERRED_INIT:
             controller._init_args[AGENT_REP] = self
-            controller._deferred_init(context=Context(source=ContextFlags.COMPOSITION))
+            controller._deferred_init(context=Context(source=ContextFlags.COMPOSITION, execution_id=None))
 
         # Note:  initialization_status here pertains to controller's status w/in the Composition
         #        (i.e., whether any Nodes and/or Projections on which it depends are not yet in the Composition)
@@ -7075,7 +7078,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         controller._activate_projections_for_compositions(self)
         # Call with context to avoid recursion by analyze_graph -> _check_inialization_status -> add_controller
-        self._analyze_graph(context=Context(source=ContextFlags.METHOD))
+        self._analyze_graph(context=Context(source=ContextFlags.METHOD, execution_id=None))
         self._update_shadows_dict(controller)
 
         # INSTANTIATE SHADOW_INPUT PROJECTIONS
@@ -7139,7 +7142,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
             # FIX: 9/14/19 - IS THE CONTEXT CORRECT (TRY TRACKING IN SYSTEM TO SEE WHAT CONTEXT IS):
             ctl_signal = controller._instantiate_control_signal(control_signal=ctl_sig_spec,
-                                                   context=Context(source=ContextFlags.COMPOSITION))
+                                                   context=Context(source=ContextFlags.COMPOSITION, execution_id=None))
             controller.control.append(ctl_signal)
             # FIX: 9/15/19 - WHAT IF NODE THAT RECEIVES ControlProjection IS NOT YET IN COMPOSITON:
             #                ?DON'T ASSIGN ControlProjection?
@@ -7149,7 +7152,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             controller._activate_projections_for_compositions(self)
         if not invalid_aux_components:
             self._controller_initialization_status = ContextFlags.INITIALIZED
-        self._analyze_graph(context=Context(source=ContextFlags.METHOD))
+        self._analyze_graph(context=Context(source=ContextFlags.METHOD, execution_id=None))
 
     def _get_control_signals_for_composition(self):
         """Return list of ControlSignals specified by Nodes in the Composition
@@ -9352,7 +9355,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             reset_val = values.get(node)
             node.reset(reset_val, context=context)
 
-    def initialize(self, values=None, include_unspecified_nodes=True, context=NotImplemented):
+    @handle_external_context(fallback_most_recent=True)
+    def initialize(self, values=None, include_unspecified_nodes=True, context=None):
         """
             Initializes the values of nodes within cycles. If `include_unspecified_nodes` is True and a value is
             provided for a given node, the node will be initialized to that value. If `include_unspecified_nodes` is
@@ -9377,9 +9381,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 self.most_recent_execution_context if one is not specified.
 
         """
-        if context is NotImplemented:
-            context = self.most_recent_context
-
         # comp must be initialized from context before cycle values are initialized
         self._initialize_from_context(context, Context(execution_id=None), override=False)
 

--- a/psyneulink/core/compositions/showgraph.py
+++ b/psyneulink/core/compositions/showgraph.py
@@ -447,7 +447,7 @@ class ShowGraph():
         self.output_rank = output_rank
 
     @tc.typecheck
-    @handle_external_context(execution_id=NotImplemented, source=ContextFlags.COMPOSITION)
+    @handle_external_context(source=ContextFlags.COMPOSITION)
     def show_graph(self,
                    show_node_structure:tc.any(bool, tc.enum(VALUES, LABELS, FUNCTIONS, MECH_FUNCTION_PARAMS,
                                                             PORT_FUNCTION_PARAMS, ROLES, ALL))=False,
@@ -612,7 +612,7 @@ class ShowGraph():
 
         composition = self.composition
 
-        if context.execution_id is NotImplemented:
+        if context.execution_id is None:
             context.execution_id = composition.default_execution_id
 
         # Args not specified by user but used in calls to show_graph for nested Compositions

--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -90,6 +90,7 @@ import warnings
 from collections import defaultdict, namedtuple
 from queue import Queue
 
+import time as py_time  # "time" is declared below
 import typecheck as tc
 
 from psyneulink.core.globals.keywords import CONTEXT, CONTROL, EXECUTING, EXECUTION_PHASE, FLAGS, INITIALIZATION_STATUS, INITIALIZING, LEARNING, SEPARATOR_BAR, SOURCE, VALIDATE
@@ -346,7 +347,7 @@ class Context():
                  # source=ContextFlags.COMPONENT,
                  source=ContextFlags.NONE,
                  runmode=ContextFlags.DEFAULT_MODE,
-                 execution_id=None,
+                 execution_id=NotImplemented,
                  string:str='',
                  time=None,
                  rpc_pipeline:Queue=None):
@@ -368,6 +369,18 @@ class Context():
                                    format(ContextFlags._get_context_string(flags & ContextFlags.SOURCE_MASK),
                                           ContextFlags._get_context_string(flags, SOURCE),
                                           self.owner.name))
+        if execution_id is NotImplemented:
+            subsecond_res = 10 ** 6
+            cur_time = py_time.time()
+            subsec = int((cur_time * subsecond_res) % subsecond_res)
+            time_format = f'%Y-%m-%d %H:%M:%S.{subsec} %Z%z'
+            execution_id = py_time.strftime(time_format, py_time.localtime(cur_time))
+        else:
+            try:
+                execution_id = execution_id.default_execution_id
+            except AttributeError:
+                pass
+
         self.execution_id = execution_id
         self.execution_time = None
         self.string = string

--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -631,6 +631,7 @@ def handle_external_context(
     source=ContextFlags.COMMAND_LINE,
     execution_phase=ContextFlags.IDLE,
     execution_id=None,
+    fallback_most_recent=False,
     **context_kwargs
 ):
     """
@@ -702,6 +703,13 @@ def handle_external_context(
                     pass
 
             if context is None:
+                if eid is None:
+                    # assume first positional arg when fallback_most_recent
+                    # true is the object that has the relevant context
+
+                    if fallback_most_recent:
+                        eid = args[0].most_recent_context.execution_id
+
                 context = Context(
                     execution_id=eid,
                     source=source,

--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -632,6 +632,7 @@ def handle_external_context(
     execution_phase=ContextFlags.IDLE,
     execution_id=None,
     fallback_most_recent=False,
+    fallback_default=False,
     **context_kwargs
 ):
     """
@@ -656,6 +657,8 @@ def handle_external_context(
 
     """
     def decorator(func):
+        assert not fallback_most_recent or not fallback_default
+
         # try to detect the position of the 'context' argument in function's
         # signature, to handle non-keyword specification in calls
         try:
@@ -704,11 +707,13 @@ def handle_external_context(
 
             if context is None:
                 if eid is None:
-                    # assume first positional arg when fallback_most_recent
+                    # assume first positional arg when fallback_most_recent or fallback_default
                     # true is the object that has the relevant context
 
                     if fallback_most_recent:
                         eid = args[0].most_recent_context.execution_id
+                    if fallback_default:
+                        eid = args[0].default_execution_id
 
                 context = Context(
                     execution_id=eid,

--- a/psyneulink/core/scheduling/scheduler.py
+++ b/psyneulink/core/scheduling/scheduler.py
@@ -595,7 +595,7 @@ class Scheduler(JSONDumpable):
     ################################################################################
     # Run methods
     ################################################################################
-
+    @handle_external_context(fallback_default=True)
     def run(self, termination_conds=None, context=None, base_context=Context(execution_id=None), skip_trial_time_increment=False):
         """
         run is a python generator, that when iterated over provides the next `TIME_STEP` of
@@ -609,9 +609,6 @@ class Scheduler(JSONDumpable):
             termination_conds = self.termination_conds
         else:
             termination_conds = self.update_termination_conditions(Scheduler._parse_termination_conditions(termination_conds))
-
-        if context is None:
-            context = Context(execution_id=self.default_execution_id)
 
         self._init_counts(context.execution_id, base_context.execution_id)
         self._reset_counts_useable(context.execution_id)

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1154,12 +1154,9 @@ class DDM(ProcessingMechanism):
 
         return mech_out, builder
 
-    @handle_external_context(execution_id=NotImplemented)
+    @handle_external_context(fallback_most_recent=True)
     def reset(self, *args, force=False, context=None):
         from psyneulink.core.components.functions.statefulfunctions.integratorfunctions import IntegratorFunction
-
-        if context.execution_id is NotImplemented:
-            context.execution_id = self.most_recent_context.execution_id
 
         # (1) reset function, (2) update mechanism value, (3) update output ports
         if isinstance(self.function, IntegratorFunction):

--- a/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
@@ -363,7 +363,7 @@ class ComparatorMechanism(ObjectiveMechanism):
                          )
 
         # Require Projection to TARGET InputPort (already required for SAMPLE as primary InputPort)
-        self.input_ports[1].parameters.require_projection_in_composition._set(True, Context())
+        self.input_ports[1].parameters.require_projection_in_composition._set(True, Context(execution_id=None))
 
     def _validate_params(self, request_set, target_set=None, context=None):
         """If sample and target values are specified, validate that they are compatible

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1238,7 +1238,7 @@ class RecurrentTransferMechanism(TransferMechanism):
 
         return super()._get_variable_from_input(input, context)
 
-    @handle_external_context(execution_id=NotImplemented)
+    @handle_external_context(fallback_most_recent=True)
     def reset(self, *args, force=False, context=None):
         super().reset(*args, force=force, context=context)
         self.parameters.value.clear_history(context)

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -3764,6 +3764,21 @@ class TestRun:
             context='custom'
         )
 
+    def test_manual_context(self):
+        t = pnl.TransferMechanism()
+        comp = pnl.Composition()
+
+        comp.add_node(t)
+
+        comp.run({t: [1]})
+        assert comp.results == [[[1]]]
+
+        context = pnl.Context()
+        t.function.parameters.slope._set(2, context)
+
+        comp.run({t: [1]}, context=context)
+        assert comp.results == [[[2]]]
+
 
 class TestCallBeforeAfterTimescale:
 
@@ -6294,7 +6309,7 @@ class TestInitialize:
         C = RecurrentTransferMechanism(name='C',
                                        auto=1.0)
 
-        context = Context(execution_id='a') if context_specified else NotImplemented
+        context = Context(execution_id='a') if context_specified else None
 
         abc_Composition = Composition(pathways=[[A, B, C]])
 
@@ -6303,7 +6318,7 @@ class TestInitialize:
         abc_Composition.run(inputs={A: [1.0, 2.0, 3.0]}, context=context)
 
         if not context_specified:
-            abc_Composition.run()
+            abc_Composition.run(context=Context(execution_id='b'))
 
         abc_Composition.run(inputs={A: [1.0, 2.0, 3.0]}, context=context)
 

--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -83,7 +83,7 @@ class TestReset:
 
         assert np.allclose([[0.3]], I.function.previous_short_term_avg)
         assert np.allclose([[0.7]], I.function.previous_long_term_avg)
-        context = Context()
+        context = Context(execution_id=None)
         print(I.value)
         print(I.function._combine_terms(0.3, 0.7, context))
         assert np.allclose(I.function._combine_terms(0.3, 0.7, context), I.value)


### PR DESCRIPTION
- Solves an issue where manually creating a Context object could cause unintended use of the None or a default context.

- Adds arguments `fallback_default` and `fallback_most_recent` to the `handle_external_context` decorator that can be used to determine whether the function should use an object's `default_execution_id` or `most_recent_context.execution_id` if context is unspecified
