### PR TITLE
DriftDiffusionIntegrator: avoid always producing 3d value

### DIFF
--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -382,7 +382,7 @@ from psyneulink.core.globals.keywords import \
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set, REPORT_OUTPUT_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
-from psyneulink.core.globals.utilities import convert_to_np_array, is_numeric, is_same_function_spec, object_has_single_value, get_global_seed
+from psyneulink.core.globals.utilities import convert_all_elements_to_np_array, is_numeric, is_same_function_spec, object_has_single_value, get_global_seed
 
 from psyneulink.core import llvm as pnlvm
 
@@ -1047,7 +1047,7 @@ class DDM(ProcessingMechanism):
             if self.initialization_status != ContextFlags.INITIALIZING:
                 logger.info('{0} {1} is at {2}'.format(type(self).__name__, self.name, result))
 
-            return convert_to_np_array([result[0], [result[1]]])
+            return convert_all_elements_to_np_array([result[0], result[1]])
 
         # EXECUTE ANALYTIC SOLUTION (TRIAL TIME SCALE) -----------------------------------------------------------
         else:
@@ -1101,8 +1101,7 @@ class DDM(ProcessingMechanism):
             builder.store(builder.load(builder.gep(mf_out, [ctx.int32_ty(0),
                                                             ctx.int32_ty(1)])),
                           builder.gep(mech_out, [ctx.int32_ty(0),
-                                                 ctx.int32_ty(1),
-                                                 ctx.int32_ty(0)]))
+                                                 ctx.int32_ty(1)]))
         elif isinstance(self.function, DriftDiffusionAnalytical):
             for res_idx, idx in enumerate((self.RESPONSE_TIME_INDEX,
                                            self.PROBABILITY_LOWER_THRESHOLD_INDEX,
@@ -1161,7 +1160,7 @@ class DDM(ProcessingMechanism):
         # (1) reset function, (2) update mechanism value, (3) update output ports
         if isinstance(self.function, IntegratorFunction):
             new_values = self.function.reset(*args, **kwargs, context=context)
-            self.parameters.value._set(convert_to_np_array(new_values), context)
+            self.parameters.value._set(convert_all_elements_to_np_array(new_values), context)
             self._update_output_ports(context=context)
 
     @handle_external_context()
@@ -1207,7 +1206,7 @@ class DDM(ProcessingMechanism):
             return ctx.bool_ty(1)
 
         # Extract scalar value from ptr
-        prev_val_ptr = builder.gep(prev_val_ptr, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(0)])
+        prev_val_ptr = builder.gep(prev_val_ptr, [ctx.int32_ty(0), ctx.int32_ty(0)])
         prev_val = builder.load(prev_val_ptr)
 
         # Take abs of previous val

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -6230,9 +6230,9 @@ class TestResetValues:
         assert np.allclose(np.asfarray(run_2_values),
                            np.asfarray(run_3_values))
         assert np.allclose(np.asfarray(run_1_values),
-                           [np.array([[0.36]]), np.array([[0.056]]), np.array([[0.056]])])
+                           [np.array([0.36]), np.array([0.056]), np.array([0.056])])
         assert np.allclose(np.asfarray(run_2_values),
-                           [np.array([[0.5904]]), np.array([[0.16384]]), np.array([[0.16384]])])
+                           [np.array([0.5904]), np.array([0.16384]), np.array([0.16384])])
 
 
 class TestNodeRoles:

--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -29,8 +29,8 @@ class TestReset:
         #  0.0 + 1.0 * 1.0 * 1.0 + 0.0
         D.execute(1.0)
         assert np.allclose(np.asfarray(D.value),  [[1.0], [1.0]])
-        assert np.allclose(D.output_ports[0].value[0][0], 1.0)
-        assert np.allclose(D.output_ports[1].value[0][0], 1.0)
+        assert np.allclose(D.output_ports[0].value[0], 1.0)
+        assert np.allclose(D.output_ports[1].value[0], 1.0)
 
         # reset function
         D.function.reset(2.0, 0.1)
@@ -38,8 +38,8 @@ class TestReset:
         assert np.allclose(D.function.previous_value, 2.0)
         assert np.allclose(D.function.previous_time, 0.1)
         assert np.allclose(np.asfarray(D.value),  [[1.0], [1.0]])
-        assert np.allclose(D.output_ports[0].value[0][0], 1.0)
-        assert np.allclose(D.output_ports[1].value[0][0], 1.0)
+        assert np.allclose(D.output_ports[0].value[0], 1.0)
+        assert np.allclose(D.output_ports[1].value[0], 1.0)
 
         # reset function without value spec
         D.function.reset()
@@ -47,8 +47,8 @@ class TestReset:
         assert np.allclose(D.function.previous_value, 0.0)
         assert np.allclose(D.function.previous_time, 0.0)
         assert np.allclose(np.asfarray(D.value), [[1.0], [1.0]])
-        assert np.allclose(D.output_ports[0].value[0][0], 1.0)
-        assert np.allclose(D.output_ports[1].value[0][0], 1.0)
+        assert np.allclose(D.output_ports[0].value[0], 1.0)
+        assert np.allclose(D.output_ports[1].value[0], 1.0)
 
         # reset mechanism
         D.reset(2.0, 0.1)
@@ -61,9 +61,9 @@ class TestReset:
 
         D.execute(1.0)
         #  2.0 + 1.0 = 3.0 ; 0.1 + 1.0 = 1.1
-        assert np.allclose(np.asfarray(D.value), [[[3.0]], [[1.1]]])
-        assert np.allclose(D.output_ports[0].value[0][0], 3.0)
-        assert np.allclose(D.output_ports[1].value[0][0], 1.1)
+        assert np.allclose(np.asfarray(D.value), [[3.0], [1.1]])
+        assert np.allclose(D.output_ports[0].value[0], 3.0)
+        assert np.allclose(D.output_ports[1].value[0], 1.1)
 
         # reset mechanism without value spec
         D.reset()
@@ -127,8 +127,8 @@ class TestThreshold:
         time_points = []
         for i in range(5):
             output = ex([variable])
-            decision_variables.append(output[0][0][0])
-            time_points.append(output[1][0][0])
+            decision_variables.append(output[0][0])
+            time_points.append(output[1][0])
 
         # decision variable accumulation stops
         assert np.allclose(decision_variables, expected)
@@ -305,7 +305,7 @@ def test_DDM_noise(mech_mode, benchmark, noise, expected):
         ex = pnlvm.execution.MechExecution(T).cuda_execute
 
     val = ex([10])
-    assert np.allclose(val[0][0][0], expected)
+    assert np.allclose(val[0][0], expected)
     if benchmark.enabled:
         benchmark(ex, [10])
 
@@ -436,7 +436,7 @@ def test_DDM_rate(benchmark, rate, expected, mech_mode):
         ex = pnlvm.execution.MechExecution(T).execute
     elif mech_mode == 'PTX':
         ex = pnlvm.execution.MechExecution(T).cuda_execute
-    val = float(ex(stim)[0][0][0])
+    val = float(ex(stim)[0][0])
     assert val == expected
     if benchmark.enabled:
         benchmark(ex, stim)
@@ -608,12 +608,12 @@ def test_DDM_time():
     np.testing.assert_allclose(time_0, 0.5, atol=1e-08)
 
     time_1 = D.execute(10)[1][0]   # t_1  = 0.5 + 0.2 = 0.7
-    np.testing.assert_allclose(time_1[0], 0.7, atol=1e-08)
+    np.testing.assert_allclose(time_1, 0.7, atol=1e-08)
 
     for i in range(10):                                     # t_11 = 0.7 + 10*0.2 = 2.7
         D.execute(10)
     time_12 = D.execute(10)[1][0]                              # t_12 = 2.7 + 0.2 = 2.9
-    np.testing.assert_allclose(time_12[0], 2.9, atol=1e-08)
+    np.testing.assert_allclose(time_12, 2.9, atol=1e-08)
 
 
 def test_WhenFinished_DDM_Analytical():

--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -543,7 +543,7 @@ class TestIntegratorFunctions:
         # P = Process(pathway=[I])
         # 10 + 10*0.5 + 0 + 10 = 25
         val = I.execute(1)
-        assert np.allclose([[[25.]], [[0.5]]], val)
+        assert np.allclose([[25.], [0.5]], val)
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism
@@ -776,7 +776,7 @@ class TestIntegratorRate:
         )
         # P = Process(pathway=[I])
         val = I.execute(10.0)
-        assert np.allclose([[[50.0]], [[1.0]]], val)
+        assert np.allclose([[50.0], [1.0]], val)
 
     # rate = list, integration_type = simple
 
@@ -1156,7 +1156,7 @@ class TestIntegratorNoise:
         )
 
         val = I.execute(10.0)
-        assert np.allclose(val, [[[4.29013944]], [[ 1.        ]]])
+        assert np.allclose(val, [[4.29013944], [ 1.        ]])
 
 # COMMENTED OUT UNTIL OU INTEGRATOR IS VALIDATED
     @pytest.mark.mechanism

--- a/tests/mechanisms/test_mechanisms.py
+++ b/tests/mechanisms/test_mechanisms.py
@@ -159,7 +159,7 @@ class TestResetValues:
 
         # Execute A twice
         #  [0] saves decision variable only (not time)
-        original_output = [A.execute(1.0)[0], A.execute(1.0)[0]]
+        original_output = [A.execute(1.0), A.execute(1.0)]
 
         # SAVING STATE  - - - - - - - - - - - - - - - - - - - - - - - - -
         reset_stateful_functions_to = {}
@@ -169,13 +169,13 @@ class TestResetValues:
         print(reset_stateful_functions_to)
         # Execute A twice AFTER saving the state so that it continues accumulating.
         # We expect the next two outputs to repeat once we reset the state b/c we will return it to the current state
-        output_after_saving_state = [A.execute(1.0)[0], A.execute(1.0)[0]]
+        output_after_saving_state = [A.execute(1.0), A.execute(1.0)]
 
         # RESETTING STATE - - - - - - - - - - - - - - - - - - - - - - - -
         A.reset(**reset_stateful_functions_to)
 
         # We expect these results to match the results from immediately after saving the state
-        output_after_reinitialization = [A.execute(1.0)[0], A.execute(1.0)[0]]
+        output_after_reinitialization = [A.execute(1.0), A.execute(1.0)]
 
         assert np.allclose(output_after_saving_state, output_after_reinitialization)
         assert np.allclose(original_output, [np.array([[1.0]]), np.array([[2.0]])])

--- a/tests/scheduling/test_scheduler.py
+++ b/tests/scheduling/test_scheduler.py
@@ -187,10 +187,10 @@ class TestScheduler:
         # Trial 1:
         # input = 2.0, termination condition = AllHaveRun
         # 1 pass (value = 2.0)
-        expected_results = [[np.array([[10.]]), np.array([[10.]])],
-                            [np.array([[2.]]), np.array([[1.]])],
-                            [np.array([[10.]]), np.array([[10.]])],
-                            [np.array([[2.]]), np.array([[1.]])]]
+        expected_results = [[np.array([10.]), np.array([10.])],
+                            [np.array([2.]), np.array([1.])],
+                            [np.array([10.]), np.array([10.])],
+                            [np.array([2.]), np.array([1.])]]
         assert np.allclose(expected_results, np.asfarray(C.results))
 
     def test_default_condition_1(self):


### PR DESCRIPTION
Fixes the specific case from #1878 but not in general. DriftDiffusionIntegrator and any owning mechanism now produces 2d value. Removes automatic 2d-cast of previous_value.