### PR TITLE
Add CI jobs to build documentation

### DIFF
--- a/.github/actions/cleanup-pip-cache/action.yml
+++ b/.github/actions/cleanup-pip-cache/action.yml
@@ -1,0 +1,18 @@
+name: 'Cleanup pip wheels cache'
+description: 'Purge pip wheels cache, keeping wheels for the installed pacakges'
+
+runs:
+  using: "composite"
+  steps:
+   - name: "Cleanup old wheels"
+     shell: bash
+     run: |
+        pip cache info
+        INSTALLED=`pip list | sed 's/-/_/g' | sed 's/  */-/' | tail -n+3`
+        CACHED=`pip cache list | cut -f 2,3 -d- | tail -n+3`
+        for P in $CACHED; do
+          # Remove cached and not installed
+          if [ `echo $INSTALLED | grep -o $P | wc -l` == "0" ] ; then
+            pip cache remove -v $P
+          fi
+        done

--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -1,0 +1,78 @@
+name: PsyNeuLink Docs CI
+
+on: push
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7] # Doesn't work in 3.8 or 3.9
+        python-architecture: ['x64']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 10
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2.2.1
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: ${{ matrix.python-architecture }}
+
+    - name: Get pip cache location
+      shell: bash
+      id: pip_cache
+      run: |
+        python -m pip install -U pip
+        python -m pip --version
+        echo ::set-output name=pip_cache_dir::$(python -m pip cache dir)
+
+    - name: Wheels cache
+      uses: actions/cache@v2.1.3
+      with:
+        path: ${{ steps.pip_cache.outputs.pip_cache_dir }}/wheels
+        key: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-v2-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-v2
+
+    - name: MacOS dependencies
+      run: HOMEBREW_NO_AUTO_UPDATE=1 brew install graphviz
+      if: startsWith(runner.os, 'macOS')
+
+    - name: Linux dependencies
+      run: sudo apt-get install -y graphviz
+      if: startsWith(runner.os, 'Linux')
+
+    - name: Windows dependencies
+      run: choco install --no-progress -y graphviz --version=2.38.0.20190211
+      if: startsWith(runner.os, 'Windows')
+
+    - name: Shared dependencies
+      shell: bash
+      run: |
+        # explicitly install numpy (https://github.com/pypa/pip/issues/9239)
+        python -m pip install --upgrade pip wheel $(grep numpy requirements.txt)
+        pip install -e .[doc]
+
+    - name: Windows pytorch
+      shell: bash
+      run: |
+        pip install $(grep -o 'torch[0-9<=\.]*' requirements.txt) -f https://download.pytorch.org/whl/cpu/torch_stable.html
+      if: startsWith(runner.os, 'Windows') && matrix.python-architecture != 'x86'
+
+    - name: Cleanup old wheels
+      uses: ./.github/actions/cleanup-pip-cache
+
+    - name: Build Documentation
+      run: sphinx-build -b html -aE docs/source pnl-html
+
+    - name: Upload Documentation
+      uses: actions/upload-artifact@v2.2.2
+      with:
+        name: Documentation-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}
+        retention-days: 1
+        path: pnl-html

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -26,39 +26,31 @@ jobs:
             os: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout sources
+      uses: actions/checkout@v2
       with:
         fetch-depth: 10
-
-    - name: Linux wheels cache
-      uses: actions/cache@v2.1.3
-      if: startsWith(runner.os, 'Linux')
-      with:
-        path: ~/.cache/pip/wheels
-        key: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-v2-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-v2
-
-    - name: MacOS wheels cache
-      uses: actions/cache@v2.1.3
-      if: startsWith(runner.os, 'macOS')
-      with:
-        path: ~/Library/Caches/pip/wheels
-        key: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-v2-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-v2
-
-    - name: Windows wheels cache
-      uses: actions/cache@v2.1.3
-      if: startsWith(runner.os, 'Windows')
-      with:
-        path: ~\AppData\Local\pip\Cache\wheels
-        key: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-v2-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-v2
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2.2.1
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
+
+    - name: Get pip cache location
+      shell: bash
+      id: pip_cache
+      run: |
+        python -m pip install -U pip
+        python -m pip --version
+        echo ::set-output name=pip_cache_dir::$(python -m pip cache dir)
+
+    - name: Wheels cache
+      uses: actions/cache@v2.1.3
+      with:
+        path: ${{ steps.pip_cache.outputs.pip_cache_dir }}/wheels
+        key: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-v2-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-v2
 
     - name: MacOS dependencies
       run: HOMEBREW_NO_AUTO_UPDATE=1 brew install graphviz

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -78,17 +78,7 @@ jobs:
       if: startsWith(runner.os, 'Windows') && matrix.python-architecture != 'x86'
 
     - name: Cleanup old wheels
-      shell: bash
-      run: |
-        pip cache info
-        INSTALLED=`pip list | sed 's/-/_/g' | sed 's/  */-/' | tail -n+3`
-        CACHED=`pip cache list | cut -f 2,3 -d- | tail -n+3`
-        for P in $CACHED; do
-          # Remove cached and not installed
-          if [ `echo $INSTALLED | grep -o $P | wc -l` == "0" ] ; then
-            pip cache remove -v $P
-          fi
-        done
+      uses: ./.github/actions/cleanup-pip-cache
 
     - name: Lint with flake8
       shell: bash


### PR DESCRIPTION
Doesn't work on python 3.8/3.9 see #1870 .
There's a lot of duplicated code, but unfortunately, GitHub actions do not allow for easy templates/sharing