### PR TITLE
travis: Explicitly install numpy ahead of other dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,8 @@ before_install:
       export RUN_COV=""
 
       # matplotlib depends on cython
-      export EXTRA_PIP="cython"
+      # explicitly install numpy (https://github.com/pypa/pip/issues/9239)
+      export EXTRA_PIP="cython $(grep numpy requirements.txt)"
     fi
     # distutils is only needed for python3.8
     # https://bugs.launchpad.net/ubuntu/+source/python3.8/+bug/1851684


### PR DESCRIPTION
This works around a problem in handling dependencies when building Python modules.
https://github.com/pypa/pip/issues/9239
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>