### PR TITLE
llvm/execution: Use correct type to print scheduler conditions structure stats

### DIFF
--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -342,7 +342,7 @@ class CompExecution(CUDAExecution):
             self.__conds = cond_type(*cond_initializer)
             if "stat" in self._debug_env:
                 print("Instantiated condition struct ( size:" ,
-                      _pretty_size(ctypes.sizeof(struct_ty)), ")",
+                      _pretty_size(ctypes.sizeof(cond_type)), ")",
                       "for", self._composition.name)
 
         return self.__conds

--- a/tests/llvm/test_debug_composition.py
+++ b/tests/llvm/test_debug_composition.py
@@ -9,7 +9,7 @@ from psyneulink.core.components.mechanisms.processing.integratormechanism import
 from psyneulink.core.components.mechanisms.processing.transfermechanism import TransferMechanism
 from psyneulink.core.compositions.composition import Composition
 
-debug_options=["const_input=[[[7]]]", "const_input", "const_data", "const_params", "const_data", "const_state"]
+debug_options=["const_input=[[[7]]]", "const_input", "const_data", "const_params", "const_data", "const_state", "stat"]
 options_combinations = (";".join(("debug_info", *c)) for i in range(len(debug_options) + 1) for c in combinations(debug_options, i))
 
 @pytest.mark.composition


### PR DESCRIPTION
Add 'stat' to the test of debugging flags.

Fixes: fd5a419271c73cc327d0f6ef6b1e6c8eee4e9f1f ("llvm/execution: Store binary buffer of scheduler structures locally")
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>