### PR TITLE
llvm: Struct generation fixes

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1412,7 +1412,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         def _get_values(p):
             param = p.get(context)
             # Modulated parameters change shape to array
-            if np.isscalar(param) and self._is_param_modulated(p):
+            if np.ndim(param) == 0 and self._is_param_modulated(p):
                 return (param,)
             elif p.name == 'num_estimates':
                 return 0 if param is None else param

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2905,6 +2905,9 @@ class Mechanism_Base(Mechanism):
             # Parameter port inputs are {original parameter, [modulations]},
             # fill in the first one.
             data_ptr = builder.gep(p_input, [ctx.int32_ty(0), ctx.int32_ty(0)])
+            assert data_ptr.type == param_in_ptr.type, \
+                "Mishandled modulation type for: {} in '{}' in '{}'".format(
+                    param_ports[i].name, obj.name, self.name)
             b.store(b.load(param_in_ptr), data_ptr)
             return b
 

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -265,7 +265,7 @@ class LLVMBuilderContext:
                 val = np.asfarray(val).flatten()
             elif p.name == 'num_estimates':  # Should always be int
                 val = np.int32(0) if val is None else np.int32(val)
-            elif np.isscalar(val) and component._is_param_modulated(p):
+            elif np.ndim(val) == 0 and component._is_param_modulated(p):
                 val = [val]   # modulation adds array wrap
             return self.convert_python_struct_to_llvm_ir(val)
 

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -674,10 +674,6 @@ def gen_composition_exec(ctx, composition, *, tags:frozenset):
 
         num_exec_locs = {}
         for idx, node in enumerate(composition._all_nodes):
-            #FIXME: This skips nested compositions
-            from psyneulink import Composition
-            if isinstance(node, Composition):
-                continue
             node_state = builder.gep(nodes_states, [ctx.int32_ty(0),
                                                     ctx.int32_ty(idx)])
             num_exec_locs[node] = helpers.get_state_ptr(builder, node,
@@ -909,10 +905,6 @@ def gen_composition_run(ctx, composition, *, tags:frozenset):
 
         # Reset internal clocks of each node
         for idx, node in enumerate(composition._all_nodes):
-            #FIXME: This skips nested nodes
-            from psyneulink import Composition
-            if isinstance(node, Composition):
-                continue
             node_state = builder.gep(state, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(idx)])
             num_executions_ptr = helpers.get_state_ptr(builder, node, node_state, "num_executions")
             num_exec_time_ptr = builder.gep(num_executions_ptr, [ctx.int32_ty(0), ctx.int32_ty(TimeScale.RUN.value)])

--- a/psyneulink/core/llvm/debug.py
+++ b/psyneulink/core/llvm/debug.py
@@ -17,7 +17,7 @@ Features:
 
 Increased debug output:
  * "compile" -- prints information messages when modules are compiled
- * "stat" -- prints code generation and compilation statistics at the end
+ * "stat" -- prints code generation and compilation statistics
  * "cuda_data" -- print data upload/download statistic (to GPU VRAM)
  * "comp_node_debug" -- print intermediate results after execution composition node wrapper.
  * "print_values" -- Enabled printfs in llvm code (from ctx printf helper)

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -531,22 +531,16 @@ class AutodiffComposition(Composition):
                                                         )
 
     def _get_state_struct_type(self, ctx):
-        node_state_type_list = (ctx.get_state_struct_type(m) for m in self._all_nodes)
-        proj_state_type_list = (ctx.get_state_struct_type(p) for p in self._inner_projections)
         comp_state_type_list = ctx.get_state_struct_type(super())
         pytorch_representation = self._build_pytorch_representation()
         optimizer_state_type = pytorch_representation._get_compiled_optimizer()._get_optimizer_struct_type(ctx)
 
         return pnlvm.ir.LiteralStructType((
-            pnlvm.ir.LiteralStructType(node_state_type_list),
-            pnlvm.ir.LiteralStructType(proj_state_type_list),
             *comp_state_type_list,
             optimizer_state_type))
 
     def _get_state_initializer(self, context):
-        node_states = (m._get_state_initializer(context=context) for m in self._all_nodes)
-        proj_states = (p._get_state_initializer(context=context) for p in self._inner_projections)
         comp_states = super()._get_state_initializer(context)
         optimizer_states = tuple()
 
-        return (tuple(node_states), tuple(proj_states), *comp_states, optimizer_states)
+        return (*comp_states, optimizer_states)

--- a/tests/models/test_greedy_agent.py
+++ b/tests/models/test_greedy_agent.py
@@ -133,7 +133,7 @@ def test_simplified_greedy_agent_random(benchmark, mode):
     pytest.param([a / 10.0 for a in range(0, 101)]),
 ], ids=lambda x: len(x))
 def test_predator_prey(benchmark, mode, samples):
-    if len(samples) > 10 and mode not in {"LLVMRun", "Python-PTX"}:
+    if len(samples) > 10 and mode not in {"LLVM", "LLVMRun", "Python-PTX"}:
         pytest.skip("This test takes too long")
     # OCM default mode is Python
     mode, ocm_mode = (mode + "-Python").split('-')[0:2]


### PR DESCRIPTION
Add option to print ctype structure sizes.
Remove duplicate structures from Autodiff composition.
Use np.dim() == 0 instead of np.scalar() to detect dimensionality change of modulated parameters.