### PR TITLE
Revert ee3d9651

### DIFF
--- a/leabra_requirements.txt
+++ b/leabra_requirements.txt
@@ -1,1 +1,0 @@
-leabra@git+https://github.com/benureau/leabra.git@master

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ setup(
 
     extras_require={
         'dev': get_requirements('dev'),
-        'leabra': get_requirements('leabra'),
         'tutorial': get_requirements('tutorial'),
     }
 )


### PR DESCRIPTION
Pypi does not allow for direct dependencies, therefore, revert commit ee3d9651 "dependencies: Add leabra extra feature"