### PR TITLE
Simplify Context

### DIFF
--- a/psyneulink/core/components/__init__.py
+++ b/psyneulink/core/components/__init__.py
@@ -53,7 +53,6 @@ __all__.extend(projections.__all__)
 __all__.extend(shellclasses.__all__)
 __all__.extend(ports.__all__)
 
-kwInitPy = '__init__.py'
 
 class InitError(Exception):
     def __init__(self, error_value):
@@ -68,18 +67,18 @@ class InitError(Exception):
 register_category(entry=ControlMechanism,
                   base_class=Mechanism_Base,
                   registry=MechanismRegistry,
-                  context=kwInitPy)
+                  )
 
 register_category(entry=DefaultControlMechanism,
                   base_class=Mechanism_Base,
                   registry=MechanismRegistry,
-                  context=kwInitPy)
+                  )
 
 # DDM (used as DefaultMechanism)
 register_category(entry=DDM,
                   base_class=Mechanism_Base,
                   registry=MechanismRegistry,
-                  context=kwInitPy)
+                  )
 
 #endregion
 
@@ -111,37 +110,37 @@ SystemDefaultControlMechanism = DefaultControlMechanism
 register_category(entry=InputPort,
                   base_class=Port_Base,
                   registry=PortRegistry,
-                  context=kwInitPy)
+                  )
 
 # ParameterPort
 register_category(entry=ParameterPort,
                   base_class=Port_Base,
                   registry=PortRegistry,
-                  context=kwInitPy)
+                  )
 
 # OutputPort
 register_category(entry=OutputPort,
                   base_class=Port_Base,
                   registry=PortRegistry,
-                  context=kwInitPy)
+                  )
 
 # LearningSignal
 register_category(entry=LearningSignal,
                   base_class=Port_Base,
                   registry=PortRegistry,
-                  context=kwInitPy)
+                  )
 
 # ControlSignal
 register_category(entry=ControlSignal,
                   base_class=Port_Base,
                   registry=PortRegistry,
-                  context=kwInitPy)
+                  )
 
 # GatingSignal
 register_category(entry=GatingSignal,
                   base_class=Port_Base,
                   registry=PortRegistry,
-                  context=kwInitPy)
+                  )
 
 
 # Projection -----------------------------------------------------------------------------------------------------------
@@ -152,25 +151,25 @@ register_category(entry=GatingSignal,
 register_category(entry=MappingProjection,
                   base_class=Projection_Base,
                   registry=ProjectionRegistry,
-                  context=kwInitPy)
+                  )
 
 # LearningProjection
 register_category(entry=LearningProjection,
                   base_class=Projection_Base,
                   registry=ProjectionRegistry,
-                  context=kwInitPy)
+                  )
 
 # ControlProjection
 register_category(entry=ControlProjection,
                   base_class=Projection_Base,
                   registry=ProjectionRegistry,
-                  context=kwInitPy)
+                  )
 
 # GatingProjection
 register_category(entry=GatingProjection,
                   base_class=Projection_Base,
                   registry=ProjectionRegistry,
-                  context=kwInitPy)
+                  )
 
 #endregion
 

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1087,7 +1087,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         self._handle_illegal_kwargs(**kwargs)
 
         context = Context(
-            source=ContextFlags.COMPONENT,
+            source=ContextFlags.CONSTRUCTOR,
             execution_phase=ContextFlags.IDLE,
             execution_id=None,
         )

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1698,7 +1698,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                           base_class=Component,
                           name=name,
                           registry=DeferredInitRegistry,
-                          context=context)
+                          )
 
     def _assign_default_name(self, **kwargs):
         return

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1897,7 +1897,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
 
         # VALIDATE VARIABLE
 
-        if not (context.source & (ContextFlags.COMMAND_LINE | ContextFlags.PROPERTY)):
+        if context.source is not ContextFlags.COMMAND_LINE:
             # if variable has been passed then validate and, if OK, assign as self.defaults.variable
             variable = self._validate_variable(variable, context=context)
 

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1707,9 +1707,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         param._set(val, context)
         if hasattr(self, "parameter_ports"):
             if param in self.parameter_ports:
-                new_port_value = self.parameter_ports[param].execute(
-                    context=Context(execution_phase=ContextFlags.EXECUTING, execution_id=context.execution_id)
-                )
+                new_port_value = self.parameter_ports[param].execute(context=context)
                 self.parameter_ports[param].parameters.value._set(new_port_value, context)
         elif hasattr(self, "owner"):
             if hasattr(self.owner, "parameter_ports"):
@@ -1723,9 +1721,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                         if isinstance(val, Component):
                             return
 
-                    new_port_value = self.owner.parameter_ports[param].execute(
-                        context=Context(execution_phase=ContextFlags.EXECUTING, execution_id=context.execution_id)
-                    )
+                    new_port_value = self.owner.parameter_ports[param].execute(context=context)
                     self.owner.parameter_ports[param].parameters.value._set(new_port_value, context)
 
     def _check_args(self, variable=None, params=None, context=None, target_set=None):

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2780,9 +2780,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         function_variable = copy.deepcopy(
             self._parse_function_variable(
                 self.defaults.variable,
-                # we can't just pass context here, because this specifically tries to bypass a
-                # branch in TransferMechanism._parse_function_variable
-                context=Context(source=ContextFlags.INSTANTIATE, execution_id=context.execution_id)
+                context
             )
         )
 

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1656,8 +1656,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         except KeyError:
             pass
 
-    @handle_external_context()
-    def _deferred_init(self, context=None):
+    def _deferred_init(self, **kwargs):
         """Use in subclasses that require deferred initialization
         """
         if self.initialization_status == ContextFlags.DEFERRED_INIT:
@@ -1666,7 +1665,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             #       (usually in _instantiate_function)
             self.initialization_status = ContextFlags.INITIALIZING
 
-            self._init_args['context'] = context
+            self._init_args.update(kwargs)
 
             # Complete initialization
             # MODIFIED 10/27/18 OLD:

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1687,7 +1687,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
 
             del self._init_args
 
-    def _assign_deferred_init_name(self, name, context):
+    def _assign_deferred_init_name(self, name):
 
         name = "{} [{}]".format(name,DEFERRED_INITIALIZATION) if name \
           else "{} {}".format(DEFERRED_INITIALIZATION,self.__class__.__name__)

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -546,7 +546,7 @@ class Function_Base(Function):
                           base_class=Function_Base,
                           registry=FunctionRegistry,
                           name=name,
-                          context=context)
+                          )
         self.owner = owner
 
         super().__init__(

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -538,7 +538,7 @@ class Function_Base(Function):
         """
 
         if self.initialization_status == ContextFlags.DEFERRED_INIT:
-            self._assign_deferred_init_name(name, context)
+            self._assign_deferred_init_name(name)
             self._init_args[NAME] = name
             return
 

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -2275,7 +2275,6 @@ class ParamEstimationFunction(OptimizationFunction):
             params=params,
             owner=owner,
             prefs=prefs,
-            context=ContextFlags.CONSTRUCTOR
         )
 
     @staticmethod

--- a/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/integratorfunctions.py
@@ -651,7 +651,7 @@ class AccumulatorIntegrator(IntegratorFunction):  # ----------------------------
 
         rate = self._get_current_parameter_value(RATE, context)
         increment = self._get_current_parameter_value(INCREMENT, context)
-        noise = self._try_execute_param(self._get_current_parameter_value(NOISE, context), variable)
+        noise = self._try_execute_param(self._get_current_parameter_value(NOISE, context), variable, context=context)
 
         previous_value = np.atleast_2d(self.parameters.previous_value._get(context))
 
@@ -1185,7 +1185,7 @@ class AdaptiveIntegrator(IntegratorFunction):  # -------------------------------
         rate = np.array(self._get_current_parameter_value(RATE, context)).astype(float)
         offset = self._get_current_parameter_value(OFFSET, context)
         # execute noise if it is a function
-        noise = self._try_execute_param(self._get_current_parameter_value(NOISE, context), variable)
+        noise = self._try_execute_param(self._get_current_parameter_value(NOISE, context), variable, context=context)
 
         # # MODIFIED 6/14/19 OLD:
         # previous_value = np.atleast_2d(self.parameters.previous_value._get(context))
@@ -1681,7 +1681,7 @@ class DualAdaptiveIntegrator(IntegratorFunction):  # ---------------------------
         """
         # rate = np.array(self._get_current_parameter_value(RATE, context)).astype(float)
         # execute noise if it is a function
-        # noise = self._try_execute_param(self._get_current_parameter_value(NOISE, context), variable)
+        # noise = self._try_execute_param(self._get_current_parameter_value(NOISE, context), variable, context=context)
         short_term_rate = self._get_current_parameter_value("short_term_rate", context)
         long_term_rate = self._get_current_parameter_value("long_term_rate", context)
 
@@ -2076,7 +2076,7 @@ class InteractiveActivationIntegrator(IntegratorFunction):  # ------------------
         min_val = np.array(self._get_current_parameter_value("min_val", context)).astype(float)
 
         # execute noise if it is a function
-        noise = self._try_execute_param(self._get_current_parameter_value(NOISE, context), variable)
+        noise = self._try_execute_param(self._get_current_parameter_value(NOISE, context), variable, context=context)
 
         current_input = variable
 

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -306,7 +306,7 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
         rate = np.array(self._get_current_parameter_value(RATE, context)).astype(float)
 
         # execute noise if it is a function
-        noise = self._try_execute_param(self._get_current_parameter_value(NOISE, context), variable)
+        noise = self._try_execute_param(self._get_current_parameter_value(NOISE, context), variable, context=context)
 
         # If this is an initialization run, leave deque empty (don't want to count it as an execution step);
         # Just return current input (for validation).
@@ -1073,7 +1073,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         storage_prob = np.array(self._get_current_parameter_value(STORAGE_PROB, context)).astype(float)
 
         # execute noise if it is a function
-        noise = self._try_execute_param(self._get_current_parameter_value(NOISE, context), variable)
+        noise = self._try_execute_param(self._get_current_parameter_value(NOISE, context), variable, context=context)
 
         # get random state
         random_state = self._get_current_parameter_value('random_state', context)

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -39,7 +39,7 @@ from psyneulink.core.globals.keywords import \
     ADDITIVE_PARAM, BUFFER_FUNCTION, MEMORY_FUNCTION, COSINE, ContentAddressableMemory_FUNCTION, \
     MIN_INDICATOR, MULTIPLICATIVE_PARAM, NEWEST, NOISE, OLDEST, OVERWRITE, RATE, RANDOM
 from psyneulink.core.globals.utilities import all_within_range, convert_to_np_array, parameter_spec, get_global_seed
-from psyneulink.core.globals.context import Context, ContextFlags, handle_external_context
+from psyneulink.core.globals.context import handle_external_context
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 
@@ -715,8 +715,8 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         )
 
         if self.previous_value.size != 0:
-            self.parameters.key_size._set(len(self.previous_value[KEYS][0]), Context(execution_id=None))
-            self.parameters.val_size._set(len(self.previous_value[VALS][0]), Context(execution_id=None))
+            self.parameters.key_size.set(len(self.previous_value[KEYS][0]))
+            self.parameters.val_size.set(len(self.previous_value[VALS][0]))
 
     def _parse_distance_function_variable(self, variable):
         # actual used variable in execution (get_memory) checks distance

--- a/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
+++ b/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
@@ -390,8 +390,13 @@ class StatefulFunction(Function_Base): #  --------------------------------------
             param = np.atleast_2d(param)
             for i in range(len(param)):
                 for j in range(len(param[i])):
-                    if callable(param[i][j]):
-                        param[i][j] = param[i][j]()
+                    try:
+                        param[i][j] = param[i][j](context=context)
+                    except TypeError:
+                        try:
+                            param[i][j] = param[i][j]()
+                        except TypeError:
+                            pass
             try:
                 param = param.reshape(param_shape)
             except ValueError:
@@ -408,7 +413,11 @@ class StatefulFunction(Function_Base): #  --------------------------------------
             # for row in var:
                 new_row = []
                 for item in row:
-                    new_row.append(param())
+                    try:
+                        val = param(context=context)
+                    except TypeError:
+                        val = param()
+                    new_row.append(val)
                 new_param.append(new_row)
             param = np.asarray(new_param)
             # FIX: [JDC 12/18/18 - HACK TO DEAL WITH ENFORCEMENT OF 2D ABOVE]

--- a/psyneulink/core/components/functions/transferfunctions.py
+++ b/psyneulink/core/components/functions/transferfunctions.py
@@ -3694,7 +3694,6 @@ class TransferWithCosts(TransferFunction):
             params=params,
             owner=owner,
             prefs=prefs,
-            context=ContextFlags.CONSTRUCTOR
         )
 
         # # MODIFIED 6/12/19 NEW: [JDC]

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -1680,7 +1680,7 @@ class Mechanism_Base(Mechanism):
                           base_class=Mechanism_Base,
                           name=name,
                           registry=MechanismRegistry,
-                          context=context)
+                          )
 
         # Create Mechanism's _portRegistry and port type entries
         from psyneulink.core.components.ports.port import Port_Base
@@ -1691,21 +1691,21 @@ class Mechanism_Base(Mechanism):
         register_category(entry=InputPort,
                           base_class=Port_Base,
                           registry=self._portRegistry,
-                          context=context)
+                          )
 
         # ParameterPort
         from psyneulink.core.components.ports.parameterport import ParameterPort
         register_category(entry=ParameterPort,
                           base_class=Port_Base,
                           registry=self._portRegistry,
-                          context=context)
+                          )
 
         # OutputPort
         from psyneulink.core.components.ports.outputport import OutputPort
         register_category(entry=OutputPort,
                           base_class=Port_Base,
                           registry=self._portRegistry,
-                          context=context)
+                          )
 
         super(Mechanism_Base, self).__init__(
             default_variable=default_variable,

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -1957,7 +1957,7 @@ class Mechanism_Base(Mechanism):
         try:
             function_param_specs = params[FUNCTION_PARAMS]
         except KeyError:
-            if context.source & (ContextFlags.COMMAND_LINE | ContextFlags.PROPERTY):
+            if context.source is ContextFlags.COMMAND_LINE:
                 pass
             elif self.prefs.verbosePref:
                 print("No params specified for {0}".format(self.__class__.__name__))

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3632,7 +3632,7 @@ class Mechanism_Base(Mechanism):
                                                                   context=context)
             for port in instantiated_input_ports:
                 if port.name is port.componentName or port.componentName + '-' in port.name:
-                        port._assign_default_port_Name(context=context)
+                        port._assign_default_port_Name()
             # self._instantiate_function(function=self.function)
         if output_ports:
             instantiated_output_ports = _instantiate_output_ports(self, output_ports, context=context)

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -1432,7 +1432,7 @@ class ControlMechanism(ModulatoryMechanism_Base):
         register_category(entry=ControlSignal,
                           base_class=Port_Base,
                           registry=self._portRegistry,
-                          context=context)
+                          )
 
     def _instantiate_control_signals(self, context):
         """Subclassess can override for class-specific implementation (see OptimiziationControlMechanism for example)"""

--- a/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
@@ -487,7 +487,7 @@ class GatingMechanism(ControlMechanism):
         register_category(entry=GatingSignal,
                           base_class=Port_Base,
                           registry=self._portRegistry,
-                          context=context)
+                          )
 
     def _instantiate_control_signal_type(self, gating_signal_spec, context):
         """Instantiate actual ControlSignal, or subclass if overridden"""

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -740,7 +740,7 @@ class OptimizationControlMechanism(ControlMechanism):
         if agent_rep is None:
             if context.source==ContextFlags.COMMAND_LINE:
                 # Temporarily name InputPort
-                self._assign_deferred_init_name(self.__class__.__name__, context)
+                self._assign_deferred_init_name(self.__class__.__name__)
                 # Store args for deferred initialization
                 self._store_deferred_init_args(**locals())
 

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1300,7 +1300,8 @@ class OptimizationControlMechanism(ControlMechanism):
     # FIX: SHOULD BE GENERALIZED AS SOMETHING LIKE update_feature_values
 
     @tc.typecheck
-    def add_features(self, features):
+    @handle_external_context()
+    def add_features(self, features, context=None):
         """Add InputPorts and Projections to OptimizationControlMechanism for features used to
         predict `net_outcome <ControlMechanism.net_outcome>`
 
@@ -1309,7 +1310,7 @@ class OptimizationControlMechanism(ControlMechanism):
 
         if features:
             features = self._parse_feature_specs(features=features,
-                                                 context=Context(source=ContextFlags.COMMAND_LINE, execution_id=None))
+                                                 context=context)
         self.add_ports(InputPort, features)
 
     @tc.typecheck

--- a/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
@@ -1212,7 +1212,7 @@ class LearningMechanism(ModulatoryMechanism_Base):
         register_category(entry=LearningSignal,
                           base_class=Port_Base,
                           registry=self._portRegistry,
-                          context=context)
+                          )
 
         # Instantiate LearningSignals if they are specified, and assign to self.output_ports
         # Notes:

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1572,8 +1572,7 @@ class TransferMechanism(ProcessingMechanism_Base):
         self.parameters.value.clear_history(context)
 
     def _parse_function_variable(self, variable, context=None):
-        if context.source is ContextFlags.INSTANTIATE:
-
+        if self.is_initializing:
             return super(TransferMechanism, self)._parse_function_variable(variable=variable, context=context)
 
         # FIX: NEED TO GET THIS TO WORK WITH CALL TO METHOD:

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1304,7 +1304,7 @@ class TransferMechanism(ProcessingMechanism_Base):
                                  "function, or array/list of these.".format(noise,
                                                                             self.name))
 
-    def _try_execute_param(self, param, var):
+    def _try_execute_param(self, param, var, context=None):
 
         # param is a list; if any element is callable, execute it
         if isinstance(param, (np.ndarray, list)):
@@ -1313,7 +1313,10 @@ class TransferMechanism(ProcessingMechanism_Base):
             for i in range(len(param)):
                 for j in range(len(param[i])):
                     if callable(param[i][j]):
-                        param[i][j] = param[i][j]()
+                        try:
+                            param[i][j] = param[i][j](context=context)
+                        except TypeError:
+                            param[i][j] = param[i][j]()
 
         # param is one function
         elif callable(param):
@@ -1322,7 +1325,11 @@ class TransferMechanism(ProcessingMechanism_Base):
             for row in np.atleast_2d(var):
                 new_row = []
                 for item in row:
-                    new_row.append(param())
+                    try:
+                        val = param(context=context)
+                    except TypeError:
+                        val = param()
+                    new_row.append(val)
                 new_param.append(new_row)
             param = new_param
 
@@ -1373,8 +1380,8 @@ class TransferMechanism(ProcessingMechanism_Base):
         #                               component=self.output_ports['RESULT'])
         # register_instance(self.output_ports['RESULT'], 'RESULT-0', OutputPort, self._portRegistry, OUTPUT_PORT)
 
-    def _get_instantaneous_function_input(self, function_variable, noise):
-        noise = self._try_execute_param(noise, function_variable)
+    def _get_instantaneous_function_input(self, function_variable, noise, context=None):
+        noise = self._try_execute_param(noise, function_variable, context=context)
         if (np.array(noise) != 0).any():
             current_input = function_variable + noise
         else:
@@ -1586,7 +1593,7 @@ class TransferMechanism(ProcessingMechanism_Base):
             return value
 
         else:
-            return self._get_instantaneous_function_input(variable, noise)
+            return self._get_instantaneous_function_input(variable, noise, context)
 
     def _instantiate_attributes_after_function(self, context=None):
         """Determine numberr of items expected by termination_measure"""

--- a/psyneulink/core/components/ports/inputport.py
+++ b/psyneulink/core/components/ports/inputport.py
@@ -811,7 +811,7 @@ class InputPort(Port_Base):
         )
 
         if self.name is self.componentName or self.componentName + '-' in self.name:
-            self._assign_default_port_Name(context=context)
+            self._assign_default_port_Name()
 
     def _assign_variable_from_projection(self, variable, size, projections):
         """Assign variable to value of Projection in projections

--- a/psyneulink/core/components/ports/inputport.py
+++ b/psyneulink/core/components/ports/inputport.py
@@ -782,7 +782,7 @@ class InputPort(Port_Base):
         # if owner is None or (variable is None and reference_value is None and projections is None):
         if owner is None:
             # Temporarily name InputPort
-            self._assign_deferred_init_name(name, context)
+            self._assign_deferred_init_name(name)
             # Store args for deferred initialization
             self._store_deferred_init_args(**locals())
 

--- a/psyneulink/core/components/ports/modulatorysignals/learningsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/learningsignal.py
@@ -378,11 +378,11 @@ class LearningSignal(ModulatorySignal):
     def learning_signal(self):
         return self.value
 
-    def _assign_default_port_Name(self, context=None):
+    def _assign_default_port_Name(self):
         # Preserve LEARNING_SIGNAL as name of the first LearningSignal
         #    as documented, and as it is used by System._instantiate_learning_graph
         if self.name is self.componentName:
             return self.name
         # Otherwise, allow ModulatorySignal to construct default name as usual
         else:
-            super()._assign_default_port_Name(context=context)
+            super()._assign_default_port_Name()

--- a/psyneulink/core/components/ports/modulatorysignals/modulatorysignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/modulatorysignal.py
@@ -655,7 +655,7 @@ class ModulatorySignal(OutputPort):
             if projection:
                 projection._assign_default_projection_name(port=self)
 
-    def _assign_default_port_Name(self, context=None):
+    def _assign_default_port_Name(self):
 
         # If the name is not a default name for the class,
         #    or the ModulatorySignal has no projections (which are used to name it)

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -946,7 +946,7 @@ class OutputPort(Port_Base):
         # if owner is None or reference_value is None:
         if owner is None:
             # Temporarily name OutputPort
-            self._assign_deferred_init_name(name, context)
+            self._assign_deferred_init_name(name)
             # Store args for deferred initialization
             self._store_deferred_init_args(**locals())
 

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -1083,7 +1083,7 @@ class Port_Base(Port):
                           name=name,
                           registry=owner._portRegistry,
                           # sub_group_attr='owner',
-                          context=context)
+                          )
 
         # VALIDATE VARIABLE, PARAM_SPECS, AND INSTANTIATE self.function
         super(Port_Base, self).__init__(

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -782,7 +782,7 @@ from psyneulink.core.components.functions.combinationfunctions import Combinatio
 from psyneulink.core.components.functions.function import Function, get_param_value_for_keyword, is_function_type
 from psyneulink.core.components.functions.transferfunctions import Linear
 from psyneulink.core.components.shellclasses import Mechanism, Projection, Port
-from psyneulink.core.globals.context import Context, ContextFlags
+from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import \
     ADDITIVE, ADDITIVE_PARAM, AUTO_ASSIGN_MATRIX, \
     CONTEXT, CONTROL_PROJECTION_PARAMS, CONTROL_SIGNAL_SPECS, DEFERRED_INITIALIZATION, DISABLE, EXPONENT, \
@@ -2326,7 +2326,10 @@ class Port_Base(Port):
         return builder
 
     @staticmethod
-    def _get_port_function_value(owner, function, variable):
+    # TODO: find out why UNSET is required to avoid many more deepcopies
+    # occurring causing slowdowns
+    @handle_external_context(source=ContextFlags.UNSET)
+    def _get_port_function_value(owner, function, variable, context=None):
         """Execute the function of a Port and return its value
         # FIX: CONSIDER INTEGRATING THIS INTO _EXECUTE FOR PORT?
 
@@ -2334,7 +2337,7 @@ class Port_Base(Port):
         Used primarily during validation, when the function may not have been fully instantiated yet
         (e.g., InputPort must sometimes embed its variable in a list-- see InputPort._get_port_function_value).
         """
-        return function.execute(variable, context=Context(source=ContextFlags.UNSET, execution_id=None))
+        return function.execute(variable, context=context)
 
     @property
     def _dependent_components(self):

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -1074,7 +1074,7 @@ class Port_Base(Port):
 
         # If name is not specified, assign default name
         if name is not None and DEFERRED_INITIALIZATION in name:
-            name = self._assign_default_port_Name(context=context)
+            name = self._assign_default_port_Name()
 
 
         # Register Port with PortRegistry of owner (Mechanism to which the Port is being assigned)
@@ -2241,7 +2241,7 @@ class Port_Base(Port):
         else:
             return self.name
 
-    def _assign_default_port_Name(self, context=None):
+    def _assign_default_port_Name(self):
         return False
 
     def _get_input_struct_type(self, ctx):

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -693,7 +693,7 @@ class Projection_Base(Projection):
         from psyneulink.core.components.ports.port import Port_Base
 
         if self.initialization_status == ContextFlags.DEFERRED_INIT:
-            self._assign_deferred_init_name(name, context)
+            self._assign_deferred_init_name(name)
             self._store_deferred_init_args(**locals())
             return
 

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -704,7 +704,7 @@ class Projection_Base(Projection):
                           base_class=Projection_Base,
                           name=name,
                           registry=ProjectionRegistry,
-                          context=context)
+                          )
 
         # Create projection's _portRegistry and ParameterPort entry
         self._portRegistry = {}
@@ -712,7 +712,7 @@ class Projection_Base(Projection):
         register_category(entry=ParameterPort,
                           base_class=Port_Base,
                           registry=self._portRegistry,
-                          context=context)
+                          )
 
         self._instantiate_sender(sender, context=context)
 

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -9361,7 +9361,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         """
         # comp must be initialized from context before cycle values are initialized
-        self._initialize_from_context(context, Context(execution_id=None), override=False)
+        self._initialize_from_context(context, override=False)
 
         if not values:
             values = {}

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -5557,6 +5557,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         else:
             pathway_arg_str = f"'pathway' arg for add_linear_procesing_pathway method of {self.name}"
 
+        context.source = ContextFlags.METHOD
+        context.string = pathway_arg_str
+
         # First, deal with Pathway() or tuple specifications
         if isinstance(pathway, Pathway):
             # Give precedence to name specified in call to add_linear_processing_pathway
@@ -5585,9 +5588,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         if _is_node_spec(pathway[0]):
             # Use add_nodes so that node spec can also be a tuple with required_roles
             self.add_nodes(nodes=[pathway[0]],
-                           context=Context(source=ContextFlags.METHOD,
-                                           execution_id=context.execution_id,
-                                           string=pathway_arg_str))
+                           context=context)
             nodes.append(pathway[0])
         else:
             # 'MappingProjection has no attribute _name' error is thrown when pathway[0] is passed to the error msg
@@ -5599,9 +5600,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             # if the current item is a Mechanism, Composition or (Mechanism, NodeRole(s)) tuple, add it
             if _is_node_spec(pathway[c]):
                 self.add_nodes(nodes=[pathway[c]],
-                               context=Context(source=ContextFlags.METHOD,
-                                               execution_id=context.execution_id,
-                                               string=pathway_arg_str))
+                               context=context)
                 nodes.append(pathway[c])
 
         # Then, delete any ControlMechanism that has its monitor_for_control attribute assigned
@@ -5775,7 +5774,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         pathway = Pathway(pathway=explicit_pathway,
                           composition=self,
                           name=pathway_name,
-                          context=Context(source=ContextFlags.METHOD, execution_id=context.execution_id))
+                          context=context)
         self.pathways.append(pathway)
 
         # FIX 4/4/20 [JDC]: Reset to None for now to replicate prior behavior,
@@ -6037,7 +6036,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # Otherwise, refer to call from this method
         else:
             pathway_arg_str = f"'pathway' arg for add_linear_procesing_pathway method of {self.name}"
-        context = Context(source=ContextFlags.METHOD, string=pathway_arg_str, execution_id=context.execution_id)
+        context.source = ContextFlags.METHOD
+        context.string = pathway_arg_str
 
         # Deal with Pathway() specifications
         if isinstance(pathway, Pathway):

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6392,7 +6392,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                    f"({learning_function}) must be a class of {LearningFunction.__name__} or a "
                                    f"learning-compatible function")
 
-        learning_mechanism.output_ports[ERROR_SIGNAL].parameters.require_projection_in_composition._set(False,
+        learning_mechanism.output_ports[ERROR_SIGNAL].parameters.require_projection_in_composition.set(False,
                                                                                                          override=True)
         return target_mechanism, objective_mechanism, learning_mechanism
 

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -3423,7 +3423,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     # ******************************************************************************************************************
 
     @handle_external_context(source=ContextFlags.COMPOSITION)
-    def _analyze_graph(self, scheduler=None, context=None):
+    def _analyze_graph(self, context=None):
         """
         Assigns `NodeRoles <NodeRole>` to nodes based on the structure of the `Graph`.
 
@@ -8223,35 +8223,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         if ContextFlags.SIMULATION_MODE not in context.runmode:
             self._check_projection_initialization_status()
 
-        # MODIFIED 8/27/19 OLD:
-        # try:
-        #     if ContextFlags.SIMULATION_MODE not in context.runmode:
-        #         self._analyze_graph()
-        # except AttributeError:
-        #     # if context is None, it has not been created for this context yet, so it is not
-        #     # in a simulation
-        #     self._analyze_graph()
-        # MODIFIED 8/27/19 NEW:
-        # FIX: MODIFIED FEEDBACK -
-        #      THIS IS NEEDED HERE (AND NO LATER) TO WORK WITH test_3_mechanisms_2_origins_1_additive_control_1_terminal
-        #      HOWEVER, WOULD BE GOOD IF CONTEXT WERE SET TO EXECUTE TO FILTER DEFERRED_INIT WARNINGS
-        #      (E.G., IN _check_projection_initialization_status)
-        #      MAYBE AT LEAST CALL _analzze_graph WITH APPOPRIATE FLAG SET?
-        # If a scheduler was passed in, first call _analyze_graph with default scheduler
-        if scheduler is not self.scheduler:
             if not skip_analyze_graph:
                 self._analyze_graph(context=context)
-        # Then call _analyze graph with scheduler actually being used (passed in or default)
-        try:
-            if ContextFlags.SIMULATION_MODE not in context.runmode:
-                if not skip_analyze_graph:
-                    self._analyze_graph(scheduler=scheduler, context=context)
-        except AttributeError:
-            # if context is None, it has not been created for this context yet,
-            # so it is not in a simulation
-            if not skip_analyze_graph:
-                self._analyze_graph(scheduler=scheduler, context=context)
-        # MODIFIED 8/27/19 END
 
         self._check_for_unnecessary_feedback_projections()
 

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6911,7 +6911,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         #    so they can be added to the Composition by _create_non_terminal_backprop_learning_components
         return error_sources, error_projections
 
-    def _get_backprop_error_projections(self, learning_mech, receiver_activity_mech):
+    def _get_backprop_error_projections(self, learning_mech, receiver_activity_mech, context):
         error_sources = []
         error_projections = []
         # for error_source in learning_mech.error_sources:
@@ -6939,8 +6939,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                     error_signal_input_port = learning_mech.add_ports(
                                                         InputPort(projections=error_source.output_ports[ERROR_SIGNAL],
                                                                   name=ERROR_SIGNAL,
-                                                                  context=Context(source=ContextFlags.METHOD, execution_id=None)),
-                                                        context=Context(source=ContextFlags.METHOD, execution_id=None))
+                                                                  context=context),
+                                                        context=context)
                 # DOES THE ABOVE GENERATE A PROJECTION?  IF SO, JUST GET AND RETURN THAT;  ELSE DO THE FOLLOWING:
                 error_projections.append(MappingProjection(sender=error_source.output_ports[ERROR_SIGNAL],
                                                            receiver=error_signal_input_port))

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6635,7 +6635,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                                                                         output_source,
                                                                                         learned_projection,
                                                                                         learning_rate,
-                                                                                        learning_update)
+                                                                                        learning_update,
+                                                                                        context)
             learning_mechanisms.append(learning_mechanism)
             learned_projections.append(learned_projection)
 
@@ -6780,7 +6781,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                                           output_source,
                                                           learned_projection,
                                                           learning_rate,
-                                                          learning_update):
+                                                          learning_update,
+                                                          context):
 
         # Get existing LearningMechanism if one exists (i.e., if this is a crossing point with another pathway)
         learning_mechanism = \
@@ -6792,13 +6794,13 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         #    error_sources will be empty (as they have been dealt with in self._get_back_prop_error_sources
         #    error_projections will contain list of any created to be added to the Composition below
         if learning_mechanism:
-            error_sources, error_projections = self._get_back_prop_error_sources(output_source, learning_mechanism)
+            error_sources, error_projections = self._get_back_prop_error_sources(output_source, learning_mechanism, context)
         # If learning_mechanism does not yet exist:
         #    error_sources will contain ones needed to create learning_mechanism
         #    error_projections will be empty since they can't be created until the learning_mechanism is created below;
         #    they will be created (using error_sources) when, and determined after learning_mechanism is created below
         else:
-            error_sources, error_projections = self._get_back_prop_error_sources(output_source)
+            error_sources, error_projections = self._get_back_prop_error_sources(output_source, context=context)
             error_signal_template = [error_source.output_ports[ERROR_SIGNAL].value for error_source in error_sources]
             default_variable = [input_source.output_ports[0].value,
                                 output_source.output_ports[0].value] + error_signal_template
@@ -6844,7 +6846,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         return learning_mechanism
 
-    def _get_back_prop_error_sources(self, receiver_activity_mech, learning_mech=None):
+    def _get_back_prop_error_sources(self, receiver_activity_mech, learning_mech=None, context=None):
         # FIX CROSSED_PATHWAYS [JDC]:  GENERALIZE THIS TO HANDLE COMPARATOR/TARGET ASSIGNMENTS IN BACKPROP
         #                              AND THEN TO HANDLE ALL FORMS OF LEARNING (AS BELOW)
         #  REFACTOR TO DEAL WITH CROSSING PATHWAYS (?CREATE METHOD ON LearningMechanism TO DO THIS?):
@@ -6892,8 +6894,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                         error_signal_input_port = learning_mech.add_ports(
                             InputPort(projections=error_source.output_ports[ERROR_SIGNAL],
                                       name=ERROR_SIGNAL,
-                                      context=Context(source=ContextFlags.METHOD, execution_id=None)),
-                            context=Context(source=ContextFlags.METHOD, execution_id=None))[0]
+                                      context=context),
+                            context=context)[0]
                     # Create Projection here so that don't have to worry about determining correct
                     #    error_signal_input_port of learning_mech in _create_non_terminal_backprop_learning_components
                     try:

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -3559,7 +3559,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # Add ControlSignals to controller and ControlProjections
         #     to any parameter_ports specified for control in node's constructor
         if self.controller:
-            self._instantiate_deferred_init_control(node)
+            self._instantiate_deferred_init_control(node, context=context)
 
         try:
             if len(invalid_aux_components) > 0:
@@ -3567,7 +3567,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         except NameError:
             pass
 
-    def _instantiate_deferred_init_control(self, node):
+    def _instantiate_deferred_init_control(self, node, context=None):
         """
         If node is a Composition with a controller, activate its nodes' deferred init control specs for its controller.
         If it does not have a controller, but self does, activate them for self's controller.
@@ -3584,7 +3584,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         hanging_control_specs = []
         if node.componentCategory == 'Composition':
             for nested_node in node.nodes:
-                hanging_control_specs.extend(node._instantiate_deferred_init_control(nested_node))
+                hanging_control_specs.extend(node._instantiate_deferred_init_control(nested_node, context=context))
         else:
             hanging_control_specs = node._get_parameter_port_deferred_init_control_specs()
         if not self.controller:
@@ -3592,8 +3592,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         else:
             for spec in hanging_control_specs:
                 control_signal = self.controller._instantiate_control_signal(control_signal=spec,
-                                                                             context=Context(
-                                                                                 source=ContextFlags.COMPOSITION, execution_id=None))
+                                                                             context=context)
                 self.controller.control.append(control_signal)
                 self.controller._activate_projections_for_compositions(self)
         return []

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -3312,10 +3312,12 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         self.cycle_vertices = set()
 
+        context = Context(source=ContextFlags.CONSTRUCTOR, execution_id=None)
+
         self._initialize_parameters(
             **param_defaults,
             retain_old_simulation_data=retain_old_simulation_data,
-            context=Context(source=ContextFlags.COMPOSITION, execution_id=None)
+            context=context
         )
 
         # Compiled resources
@@ -3361,10 +3363,10 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             projections = convert_to_list(projections)
             self.add_projections(projections)
 
-        self.add_pathways(pathways, context=Context(source=ContextFlags.CONSTRUCTOR, execution_id=None))
+        self.add_pathways(pathways, context=context)
 
         # Call with context = COMPOSITION to avoid calling _check_initialization_status again
-        self._analyze_graph(context=Context(source=ContextFlags.COMPOSITION, execution_id=None))
+        self._analyze_graph(context=context)
 
         show_graph_attributes = show_graph_attributes or {}
         self._show_graph = ShowGraph(self, **show_graph_attributes)

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6642,7 +6642,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # Add error_signal projections to any learning_mechanisms that are now dependent on the new one
         for lm in learning_mechanisms:
             if lm.dependent_learning_mechanisms:
-                projections = self._add_error_projection_to_dependent_learning_mechs(lm)
+                projections = self._add_error_projection_to_dependent_learning_mechs(lm, context)
                 self.add_projections(projections)
 
         # Suppress "no efferent connections" warning for:
@@ -6953,7 +6953,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         #       and error_matrix to its self.error_matrices attribute
         #     - add new error_signal projection
 
-    def _add_error_projection_to_dependent_learning_mechs(self, error_source):
+    def _add_error_projection_to_dependent_learning_mechs(self, error_source, context=None):
         projections = []
         # Get all afferents to receiver_activity_mech in Composition that have LearningProjections
         for afferent in [p for p in error_source.input_source.path_afferents
@@ -6968,8 +6968,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 error_signal_input_port = dependent_learning_mech.add_ports(
                                                     InputPort(projections=error_source.output_ports[ERROR_SIGNAL],
                                                               name=ERROR_SIGNAL,
-                                                              context=Context(source=ContextFlags.METHOD, execution_id=None)),
-                                                    context=Context(source=ContextFlags.METHOD, execution_id=None))
+                                                              context=context),
+                                                    context=context)
                 projections.append(error_signal_input_port[0].path_afferents[0])
                 # projections.append(MappingProjection(sender=error_source.output_ports[ERROR_SIGNAL],
                 #                                      receiver=error_signal_input_port[0]))

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -5547,11 +5547,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         nodes = []
 
-        # If called from add_pathways(), use its pathway_arg_str in error messages (in context.string)
-        if context.source == ContextFlags.METHOD:
-            pathway_arg_str = context.string
-        # If call from _create_backpropagation_learning_pathway, use its pathway_arg_str
-        elif context.source == ContextFlags.INITIALIZING:
+        # If called internally, use its pathway_arg_str in error messages (in context.string)
+        if context.source is not ContextFlags.COMMAND_LINE:
             pathway_arg_str = context.string
         # Otherwise, refer to call from this method
         else:
@@ -6512,10 +6509,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # Add pathway to graph and get its full specification (includes all ProcessingMechanisms and MappingProjections)
         # Pass ContextFlags.INITIALIZING so that it can be passed on to _analyze_graph() and then
         #    _check_for_projection_assignments() in order to ignore checks for require_projection_in_composition
-        pathway_arg_str = f"'pathway' arg for add_backpropagation_learning_pathway method of {self.name}"
-        learning_pathway = self.add_linear_processing_pathway(pathway, name, Context(source=ContextFlags.INITIALIZING,
-                                                                                     execution_id=context.execution_id,
-                                                                                     string=pathway_arg_str))
+        context.string = f"'pathway' arg for add_backpropagation_learning_pathway method of {self.name}"
+        learning_pathway = self.add_linear_processing_pathway(pathway, name, context)
         processing_pathway = learning_pathway.pathway
 
         path_length = len(processing_pathway)
@@ -6622,7 +6617,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             self._terminal_backprop_sequences[output_source] = {LEARNING_MECHANISM: learning_mechanism,
                                                                 TARGET_MECHANISM: target,
                                                                 OBJECTIVE_MECHANISM: comparator}
-            self._add_required_node_role(processing_pathway[-1], NodeRole.OUTPUT, Context(source=ContextFlags.METHOD, execution_id=context.execution_id))
+            self._add_required_node_role(processing_pathway[-1], NodeRole.OUTPUT, context)
 
             sequence_end = path_length - 3
 

--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -164,15 +164,13 @@ class ContextFlags(enum.IntFlag):
     """Call from Component's constructor method."""
     METHOD = enum.auto()
     """Call by method of the Component other than its constructor."""
-    PROPERTY = enum.auto()
-    """Call by property of the Component."""
     COMPOSITION = enum.auto()
     """Call by a/the Composition to which the Component belongs."""
 
     NONE = enum.auto()
 
     """Call by a/the Composition to which the Component belongs."""
-    SOURCE_MASK = COMMAND_LINE | CONSTRUCTOR | METHOD | PROPERTY | COMPOSITION | NONE
+    SOURCE_MASK = COMMAND_LINE | CONSTRUCTOR | METHOD | COMPOSITION | NONE
 
     # runmode flags:
     DEFAULT_MODE = enum.auto()
@@ -254,7 +252,6 @@ EXECUTION_PHASE_FLAGS = {ContextFlags.PREPARING,
 SOURCE_FLAGS = {ContextFlags.COMMAND_LINE,
                 ContextFlags.CONSTRUCTOR,
                 ContextFlags.METHOD,
-                ContextFlags.PROPERTY,
                 ContextFlags.COMPOSITION,
                 ContextFlags.NONE}
 

--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -162,8 +162,6 @@ class ContextFlags(enum.IntFlag):
     """Direct call by user (either interactively from the command line, or in a script)."""
     CONSTRUCTOR = enum.auto()
     """Call from Component's constructor method."""
-    INSTANTIATE = enum.auto()
-    """Call by an instantiation method."""
     COMPONENT = enum.auto()
     """Call by Component __init__."""
     METHOD = enum.auto()
@@ -176,7 +174,7 @@ class ContextFlags(enum.IntFlag):
     NONE = enum.auto()
 
     """Call by a/the Composition to which the Component belongs."""
-    SOURCE_MASK = COMMAND_LINE | CONSTRUCTOR | INSTANTIATE | COMPONENT | METHOD | PROPERTY | COMPOSITION | NONE
+    SOURCE_MASK = COMMAND_LINE | CONSTRUCTOR | COMPONENT | METHOD | PROPERTY | COMPOSITION | NONE
 
     # runmode flags:
     DEFAULT_MODE = enum.auto()
@@ -257,7 +255,6 @@ EXECUTION_PHASE_FLAGS = {ContextFlags.PREPARING,
 
 SOURCE_FLAGS = {ContextFlags.COMMAND_LINE,
                 ContextFlags.CONSTRUCTOR,
-                ContextFlags.INSTANTIATE,
                 ContextFlags.COMPONENT,
                 ContextFlags.METHOD,
                 ContextFlags.PROPERTY,

--- a/psyneulink/core/globals/context.py
+++ b/psyneulink/core/globals/context.py
@@ -162,8 +162,6 @@ class ContextFlags(enum.IntFlag):
     """Direct call by user (either interactively from the command line, or in a script)."""
     CONSTRUCTOR = enum.auto()
     """Call from Component's constructor method."""
-    COMPONENT = enum.auto()
-    """Call by Component __init__."""
     METHOD = enum.auto()
     """Call by method of the Component other than its constructor."""
     PROPERTY = enum.auto()
@@ -174,7 +172,7 @@ class ContextFlags(enum.IntFlag):
     NONE = enum.auto()
 
     """Call by a/the Composition to which the Component belongs."""
-    SOURCE_MASK = COMMAND_LINE | CONSTRUCTOR | COMPONENT | METHOD | PROPERTY | COMPOSITION | NONE
+    SOURCE_MASK = COMMAND_LINE | CONSTRUCTOR | METHOD | PROPERTY | COMPOSITION | NONE
 
     # runmode flags:
     DEFAULT_MODE = enum.auto()
@@ -255,7 +253,6 @@ EXECUTION_PHASE_FLAGS = {ContextFlags.PREPARING,
 
 SOURCE_FLAGS = {ContextFlags.COMMAND_LINE,
                 ContextFlags.CONSTRUCTOR,
-                ContextFlags.COMPONENT,
                 ContextFlags.METHOD,
                 ContextFlags.PROPERTY,
                 ContextFlags.COMPOSITION,
@@ -309,7 +306,6 @@ class Context():
 
             * `CONSTRUCTOR <ContextFlags.CONSTRUCTOR>`
             * `COMMAND_LINE <ContextFlags.COMMAND_LINE>`
-            * `COMPONENT <ContextFlags.COMPONENT>`
             * `COMPOSITION <ContextFlags.COMPOSITION>`
 
     composition : Composition
@@ -341,7 +337,6 @@ class Context():
                  composition=None,
                  flags=None,
                  execution_phase=ContextFlags.IDLE,
-                 # source=ContextFlags.COMPONENT,
                  source=ContextFlags.NONE,
                  runmode=ContextFlags.DEFAULT_MODE,
                  execution_id=NotImplemented,
@@ -361,7 +356,7 @@ class Context():
                                    "of Context for {}".
                                    format(ContextFlags._get_context_string(flags & ContextFlags.EXECUTION_PHASE_MASK),
                                           ContextFlags._get_context_string(flags, EXECUTION_PHASE), self.owner.name))
-            if (source != ContextFlags.COMPONENT) and not (flags & ContextFlags.SOURCE_MASK & source):
+            if not (flags & ContextFlags.SOURCE_MASK & source):
                 raise ContextError("Conflict in assignment to flags ({}) and source ({}) arguments of Context for {}".
                                    format(ContextFlags._get_context_string(flags & ContextFlags.SOURCE_MASK),
                                           ContextFlags._get_context_string(flags, SOURCE),

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -1240,7 +1240,7 @@ class Parameter(ParameterBase):
 
         return self._set(self._parse(value), context, skip_history, skip_log, **kwargs)
 
-    def _set(self, value, context=None, skip_history=False, skip_log=False, **kwargs):
+    def _set(self, value, context, skip_history=False, skip_log=False, **kwargs):
         if not self.stateful:
             execution_id = None
         else:

--- a/psyneulink/core/globals/preferences/preferenceset.py
+++ b/psyneulink/core/globals/preferences/preferenceset.py
@@ -241,7 +241,7 @@ class PreferenceSet(object):
                           base_class=PreferenceSet,
                           name=name,
                           registry=PreferenceSetRegistry,
-                          context=context)
+                          )
 
         # ASSIGN PREFS
         condition = 0

--- a/psyneulink/core/globals/registry.py
+++ b/psyneulink/core/globals/registry.py
@@ -63,7 +63,7 @@ def register_category(entry,
                       base_class,
                       name=None,
                       registry=None,
-                      context='Registry'):
+                      ):
     """Create a category within the specified registry.
 
     Arguments

--- a/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
@@ -151,7 +151,6 @@ from psyneulink.core.components.shellclasses import Mechanism
 from psyneulink.core.components.ports.inputport import InputPort
 from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.components.ports.port import _parse_port_spec
-from psyneulink.core.globals.context import Context
 from psyneulink.core.globals.keywords import \
     COMPARATOR_MECHANISM, FUNCTION, INPUT_PORTS, NAME, OUTCOME, SAMPLE, TARGET, VARIABLE, PREFERENCE_SET_NAME, MSE, SSE
 from psyneulink.core.globals.parameters import Parameter
@@ -363,7 +362,7 @@ class ComparatorMechanism(ObjectiveMechanism):
                          )
 
         # Require Projection to TARGET InputPort (already required for SAMPLE as primary InputPort)
-        self.input_ports[1].parameters.require_projection_in_composition._set(True, Context(execution_id=None))
+        self.input_ports[1].parameters.require_projection_in_composition.set(True, override=True)
 
     def _validate_params(self, request_set, target_set=None, context=None):
         """If sample and target values are specified, validate that they are compatible

--- a/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
@@ -402,7 +402,7 @@ class KohonenMechanism(TransferMechanism):
         self.learning_mechanism = self._instantiate_learning_mechanism(learning_function=self.learning_function,
                                                                        learning_rate=self.learning_rate,
                                                                        learned_projection=self.learned_projection,
-                                                                       context=context)
+                                                                       )
 
         self.learning_projection = self.learning_mechanism.output_ports[LEARNING_SIGNAL].efferents[0]
 
@@ -414,7 +414,7 @@ class KohonenMechanism(TransferMechanism):
                                         learning_function,
                                         learning_rate,
                                         learned_projection,
-                                        context=None):
+                                        ):
 
         learning_mechanism = KohonenLearningMechanism(default_variable=[self.learned_projection.sender.value,
                                                                         self.learned_projection.receiver.value],

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1110,7 +1110,7 @@ class RecurrentTransferMechanism(TransferMechanism):
                                         learning_rate,
                                         learning_condition,
                                         matrix,
-                                        context=None):
+                                        ):
 
         learning_mechanism = AutoAssociativeLearningMechanism(default_variable=copy.deepcopy([activity_vector.defaults.value]),
                                                               # learning_signals=[self.recurrent_projection],
@@ -1202,7 +1202,7 @@ class RecurrentTransferMechanism(TransferMechanism):
                                                                        learning_rate=learning_rate,
                                                                        learning_condition=learning_condition,
                                                                        matrix=self.recurrent_projection,
-                                                                       context=context)
+                                                                       )
 
         self.learning_projection = self.learning_mechanism.output_ports[LEARNING_SIGNAL].efferents[0]
         if self.learning_mechanism is None:

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -194,7 +194,7 @@ class TestTransferMechanismNoise:
         )
         T.reset_stateful_function_when = Never()
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.01034782, 0.90104733, 0.95869664, -0.81762271]])
+        assert np.allclose(val, [[-0.6931771, 1.00018003, 2.5496904, -0.71562799]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -293,7 +293,7 @@ class TestDistributionFunctions:
         )
 
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.01034782, 0.90104733, 0.95869664, -0.81762271]])
+        assert np.allclose(val, [[-0.6931771 ,  1.00018003,  2.5496904 , -0.71562799]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -325,7 +325,7 @@ class TestDistributionFunctions:
             integrator_mode=True,
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[2.38719447, 0.7025651, 0.33105989, 1.40978493]])
+        assert np.allclose(val, [[1.53154485, 0.36141864, 0.64740347, 0.87558564]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -368,7 +368,7 @@ class TestDistributionFunctions:
             integrator_mode=True
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.90811289, 0.50468686, 0.28183784, 0.7558042]])
+        assert np.allclose(val, [[0.78379859, 0.30331273, 0.47659695, 0.58338204]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -383,7 +383,7 @@ class TestDistributionFunctions:
             integrator_mode=True
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[2.38719447, 0.7025651, 0.33105989, 1.40978493]])
+        assert np.allclose(val, [[1.53154485, 0.36141864, 0.64740347, 0.87558564]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -398,7 +398,7 @@ class TestDistributionFunctions:
             integrator_mode=True
         )
         val = T.execute([0, 0, 0, 0])
-        assert np.allclose(val, [[0.40277101, 1.0678432, 0.34512569, 1.07265769]])
+        assert np.allclose(val, [[0.39640095, 0.45094588, 2.88271841, 0.41203028]])
 
 
 class TestTransferMechanismFunctions:
@@ -1563,7 +1563,7 @@ class TestTransferMechanismMultipleInputPorts:
             default_variable=[[0.0, 0.0], [0.0, 0.0]]
         )
         val = T.execute([[1.0, 2.0], [3.0, 4.0]])
-        assert np.allclose(val, [[3.02069564, 6.80209467], [8.91739329, 7.36475458]])
+        assert np.allclose(val, [[1.6136458, 7.00036006], [12.09938081, 7.56874402]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism


### PR DESCRIPTION
- Reduce the number of individual places in which new Context objects are manually created or modified to affect execution

- Remove or condense several `ContextFlags` where similar in intent or behavior:
    - `ContextFlags.COMPONENT` -> `ContextFlags.CONSTRUCTOR`
    - `ContextFlags.PROPERTY`
    - `ContextFlags.INSTANTIATE` in favor of `is_initializing`

Compared to devel, these tests changed as a result of the following
numbers of calls to the random_state parameter of noise functions during
initialization:

| Test Name | random_state Parameter RNG method | offset |
| - | - | - |
test_transfer_mech_array_var_normal_len_1_noise | random_state.normal | -4
test_transfer_mech_normal_noise | random_state.normal | -4
test_transfer_mech_exponential_noise | random_state.random | -4
test_transfer_mech_Uniform_noise | random_state.random | -4
test_transfer_mech_Gamma_noise | random_state.random | -4
test_transfer_mech_wald_noise | random_state.wald | -4
test_transfer_mech_2d_variable_noise | random_state.normal | -4
