### PR TITLE
travis: Restrict cache to built wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
 # This needs to be explicit, 'cache: pip' only works with 'language: python'
 cache:
   directories:
-    - $HOME/.cache/pip
+    - $HOME/.cache/pip/wheels
 
 addons:
   apt:


### PR DESCRIPTION
Prevents unbounded growth of pip's http cache.

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>