### PR TITLE
library models: generate figures during testing

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import doctest
+import psyneulink
 import pytest
 import numpy as np
 
@@ -88,3 +89,9 @@ def expand_np_ndarray(arr):
                 nested_elem = [nested_elem]
             results_list.extend(nested_elem)
     return results_list
+
+
+# flag when run from pytest
+# https://docs.pytest.org/en/stable/example/simple.html#detect-if-running-from-within-a-pytest-run
+def pytest_configure(config):
+    psyneulink._called_from_pytest = True

--- a/psyneulink/__init__.py
+++ b/psyneulink/__init__.py
@@ -34,6 +34,8 @@ from .library import *
 _pnl_global_names = [
     'primary_registries', 'System', 'Process'
 ]
+# flag when run from pytest (see conftest.py)
+_called_from_pytest = False
 
 __all__ = list(_pnl_global_names)
 __all__.extend(core.__all__)

--- a/psyneulink/library/models/Cohen_Huston1994.py
+++ b/psyneulink/library/models/Cohen_Huston1994.py
@@ -441,7 +441,7 @@ if args.enable_plot:
     plt.plot(response_all3[0])
     plt.plot(response_all3[1])
     plt.plot(response_all3[2])
-    plt.show()
+    plt.show(block=not pnl._called_from_pytest)
     # Second, plot regression plot
     # regression
     reg = np.dot(response_all2, 5) + 115
@@ -454,4 +454,4 @@ if args.enable_plot:
     plt.legend(['color naming', 'word reading'])
     plt.xticks(np.arange(3), ('control', 'incongruent', 'congruent'))
     plt.ylabel('reaction time in ms')
-    plt.show()
+    plt.show(block=not pnl._called_from_pytest)

--- a/psyneulink/library/models/Cohen_Huston1994_horse_race.py
+++ b/psyneulink/library/models/Cohen_Huston1994_horse_race.py
@@ -366,4 +366,4 @@ if args.enable_plot:
     plt.title('stimulus onset asynchrony - horse race model ')
     plt.legend(['congruent', 'incongruent', 'neutral'])
     plt.ylabel('reaction time in ms')
-    plt.show()
+    plt.show(block=not pnl._called_from_pytest)

--- a/psyneulink/library/models/GilzenratModel.py
+++ b/psyneulink/library/models/GilzenratModel.py
@@ -274,7 +274,7 @@ if args.enable_plot:
     plt.xticks(x_values)
     plt.title('GILZENRAT 2002 PsyNeuLink', fontweight='bold')
 
-    plt.show()
+    plt.show(block=not pnl._called_from_pytest)
 
     task.show_graph()
     print('\nPlots generated')

--- a/psyneulink/library/models/Kalanthroff_PCTC_2018.py
+++ b/psyneulink/library/models/Kalanthroff_PCTC_2018.py
@@ -561,4 +561,4 @@ if args.enable_plot:
     axes[2, 3].plot(www_incong[settle:, 0], 'b')
     axes[2, 3].plot(www_incong[settle:, 1], 'g')
 
-    plt.show()
+    plt.show(block=not pnl._called_from_pytest)

--- a/psyneulink/library/models/MontagueDayanSejnowski96.py
+++ b/psyneulink/library/models/MontagueDayanSejnowski96.py
@@ -123,7 +123,7 @@ def figure_5a():
             plt.legend()
             plt.xlim(xmin=35)
             plt.xticks()
-            plt.show()
+            plt.show(block=not pnl._called_from_pytest)
 
     return comp
 
@@ -189,7 +189,7 @@ def figure_5b():
             ax.set_xlim(0, 120)
             ax.set_zlim(-1, 1)
             ax.set_title("Montague et. al. (1996) -- Figure 5B")
-            plt.show()
+            plt.show(block=not pnl._called_from_pytest)
 
     return comp
 
@@ -253,7 +253,7 @@ def figure_5c():
             ax.set_ylabel("Timestep")
             ax.set_zlabel("∂")
             ax.set_title("Montague et. al. (1996) -- Figure 5C")
-            plt.show()
+            plt.show(block=not pnl._called_from_pytest)
 
     return comp
 

--- a/psyneulink/library/models/Nieuwenhuis2005Model.py
+++ b/psyneulink/library/models/Nieuwenhuis2005Model.py
@@ -246,4 +246,4 @@ if args.enable_plot:
     plt.title('Nieuwenhuis 2005 PsyNeuLink Lag 2 without noise', fontweight='bold')  # Set title
     ax.set_ylim((-0.2, 1.0))                     # Set left y axis limits
     ax2.set_ylim((0.0, 0.4))                    # Set right y axis limits
-    plt.show()
+    plt.show(block=not pnl._called_from_pytest)

--- a/tests/models/test_documentation_models.py
+++ b/tests/models/test_documentation_models.py
@@ -90,7 +90,7 @@ def test_documentation_models(
     )
     model_file = os.path.join(models_dir, f'{model_name}.py')
     old_argv = sys.argv
-    sys.argv = [model_file, '--no-plot'] + additional_args
+    sys.argv = [model_file] + additional_args
     script_globals = runpy.run_path(model_file)
     sys.argv = old_argv
 


### PR DESCRIPTION
matplotlib figures block execution normally; disable this in all documentation models in `psyneulink/library/models/` when running pytest