### PR TITLE
llvm: Stop using SharedParams in compiled code

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1287,6 +1287,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         def _is_compilation_state(p):
             #FIXME: This should use defaults instead of 'p.get'
             return p.name not in blacklist and \
+                   not isinstance(p, (ParameterAlias, SharedParameter)) and \
                    (p.name in whitelist or isinstance(p.get(), Component))
 
         return filter(_is_compilation_state, self.parameters)
@@ -1346,7 +1347,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         if hasattr(self, 'ports'):
             blacklist.update(["matrix", "integration_rate"])
         def _is_compilation_param(p):
-            if p.name not in blacklist and not isinstance(p, ParameterAlias):
+            if p.name not in blacklist and not isinstance(p, (ParameterAlias, SharedParameter)):
                 #FIXME: this should use defaults
                 val = p.get()
                 # Check if the value type is valid for compilation

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -1317,20 +1317,27 @@ class OutputPort(Port_Base):
         # FIXME: Add support for other cost types
         assert self.cost_options == CostFunctions.INTENSITY
 
-        func = ctx.import_llvm_function(self.intensity_cost_function)
-        func_params = pnlvm.helpers.get_param_ptr(builder, self, params,
-                                                  "intensity_cost_function")
-        func_state = pnlvm.helpers.get_state_ptr(builder, self, state,
-                                                 "intensity_cost_function")
-        func_out = builder.alloca(func.args[3].type.pointee)
-        # Port input is always struct
-        func_in = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(0)])
+        ifunc = ctx.import_llvm_function(self.function.intensity_cost_fct)
 
-        builder.call(func, [func_params, func_state, func_in, func_out])
+        func_params = pnlvm.helpers.get_param_ptr(builder, self, params,
+                                                  "function")
+        func_state = pnlvm.helpers.get_state_ptr(builder, self, state,
+                                                 "function")
+        ifunc_params = pnlvm.helpers.get_param_ptr(builder, self.function,
+                                                   func_params,
+                                                   "intensity_cost_fct")
+        ifunc_state = pnlvm.helpers.get_state_ptr(builder, self.function,
+                                                  func_state,
+                                                  "intensity_cost_fct")
+        ifunc_out = builder.alloca(ifunc.args[3].type.pointee)
+        # Port input is always struct
+        ifunc_in = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(0)])
+
+        builder.call(ifunc, [ifunc_params, ifunc_state, ifunc_in, ifunc_out])
 
 
         # Cost function output is 1 element array
-        ret_ptr = builder.gep(func_out, [ctx.int32_ty(0), ctx.int32_ty(0)])
+        ret_ptr = builder.gep(ifunc_out, [ctx.int32_ty(0), ctx.int32_ty(0)])
         ret_val = builder.load(ret_ptr)
         builder.ret(ret_val)
 

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -390,6 +390,11 @@ class CompExecution(CUDAExecution):
                     self._copy_params_to_pnl(context=context,
                                              component=projection,
                                              params=projection_params)
+            elif attribute == 'function':
+                function_params = getattr(params, params._fields_[idx][0])
+                self._copy_params_to_pnl(context=context,
+                                         component=component.function,
+                                         params=function_params)
             elif attribute == 'matrix':
                 pnl_param = component.parameters.matrix
                 parameter_ctype = getattr(params, params._fields_[idx][0])

--- a/psyneulink/library/compositions/pytorchcomponents.py
+++ b/psyneulink/library/compositions/pytorchcomponents.py
@@ -179,7 +179,8 @@ class PytorchProjectionWrapper():
                                            ctx.int32_ty(self._idx)])
 
         dim_x, dim_y = self.matrix.detach().numpy().shape
-        proj_matrix = pnlvm.helpers.get_param_ptr(builder, self._projection, proj_params, "matrix")
+        proj_func = pnlvm.helpers.get_param_ptr(builder, self._projection, proj_params, "function")
+        proj_matrix = pnlvm.helpers.get_param_ptr(builder, self._projection.function, proj_func, "matrix")
         proj_matrix = builder.bitcast(proj_matrix, pnlvm.ir.types.ArrayType(
             pnlvm.ir.types.ArrayType(ctx.float_ty, dim_y), dim_x).as_pointer())
 


### PR DESCRIPTION
The values are already in their original locations.