### PR TITLE
Update JSON/MDF format to latest spec

### DIFF
--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -9669,12 +9669,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     def _dict_summary(self):
         super_summary = super()._dict_summary
 
-        try:
-            super_summary[self._model_spec_id_parameters][MODEL_SPEC_ID_PSYNEULINK]['scheduler'] = self.scheduler._dict_summary
-        except KeyError:
-            super_summary[self._model_spec_id_parameters][MODEL_SPEC_ID_PSYNEULINK] = {}
-            super_summary[self._model_spec_id_parameters][MODEL_SPEC_ID_PSYNEULINK]['scheduler'] = self.scheduler._dict_summary
-
         nodes_dict = {MODEL_SPEC_ID_PSYNEULINK: {}}
         projections_dict = {MODEL_SPEC_ID_PSYNEULINK: {}}
 
@@ -9733,6 +9727,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         return {
             MODEL_SPEC_ID_COMPOSITION: [{
                 **super_summary,
+                **self.scheduler._dict_summary,
                 **{
                     MODEL_SPEC_ID_NODES: nodes_dict,
                     MODEL_SPEC_ID_PROJECTIONS: projections_dict,

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -9667,17 +9667,13 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
     @property
     def _dict_summary(self):
-        scheduler_dict = {
-            str(ContextFlags.PROCESSING): self.scheduler._dict_summary
-        }
-
         super_summary = super()._dict_summary
 
         try:
-            super_summary[self._model_spec_id_parameters][MODEL_SPEC_ID_PSYNEULINK]['schedulers'] = scheduler_dict
+            super_summary[self._model_spec_id_parameters][MODEL_SPEC_ID_PSYNEULINK]['scheduler'] = self.scheduler._dict_summary
         except KeyError:
             super_summary[self._model_spec_id_parameters][MODEL_SPEC_ID_PSYNEULINK] = {}
-            super_summary[self._model_spec_id_parameters][MODEL_SPEC_ID_PSYNEULINK]['schedulers'] = scheduler_dict
+            super_summary[self._model_spec_id_parameters][MODEL_SPEC_ID_PSYNEULINK]['scheduler'] = self.scheduler._dict_summary
 
         nodes_dict = {MODEL_SPEC_ID_PSYNEULINK: {}}
         projections_dict = {MODEL_SPEC_ID_PSYNEULINK: {}}

--- a/psyneulink/core/globals/json.py
+++ b/psyneulink/core/globals/json.py
@@ -577,7 +577,7 @@ def _generate_scheduler_string(
         termination_str.insert(
             1,
             'psyneulink.{0}: {1}'.format(
-                scale,
+                f'TimeScale.{str.upper(scale)}',
                 _generate_condition_string(cond, component_identifiers)
             )
         )

--- a/psyneulink/core/globals/json.py
+++ b/psyneulink/core/globals/json.py
@@ -557,7 +557,7 @@ def _generate_scheduler_string(
     blacklist=[]
 ):
     output = []
-    for node, condition in scheduler_dict['conditions']['node'].items():
+    for node, condition in scheduler_dict['node'].items():
         if node not in blacklist:
             output.append(
                 '{0}.add_condition({1}, {2})'.format(
@@ -573,7 +573,7 @@ def _generate_scheduler_string(
     output.append('')
 
     termination_str = []
-    for scale, cond in scheduler_dict['conditions']['termination'].items():
+    for scale, cond in scheduler_dict['termination'].items():
         termination_str.insert(
             1,
             'psyneulink.{0}: {1}'.format(
@@ -904,15 +904,13 @@ def _generate_composition_string(composition_list, component_identifiers):
             )
 
         # add schedulers
-        sched_dict = composition_dict[comp_type._model_spec_id_parameters][MODEL_SPEC_ID_PSYNEULINK]['scheduler']
-
         # blacklist automatically generated nodes because they will
         # not exist in the script namespace
         output.append('')
         output.append(
             _generate_scheduler_string(
                 f'{comp_identifer}.scheduler',
-                sched_dict,
+                composition_dict['conditions'],
                 component_identifiers,
                 blacklist=implicit_names
             )

--- a/psyneulink/core/globals/json.py
+++ b/psyneulink/core/globals/json.py
@@ -557,7 +557,7 @@ def _generate_scheduler_string(
     blacklist=[]
 ):
     output = []
-    for node, condition in scheduler_dict['node'].items():
+    for node, condition in scheduler_dict['node_specific'].items():
         if node not in blacklist:
             output.append(
                 '{0}.add_condition({1}, {2})'.format(

--- a/psyneulink/core/globals/json.py
+++ b/psyneulink/core/globals/json.py
@@ -904,37 +904,19 @@ def _generate_composition_string(composition_list, component_identifiers):
             )
 
         # add schedulers
-        try:
-            schedulers = composition_dict[comp_type._model_spec_id_parameters][MODEL_SPEC_ID_PSYNEULINK]['schedulers']
+        sched_dict = composition_dict[comp_type._model_spec_id_parameters][MODEL_SPEC_ID_PSYNEULINK]['scheduler']
 
-            ContextFlags = psyneulink.core.globals.context.ContextFlags
-            scheduler_attr_mappings = {
-                str(ContextFlags.PROCESSING): 'scheduler',
-                str(ContextFlags.LEARNING): 'scheduler_learning',
-            }
-
-            for phase, sched_dict in schedulers.items():
-                try:
-                    sched_attr = scheduler_attr_mappings[phase]
-                except KeyError as e:
-                    raise PNLJSONError(
-                        f'Invalid scheduler phase in JSON: {phase}'
-                    ) from e
-
-                # blacklist automatically generated nodes because they will
-                # not exist in the script namespace
-                output.append('')
-                output.append(
-                    _generate_scheduler_string(
-                        f'{comp_identifer}.{sched_attr}',
-                        sched_dict,
-                        component_identifiers,
-                        blacklist=implicit_names
-                    )
-                )
-
-        except KeyError:
-            pass
+        # blacklist automatically generated nodes because they will
+        # not exist in the script namespace
+        output.append('')
+        output.append(
+            _generate_scheduler_string(
+                f'{comp_identifer}.scheduler',
+                sched_dict,
+                component_identifiers,
+                blacklist=implicit_names
+            )
+        )
 
     return '\n'.join(output)
 

--- a/psyneulink/core/scheduling/scheduler.py
+++ b/psyneulink/core/scheduling/scheduler.py
@@ -696,7 +696,7 @@ class Scheduler(JSONDumpable):
         return {
             'conditions': {
                 'termination': {
-                    str(k): v._dict_summary for k, v in self.termination_conds.items()
+                    str.lower(k.name): v._dict_summary for k, v in self.termination_conds.items()
                 },
                 'node': {
                     n.name: self.conditions[n]._dict_summary for n in self.nodes if n in self.conditions

--- a/psyneulink/core/scheduling/scheduler.py
+++ b/psyneulink/core/scheduling/scheduler.py
@@ -698,7 +698,7 @@ class Scheduler(JSONDumpable):
                 'termination': {
                     str.lower(k.name): v._dict_summary for k, v in self.termination_conds.items()
                 },
-                'node': {
+                'node_specific': {
                     n.name: self.conditions[n]._dict_summary for n in self.nodes if n in self.conditions
                 }
             }


### PR DESCRIPTION
- "conditions" entry moved from graph["parameters"]["schedulers"][\<execution phase>]["conditions"] to graph["conditions"]
    - Compositions now have only one scheduler, for any execution phase, so execution phase entry was obsolete. other change is for spec redefinition
- uses of TimeScale in termination conditions dict replaced with string name of the scale
- ["conditions"]["node"] renamed to ["conditions"]["node_specific"]