### PR TITLE
Revert "deps: Convert leabra to 'extra' dependency"

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -73,7 +73,8 @@ jobs:
       shell: bash
       run: |
         python -m pip install --upgrade pip wheel
-        pip install -e .[dev,leabra]
+        pip install -e .[dev]
+        pip install --user git+https://github.com/benureau/leabra.git@master
 
     - name: Cleanup old wheels
       shell: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,9 @@ before_cache:
 
 install:
   - pip install coveralls
-  - pip install -e .[dev,leabra]
+  - pip install -e .[dev]
+  # This should be installed after PNL to avoid pulling incompatible deps
+  - pip install git+https://github.com/benureau/leabra.git@master
 
 
 script:

--- a/leabra_requirements.txt
+++ b/leabra_requirements.txt
@@ -1,1 +1,0 @@
-leabra@git+https://github.com/benureau/leabra.git@master

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ setup(
 
     extras_require={
         'dev': get_requirements('dev'),
-        'leabra': get_requirements('leabra'),
         'tutorial': get_requirements('tutorial'),
     }
 )


### PR DESCRIPTION
Reverts PrincetonUniversity/PsyNeuLink#1815

#1815 broke pypi compatibility by including `leabra` as a direct dependency

See [here](https://github.com/benureau/leabra/issues/7) for more information