### PR TITLE
Fix overeager modulatory specification parsing

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1009,7 +1009,10 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             return None
 
         def _parse_modulable(self, param_name, param_value):
-            from psyneulink.core.components.functions.distributionfunctions import DistributionFunction
+            from psyneulink.core.components.mechanisms.modulatory.modulatorymechanism import ModulatoryMechanism_Base
+            from psyneulink.core.components.ports.modulatorysignals import ModulatorySignal
+            from psyneulink.core.components.projections.modulatory.modulatoryprojection import ModulatoryProjection_Base
+
             # assume 2-tuple with class/instance as second item is a proper
             # modulatory spec, can possibly add in a flag on acceptable
             # classes in the future
@@ -1025,14 +1028,10 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 )
             ):
                 value = param_value[0]
-            # assume a DistributionFunction is allowed to persist, for noise
             elif (
-                (
-                    is_instance_or_subclass(param_value, Component)
-                    and not is_instance_or_subclass(
-                        param_value,
-                        DistributionFunction
-                    )
+                is_instance_or_subclass(
+                    param_value,
+                    (ModulatoryMechanism_Base, ModulatorySignal, ModulatoryProjection_Base)
                 )
                 or (
                     isinstance(param_value, str)

--- a/tests/mechanisms/test_mechanisms.py
+++ b/tests/mechanisms/test_mechanisms.py
@@ -41,6 +41,21 @@ class TestMechanism:
         assert M.defaults.value.shape == mechanism_value.shape
         assert M.function.defaults.value.shape == function_value.shape
 
+    @pytest.mark.parametrize(
+        'noise',
+        [pnl.GaussianDistort, pnl.NormalDist]
+    )
+    def test_noise_variations(self, noise):
+        t1 = pnl.TransferMechanism(name='t1', size=2, noise=noise())
+        t2 = pnl.TransferMechanism(name='t2', size=2)
+        t2.integrator_function.parameters.noise.set(noise())
+
+        t1.integrator_function.noise.base.random_state = np.random.RandomState([0])
+        t2.integrator_function.noise.base.random_state = np.random.RandomState([0])
+
+        for _ in range(5):
+            np.testing.assert_equal(t1.execute([1, 1]), t2.execute([1, 1]))
+
 
 class TestMechanismFunctionParameters:
     f = pnl.Linear()


### PR DESCRIPTION
Instead of assuming any Component other than a DistributionFunction is part of a modulatory specification, parse only ModulatoryMechanism_Base, ModulatorySignal, ModulatoryProjection_Base. 
Corrects problem where noise functions other than DistributionFunctions would not run during execution unless set after initialization of the owning Component.