### PR TITLE
llvm/scheduler: Restore and reimplement 'EveryNCalls' scheduling condition

### DIFF
--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -327,15 +327,19 @@ class ConditionGenerator:
                                                   self.ctx.int32_ty,   # Pass
                                                   self.ctx.int32_ty])  # Step
 
+        status_struct = ir.LiteralStructType([
+                    self.ctx.int32_ty,  # number of executions in this run
+                    time_stamp_struct   # time stamp of last execution
+                ])
         structure = ir.LiteralStructType([
             time_stamp_struct,  # current time stamp
-            ir.ArrayType(time_stamp_struct, len(composition.nodes))  # for each node
+            ir.ArrayType(status_struct, len(composition.nodes))  # for each node
         ])
         return structure
 
     def get_private_condition_initializer(self, composition):
         return ((0, 0, 0),
-                tuple((-1, -1, -1) for _ in composition.nodes))
+                tuple((0, (-1, -1, -1)) for _ in composition.nodes))
 
     def get_condition_struct_type(self, composition=None):
         composition = self.composition if composition is None else composition
@@ -402,13 +406,14 @@ class ConditionGenerator:
 
         return result
 
-    def __get_node_ts_ptr(self, builder, cond_ptr, node):
+    def __get_node_status_ptr(self, builder, cond_ptr, node):
         node_idx = self.ctx.int32_ty(self.composition.nodes.index(node))
-        return builder.gep(cond_ptr, [self._zero, self._zero,
-                                      self.ctx.int32_ty(1), node_idx])
+        return builder.gep(cond_ptr, [self._zero, self._zero, self.ctx.int32_ty(1), node_idx])
 
     def __get_node_ts(self, builder, cond_ptr, node):
-        ts_ptr = self.__get_node_ts_ptr(builder, cond_ptr, node)
+        status_ptr = self.__get_node_status_ptr(builder, cond_ptr, node)
+        ts_ptr = builder.gep(status_ptr, [self.ctx.int32_ty(0),
+                                          self.ctx.int32_ty(1)])
         return builder.load(ts_ptr)
 
     def get_global_ts(self, builder, cond_ptr):
@@ -416,10 +421,19 @@ class ConditionGenerator:
         return builder.load(ts_ptr)
 
     def generate_update_after_run(self, builder, cond_ptr, node):
-        # Copy global TS
-        ts_ptr = self.__get_node_ts_ptr(builder, cond_ptr, node)
+        status_ptr = self.__get_node_status_ptr(builder, cond_ptr, node)
+        status = builder.load(status_ptr)
+
+        # Update number of runs
+        runs = builder.extract_value(status, 0)
+        runs = builder.add(runs, self.ctx.int32_ty(1))
+        status = builder.insert_value(status, runs, 0)
+
+        # Update time stamp
         ts = self.get_global_ts(builder, cond_ptr)
-        builder.store(ts, ts_ptr)
+        status = builder.insert_value(status, ts, 1)
+
+        builder.store(status, status_ptr)
 
     def generate_ran_this_pass(self, builder, cond_ptr, node):
         global_ts = self.get_global_ts(builder, cond_ptr)

--- a/tests/scheduling/test_scheduler.py
+++ b/tests/scheduling/test_scheduler.py
@@ -1551,6 +1551,7 @@ class TestFeedback:
     @pytest.mark.parametrize("condition,scale,expected_result",
                              [(pnl.BeforeNCalls, TimeScale.TRIAL, [[.05, .05]]),
                               (pnl.BeforeNCalls, TimeScale.PASS, [[.05, .05]]),
+                              (pnl.EveryNCalls, None, [[0.05, .05]]),
                               (pnl.AtNCalls, TimeScale.TRIAL, [[.25, .25]]),
                               (pnl.AtNCalls, TimeScale.RUN, [[.25, .25]]),
                               (pnl.AfterNCalls, TimeScale.TRIAL, [[.25, .25]]),
@@ -1593,6 +1594,8 @@ class TestFeedback:
             c = 1 if scale is TimeScale.PASS else 5
             comp.scheduler.add_condition(response, condition(decisionMaker, c,
                                                              time_scale=scale))
+        elif condition is pnl.EveryNCalls:
+            comp.scheduler.add_condition(response, condition(decisionMaker, 1))
         elif condition is pnl.WhenFinished:
             comp.scheduler.add_condition(response, condition(decisionMaker))
         elif condition is pnl.WhenFinishedAny:


### PR DESCRIPTION
We can match the semantics in N=1 special case.
This is needed to support autogenerated conditions for nodes that don't have any.

Fixes Python-PTX execution mode since dac19d4fb6df901dd1a020c38d1c40253997e517 ("llvm/scheduler: Remove 'EveryNCalls' scheduling condition")
Partially reverts dac19d4fb6df901dd1a020c38d1c40253997e517 ("llvm/scheduler: Remove 'EveryNCalls' scheduling condition")