### PR TITLE
llvm: Move generated binary structures from parameters to execution

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1068,10 +1068,6 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         '_init_args',
     ])
 
-    class _CompilationData(ParametersBase):
-        parameter_struct = None
-        state_struct = None
-
     def __init__(self,
                  default_variable,
                  param_defaults,
@@ -1242,8 +1238,6 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
 
         self.initialization_status = ContextFlags.INITIALIZED
 
-        self._compilation_data = self._CompilationData(owner=self)
-
         self._update_parameter_components(context)
 
     def __repr__(self):
@@ -1269,7 +1263,6 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             # may be in DEFERRED INIT, so parameters/defaults belongs to class
             newone.parameters._owner = newone
             newone.defaults._owner = newone
-            newone._compilation_data._owner = newone
 
         # by copying, this instance is no longer "inherent" to a single
         # 'import psyneulink' call

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -3352,7 +3352,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         parameter_struct = None
         state_struct = None
         data_struct = None
-        scheduler_conditions = None
 
 
     def __init__(

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -3349,10 +3349,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
     class _CompilationData(ParametersBase):
         execution = None
-        parameter_struct = None
-        state_struct = None
-        data_struct = None
-
 
     def __init__(
             self,

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -380,6 +380,34 @@ class CompExecution(CUDAExecution):
 
         return self._get_compilation_param('parameter_struct', '_get_param_initializer', 1, self._execution_contexts[0])
 
+    @property
+    def _state_struct(self):
+        if len(self._execution_contexts) > 1:
+            if self.__state_struct is None:
+                self.__state_struct = self._get_multirun_struct(0, '_get_state_initializer')
+            return self.__state_struct
+
+        return self._get_compilation_param('state_struct', '_get_state_initializer', 0, self._execution_contexts[0])
+
+    @property
+    def _data_struct(self):
+        # Run wrapper changed argument order
+        arg = 2 if self._bin_func is self.__bin_run_func else 3
+
+        if len(self._execution_contexts) > 1:
+            if self.__data_struct is None:
+                self.__data_struct = self._get_multirun_struct(arg, '_get_data_initializer')
+            return self.__data_struct
+
+        return self._get_compilation_param('data_struct', '_get_data_initializer', arg, self._execution_contexts[0])
+
+    @_data_struct.setter
+    def _data_struct(self, data_struct):
+        if len(self._execution_contexts) > 1:
+            self.__data_struct = data_struct
+        else:
+            self._composition._compilation_data.data_struct._set(data_struct, context=self._execution_contexts[0])
+
     def _copy_params_to_pnl(self, context=None, component=None, params=None):
         # need to special case compositions
         from psyneulink.core.compositions import Composition
@@ -415,34 +443,6 @@ class CompExecution(CUDAExecution):
                     # FIXME: this seems to break something when generalized for all attributes
                     value = np.array(value).reshape(component.parameters.matrix._get(context).shape)
                     to_set._set(value, context=context)
-
-    @property
-    def _state_struct(self):
-        if len(self._execution_contexts) > 1:
-            if self.__state_struct is None:
-                self.__state_struct = self._get_multirun_struct(0, '_get_state_initializer')
-            return self.__state_struct
-
-        return self._get_compilation_param('state_struct', '_get_state_initializer', 0, self._execution_contexts[0])
-
-    @property
-    def _data_struct(self):
-        # Run wrapper changed argument order
-        arg = 2 if self._bin_func is self.__bin_run_func else 3
-
-        if len(self._execution_contexts) > 1:
-            if self.__data_struct is None:
-                self.__data_struct = self._get_multirun_struct(arg, '_get_data_initializer')
-            return self.__data_struct
-
-        return self._get_compilation_param('data_struct', '_get_data_initializer', arg, self._execution_contexts[0])
-
-    @_data_struct.setter
-    def _data_struct(self, data_struct):
-        if len(self._execution_contexts) > 1:
-            self.__data_struct = data_struct
-        else:
-            self._composition._compilation_data.data_struct._set(data_struct, context=self._execution_contexts[0])
 
     def _extract_node_struct(self, node, data):
         # context structure consists of a list of node contexts,

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -286,6 +286,21 @@ class CompExecution(CUDAExecution):
             self.__conds = None
             self._ct_len = ctypes.c_int(len(execution_ids))
 
+    @staticmethod
+    def get(composition, context, additional_tags=frozenset()):
+        executions = composition._compilation_data.execution._get(context)
+        if executions is None:
+            executions = dict()
+            composition._compilation_data.execution._set(executions, context)
+
+        execution = executions.get(additional_tags, None)
+        if execution is None:
+            execution = pnlvm.CompExecution(composition, [context.execution_id],
+                                            additional_tags=additional_tags)
+            executions[additional_tags] = execution
+
+        return execution
+
     @property
     def _bin_func(self):
         if self.__bin_func is not None:

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -231,15 +231,14 @@ class FuncExecution(CUDAExecution):
         new_variable = np.asfarray(np.atleast_2d(variable),
                                    dtype=self._vi_dty)
 
+        ct_vi = np.ctypeslib.as_ctypes(new_variable)
         if len(self._execution_contexts) > 1:
             # wrap_call casts the arguments so we only need contiguous data
             # layout
-            ct_vi = np.ctypeslib.as_ctypes(new_variable)
             self._bin_multirun.wrap_call(self._param_struct,
                                          self._state_struct,
                                          ct_vi, self._ct_vo, self._ct_len)
         else:
-            ct_vi = np.ctypeslib.as_ctypes(new_variable)
             self._bin_func(ctypes.byref(self._param_struct),
                            ctypes.byref(self._state_struct),
                            ct_vi, ctypes.byref(self._ct_vo))

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -661,7 +661,7 @@ class CompExecution(CUDAExecution):
         assert len(bin_func.byref_arg_types) == 6
 
         # There are 6 arguments to evaluate:
-        # comp_param, comp_state, allocations, results, output, input, comp_data
+        # comp_param, comp_state, allocations, results, input, comp_data
         # all but #2 and #3 are shared
 
         # Directly initialized structures

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,8 +93,7 @@ exclude_lines =
     # Don't complain about missing debug-only code:
     def __repr__
     if self\.debug
-    if .* in debug_env:
-    if .* in self.__debug_env:
+    if .* in .*debug_env:
 
     # Don't complain if tests don't hit defensive assertion code:
     raise .*Error

--- a/tests/functions/test_distance.py
+++ b/tests/functions/test_distance.py
@@ -66,7 +66,7 @@ names = [
 @pytest.mark.distance_function
 @pytest.mark.benchmark
 @pytest.mark.parametrize("metric, normalize, fail, expected", test_data, ids=names)
-@pytest.mark.parametrize("variable", [test_var, test_var.astype(np.float32), test_var.tolist()], ids=["np.float", "np.float32", "list"])
+@pytest.mark.parametrize("variable", [test_var, test_var.astype(np.float32), test_var.tolist()], ids=["np.default", "np.float32", "list"])
 @pytest.mark.parametrize("mode", ['Python',
                                   pytest.param('LLVM', marks=pytest.mark.llvm),
                                   pytest.param('PTX', marks=[pytest.mark.llvm, pytest.mark.cuda])

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -146,27 +146,27 @@ def test_transfer_with_costs_function():
     assert np.allclose(f.intensity_cost, 7.38905609893065)
     assert f.adjustment_cost is None
     assert f.duration_cost is None
-    assert np.allclose(np.float(f.combined_costs), 7.38905609893065)
+    assert np.allclose(f.combined_costs, 7.38905609893065)
     f.toggle_cost(Functions.CostFunctions.ADJUSTMENT)
     result = f(3)
     assert np.allclose(result, 3)
     assert np.allclose(f.intensity_cost, 20.085536923187668)
     assert np.allclose(f.adjustment_cost, 1)
     assert f.duration_cost is None
-    assert np.allclose(np.float(f.combined_costs), 21.085536923187668)
+    assert np.allclose(f.combined_costs, 21.085536923187668)
     f.toggle_cost(Functions.CostFunctions.DURATION)
     result = f(5)
     assert np.allclose(result, 5)
     assert np.allclose(f.intensity_cost, 148.413159102576603)
     assert np.allclose(f.adjustment_cost, 2)
     assert np.allclose(f.duration_cost, 5)
-    assert np.allclose(np.float(f.combined_costs), 155.413159102576603)
+    assert np.allclose(f.combined_costs, 155.413159102576603)
     result = f(1)
     assert np.allclose(result, 1)
     assert np.allclose(f.intensity_cost, 2.718281828459045)
     assert np.allclose(f.adjustment_cost, 4)
     assert np.allclose(f.duration_cost, 6)
-    assert np.allclose(np.float(f.combined_costs), 12.718281828459045)
+    assert np.allclose(f.combined_costs, 12.718281828459045)
 
 
 @pytest.mark.parametrize(

--- a/tests/llvm/test_helpers.py
+++ b/tests/llvm/test_helpers.py
@@ -430,8 +430,8 @@ def test_helper_numerical(mode, op, var, expected):
 @pytest.mark.parametrize('mode', ['CPU',
                                   pytest.param('PTX', marks=pytest.mark.cuda)])
 @pytest.mark.parametrize('var,expected', [
-    (np.array([1,2,3], dtype=np.float), np.array([2,3,4], dtype=np.float)),
-    (np.array([[1,2],[3,4]], dtype=np.float), np.array([[2,3],[4,5]], dtype=np.float)),
+    (np.array([1,2,3], dtype=np.float64), np.array([2,3,4], dtype=np.float64)),
+    (np.array([[1,2],[3,4]], dtype=np.float64), np.array([[2,3],[4,5]], dtype=np.float64)),
 ], ids=["vector", "matrix"])
 def test_helper_elementwise_op(mode, var, expected):
     with pnlvm.LLVMBuilderContext() as ctx:


### PR DESCRIPTION
Provide factory interface for generating single context executions.
Store composition executions as param composition param for both CPU and GPU 