### PR TITLE
Fix dot-notation bypass of read-only parameter warning, parsing

### DIFF
--- a/Scripts/Examples/LC Control Mechanism Composition.py
+++ b/Scripts/Examples/LC Control Mechanism Composition.py
@@ -7,7 +7,7 @@ user_specified_gain = 1.0
 
 A = TransferMechanism(function=Logistic(gain=user_specified_gain), name='A')
 B = TransferMechanism(function=Logistic(gain=user_specified_gain), name='B')
-# B.output_ports[0].value *= 0.0  # Reset after init | Doesn't matter here b/c default var = zero, no intercept
+# B.output_ports[0].parameters.value.set(0.0, override=True)  # Reset after init | Doesn't matter here b/c default var = zero, no intercept
 
 LC = LCControlMechanism(
     modulated_mechanisms=[A, B],

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -650,7 +650,14 @@ def make_parameter_property(param):
                 f' for example, <object>.{param.name}.base = {value}',
                 FutureWarning,
             )
-        getattr(self.parameters, p.name).set(value, self.most_recent_context)
+        try:
+            getattr(self.parameters, p.name).set(value, self.most_recent_context)
+        except ParameterError as e:
+            if 'Pass override=True to force set.' in str(e):
+                raise ParameterError(
+                    f"Parameter '{p.name}' is read-only. Set at your own risk."
+                    f' Use .parameters.{p.name}.set with override=True to force set.'
+                ) from None
 
     return property(getter).setter(setter)
 

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2704,7 +2704,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
 
         return value
 
-    def _validate_function(self, function):
+    def _validate_function(self, function, context=None):
         """Check that either params[FUNCTION] and/or self.execute are implemented
 
         # FROM _validate_params:
@@ -2752,7 +2752,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             or isinstance(function, types.MethodType)
             or is_instance_or_subclass(function, Function)
         ):
-            self.function = function
+            self.parameters.function._set(function, context)
             return
         # self.function is NOT OK, so raise exception
         else:
@@ -2813,7 +2813,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         # Specification is a standard python function, so wrap as a UserDefnedFunction
         # Note:  parameter_ports for function's parameters will be created in_instantiate_attributes_after_function
         if isinstance(function, types.FunctionType):
-            self.function = UserDefinedFunction(default_variable=function_variable,
+            function = UserDefinedFunction(default_variable=function_variable,
                                                 custom_function=function,
                                                 owner=self,
                                                 context=context)
@@ -2840,9 +2840,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             # class default functions should always be copied, otherwise anything this component
             # does with its function will propagate to anything else that wants to use
             # the default
-            if function.owner is None:
-                self.function = function
-            elif function.owner is self:
+            if function.owner is self:
                 try:
                     if function._is_pnl_inherent:
                         # This will most often occur if a Function instance is
@@ -2860,15 +2858,15 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                             ' psyneulinkhelp@princeton.edu or'
                             ' https://github.com/PrincetonUniversity/PsyNeuLink/issues'
                         )
-                        self.function = copy.deepcopy(function)
+                        function = copy.deepcopy(function)
                 except AttributeError:
-                    self.function = function
-            else:
-                self.function = copy.deepcopy(function)
+                    pass
+            elif function.owner is not None:
+                function = copy.deepcopy(function)
 
             # set owner first because needed for is_initializing calls
-            self.function.owner = self
-            self.function._update_default_variable(function_variable, context)
+            function.owner = self
+            function._update_default_variable(function_variable, context)
 
         # Specification is Function class
         # Note:  parameter_ports for function's parameters will be created in_instantiate_attributes_after_function
@@ -2899,10 +2897,12 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                         pass
 
             _, kwargs = prune_unused_args(function.__init__, args=[], kwargs=kwargs_to_instantiate)
-            self.function = function(default_variable=function_variable, owner=self, **kwargs)
+            function = function(default_variable=function_variable, owner=self, **kwargs)
 
         else:
             raise ComponentError(f'Unsupported function type: {type(function)}, function={function}.')
+
+        self.parameters.function._set(function, context)
 
         # KAM added 6/14/18 for functions that do not pass their has_initializers status up to their owner via property
         # FIX: need comprehensive solution for has_initializers; need to determine whether ports affect mechanism's

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -3840,4 +3840,4 @@ class ParameterValue:
 
     @base.setter
     def base(self, value):
-        self._parameter._set(value, self._owner.most_recent_context)
+        self._parameter.set(value, self._owner.most_recent_context)

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2040,8 +2040,9 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 if isinstance(val, Function):
                     val.owner = self
 
+                val = p._parse(val)
                 p._validate(val)
-                p.set(val, context=context, skip_history=True, override=True)
+                p._set(val, context=context, skip_history=True, override=True)
 
             if isinstance(p.default_value, Function):
                 p.default_value.owner = p

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -650,7 +650,7 @@ def make_parameter_property(param):
                 f' for example, <object>.{param.name}.base = {value}',
                 FutureWarning,
             )
-        getattr(self.parameters, p.name)._set(value, self.most_recent_context)
+        getattr(self.parameters, p.name).set(value, self.most_recent_context)
 
     return property(getter).setter(setter)
 

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2141,7 +2141,7 @@ class Mechanism_Base(Mechanism):
         with warnings.catch_warnings():
             warnings.simplefilter(action='ignore', category=UserWarning)
             self.function.output_type = FunctionOutputType.NP_2D_ARRAY
-            self.function.enable_output_type_conversion = True
+            self.function.parameters.enable_output_type_conversion._set(True, context)
 
         self.function._instantiate_value(context)
 

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -1483,7 +1483,7 @@ class ControlMechanism(ModulatoryMechanism_Base):
         """
 
         if self.output_ports is None:
-            self.output_ports = []
+            self.parameters.output_ports._set([], context)
 
         control_signal = self._instantiate_control_signal_type(control_signal, context)
         control_signal.owner = self

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -1325,17 +1325,17 @@ class ControlMechanism(ModulatoryMechanism_Base):
 
         monitored_output_ports = []
 
-        self.monitor_for_control = self.monitor_for_control or []
-        if not isinstance(self.monitor_for_control, list):
-            self.monitor_for_control = [self.monitor_for_control]
+        monitor_for_control = self.monitor_for_control or []
+        if not isinstance(monitor_for_control, list):
+            monitor_for_control = [monitor_for_control]
 
         # If objective_mechanism is used to specify OutputPorts to be monitored (legacy feature)
         #    move them to monitor_for_control
         if isinstance(self.objective_mechanism, list):
-            self.monitor_for_control.extend(self.objective_mechanism)
+            monitor_for_control.extend(self.objective_mechanism)
 
         # Add items in monitor_for_control to monitored_output_ports
-        for i, item in enumerate(self.monitor_for_control):
+        for i, item in enumerate(monitor_for_control):
             # If it is already in the list received from System, ignore
             if item in monitored_output_ports:
                 # NOTE: this can happen if ControlMechanisms is being constructed by System
@@ -1389,7 +1389,7 @@ class ControlMechanism(ModulatoryMechanism_Base):
         # ASSIGN ATTRIBUTES
 
         self._objective_projection = projection_from_objective
-        self.monitor_for_control = self.monitored_output_ports
+        self.parameters.monitor_for_control._set(self.monitored_output_ports, context)
 
     def _instantiate_input_ports(self, context=None):
 

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -794,13 +794,15 @@ class OptimizationControlMechanism(ControlMechanism):
 
         # If any features were specified (assigned to self.input_ports in __init__):
         if self.input_ports:
-            self.input_ports = _parse_shadow_inputs(self, self.input_ports)
-            self.input_ports = self._parse_feature_specs(self.input_ports, self.feature_function)
+            input_ports = _parse_shadow_inputs(self, self.input_ports)
+            input_ports = self._parse_feature_specs(input_ports, self.feature_function)
             # Insert primary InputPort for outcome from ObjectiveMechanism;
             #     assumes this will be a single scalar value and must be named OUTCOME by convention of ControlSignal
-            self.input_ports.insert(0, outcome_input_port),
+            input_ports.insert(0, outcome_input_port),
         else:
-            self.input_ports = [outcome_input_port]
+            input_ports = [outcome_input_port]
+
+        self.parameters.input_ports._set(input_ports, context)
 
         # Configure default_variable to comport with full set of input_ports
         self.defaults.variable, _ = self._handle_arg_input_ports(self.input_ports)

--- a/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
@@ -1180,7 +1180,10 @@ class LearningMechanism(ModulatoryMechanism_Base):
         """
 
         if self._error_sources:
-            self.input_ports = self.input_ports[:2] + [ERROR_SIGNAL] * len(self._error_sources)
+            self.parameters.input_ports._set(
+                self.input_ports[:2] + [ERROR_SIGNAL] * len(self._error_sources),
+                context
+            )
 
         super()._instantiate_attributes_before_function(function=function, context=context)
 

--- a/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
@@ -1250,9 +1250,13 @@ class LearningMechanism(ModulatoryMechanism_Base):
 
         # Reassign learning_signals to capture any user_defined LearningSignals instantiated in call to super
         #   and assign them to a ContentAddressableList
-        self.learning_signals = ContentAddressableList(component_type=LearningSignal,
-                                                        list=[port for port in self.output_ports if
-                                                                  isinstance(port, LearningSignal)])
+        self.parameters.learning_signals._set(
+            ContentAddressableList(
+                component_type=LearningSignal,
+                list=[port for port in self.output_ports if isinstance(port, LearningSignal)]
+            ),
+            context
+        )
 
         # Initialize _error_signals;  this is assigned for efficiency (rather than just using the property)
         #    since it is used by the execute method

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1333,11 +1333,12 @@ class TransferMechanism(ProcessingMechanism_Base):
         # then assign one OutputPort (with the default name, indexed by the number of the item) per item of variable
         if len(self.output_ports) == 1 and self.output_ports[0] == RESULTS:
             if len(self.defaults.variable) == 1:
-                self.output_ports = [RESULT]
+                output_ports = [RESULT]
             else:
-                self.output_ports = []
+                output_ports = []
                 for i, item in enumerate(self.defaults.variable):
-                    self.output_ports.append({NAME: f'{RESULT}-{i}', VARIABLE: (OWNER_VALUE, i)})
+                    output_ports.append({NAME: f'{RESULT}-{i}', VARIABLE: (OWNER_VALUE, i)})
+            self.parameters.output_ports._set(output_ports, context)
         super()._instantiate_output_ports(context=context)
 
         # # Relabel first output_port:

--- a/psyneulink/core/components/ports/inputport.py
+++ b/psyneulink/core/components/ports/inputport.py
@@ -1360,7 +1360,7 @@ def _instantiate_input_ports(owner, input_ports=None, reference_value=None, cont
     if context.source & (ContextFlags.METHOD | ContextFlags.COMMAND_LINE):
         owner.input_ports.extend(port_list)
     else:
-        owner.input_ports = port_list
+        owner.parameters.input_ports._set(port_list, context)
 
     # Assign value of require_projection_in_composition
     for port in owner.input_ports:

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -1500,7 +1500,7 @@ def _instantiate_output_ports(owner, output_ports=None, context=None):
     if context.source & (ContextFlags.COMMAND_LINE | ContextFlags.METHOD):
         owner.output_ports.extend(port_list)
     else:
-        owner.output_ports = port_list
+        owner.parameters.output_ports._set(port_list, context)
 
     # Assign value of require_projection_in_composition
     for port in owner.output_ports:

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -2052,13 +2052,18 @@ def _add_projection_to(receiver, port, projection_spec, context=None):
 
     #  Update InputPort and input_ports
     if receiver.input_ports:
-        receiver.input_ports[input_port.name] = input_port
+        receiver.parameters.input_ports._get(context)[input_port.name] = input_port
 
     # No InputPort(s) yet, so create them
     else:
-        receiver.input_ports = ContentAddressableList(component_type=Port_Base,
-                                                      list=[input_port],
-                                                      name=receiver.name + '.input_ports')
+        receiver.parameters.input_ports._set(
+            ContentAddressableList(
+                component_type=Port_Base,
+                list=[input_port],
+                name=receiver.name + '.input_ports'
+            ),
+            context
+        )
 
     return input_port._instantiate_projections_to_port(projections=projection_spec, context=context)
 
@@ -2160,8 +2165,12 @@ def _add_projection_from(sender, port, projection_spec, receiver, context=None):
     # No OutputPort(s) yet, so create them
     except AttributeError:
         from psyneulink.core.components.ports.port import Port_Base
-        sender.output_ports = ContentAddressableList(component_type=Port_Base,
-                                                      list=[output_port],
-                                                      name=sender.name + '.output_ports')
+        sender.parameters.output_ports._set(
+            ContentAddressableList(
+                component_type=Port_Base,
+                list=[output_port],
+                name=sender.name + '.output_ports'
+            )
+        )
 
     output_port._instantiate_projections_to_port(projections=projection_spec, context=context)

--- a/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
@@ -798,7 +798,7 @@ class LCControlMechanism(ControlMechanism):
             ctl_sig_projs = []
             for mech, mult_param_name in zip(self.modulated_mechanisms, multiplicative_param_names):
                 ctl_sig_projs.append((mult_param_name, mech))
-            self.control = [{PROJECTIONS: ctl_sig_projs}]
+            self.parameters.control._set([{PROJECTIONS: ctl_sig_projs}], context)
             self.parameters.control_allocation.default_value = self.value[0]
 
         super()._instantiate_output_ports(context=context)

--- a/psyneulink/library/models/Nieuwenhuis2005Model.py
+++ b/psyneulink/library/models/Nieuwenhuis2005Model.py
@@ -75,7 +75,7 @@ decision_layer = pnl.LCAMechanism(
 decision_layer.set_log_conditions('value')  # Log value of the decision layer
 
 for output_port in decision_layer.output_ports:
-    output_port.value *= 0.0                                       # Set initial output values for decision layer to 0
+    output_port.parameters.value.set(output_port.value * 0.0, override=True)  # Set initial output values for decision layer to 0
 
 # Create Response Layer  --- [ Target1, Target2 ]
 response_layer = pnl.LCAMechanism(
@@ -93,7 +93,7 @@ response_layer = pnl.LCAMechanism(
 
 response_layer.set_log_conditions('RESULT')     # Log RESULT of the response layer
 for output_port in response_layer.output_ports:
-    output_port.value *= 0.0                   # Set initial output values for response layer to 0
+    output_port.parameters.value.set(output_port.value * 0.0, override=True)  # Set initial output values for response layer to 0
 
 # Connect mechanisms --------------------------------------------------------------------------------------------------
 # Weight matrix from Input Layer --> Decision Layer
@@ -164,7 +164,7 @@ LC.set_log_conditions('value')
 # Set initial gain to G + k*initial_w, when the System runs the very first time,
 # since the decison layer executes before the LC and hence needs one initial gain value to start with.
 for output_port in LC.output_ports:
-    output_port.value *= G + k * initial_w
+    output_port.parameters.value.set(output_port.value * (G + k * initial_w), override=True)
 
 task = pnl.Composition()
 task.add_linear_processing_pathway(decision_pathway)
@@ -212,10 +212,10 @@ task.run(stim_list_dict, num_trials=trials)
 LC_results = LC.log.nparray()[1][1]        # get logged results
 LC_results_w = np.zeros([trials])          # get LC_results_w
 for i in range(trials):
-    LC_results_w[i] = LC_results[4][i + 1][2][0][0]
+    LC_results_w[i] = LC_results[5][i + 1][2][0][0]
 LC_results_v = np.zeros([trials])          # get LC_results_v
 for i in range(trials):
-    LC_results_v[i] = LC_results[4][i + 1][1][0][0]
+    LC_results_v[i] = LC_results[5][i + 1][1][0][0]
 
 
 def h_v(v, C, d):                   # Compute h(v)

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -1797,7 +1797,7 @@ class TestExecutionOrder:
         D.set_log_conditions("OutputPort-0")
         cycle_nodes = [B, C, D]
         for cycle_node in cycle_nodes:
-            cycle_node.output_ports[0].value = [1.0]
+            cycle_node.output_ports[0].parameters.value.set([1.0], override=True)
 
         comp.run(inputs={A: [1.0]})
         expected_values = {A: 1.0,

--- a/tests/control/test_gilzenrat.py
+++ b/tests/control/test_gilzenrat.py
@@ -49,7 +49,7 @@ class TestGilzenratMechanisms:
                          initial_value=np.array([[1.0]]))
 
         C = Composition(pathways=[G])
-        G.output_port.value = [0.0]
+        G.output_port.parameters.value.set([0.0], override=True)
 
         # - - - - - LCAMechanism integrator functions - - - - -
         # X = previous_value + (rate * previous_value + variable) * self.time_step_size + noise


### PR DESCRIPTION
Parameter dot-notation used `Parameter._set`, which allowed users to change read-only parameters with no warning and skip parsing. Dot notation now uses `set` to require explicit use of `.set` with `override=True` to bypass read-only restrictions.