### PR TITLE
github-actions: Restrict graphviz version on windows

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -61,7 +61,7 @@ jobs:
       if: startsWith(runner.os, 'Linux')
 
     - name: Windows dependencies
-      run: choco install --no-progress -y graphviz
+      run: choco install --no-progress -y graphviz --version=2.38.0.20190211
       if: startsWith(runner.os, 'Windows')
 
     - name: Windows pytorch


### PR DESCRIPTION
The new cmake built version has problems with locations of executables:
https://chocolatey.org/packages/Graphviz/2.44.1

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>