### PR TITLE
dependabot: Allow up to 15 open pull requests for pip packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,4 @@ updates:
       prefix: "requirements"
     labels:
       - "deps"
+    open-pull-requests-limit: 15


### PR DESCRIPTION
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>