### PR TITLE
Determine resettable attributes from Parameters

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2992,7 +2992,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         pass
 
     @handle_external_context(fallback_most_recent=True)
-    def reset(self, *args, context=None):
+    def reset(self, *args, context=None, **kwargs):
         """
             If the component's execute method involves execution of an `IntegratorFunction` Function, this method
             effectively begins the function's accumulation over again at the specified value, and may update related
@@ -3001,7 +3001,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         """
         from psyneulink.core.components.functions.statefulfunctions.integratorfunctions import IntegratorFunction
         if isinstance(self.function, IntegratorFunction):
-            new_value = self.function.reset(*args, context=context)
+            new_value = self.function.reset(*args, **kwargs, context=context)
             self.parameters.value.set(np.atleast_2d(new_value), context, override=True)
         else:
             raise ComponentError(f"Resetting {self.name} is not allowed because this Component is not stateful. "
@@ -3573,6 +3573,14 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             may change during runtime
         """
         return [param for param in self.parameters if param.stateful]
+
+    @property
+    def stateful_attributes(self):
+        return [p.name for p in self.parameters if p.initializer is not None]
+
+    @property
+    def initializers(self):
+        return [getattr(self.parameters, p).initializer for p in self.stateful_attributes]
 
     @property
     def function_parameters(self):

--- a/psyneulink/core/components/functions/learningfunctions.py
+++ b/psyneulink/core/components/functions/learningfunctions.py
@@ -32,7 +32,7 @@ from psyneulink.core.components.functions.function import Function_Base, Functio
 from psyneulink.core.components.functions.transferfunctions import Logistic
 from psyneulink.core.components.component import ComponentError
 from psyneulink.core.globals.keywords import \
-    CONTRASTIVE_HEBBIAN_FUNCTION, DEFAULT_VARIABLE, TDLEARNING_FUNCTION, LEARNING_FUNCTION_TYPE, LEARNING_RATE, \
+    CONTRASTIVE_HEBBIAN_FUNCTION, TDLEARNING_FUNCTION, LEARNING_FUNCTION_TYPE, LEARNING_RATE, \
     KOHONEN_FUNCTION, GAUSSIAN, LINEAR, EXPONENTIAL, HEBBIAN_FUNCTION, RL_FUNCTION, BACKPROPAGATION_FUNCTION, MATRIX, \
     MSE, SSE
 from psyneulink.core.globals.parameters import Parameter
@@ -522,12 +522,14 @@ class BayesGLM(LearningFunction):
         self.gamma_size_n = self.gamma_size_0
 
     @handle_external_context(fallback_most_recent=True)
-    def reset(self, *args, context=None):
+    def reset(self, default_variable=None, context=None):
         # If variable passed during execution does not match default assigned during initialization,
         #    reassign default and re-initialize priors
-        if DEFAULT_VARIABLE in args[0]:
-            self.defaults.variable = np.array([np.zeros_like(args[0][DEFAULT_VARIABLE][0]),
-                                                        np.zeros_like(args[0][DEFAULT_VARIABLE][1])])
+        if default_variable is not None:
+            self._update_default_variable(
+                np.array([np.zeros_like(default_variable), np.zeros_like(default_variable)]),
+                context=context
+            )
             self.initialize_priors()
 
     def _function(

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -842,7 +842,7 @@ class GradientOptimization(OptimizationFunction):
 
         # these should be removed and use switched to .get_previous()
         previous_variable = Parameter([[0], [0]], read_only=True, pnl_internal=True, constructor_argument='default_variable')
-        previous_value = Parameter([[0], [0]], read_only=True, pnl_internal=True)
+        previous_value = Parameter([[0], [0]], read_only=True, initializer='initializer', pnl_internal=True)
 
         gradient_function = Parameter(None, stateful=False, loggable=False)
         step_size = Parameter(1.0, modulable=True)

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -218,7 +218,7 @@ class IntegratorFunction(StatefulFunction):  # ---------------------------------
         """
         rate = Parameter(1.0, modulable=True, function_arg=True)
         noise = Parameter(0.0, modulable=True, function_arg=True)
-        previous_value = Parameter(np.array([0]), pnl_internal=True)
+        previous_value = Parameter(np.array([0]), initializer='initializer', pnl_internal=True)
         initializer = Parameter(np.array([0]), pnl_internal=True)
 
     @tc.typecheck
@@ -1534,8 +1534,8 @@ class DualAdaptiveIntegrator(IntegratorFunction):  # ---------------------------
         long_term_rate = Parameter(0.1, modulable=True, function_arg=True)
         operation = PRODUCT
         offset = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM], function_arg=True)
-        previous_short_term_avg = Parameter(None, pnl_internal=True)
-        previous_long_term_avg = Parameter(None, pnl_internal=True)
+        previous_short_term_avg = Parameter(None, initializer='initial_short_term_avg', pnl_internal=True)
+        previous_long_term_avg = Parameter(None, initializer='initial_long_term_avg', pnl_internal=True)
         short_term_logistic = None
         long_term_logistic = None
 
@@ -2372,7 +2372,7 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
         starting_point = 0.0
         threshold = Parameter(100.0, modulable=True)
         time_step_size = Parameter(1.0, modulable=True)
-        previous_time = Parameter(None, pnl_internal=True)
+        previous_time = Parameter(None, initializer='starting_point', pnl_internal=True)
         seed = Parameter(None, read_only=True)
         random_state = Parameter(None, stateful=True, loggable=False)
         enable_output_type_conversion = Parameter(
@@ -2788,7 +2788,7 @@ class OrnsteinUhlenbeckIntegrator(IntegratorFunction):  # ----------------------
         offset = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
         time_step_size = Parameter(1.0, modulable=True)
         starting_point = 0.0
-        previous_time = Parameter(0.0, pnl_internal=True)
+        previous_time = Parameter(0.0, initializer='starting_point', pnl_internal=True)
         random_state = Parameter(None, stateful=True, loggable=False)
         enable_output_type_conversion = Parameter(
             False,
@@ -3754,9 +3754,13 @@ class FitzHughNagumoIntegrator(IntegratorFunction):  # -------------------------
         initial_w = 0.0
         initial_v = 0.0
         t_0 = 0.0
-        previous_w = Parameter(np.array([1.0]), pnl_internal=True)
-        previous_v = Parameter(np.array([1.0]), pnl_internal=True)
-        previous_time = Parameter(0.0, pnl_internal=True)
+        previous_w = Parameter(np.array([1.0]), initializer='initial_w', pnl_internal=True)
+        previous_v = Parameter(np.array([1.0]), initializer='initial_v', pnl_internal=True)
+        previous_time = Parameter(0.0, initializer='t_0', pnl_internal=True)
+
+        # this should be removed because it's unused, but this will
+        # require a larger refactoring on previous_value/value
+        previous_value = Parameter(None, initializer='initializer', pnl_internal=True)
 
         enable_output_type_conversion = Parameter(
             False,

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -253,7 +253,7 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
         )
 
     @handle_external_context(fallback_most_recent=True)
-    def reset(self, *args, context=None):
+    def reset(self, previous_value=None, context=None):
         """
 
         Clears the `previous_value <Buffer.previous_value>` deque.
@@ -266,26 +266,15 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
 
         """
         # no arguments were passed in -- use current values of initializer attributes
-        if len(args) == 0 or args is None:
-            reinitialization_value = self._get_current_parameter_value("initializer", context)
+        if previous_value is None:
+            previous_value = self._get_current_parameter_value("initializer", context)
 
-        elif len(args) == 1:
-            reinitialization_value = args[0]
-
-        # arguments were passed in, but there was a mistake in their specification -- raise error!
-        else:
-            raise FunctionError("Invalid arguments ({}) specified for {}. Either one value must be passed to "
-                                "reset its stateful attribute (previous_value), or reset must be called "
-                                "without any arguments, in which case the current initializer value, will be used to "
-                                "reset previous_value".format(args,
-                                                                     self.name))
-
-        if reinitialization_value is None or reinitialization_value == []:
+        if previous_value is None or previous_value == []:
             self.get_previous_value(context).clear()
             value = deque([], maxlen=self.parameters.history.get(context))
 
         else:
-            value = self._initialize_previous_value(reinitialization_value, context=context)
+            value = self._initialize_previous_value(previous_value, context=context)
 
         self.parameters.value.set(value, context, override=True)
         return value
@@ -1019,7 +1008,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
             self.selection_function = self.selection_function(context=context)
 
     @handle_external_context(fallback_most_recent=True)
-    def reset(self, *args, context=None):
+    def reset(self, previous_value=None, context=None):
         """
         reset(<new_dictionary> default={})
 
@@ -1034,25 +1023,15 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         `previous_value <ContentAddressableMemory.previous_value>`.
         """
         # no arguments were passed in -- use current values of initializer attributes
-        if len(args) == 0 or args is None:
-            reinitialization_value = self._get_current_parameter_value("initializer", context)
+        if previous_value is None:
+            previous_value = self._get_current_parameter_value("initializer", context)
 
-        elif len(args) == 1:
-            reinitialization_value = args[0]
-
-        # arguments were passed in, but there was a mistake in their specification -- raise error!
-        else:
-            raise FunctionError("Invalid arguments ({}) specified for {}. Either one value must be passed to "
-                                "reset its stateful attribute (previous_value), or reset must be called "
-                                "without any arguments, in which case the current initializer value will be used to "
-                                "reset previous_value".format(args, self.name))
-
-        if reinitialization_value == []:
+        if previous_value == []:
             self.get_previous_value(context).clear()
             value = np.ndarray(shape=(2, 0, len(self.defaults.variable[0])))
 
         else:
-            value = self._initialize_previous_value(reinitialization_value, context=context)
+            value = self._initialize_previous_value(previous_value, context=context)
 
         self.parameters.value.set(value, context, override=True)
         return value

--- a/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
+++ b/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
@@ -438,8 +438,8 @@ class StatefulFunction(Function_Base): #  --------------------------------------
 
         # create all stateful attributes and initialize their values to the current values of their
         # corresponding initializer attributes
-        for i, attr_name in enumerate(self.stateful_attributes):
-            initializer_value = getattr(self.parameters, self.initializers[i])._get(context).copy()
+        for attr_name in self.stateful_attributes:
+            initializer_value = getattr(self.parameters, getattr(self.parameters, attr_name).initializer)._get(context).copy()
             getattr(self.parameters, attr_name)._set(initializer_value, context)
 
         super()._instantiate_attributes_before_function(function=function, context=context)
@@ -462,8 +462,17 @@ class StatefulFunction(Function_Base): #  --------------------------------------
 
         super()._update_default_variable(new_default_variable, context=context)
 
+    def _parse_value_order(self, **kwargs):
+        """
+            Returns:
+                tuple: the values of the keyword arguments in the order
+                in which they appear in this Component's `value
+                <Component.value>`
+        """
+        return tuple(v for k, v in kwargs.items())
+
     @handle_external_context(fallback_most_recent=True)
-    def reset(self, *args, context=None):
+    def reset(self, *args, context=None, **kwargs):
         """
             Resets `value <StatefulFunction.previous_value>`  and `previous_value <StatefulFunction.previous_value>`
             to the specified value(s).
@@ -488,74 +497,80 @@ class StatefulFunction(Function_Base): #  --------------------------------------
             reinitialization steps.
 
         """
-        reinitialization_values = []
+        num_stateful_attrs = len(self.stateful_attributes)
+        if num_stateful_attrs >= 2:
+            # old args specification can be supported only in subclasses
+            # that explicitly define an order by overriding reset
+            if len(args) > 0:
+                raise FunctionError(
+                    f'{self}.reset has more than one stateful attribute'
+                    f' ({self.stateful_attributes}). You must specify reset'
+                    ' values by keyword.'
+                )
+            if len(kwargs) != num_stateful_attrs:
+                type_name = type(self).__name__
+                raise FunctionError(
+                    'StatefulFunction.reset must receive a keyword argument for'
+                    f' each item in {type_name}.stateful_attributes in the order in'
+                    f' which they appear in {type_name}.value'
+                )
 
-        # no arguments were passed in -- use current values of initializer attributes
-        if len(args) == 0 or args is None or all(arg is None for arg in args):
-            for i in range(len(self.initializers)):
-                initializer_name = self.initializers[i]
-                reinitialization_values.append(self._get_current_parameter_value(initializer_name, context))
+        if num_stateful_attrs == 1:
+            try:
+                kwargs[self.stateful_attributes[0]]
+            except KeyError:
+                try:
+                    kwargs[self.stateful_attributes[0]] = args[0]
+                except IndexError:
+                    kwargs[self.stateful_attributes[0]] = None
 
-        elif len(args) == len(self.initializers):
-            for i in range(len(self.initializers)):
-                initializer_name = self.initializers[i]
-                if args[i] is None:
-                    reinitialization_values.append(self._get_current_parameter_value(initializer_name, context))
-                else:
-                    # Not sure if np.atleast_1d is necessary here:
-                    reinitialization_values.append(np.atleast_1d(args[i]))
+        invalid_args = []
 
-        # arguments were passed in, but there was a mistake in their specification -- raise error!
-        else:
-            stateful_attributes_string = self.stateful_attributes[0]
-            if len(self.stateful_attributes) > 1:
-                for i in range(1, len(self.stateful_attributes) - 1):
-                    stateful_attributes_string += ", "
-                    stateful_attributes_string += self.stateful_attributes[i]
-                stateful_attributes_string += " and "
-                stateful_attributes_string += self.stateful_attributes[len(self.stateful_attributes) - 1]
+        # iterates in order arguments are sent in function call, so it
+        # will match their order in value as long as they are listed
+        # properly in subclass reset method signatures
+        for attr in kwargs:
+            try:
+                kwargs[attr]
+            except KeyError:
+                kwargs[attr] = None
 
-            initializers_string = self.initializers[0]
-            if len(self.initializers) > 1:
-                for i in range(1, len(self.initializers) - 1):
-                    initializers_string += ", "
-                    initializers_string += self.initializers[i]
-                initializers_string += " and "
-                initializers_string += self.initializers[len(self.initializers) - 1]
+            if kwargs[attr] is not None:
+                # from before: unsure if conversion to 1d necessary
+                kwargs[attr] = np.atleast_1d(kwargs[attr])
+            else:
+                try:
+                    kwargs[attr] = self._get_current_parameter_value(getattr(self.parameters, attr).initializer, context=context)
+                except AttributeError:
+                    invalid_args.append(attr)
 
-            raise FunctionError("Invalid arguments ({}) specified for {}. If arguments are specified for the "
-                                "reset method of {}, then a value must be passed to reset each of its "
-                                "stateful_attributes: {}, in that order. Alternatively, reset may be called "
-                                "without any arguments, in which case the current values of {}'s initializers: {}, will"
-                                " be used to reset their corresponding stateful_attributes."
-                                .format(args,
-                                        self.name,
-                                        self.name,
-                                        stateful_attributes_string,
-                                        self.name,
-                                        initializers_string))
+        if len(invalid_args) > 0:
+            raise FunctionError(
+                f'Arguments {invalid_args} to reset are invalid because they do'
+                f" not correspond to any of {self}'s stateful_attributes"
+            )
 
         # rebuilding value rather than simply returning reinitialization_values in case any of the stateful
         # attrs are modified during assignment
         value = []
-        for i, attr in enumerate(self.stateful_attributes):
+        for attr, v in kwargs.items():
             # FIXME: HACK: Do not reinitialize random_state
             if attr != "random_state":
-                setattr(self, attr, reinitialization_values[i])
-                getattr(self.parameters, attr).set(reinitialization_values[i],
+                getattr(self.parameters, attr).set(kwargs[attr],
                                                    context, override=True)
-                value.append(getattr(self.parameters, self.stateful_attributes[i])._get(context))
+                value.append(getattr(self.parameters, attr)._get(context))
 
         self.parameters.value.set(value, context, override=True)
         return value
 
     def _gen_llvm_function_reset(self, ctx, builder, params, state, arg_in, arg_out, *, tags:frozenset):
         assert "reset" in tags
-        for i, a in enumerate(self.stateful_attributes):
-            source_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, self.initializers[i])
+        for a in self.stateful_attributes:
+            initializer = getattr(self.parameters, a).initializer
+            source_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, initializer)
             dest_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, a)
             if source_ptr.type != dest_ptr.type:
-                warnings.warn("Shape mismatch: stateful param does not match the initializer: {}({}) vs. {}({})".format(self.initializers[i], source_ptr.type, a, dest_ptr.type))
+                warnings.warn("Shape mismatch: stateful param does not match the initializer: {}({}) vs. {}({})".format(initializer, source_ptr.type, a, dest_ptr.type))
                 # Take a guess that dest just has an extra dimension
                 assert len(dest_ptr.type.pointee) == 1
                 dest_ptr = builder.gep(dest_ptr, [ctx.int32_ty(0),

--- a/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
+++ b/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
@@ -192,7 +192,7 @@ class StatefulFunction(Function_Base): #  --------------------------------------
         """
         noise = Parameter(0.0, modulable=True)
         rate = Parameter(1.0, modulable=True)
-        previous_value = Parameter(np.array([0]), pnl_internal=True)
+        previous_value = Parameter(np.array([0]), initializer='initializer', pnl_internal=True)
         initializer = Parameter(np.array([0]), pnl_internal=True)
         has_initializers = Parameter(True, setter=_has_initializers_setter, pnl_internal=True)
 

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2214,7 +2214,7 @@ class Mechanism_Base(Mechanism):
         pass
 
     @handle_external_context(fallback_most_recent=True)
-    def reset(self, *args, force=False, context=None):
+    def reset(self, *args, force=False, context=None, **kwargs):
         """Reset `value <Mechanism_Base.value>` if Mechanisms is stateful.
 
         If the mechanism's `function <Mechanism.function>` is an `IntegratorFunction`, or if the mechanism has and
@@ -2268,7 +2268,7 @@ class Mechanism_Base(Mechanism):
         # If the primary function of the mechanism is stateful:
         # (1) reset it, (2) update value, (3) update output ports
         if isinstance(self.function, StatefulFunction):
-            new_value = self.function.reset(*args, context=context)
+            new_value = self.function.reset(*args, **kwargs, context=context)
             self.parameters.value._set(convert_to_np_array(new_value, dimension=2), context=context)
             self._update_output_ports(context=context)
 
@@ -2284,7 +2284,7 @@ class Mechanism_Base(Mechanism):
                 )
 
             if self.parameters.integrator_mode._get(context) or force:
-                new_input = self.integrator_function.reset(*args, context=context)[0]
+                new_input = self.integrator_function.reset(*args, **kwargs, context=context)[0]
                 self.parameters.value._set(
                     self.function.execute(variable=new_input, context=context),
                     context=context,

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -742,7 +742,7 @@ class DefaultAllocationFunction(Function_Base):
         result = np.array([variable[0]] * num_ctl_sigs)
         return self.convert_output_type(result)
 
-    def reset(self, *args, force=False, context=None):
+    def reset(self, *args, force=False, context=None, **kwargs):
         # Override Component.reset which requires that the Component is stateful
         pass
 

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -877,7 +877,7 @@ class OptimizationControlMechanism(ControlMechanism):
             self.parameters.search_space._set(corrected_search_space, context)
 
         # Assign parameters to function (OptimizationFunction) that rely on OptimizationControlMechanism
-        self.function.reset({
+        self.function.reset(**{
             DEFAULT_VARIABLE: self.parameters.control_allocation._get(context),
             OBJECTIVE_FUNCTION: self.evaluation_function,
             # SEARCH_FUNCTION: self.search_function,

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1567,8 +1567,8 @@ class TransferMechanism(ProcessingMechanism_Base):
         return value
 
     @handle_external_context(fallback_most_recent=True)
-    def reset(self, *args, force=False, context=None):
-        super().reset(*args, force=force, context=context)
+    def reset(self, *args, force=False, context=None, **kwargs):
+        super().reset(*args, force=force, context=context, **kwargs)
         self.parameters.value.clear_history(context)
 
     def _parse_function_variable(self, variable, context=None):

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -8311,7 +8311,10 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             if (isinstance(reset_stateful_functions_when, Never) or
                     node not in reset_stateful_functions_when) and \
                     isinstance(node.reset_stateful_function_when, Never):
-                node.reset(*vals, context=context)
+                try:
+                    node.reset(**vals, context=context)
+                except TypeError:
+                    node.reset(*vals, context=context)
 
         # cache and set reset_stateful_function_when conditions for nodes, matching old System behavior
         # Validate
@@ -8882,7 +8885,10 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                         )
                     ):
                         vals = reset_stateful_functions_to.get(node, [None])
-                        node.reset(*vals, context=context)
+                        try:
+                            node.reset(**vals, context=context)
+                        except TypeError:
+                            node.reset(*vals, context=context)
                 except AttributeError:
                     pass
 

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -737,6 +737,12 @@ class Parameter(ParameterBase):
 
             :default: None
 
+        initializer
+            the name of another Parameter that serves as this
+            Parameter's `initializer <StatefulFunction.initializers>`
+
+            :default: None
+
     """
     # The values of these attributes will never be inherited from parent Parameters
     # KDM 7/12/18: consider inheriting ONLY default_value?
@@ -746,7 +752,7 @@ class Parameter(ParameterBase):
     # display if the function is True based on the value of the attribute
     _hidden_if_unset_attrs = {
         'aliases', 'getter', 'setter', 'constructor_argument', 'spec',
-        'modulation_combination_function', 'valid_types'
+        'modulation_combination_function', 'valid_types', 'initializer'
     }
     _hidden_if_false_attrs = {'read_only', 'modulable', 'fallback_default', 'retain_old_simulation_data'}
     _hidden_when = {
@@ -799,6 +805,7 @@ class Parameter(ParameterBase):
         valid_types=None,
         reference=False,
         dependencies=None,
+        initializer=None,
         _owner=None,
         _inherited=False,
         # this stores a reference to the Parameter object that is the
@@ -859,6 +866,7 @@ class Parameter(ParameterBase):
             valid_types=valid_types,
             reference=reference,
             dependencies=dependencies,
+            initializer=initializer,
             _inherited=_inherited,
             _inherited_source=_inherited_source,
             _user_specified=_user_specified,

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1155,12 +1155,12 @@ class DDM(ProcessingMechanism):
         return mech_out, builder
 
     @handle_external_context(fallback_most_recent=True)
-    def reset(self, *args, force=False, context=None):
+    def reset(self, *args, force=False, context=None, **kwargs):
         from psyneulink.core.components.functions.statefulfunctions.integratorfunctions import IntegratorFunction
 
         # (1) reset function, (2) update mechanism value, (3) update output ports
         if isinstance(self.function, IntegratorFunction):
-            new_values = self.function.reset(*args, context=context)
+            new_values = self.function.reset(*args, **kwargs, context=context)
             self.parameters.value._set(convert_to_np_array(new_values), context)
             self._update_output_ports(context=context)
 

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1238,11 +1238,6 @@ class RecurrentTransferMechanism(TransferMechanism):
 
         return super()._get_variable_from_input(input, context)
 
-    @handle_external_context(fallback_most_recent=True)
-    def reset(self, *args, force=False, context=None):
-        super().reset(*args, force=force, context=context)
-        self.parameters.value.clear_history(context)
-
     @property
     def _learning_signal_source(self):
         """Return default source of learning signal (`Primary OutputPort <OutputPort_Primary>)`

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -6572,15 +6572,15 @@ class TestResetValues:
             # "save" the current state of each stateful mechanism by storing the values of each of its stateful
             # attributes in the reinitialization_values dictionary; this gets passed into run and used to call
             # the reset method on each stateful mechanism.
-            reinitialization_value = []
+            reinitialization_value = {}
 
             if isinstance(mechanism.function, IntegratorFunction):
                 for attr in mechanism.function.stateful_attributes:
-                    reinitialization_value.append(getattr(mechanism.function.parameters, attr).get(comp))
+                    reinitialization_value[attr] = getattr(mechanism.function.parameters, attr).get(comp)
             elif hasattr(mechanism, "integrator_function"):
                 if isinstance(mechanism.integrator_function, IntegratorFunction):
                     for attr in mechanism.integrator_function.stateful_attributes:
-                        reinitialization_value.append(getattr(mechanism.integrator_function.parameters, attr).get(comp))
+                        reinitialization_value[attr] = getattr(mechanism.integrator_function.parameters, attr).get(comp)
 
             reinitialization_values[mechanism] = reinitialization_value
 

--- a/tests/mechanisms/test_mechanisms.py
+++ b/tests/mechanisms/test_mechanisms.py
@@ -147,16 +147,17 @@ class TestResetValues:
         original_output = [A.execute(1.0)[0], A.execute(1.0)[0]]
 
         # SAVING STATE  - - - - - - - - - - - - - - - - - - - - - - - - -
-        reset_stateful_functions_to = []
+        reset_stateful_functions_to = {}
         for attr in A.function.stateful_attributes:
-            reset_stateful_functions_to.append(getattr(A.function, attr))
+            reset_stateful_functions_to[attr] = getattr(A.function, attr)
 
+        print(reset_stateful_functions_to)
         # Execute A twice AFTER saving the state so that it continues accumulating.
         # We expect the next two outputs to repeat once we reset the state b/c we will return it to the current state
         output_after_saving_state = [A.execute(1.0)[0], A.execute(1.0)[0]]
 
         # RESETTING STATE - - - - - - - - - - - - - - - - - - - - - - - -
-        A.reset(*reset_stateful_functions_to)
+        A.reset(**reset_stateful_functions_to)
 
         # We expect these results to match the results from immediately after saving the state
         output_after_reinitialization = [A.execute(1.0)[0], A.execute(1.0)[0]]
@@ -172,17 +173,17 @@ class TestResetValues:
         original_output = [A.execute(1.0), A.execute(1.0)]
 
         # SAVING STATE  - - - - - - - - - - - - - - - - - - - - - - - - -
-        reset_stateful_functions_to = []
+        reset_stateful_functions_to = {}
 
         for attr in A.integrator_function.stateful_attributes:
-            reset_stateful_functions_to.append(getattr(A.integrator_function, attr))
+            reset_stateful_functions_to[attr] = getattr(A.integrator_function, attr)
 
         # Execute A twice AFTER saving the state so that it continues accumulating.
         # We expect the next two outputs to repeat once we reset the state b/c we will return it to the current state
         output_after_saving_state = [A.execute(1.0), A.execute(1.0)]
 
         # RESETTING STATE - - - - - - - - - - - - - - - - - - - - - - - -
-        A.reset(*reset_stateful_functions_to)
+        A.reset(**reset_stateful_functions_to)
 
         # We expect these results to match the results from immediately after saving the state
         output_after_reinitialization = [A.execute(1.0), A.execute(1.0)]


### PR DESCRIPTION
- Add `initializer` flag to `Parameter` that when specified as the name of another Parameter identifies it as a `stateful_attribute` (resettable)
- Accept keyword arguments for `Component.reset`