### PR TITLE
Consolidate and generalize noise value generation

### DIFF
--- a/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
+++ b/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
@@ -30,7 +30,7 @@ from psyneulink.core.components.functions.function import Function_Base, Functio
 from psyneulink.core.components.functions.distributionfunctions import DistributionFunction
 from psyneulink.core.globals.keywords import STATEFUL_FUNCTION_TYPE, STATEFUL_FUNCTION, NOISE, RATE
 from psyneulink.core.globals.parameters import Parameter
-from psyneulink.core.globals.utilities import parameter_spec, iscompatible, object_has_single_value, convert_to_np_array, contains_type
+from psyneulink.core.globals.utilities import parameter_spec, iscompatible, convert_to_np_array, contains_type
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
 

--- a/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
+++ b/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
@@ -387,58 +387,6 @@ class StatefulFunction(Function_Base): #  --------------------------------------
                         raise FunctionError("The elements of a noise list or array must be scalars or functions. "
                                             "{} is not a valid noise element for {}".format(noise[i], self.name))
 
-    def _try_execute_param(self, param, var, context=None):
-
-        # FIX: [JDC 12/18/18 - HACK TO DEAL WITH ENFORCEMENT OF 2D BELOW]
-        param_shape = np.array(param).shape
-        if not len(param_shape):
-            param_shape = np.array(var).shape
-        # param is a list; if any element is callable, execute it
-        if isinstance(param, (np.ndarray, list)):
-            # NOTE: np.atleast_2d will cause problems if the param has "rows" of different lengths
-            # FIX: WHY FORCE 2d??
-            param = np.atleast_2d(param)
-            for i in range(len(param)):
-                for j in range(len(param[i])):
-                    try:
-                        param[i][j] = param[i][j](context=context)
-                    except TypeError:
-                        try:
-                            param[i][j] = param[i][j]()
-                        except TypeError:
-                            pass
-            try:
-                param = param.reshape(param_shape)
-            except ValueError:
-                if object_has_single_value(param):
-                    param = np.full(param_shape, float(param))
-
-        # param is one function
-        elif callable(param):
-            # NOTE: np.atleast_2d will cause problems if the param has "rows" of different lengths
-            new_param = []
-            # FIX: WHY FORCE 2d??
-            for row in np.atleast_2d(var):
-            # for row in np.atleast_1d(var):
-            # for row in var:
-                new_row = []
-                for item in row:
-                    try:
-                        val = param(context=context)
-                    except TypeError:
-                        val = param()
-                    new_row.append(val)
-                new_param.append(new_row)
-            param = np.asarray(new_param)
-            # FIX: [JDC 12/18/18 - HACK TO DEAL WITH ENFORCEMENT OF 2D ABOVE]
-            try:
-                if len(np.squeeze(param)):
-                    param = param.reshape(param_shape)
-            except TypeError:
-                pass
-
-        return param
-
     def _instantiate_attributes_before_function(self, function=None, context=None):
         if not self.parameters.initializer._user_specified:
             self._initialize_previous_value(np.zeros_like(self.defaults.variable), context)

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -640,7 +640,7 @@ from psyneulink.core.globals.parameters import Parameter, FunctionParameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import \
-    all_within_range, append_type_to_name, iscompatible, is_comparison_operator, convert_to_np_array
+    all_within_range, append_type_to_name, iscompatible, is_comparison_operator, convert_to_np_array, safe_equals
 from psyneulink.core.scheduling.condition import TimeScale
 from psyneulink.core.globals.registry import remove_instance_from_registry, register_instance
 
@@ -1351,7 +1351,7 @@ class TransferMechanism(ProcessingMechanism_Base):
 
     def _get_instantaneous_function_input(self, function_variable, noise, context=None):
         noise = self._try_execute_param(noise, function_variable, context=context)
-        if (np.array(noise) != 0).any():
+        if noise is not None and not safe_equals(noise, 0):
             current_input = function_variable + noise
         else:
             current_input = function_variable

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1304,37 +1304,6 @@ class TransferMechanism(ProcessingMechanism_Base):
                                  "function, or array/list of these.".format(noise,
                                                                             self.name))
 
-    def _try_execute_param(self, param, var, context=None):
-
-        # param is a list; if any element is callable, execute it
-        if isinstance(param, (np.ndarray, list)):
-            # NOTE: np.atleast_2d will cause problems if the param has "rows" of different lengths
-            param = np.atleast_2d(param)
-            for i in range(len(param)):
-                for j in range(len(param[i])):
-                    if callable(param[i][j]):
-                        try:
-                            param[i][j] = param[i][j](context=context)
-                        except TypeError:
-                            param[i][j] = param[i][j]()
-
-        # param is one function
-        elif callable(param):
-            # NOTE: np.atleast_2d will cause problems if the param has "rows" of different lengths
-            new_param = []
-            for row in np.atleast_2d(var):
-                new_row = []
-                for item in row:
-                    try:
-                        val = param(context=context)
-                    except TypeError:
-                        val = param()
-                    new_row.append(val)
-                new_param.append(new_row)
-            param = new_param
-
-        return param
-
     def _instantiate_parameter_ports(self, function=None, context=None):
 
         # If function is a logistic, and clip has not been specified, bound it between 0 and 1

--- a/tests/functions/test_accumulator_integrator.py
+++ b/tests/functions/test_accumulator_integrator.py
@@ -160,7 +160,7 @@ class TestAccumulator():
         A()
         A()
         val = A()
-        expected_val = [[40.0, 0.2480800486427607, 80.0]]
+        expected_val = [[40.0, -0.43300219, 80.0]]
         for i in range(len(val)):
             for j in range(len(val[i])):
                 assert np.allclose(expected_val[i][j], val[i][j])

--- a/tests/functions/test_buffer.py
+++ b/tests/functions/test_buffer.py
@@ -154,6 +154,7 @@ class TestBuffer():
                                                 history=3))
         val = P.execute(1.0)
 
+        # NOTE: actual output is [0, [[1]]]
         assert np.allclose(np.asfarray(val), [[0., 1.]])
         if benchmark.enabled:
             benchmark(P.execute, 5.0)

--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -1055,6 +1055,48 @@ class TestIntegratorNoise:
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism
+    def test_integrator_simple_noise_fn_noise_list(self):
+        I = IntegratorMechanism(
+            name='IntegratorMechanism',
+            function=SimpleIntegrator(
+                noise=[NormalDist()]
+            ),
+        )
+        val = float(I.execute(10))
+
+        np.testing.assert_allclose(val, 10.302846)
+
+    @pytest.mark.mechanism
+    @pytest.mark.integrator_mechanism
+    def test_integrator_simple_noise_fn_noise_list_squeezed(self):
+        I = IntegratorMechanism(
+            name='IntegratorMechanism',
+            function=SimpleIntegrator(
+                default_variable=[[0, 0, 0]],
+                noise=[NormalDist(seed=0), NormalDist(seed=0), NormalDist(seed=0)], # seed to check elementwise
+            ),
+        )
+        val = I.execute([10, 10, 10])
+
+        np.testing.assert_allclose(val, [[10.302846, 10.302846, 10.302846]])
+
+    @pytest.mark.mechanism
+    @pytest.mark.integrator_mechanism
+    def test_integrator_simple_noise_fn_noise_shaped(self):
+        I = IntegratorMechanism(
+            variable=[[0], [0], [0]],
+            name='IntegratorMechanism',
+            function=SimpleIntegrator(
+                default_variable=[[0], [0], [0]],
+                noise=NormalDist([[0], [0], [0]]),
+            ),
+        )
+        val = I.execute([[10], [10], [10]])
+
+        np.testing.assert_allclose(val, [[10.660535], [11.108879], [ 9.084011]])
+
+    @pytest.mark.mechanism
+    @pytest.mark.integrator_mechanism
     def test_integrator_simple_noise_fn_var_list(self):
         I = IntegratorMechanism(
             name='IntegratorMechanism',

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -210,7 +210,7 @@ class TestTransferMechanismNoise:
         )
         T.reset_stateful_function_when = Never()
         val = T.execute([0, 0, 0, 0])
-        expected = [0.6202001216069017, 0.840166034615641, 0.7279826246296707, -1.5678942459349325]
+        expected = [[-1.56404341, -3.01320403, -1.22503678, 1.3093712]]
         assert np.allclose(np.asfarray(val[0]), expected)
 
     @pytest.mark.mechanism


### PR DESCRIPTION
`_try_execute_param`, which generates noise values from functions, is moved to Component and now supports variables of any length or dimension. Noise may be specified with the same flexibility and is applied elementwise, as in the `i`th element of noise will be executed (if a function) and applied to the `i`th element of variable, including any deeper dimension. For example, with a noise specification of `[pnl.NormalDist(), pnl.UniformDist()]` and a variable of `[[a, b], [c]]`, normal noise will be individually applied to elements `a` and `b` and uniform noise to `c`. 

There are two convenience exceptions:

1. if the variable shape is the same as the noise shape except with extra wrapping dimensions, the noise will be applied to the deepest dimension of variable (e.g. variable `[[[[a, b]]]]` and noise `[pnl.NormalDist(), pnl.UniformDist()]`, normal will apply to `a` and uniform to `b`. 
2. if noise is specified as a single psyneulink Function whose output/value shape matches variable, that noise function will be executed once and its value will be applied elementwise to variable


The following test expected values were changed because repeated executions of the tested mechanism incorrectly used the same numeric noise values as the first execution, which is now fixed:
    
- `test_accumulator_standalone_noise_function_in_array`
- `test_transfer_mech_array_var_normal_array_noise`