### PR TITLE
requirements: Bump pytorch to 1.7.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ networkx<2.6
 numpy<1.19.5
 pillow<8.1.0
 toposort<=1.5
-torch<=1.6.0; sys_platform != 'win32' and platform_machine == 'x86_64' and platform_python_implementation == 'CPython'
+torch<1.8.0; sys_platform != 'win32' and platform_machine == 'x86_64' and platform_python_implementation == 'CPython'
 typecheck-decorator<=1.2
 leabra-psyneulink<=0.3.2


### PR DESCRIPTION
Not sure why dependabot didn't pick this one up.
1.7.1 includes python3.9 wheels