### PR TITLE
llvm: Rework scheduler to make use of stored execution counts

### DIFF
--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -1459,7 +1459,7 @@ class GridSearch(OptimizationFunction):
 
         # KDM 8/22/19: nonstateful direction here - OK?
         direction = "<" if self.direction == MINIMIZE else ">"
-        replace_ptr = builder.alloca(pnlvm.ir.IntType(1))
+        replace_ptr = builder.alloca(ctx.bool_ty)
 
         # Check the value against current min
         with pnlvm.helpers.for_loop_zero_inc(builder, count, "compare_loop") as (b, idx):

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -780,7 +780,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         out_val_ptr = builder.gep(arg_out, [ctx.int32_ty(0), ctx.int32_ty(1)])
 
         # Check retrieval probability
-        retr_ptr = builder.alloca(pnlvm.ir.IntType(1))
+        retr_ptr = builder.alloca(ctx.bool_ty)
         builder.store(retr_ptr.type.pointee(1), retr_ptr)
         retr_prob_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, RETRIEVAL_PROB)
 
@@ -844,7 +844,7 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
             builder.store(selected_val, out_val_ptr)
 
         # Check storage probability
-        store_ptr = builder.alloca(pnlvm.ir.IntType(1))
+        store_ptr = builder.alloca(ctx.bool_ty)
         builder.store(store_ptr.type.pointee(1), store_ptr)
         store_prob_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, STORAGE_PROB)
 
@@ -866,14 +866,14 @@ class ContentAddressableMemory(MemoryFunction):  # -----------------------------
         with builder.if_then(store, likely=True):
 
             # Check if such key already exists
-            is_new_key_ptr = builder.alloca(pnlvm.ir.IntType(1))
+            is_new_key_ptr = builder.alloca(ctx.bool_ty)
             builder.store(is_new_key_ptr.type.pointee(1), is_new_key_ptr)
             with pnlvm.helpers.for_loop_zero_inc(builder, entries, "distance_loop") as (b,idx):
                 cmp_key_ptr = b.gep(keys_ptr, [ctx.int32_ty(0), idx])
 
                 # Vector compare
                 # TODO: move this to helpers
-                key_differs_ptr = b.alloca(pnlvm.ir.IntType(1))
+                key_differs_ptr = b.alloca(ctx.bool_ty)
                 b.store(key_differs_ptr.type.pointee(0), key_differs_ptr)
                 with pnlvm.helpers.array_ptr_loop(b, cmp_key_ptr, "key_compare") as (b2, idx2):
                     var_key_element = b2.gep(var_key_ptr, [ctx.int32_ty(0), idx2])

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2965,7 +2965,7 @@ class Mechanism_Base(Mechanism):
         return fun_out, builder
 
     def _gen_llvm_is_finished_cond(self, ctx, builder, params, state):
-        return pnlvm.ir.IntType(1)(1)
+        return ctx.bool_ty(1)
 
     def _gen_llvm_mechanism_functions(self, ctx, builder, params, state, arg_in,
                                       ip_output, *, tags:frozenset):
@@ -3043,8 +3043,7 @@ class Mechanism_Base(Mechanism):
                 ctx.get_input_struct_type(self).as_pointer(),
                 ctx.get_output_struct_type(self).as_pointer()]
 
-        builder = ctx.create_llvm_function(args, self,
-                                           return_type=pnlvm.ir.IntType(1),
+        builder = ctx.create_llvm_function(args, self, return_type=ctx.bool_ty,
                                            tags=tags)
         params, state = builder.function.args[:2]
         finished = self._gen_llvm_is_finished_cond(ctx, builder, params, state)
@@ -3083,7 +3082,7 @@ class Mechanism_Base(Mechanism):
         args_t = [a.type for a in builder.function.args]
         internal_builder = ctx.create_llvm_function(args_t, self,
                                                     name=builder.function.name + "_internal",
-                                                    return_type=pnlvm.ir.IntType(1))
+                                                    return_type=ctx.bool_ty)
         iparams, istate, iin, iout = internal_builder.function.args[:4]
         internal_builder, is_finished = self._gen_llvm_function_internal(ctx, internal_builder,
                                                                          iparams, istate, iin, iout, tags=tags)

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -123,8 +123,8 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
                 self.register[k] = numpy_handlers
 
         name_constants = {
-            True: ir.IntType(1)(1),
-            False: ir.IntType(1)(0),
+            True: ctx.bool_ty(1),
+            False: ctx.bool_ty(0),
         }
         self.name_constants = name_constants
         super().__init__()
@@ -883,7 +883,7 @@ def gen_composition_exec(ctx, composition, *, tags:frozenset):
 
 
         # Allocate run set structure
-        run_set_type = ir.ArrayType(ir.IntType(1), len(composition.nodes))
+        run_set_type = ir.ArrayType(ctx.bool_ty, len(composition.nodes))
         run_set_ptr = builder.alloca(run_set_type, name="run_set")
         builder.store(run_set_type(None), run_set_ptr)
 
@@ -919,7 +919,7 @@ def gen_composition_exec(ctx, composition, *, tags:frozenset):
         builder.position_at_end(loop_body)
 
         zero = ctx.int32_ty(0)
-        any_cond = ir.IntType(1)(0)
+        any_cond = ctx.bool_ty(0)
         # Calculate execution set before running the mechanisms
         for idx, node in enumerate(composition.nodes):
             run_set_node_ptr = builder.gep(run_set_ptr,

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -879,7 +879,7 @@ def gen_composition_exec(ctx, composition, *, tags:frozenset):
                 continue
 
             reinit_cond = cond_gen.generate_sched_condition(
-                builder, when, cond, node, None)
+                builder, when, cond, node, is_finished_callbacks, num_exec_locs)
             with builder.if_then(reinit_cond):
                 node_w = ctx.get_node_wrapper(composition, node)
                 node_reinit_f = ctx.import_llvm_function(node_w, tags=node_tags.union({"reset"}))
@@ -913,7 +913,7 @@ def gen_composition_exec(ctx, composition, *, tags:frozenset):
 
         run_cond = cond_gen.generate_sched_condition(
             builder, composition.termination_processing[TimeScale.TRIAL],
-            cond, None, is_finished_callbacks)
+            cond, None, is_finished_callbacks, num_exec_locs)
         run_cond = builder.not_(run_cond, name="not_run_cond")
 
         loop_body = builder.append_basic_block(name="scheduling_loop_body")
@@ -932,7 +932,7 @@ def gen_composition_exec(ctx, composition, *, tags:frozenset):
                                            name="run_cond_ptr_" + node.name)
             node_cond = cond_gen.generate_sched_condition(
                 builder, composition._get_processing_condition_set(node),
-                cond, node, is_finished_callbacks)
+                cond, node, is_finished_callbacks, num_exec_locs)
             ran = cond_gen.generate_ran_this_pass(builder, cond, node)
             node_cond = builder.and_(node_cond, builder.not_(ran),
                                      name="run_cond_" + node.name)

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -457,7 +457,8 @@ class ConditionGenerator:
 
         return builder.icmp_signed("==", node_trial, global_trial)
 
-    def generate_sched_condition(self, builder, condition, cond_ptr, node, is_finished_callbacks):
+    def generate_sched_condition(self, builder, condition, cond_ptr, node,
+                                 is_finished_callbacks, num_exec_locs):
 
 
         if isinstance(condition, Always):
@@ -467,13 +468,13 @@ class ConditionGenerator:
             return self.ctx.bool_ty(0)
 
         elif isinstance(condition, Not):
-            orig_condition = self.generate_sched_condition(builder, condition.condition, cond_ptr, node, is_finished_callbacks)
+            orig_condition = self.generate_sched_condition(builder, condition.condition, cond_ptr, node, is_finished_callbacks, num_exec_locs)
             return builder.not_(orig_condition)
 
         elif isinstance(condition, All):
             agg_cond = self.ctx.bool_ty(1)
             for cond in condition.args:
-                cond_res = self.generate_sched_condition(builder, cond, cond_ptr, node, is_finished_callbacks)
+                cond_res = self.generate_sched_condition(builder, cond, cond_ptr, node, is_finished_callbacks, num_exec_locs)
                 agg_cond = builder.and_(agg_cond, cond_res)
             return agg_cond
 
@@ -497,7 +498,7 @@ class ConditionGenerator:
         elif isinstance(condition, Any):
             agg_cond = self.ctx.bool_ty(0)
             for cond in condition.args:
-                cond_res = self.generate_sched_condition(builder, cond, cond_ptr, node, is_finished_callbacks)
+                cond_res = self.generate_sched_condition(builder, cond, cond_ptr, node, is_finished_callbacks, num_exec_locs)
                 agg_cond = builder.or_(agg_cond, cond_res)
             return agg_cond
 

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -537,9 +537,7 @@ class ConditionGenerator:
 
         elif isinstance(condition, BeforeNCalls):
             target, count = condition.args
-            # FIXME: Add support for other scales.
-            # This needs to be stored in the condition itself.
-            scale = TimeScale.TRIAL.value
+            scale = condition.time_scale.value
             target_num_execs_in_scale = builder.gep(num_exec_locs[target],
                                                     [self.ctx.int32_ty(0),
                                                      self.ctx.int32_ty(scale)])
@@ -549,9 +547,7 @@ class ConditionGenerator:
 
         elif isinstance(condition, AtNCalls):
             target, count = condition.args
-            # FIXME: Add support for other scales.
-            # This needs to be stored in the condition itself.
-            scale = TimeScale.TRIAL.value
+            scale = condition.time_scale.value
             target_num_execs_in_scale = builder.gep(num_exec_locs[target],
                                                     [self.ctx.int32_ty(0),
                                                      self.ctx.int32_ty(scale)])
@@ -560,9 +556,7 @@ class ConditionGenerator:
 
         elif isinstance(condition, AfterNCalls):
             target, count = condition.args
-            # FIXME: Add support for other scales.
-            # This needs to be stored in the condition itself.
-            scale = TimeScale.TRIAL.value
+            scale = condition.time_scale.value
             target_num_execs_in_scale = builder.gep(num_exec_locs[target],
                                                     [self.ctx.int32_ty(0),
                                                      self.ctx.int32_ty(scale)])

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -537,33 +537,37 @@ class ConditionGenerator:
 
         elif isinstance(condition, BeforeNCalls):
             target, count = condition.args
+            # FIXME: Add support for other scales.
+            # This needs to be stored in the condition itself.
+            scale = TimeScale.TRIAL.value
+            target_num_execs_in_scale = builder.gep(num_exec_locs[target],
+                                                    [self.ctx.int32_ty(0),
+                                                     self.ctx.int32_ty(scale)])
+            num_execs = builder.load(target_num_execs_in_scale)
 
-            target_status = builder.load(self.__get_node_status_ptr(builder, cond_ptr, target))
-
-            # Check number of runs
-            target_runs = builder.extract_value(target_status, 0, target.name + " runs")
-            return builder.icmp_unsigned('<', target_runs, self.ctx.int32_ty(count))
+            return builder.icmp_unsigned('<', num_execs, self.ctx.int32_ty(count))
 
         elif isinstance(condition, AtNCalls):
             target, count = condition.args
-
-            target_status = builder.load(self.__get_node_status_ptr(builder, cond_ptr, target))
-
-            # Check number of runs
-            target_runs = builder.extract_value(target_status, 0, target.name + " runs")
-            return builder.icmp_unsigned('==', target_runs, self.ctx.int32_ty(count))
+            # FIXME: Add support for other scales.
+            # This needs to be stored in the condition itself.
+            scale = TimeScale.TRIAL.value
+            target_num_execs_in_scale = builder.gep(num_exec_locs[target],
+                                                    [self.ctx.int32_ty(0),
+                                                     self.ctx.int32_ty(scale)])
+            num_execs = builder.load(target_num_execs_in_scale)
+            return builder.icmp_unsigned('==', num_execs, self.ctx.int32_ty(count))
 
         elif isinstance(condition, AfterNCalls):
             target, count = condition.args
-
-            target_idx = self.ctx.int32_ty(self.composition.nodes.index(target))
-
-            array_ptr = builder.gep(cond_ptr, [self._zero, self._zero, self.ctx.int32_ty(1)])
-            target_status = builder.load(builder.gep(array_ptr, [self._zero, target_idx]))
-
-            # Check number of runs
-            target_runs = builder.extract_value(target_status, 0, target.name + " runs")
-            return builder.icmp_unsigned('>=', target_runs, self.ctx.int32_ty(count))
+            # FIXME: Add support for other scales.
+            # This needs to be stored in the condition itself.
+            scale = TimeScale.TRIAL.value
+            target_num_execs_in_scale = builder.gep(num_exec_locs[target],
+                                                    [self.ctx.int32_ty(0),
+                                                     self.ctx.int32_ty(scale)])
+            num_execs = builder.load(target_num_execs_in_scale)
+            return builder.icmp_unsigned('>=', num_execs, self.ctx.int32_ty(count))
 
         elif isinstance(condition, WhenFinished):
             # The first argument is the target node

--- a/psyneulink/core/scheduling/condition.py
+++ b/psyneulink/core/scheduling/condition.py
@@ -1243,6 +1243,8 @@ class BeforeNCalls(_DependencyValidation, Condition):
 
     """
     def __init__(self, dependency, n, time_scale=TimeScale.TRIAL):
+        self.time_scale = time_scale
+
         def func(dependency, n, scheduler=None, execution_id=None):
             try:
                 num_calls = scheduler.counts_total[execution_id][time_scale][dependency]
@@ -1279,6 +1281,8 @@ class AtNCalls(_DependencyValidation, Condition):
 
     """
     def __init__(self, dependency, n, time_scale=TimeScale.TRIAL):
+        self.time_scale = time_scale
+
         def func(dependency, n, scheduler=None, execution_id=None):
             try:
                 num_calls = scheduler.counts_total[execution_id][time_scale][dependency]
@@ -1339,6 +1343,8 @@ class AfterNCalls(_DependencyValidation, Condition):
 
     """
     def __init__(self, dependency, n, time_scale=TimeScale.TRIAL):
+        self.time_scale = time_scale
+
         def func(dependency, n, scheduler=None, execution_id=None):
             try:
                 num_calls = scheduler.counts_total[execution_id][time_scale][dependency]

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1204,7 +1204,7 @@ class DDM(ProcessingMechanism):
         try:
             prev_val_ptr = pnlvm.helpers.get_state_ptr(builder, self.function, func_state_ptr, "previous_value")
         except ValueError:
-            return pnlvm.ir.IntType(1)(1)
+            return ctx.bool_ty(1)
 
         # Extract scalar value from ptr
         prev_val_ptr = builder.gep(prev_val_ptr, [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(0)])

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -4328,7 +4328,7 @@ class TestSchedulerConditions:
                               (pnl.Not, None, [[.05, .05]]),
                               (pnl.AllHaveRun, None, [[.05, .05]]),
                               (pnl.Always, None, [[0.05, 0.05]]),
-                              (pnl.AtPass, None, [[.3, .3]]), #FIXME: Differing result between llvm and python
+                              (pnl.AtPass, None, [[.3, .3]]),
                               (pnl.AtTrial, None, [[0.05, 0.05]]),
                               #(pnl.Never), #TODO: Find a good test case for this!
                             ])

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -4315,8 +4315,11 @@ class TestSchedulerConditions:
     @pytest.mark.parametrize("condition,scale,expected_result",
                              [(pnl.EveryNCalls, None, [[.25, .25]]),
                               (pnl.BeforeNCalls, TimeScale.TRIAL, [[.05, .05]]),
+                              (pnl.BeforeNCalls, TimeScale.PASS, [[.05, .05]]),
                               (pnl.AtNCalls, TimeScale.TRIAL, [[.25, .25]]),
+                              (pnl.AtNCalls, TimeScale.RUN, [[.25, .25]]),
                               (pnl.AfterNCalls, TimeScale.TRIAL, [[.25, .25]]),
+                              (pnl.AfterNCalls, TimeScale.PASS, [[.05, .05]]),
                               (pnl.WhenFinished, None, [[1.0, 1.0]]),
                               (pnl.WhenFinishedAny, None, [[1.0, 1.0]]),
                               (pnl.WhenFinishedAll, None, [[1.0, 1.0]]),
@@ -4352,7 +4355,10 @@ class TestSchedulerConditions:
             comp.scheduler.add_condition(response, condition(decisionMaker, 5,
                                                              time_scale=scale))
         elif condition is pnl.AfterNCalls:
-            comp.scheduler.add_condition(response, condition(decisionMaker, 5,
+            # Mechanisms run only once per PASS unless they are in
+            # 'run_until_finished' mode.
+            c = 1 if scale is TimeScale.PASS else 5
+            comp.scheduler.add_condition(response, condition(decisionMaker, c,
                                                              time_scale=scale))
         elif condition is pnl.WhenFinished:
             comp.scheduler.add_condition(response, condition(decisionMaker))

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -4312,24 +4312,24 @@ class TestSchedulerConditions:
                                       pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                       pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                      ])
-    @pytest.mark.parametrize(["condition", "expected_result"],
-                             [(pnl.EveryNCalls, [[.25, .25]]),
-                              (pnl.BeforeNCalls, [[.05, .05]]),
-                              (pnl.AtNCalls, [[.25, .25]]),
-                              (pnl.AfterNCalls, [[.25, .25]]),
-                              (pnl.WhenFinished, [[1.0, 1.0]]),
-                              (pnl.WhenFinishedAny, [[1.0, 1.0]]),
-                              (pnl.WhenFinishedAll, [[1.0, 1.0]]),
-                              (pnl.All, [[1.0, 1.0]]),
-                              (pnl.Any, [[1.0, 1.0]]),
-                              (pnl.Not, [[.05, .05]]),
-                              (pnl.AllHaveRun, [[.05, .05]]),
-                              (pnl.Always, [[0.05, 0.05]]),
-                              (pnl.AtPass, [[.3, .3]]), #FIXME: Differing result between llvm and python
-                              (pnl.AtTrial,[[0.05, 0.05]]),
+    @pytest.mark.parametrize("condition,scale,expected_result",
+                             [(pnl.EveryNCalls, None, [[.25, .25]]),
+                              (pnl.BeforeNCalls, TimeScale.TRIAL, [[.05, .05]]),
+                              (pnl.AtNCalls, TimeScale.TRIAL, [[.25, .25]]),
+                              (pnl.AfterNCalls, TimeScale.TRIAL, [[.25, .25]]),
+                              (pnl.WhenFinished, None, [[1.0, 1.0]]),
+                              (pnl.WhenFinishedAny, None, [[1.0, 1.0]]),
+                              (pnl.WhenFinishedAll, None, [[1.0, 1.0]]),
+                              (pnl.All, None, [[1.0, 1.0]]),
+                              (pnl.Any, None, [[1.0, 1.0]]),
+                              (pnl.Not, None, [[.05, .05]]),
+                              (pnl.AllHaveRun, None, [[.05, .05]]),
+                              (pnl.Always, None, [[0.05, 0.05]]),
+                              (pnl.AtPass, None, [[.3, .3]]), #FIXME: Differing result between llvm and python
+                              (pnl.AtTrial, None, [[0.05, 0.05]]),
                               #(pnl.Never), #TODO: Find a good test case for this!
                             ])
-    def test_scheduler_conditions(self, mode, condition, expected_result):
+    def test_scheduler_conditions(self, mode, condition, scale, expected_result):
         decisionMaker = pnl.DDM(
                         function=pnl.DriftDiffusionIntegrator(starting_point=0,
                                                               threshold=1,
@@ -4341,18 +4341,19 @@ class TestSchedulerConditions:
         response = pnl.ProcessingMechanism(size=2, name="GATE")
 
         comp = pnl.Composition()
-        comp.add_node(decisionMaker)
-        comp.add_node(response)
-        comp.add_projection(pnl.MappingProjection(), sender=decisionMaker, receiver=response)
+        comp.add_linear_processing_pathway([decisionMaker, response])
 
         if condition is pnl.EveryNCalls:
             comp.scheduler.add_condition(response, condition(decisionMaker, 5))
         elif condition is pnl.BeforeNCalls:
-            comp.scheduler.add_condition(response, condition(decisionMaker, 5))
+            comp.scheduler.add_condition(response, condition(decisionMaker, 5,
+                                                             time_scale=scale))
         elif condition is pnl.AtNCalls:
-            comp.scheduler.add_condition(response, condition(decisionMaker, 5))
+            comp.scheduler.add_condition(response, condition(decisionMaker, 5,
+                                                             time_scale=scale))
         elif condition is pnl.AfterNCalls:
-            comp.scheduler.add_condition(response, condition(decisionMaker, 5))
+            comp.scheduler.add_condition(response, condition(decisionMaker, 5,
+                                                             time_scale=scale))
         elif condition is pnl.WhenFinished:
             comp.scheduler.add_condition(response, condition(decisionMaker))
         elif condition is pnl.WhenFinishedAny:

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -4306,13 +4306,12 @@ class TestCallBeforeAfterTimescale:
 class TestSchedulerConditions:
     @pytest.mark.composition
     @pytest.mark.parametrize("mode", ['Python',
-                                     #FIXME: "Exec" versions see different shape of previous_value parameter ([0] vs. [[0]])
-                                     #pytest.param('LLVM', marks=pytest.mark.llvm),
-                                     #pytest.param('LLVMExec', marks=pytest.mark.llvm),
-                                     pytest.param('LLVMRun', marks=pytest.mark.llvm),
-                                     #pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
-                                     pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda]),
-                                    ])
+                                      # 'LLVM' mode is not supported, because synchronization of compiler and python values during execution is not implemented.
+                                      pytest.param('LLVMExec', marks=pytest.mark.llvm),
+                                      pytest.param('LLVMRun', marks=pytest.mark.llvm),
+                                      pytest.param('PTXExec', marks=[pytest.mark.llvm, pytest.mark.cuda]),
+                                      pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda]),
+                                     ])
     @pytest.mark.parametrize(["condition", "expected_result"],
                              [(pnl.EveryNCalls, [[.25, .25]]),
                               (pnl.BeforeNCalls, [[.05, .05]]),

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -4313,8 +4313,7 @@ class TestSchedulerConditions:
                                       pytest.param('PTXRun', marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                      ])
     @pytest.mark.parametrize("condition,scale,expected_result",
-                             [(pnl.EveryNCalls, None, [[.25, .25]]),
-                              (pnl.BeforeNCalls, TimeScale.TRIAL, [[.05, .05]]),
+                             [(pnl.BeforeNCalls, TimeScale.TRIAL, [[.05, .05]]),
                               (pnl.BeforeNCalls, TimeScale.PASS, [[.05, .05]]),
                               (pnl.AtNCalls, TimeScale.TRIAL, [[.25, .25]]),
                               (pnl.AtNCalls, TimeScale.RUN, [[.25, .25]]),
@@ -4346,9 +4345,7 @@ class TestSchedulerConditions:
         comp = pnl.Composition()
         comp.add_linear_processing_pathway([decisionMaker, response])
 
-        if condition is pnl.EveryNCalls:
-            comp.scheduler.add_condition(response, condition(decisionMaker, 5))
-        elif condition is pnl.BeforeNCalls:
+        if condition is pnl.BeforeNCalls:
             comp.scheduler.add_condition(response, condition(decisionMaker, 5,
                                                              time_scale=scale))
         elif condition is pnl.AtNCalls:


### PR DESCRIPTION
Drop `EveryNCalls` scheduling condition. The implementation was incorrect and unused.
Fix reset of PASS scale execution counts.
Add TimeScale parameter to {At,After,Before}NCalls scheduling conditions.
Regresses: https://github.com/PrincetonUniversity/PsyNeuLink/issues/1580