### PR TITLE
Mechanism: slim reportOutputPref printing, add option

### DIFF
--- a/docs/source/Preferences.rst
+++ b/docs/source/Preferences.rst
@@ -7,7 +7,8 @@ Standard prefereces:
 
 - paramValidation (bool): enables/disables run-time validation of the execute method of a Function object
 
-- reportOutput (bool): enables/disables reporting of execution of execute method
+- reportOutput ([bool, str]): enables/disables reporting of execution of execute method:
+   True prints input/output, 'params' or 'parameters' includes parameter values
 
 - log (bool): sets LogCondition for a given Component
 

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1596,18 +1596,21 @@ class TransferMechanism(ProcessingMechanism_Base):
 
         self.parameters.value.history_min_length = self._termination_measure_num_items_expected - 1
 
-    def _report_mechanism_execution(self, input, params, output, context=None):
+    def _report_mechanism_execution(self, input, params=None, output=None, context=None):
         """Override super to report previous_input rather than input, and selected params
         """
         # KAM Changed 8/29/17 print_input = self.previous_input --> print_input = input
         # because self.previous_input is not a valid attrib of TransferMechanism
 
         print_input = input
-        print_params = params.copy()
-        # Suppress reporting of range (not currently used)
-        del print_params[CLIP]
+        try:
+            params = params.copy()
+            # Suppress reporting of range (not currently used)
+            del params[CLIP]
+        except (AttributeError, KeyError):
+            pass
 
-        super()._report_mechanism_execution(input_val=print_input, params=print_params, context=context)
+        super()._report_mechanism_execution(input_val=print_input, params=params, context=context)
 
     @handle_external_context()
     def is_finished(self, context=None):

--- a/psyneulink/core/globals/preferences/basepreferenceset.py
+++ b/psyneulink/core/globals/preferences/basepreferenceset.py
@@ -132,7 +132,8 @@ class BasePreferenceSet(PreferenceSet):
         Implement the following preferences:
             - verbose (bool): enables/disables reporting of (non-exception) warnings and system function
             - paramValidation (bool):  enables/disables run-time validation of the execute method of a Function object
-            - reportOutput (bool): enables/disables reporting of execution of execute method
+            - reportOutput ([bool, str]): enables/disables reporting of execution of execute method:
+              True prints input/output, 'params' or 'parameters' includes parameter values
             - log (bool): sets LogCondition for a given Component
             - functionRunTimeParams (Modulation): uses run-time params to modulate execute method params
         Implement the following preference levels:


### PR DESCRIPTION
`reportOutputPref = True` prints only input/output for mechanism execution
`reportOutputPref = 'params'` or `'parameters'` prints values of parameters as well (fix printing of full Parameter class)