### PR TITLE
github-actions: Restrict tests to 80 mins

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -90,6 +90,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Test with pytest
+      timeout-minutes: 80
       run: pytest --junit-xml=tests_out.xml --verbosity=0 -n auto --maxprocesses=2
 
     - name: Upload test results


### PR DESCRIPTION
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>