### PR TITLE
Add CI script checking differences in generated documentation

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -1,6 +1,14 @@
 name: PsyNeuLink CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'doc_requirements.txt'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'doc_requirements.txt'
 
 jobs:
   build:

--- a/.github/workflows/pnl-docs.yml
+++ b/.github/workflows/pnl-docs.yml
@@ -1,0 +1,107 @@
+name: PsyNeuLink Docs Compare
+
+on: pull_request
+
+jobs:
+  docs-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7]
+        os: [ubuntu-latest]
+        pnl-version: [ 'base', 'merge']
+
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout merge commit
+      uses: actions/checkout@v2
+      if: ${{ matrix.pnl-version == 'merge' }}
+      with:
+        fetch-depth: 10
+        ref: ${{ github.ref }}
+
+    - name: Checkout pull base
+      uses: actions/checkout@v2
+      if: ${{ matrix.pnl-version == 'base' }}
+      with:
+        fetch-depth: 10
+        ref: ${{ github.base_ref }}
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2.2.1
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.python-architecture }}
+
+    - name: Docs dependencies
+      run: |
+        # Install numpy first
+        python -m pip install --upgrade pip wheel $(grep numpy requirements.txt)
+        # We need to install all PNL deps since docs config imports psyneulink module
+        pip install -e .[doc]
+
+    - name: Add git tag
+      # The generated docs include PNL version,
+      # set it to a fixed value to prevent polluting the diff
+      run: git tag 'v999.999.999.999'
+
+    - name: Build docs
+      run: sphinx-build -b html -aE docs/source pnl-html
+
+    - name: Upload generated docs
+      uses: actions/upload-artifact@v2
+      with:
+        name: docs-${{ matrix.pnl-version }}-${{ matrix.os }}-${{ matrix.python-version }}
+        path: pnl-html
+        retention-days: 1
+
+  docs-compare:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7]
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+    needs: [docs-build]
+
+    steps:
+
+    - name: Download generated base docs
+      uses: actions/download-artifact@v2
+      with:
+        name: docs-base-${{ matrix.os }}-${{ matrix.python-version }}
+        path: docs-base
+
+    - name: Download generated merge docs
+      uses: actions/download-artifact@v2
+      with:
+        name: docs-merge-${{ matrix.os }}-${{ matrix.python-version }}
+        path: docs-merge
+
+    - name: Compare
+      shell: bash
+      run: |
+        # Store the resulting diff, or 'No differences!' to and output file
+        # The 'or true' part is needed to workaourd 'pipefail' flag used by github-actions
+        (diff -r docs-base docs-merge && echo 'No differences!' || true) | tee result.diff
+
+    - name: Post comment
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          var fs = require("fs");
+          var text = fs.readFileSync("./result.diff").slice(0,16384);
+
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'This PR causes the following changes to the html docs (${{ matrix.os }}, python-${{ matrix.python-version }}):\n```\n' + text + '\n...\n```\nSee CI logs for the full diff.'
+          })


### PR DESCRIPTION
Don't run full CI on documentation only changes.
Adds script that generates 'before' and 'after' html documentation and posts diff as a comment.
Comment posting works only on PRs within one repo (should cover  dependabot requests)