### PR TITLE
Fix jupyter detection for rich while running on colab

### DIFF
--- a/psyneulink/__init__.py
+++ b/psyneulink/__init__.py
@@ -19,6 +19,26 @@ If you have trouble installing PsyNeuLink, run into any bugs, or have suggestion
 please contact psyneulinkhelp@princeton.edu.
 """
 
+# Monkey patch rich._is_juptyer to work on Google colab
+import rich
+def _is_jupyter() -> bool:  # pragma: no cover
+    """Check if we're running in a Jupyter notebook."""
+    try:
+        get_ipython  # type: ignore
+    except NameError:
+        return False
+    shell = get_ipython().__class__.__name__  # type: ignore
+    full_class = str(get_ipython().__class__)  # type: ignore
+    if shell == "ZMQInteractiveShell":
+        return True  # Jupyter notebook or qtconsole
+    elif shell == "TerminalInteractiveShell":
+        return False  # Terminal running IPython
+    elif "google.colab" in full_class:  # IPython in Google Colab
+        return True
+    else:
+        return False  # Other type (?)
+rich.console._is_jupyter = _is_jupyter
+
 import logging as _logging
 
 import numpy as _numpy

--- a/psyneulink/__init__.py
+++ b/psyneulink/__init__.py
@@ -20,7 +20,7 @@ please contact psyneulinkhelp@princeton.edu.
 """
 
 # Monkey patch rich._is_juptyer to work on Google colab
-import rich
+import rich.console
 def _is_jupyter() -> bool:  # pragma: no cover
     """Check if we're running in a Jupyter notebook."""
     try:

--- a/psyneulink/__init__.py
+++ b/psyneulink/__init__.py
@@ -19,8 +19,26 @@ If you have trouble installing PsyNeuLink, run into any bugs, or have suggestion
 please contact psyneulinkhelp@princeton.edu.
 """
 
-# Monkey patch rich._is_juptyer to work on Google colab
+import logging as _logging
+
+import numpy as _numpy
+
+# We need to import rich here so we can monkey patch console._is_jupyter to work on
+# google colab. This fix to rich is up as a pull request. See:
+# https://github.com/willmcgugan/rich/pull/1085
+# If accepted then this import and the monkey patch below can be removed.
 import rich.console
+
+# starred imports to allow user imports from top level
+from . import core
+from . import library
+
+from ._version import get_versions
+from .core import *
+from .library import *
+
+
+# Monkey patch rich
 def _is_jupyter() -> bool:  # pragma: no cover
     """Check if we're running in a Jupyter notebook."""
     try:
@@ -39,20 +57,6 @@ def _is_jupyter() -> bool:  # pragma: no cover
         return False  # Other type (?)
 rich.console._is_jupyter = _is_jupyter
 
-import logging as _logging
-
-import numpy as _numpy
-
-# starred imports to allow user imports from top level
-from . import core
-from . import library
-
-from ._version import get_versions
-from .core import *
-from .library import *
-
-# from rich import print, box
-# print("Initializing...")
 
 _pnl_global_names = [
     'primary_registries', 'System', 'Process'

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ toposort<1.7
 torch<1.8.0; sys_platform != 'win32' and platform_machine == 'x86_64' and platform_python_implementation == 'CPython'
 typecheck-decorator<=1.2
 leabra-psyneulink<=0.3.2
-rich<=9.11.0
+rich>=9.11


### PR DESCRIPTION
Rich does not detect it is running in a jupyter notebook on Google colab. This is a bug in rich for which I have made a pull request.
See [here](https://github.com/willmcgugan/rich/pull/1085). Until this is accepted I suggest we just monkey patch rich.console._is_jupyter. If the pull request is accepted then this can be reverted.