### PR TITLE
fix(scheduler): default condition dependencies

### DIFF
--- a/psyneulink/core/scheduling/scheduler.py
+++ b/psyneulink/core/scheduling/scheduler.py
@@ -565,23 +565,13 @@ class Scheduler(JSONDumpable):
         unspecified_nodes = []
         for node in self.nodes:
             if node not in self.conditions:
-                # determine parent nodes
-                node_index = 0
-                for i in range(len(self.consideration_queue)):
-                    if node in self.consideration_queue[i]:
-                        node_index = i
-                        break
-
-                if node_index > 0:
-                    dependencies = list(self.consideration_queue[i - 1])
-                    if len(dependencies) == 1:
-                        cond = EveryNCalls(dependencies[0], 1)
-                    elif len(dependencies) > 1:
-                        cond = All(*[EveryNCalls(x, 1) for x in dependencies])
-                    else:
-                        raise SchedulerError(f'{self}: Empty consideration set in consideration_queue[{i - 1}]')
-                else:
+                dependencies = list(self.dependency_dict[node])
+                if len(dependencies) == 0:
                     cond = Always()
+                elif len(dependencies) == 1:
+                    cond = EveryNCalls(dependencies[0], 1)
+                else:
+                    cond = All(*[EveryNCalls(x, 1) for x in dependencies])
 
                 self.conditions.add_condition(node, cond)
                 unspecified_nodes.append(node)

--- a/tests/scheduling/test_scheduler.py
+++ b/tests/scheduling/test_scheduler.py
@@ -193,6 +193,31 @@ class TestScheduler:
                             [np.array([[2.]]), np.array([[1.]])]]
         assert np.allclose(expected_results, np.asfarray(C.results))
 
+    def test_default_condition_1(self):
+        A = pnl.TransferMechanism(name='A')
+        B = pnl.TransferMechanism(name='B')
+        C = pnl.TransferMechanism(name='C')
+
+        comp = pnl.Composition(pathways=[[A, C], [A, B, C]])
+        comp.scheduler.add_condition(A, AtPass(1))
+        comp.scheduler.add_condition(B, Always())
+
+        output = list(comp.scheduler.run())
+        expected_output = [B, A, B, C]
+        assert output == pytest.helpers.setify_expected_output(expected_output)
+
+    def test_default_condition_2(self):
+        A = pnl.TransferMechanism(name='A')
+        B = pnl.TransferMechanism(name='B')
+        C = pnl.TransferMechanism(name='C')
+
+        comp = pnl.Composition(pathways=[[A, B], [C]])
+        comp.scheduler.add_condition(C, AtPass(1))
+
+        output = list(comp.scheduler.run())
+        expected_output = [A, B, {C, A}]
+        assert output == pytest.helpers.setify_expected_output(expected_output)
+
 
 class TestLinear:
 


### PR DESCRIPTION
condition incorrectly depended on the execution of all nodes in the previous consideration set, instead of its structural parents