### PR TITLE
github-actions: Add script to create github release draft and optionally upload packages to PyPI

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -126,3 +126,72 @@ jobs:
         name: dist-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}
         path: dist/
       if: contains(github.ref, 'tags') && steps.on_master.outputs.on_master == 'master'
+
+  publish:
+    strategy:
+      matrix:
+        python-version: [3.7]
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+    needs: [build]
+    if: contains(github.ref, 'tags') && contains(needs.*.outputs.on_master, 'master')
+
+    steps:
+    - name: Download sdist and wheels
+      uses: actions/download-artifact@v2
+      with:
+        name: dist-${{ matrix.os }}-${{ matrix.python-version }}-x64
+        path: dist/
+
+    - name: Upload dist files to PyPI
+      id: file_assets
+      shell: bash
+      run: |
+        # Include implicit dependency on setuptools{,-rust}
+        # and preinstall wheel
+        pip3 install setuptools setuptools-rust wheel
+        pip3 install twine
+        # This expects TWINE_USERNAME, TWINE_PASSWORD, and TWINE_REPOSITORY
+        # environment variables
+        if [ -n "$TWINE_REPOSITORY" ]; then
+                twine upload dist/*
+        fi
+        cd dist
+        echo ::set-output name=src_file_name::$(ls *.tar.gz)
+        echo ::set-output name=whl_file_name::$(ls *.whl)
+
+      env:
+        TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+        TWINE_REPOSITORY: ${{ secrets.TWINE_REPOSITORY }}
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: true
+
+    - name: Upload release asset sdist
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: dist/${{ steps.file_assets.outputs.src_file_name }}
+        asset_name: ${{ steps.file_assets.outputs.src_file_name }}
+        asset_content_type: application/gzip
+
+    - name: Upload release asset wheel
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: dist/${{ steps.file_assets.outputs.whl_file_name }}
+        asset_name: ${{ steps.file_assets.outputs.whl_file_name }}
+        asset_content_type: application/octet-stream

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -25,11 +25,14 @@ jobs:
             python-architecture: 'x86'
             os: windows-latest
 
+    outputs:
+      on_master: ${{ steps.on_master.outputs.on_master }}
+
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
       with:
-        fetch-depth: 10
+        fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2.2.1
@@ -99,16 +102,27 @@ jobs:
         path: tests_out.xml
       if: success() || failure()
 
-    # Actions below build bdist wheel. Run only for tags.
+    # Actions below build bdist wheel. Run only for tags on master.
+    - name: Check if on master
+      id: on_master
+      shell: bash
+      run: |
+        git branch -a --contains $GITHUB_REF
+        git describe --always --tags
+        export ON_MASTER=$(git branch -a --contains $GITHUB_REF | grep -q '^  remotes/origin/master$' && echo "master" || echo "")
+        echo "Found out: ${ON_MASTER}"
+        echo ::set-output name=on_master::$ON_MASTER
+      if: contains(github.ref, 'tags')
+
     - name: Build dist
       run: |
         pip install setuptools wheel
         python setup.py sdist bdist_wheel
-      if: contains(github.ref, 'tags')
+      if: contains(github.ref, 'tags') && steps.on_master.outputs.on_master == 'master'
 
     - name: Upload dist packages
       uses: actions/upload-artifact@v2.2.2
       with:
         name: dist-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}
         path: dist/
-      if: contains(github.ref, 'tags')
+      if: contains(github.ref, 'tags') && steps.on_master.outputs.on_master == 'master'


### PR DESCRIPTION
Create a draft release and uploads both the sdist and the wheel files as assets.
`twine` upload is optional and needs the login credentials as well as the target repo to be configured in secrets.
The current version uses linux/python3.7 generated packages, but there shouldn't be major differences.

It still leaves the final steps to the release manager:
1.) publish the github release draft,
2.) Upload files to PyPI