### PR TITLE
tests: Add fixture for compiled composition tests that don't support per-node compiled execution

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -59,7 +59,12 @@ def pytest_generate_tests(metafunc):
     if "mech_mode" in metafunc.fixturenames:
         metafunc.parametrize("mech_mode", mech_and_func_modes)
 
-    if "comp_mode" in metafunc.fixturenames:
+    if "comp_mode_no_llvm" in metafunc.fixturenames:
+        modes = [m for m in get_comp_execution_modes()
+                 if m.values[0] is not pnlvm.ExecutionMode.LLVM]
+        metafunc.parametrize("comp_mode", modes)
+
+    elif "comp_mode" in metafunc.fixturenames:
         metafunc.parametrize("comp_mode", get_comp_execution_modes())
 
     if "autodiff_mode" in metafunc.fixturenames:
@@ -85,9 +90,14 @@ def pytest_runtest_teardown(item):
 
     pnlvm.cleanup()
 
+@pytest.fixture
+def comp_mode_no_llvm():
+    # dummy fixture to allow 'comp_mode' filtering
+    pass
+
 @pytest.helpers.register
 def get_comp_execution_modes():
-    return [pnlvm.ExecutionMode.Python,
+    return [pytest.param(pnlvm.ExecutionMode.Python),
             pytest.param(pnlvm.ExecutionMode.LLVM, marks=pytest.mark.llvm),
             pytest.param(pnlvm.ExecutionMode.LLVMExec, marks=pytest.mark.llvm),
             pytest.param(pnlvm.ExecutionMode.LLVMRun, marks=pytest.mark.llvm),

--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -1188,14 +1188,6 @@ class TestStatefulness:
 
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism
-    @pytest.mark.parametrize('mode', [pnl.ExecutionMode.Python,
-                                      # 'LLVM' mode is not supported, because
-                                      # 'reset_when' needs compiled scheduler
-                                      pytest.param(pnl.ExecutionMode.LLVMExec, marks=pytest.mark.llvm),
-                                      pytest.param(pnl.ExecutionMode.LLVMRun, marks=pytest.mark.llvm),
-                                      pytest.param(pnl.ExecutionMode.PTXExec, marks=[pytest.mark.llvm, pytest.mark.cuda]),
-                                      pytest.param(pnl.ExecutionMode.PTXRun, marks=[pytest.mark.llvm, pytest.mark.cuda])
-                                     ])
     @pytest.mark.parametrize('cond0, cond1, expected', [
         (pnl.Never(), pnl.AtTrial(2),
          [[np.array([0.5]), np.array([0.5])],
@@ -1222,7 +1214,10 @@ class TestStatefulness:
           [np.array([0.5]), np.array([0.9375])],
           [np.array([0.5]), np.array([0.96875])]]),
         ], ids=lambda x: str(x) if isinstance(x, pnl.Condition) else "")
-    def test_reset_stateful_function_when_composition(self, mode, cond0, cond1, expected):
+    # 'LLVM' mode is not supported, because synchronization of compiler and
+    # python values during execution is not implemented.
+    @pytest.mark.usefixtures("comp_mode_no_llvm")
+    def test_reset_stateful_function_when_composition(self, comp_mode, cond0, cond1, expected):
         I1 = pnl.IntegratorMechanism()
         I2 = pnl.IntegratorMechanism()
         I1.reset_stateful_function_when = cond0
@@ -1231,7 +1226,7 @@ class TestStatefulness:
         C.add_node(I1)
         C.add_node(I2)
 
-        C.run(inputs={I1: [[1.0]], I2: [[1.0]]}, num_trials=7, execution_mode=mode)
+        C.run(inputs={I1: [[1.0]], I2: [[1.0]]}, num_trials=7, execution_mode=comp_mode)
 
         assert np.allclose(expected, C.results)
 

--- a/tests/scheduling/test_scheduler.py
+++ b/tests/scheduling/test_scheduler.py
@@ -1498,23 +1498,16 @@ class TestFeedback:
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
-    @pytest.mark.parametrize('mode', [pnl.ExecutionMode.Python,
-                                      # 'LLVM' mode is not supported
-                                      # the comparison values and checks
-                                      # are not synced between binary
-                                      # and Python structures
-                                      pytest.param(pnl.ExecutionMode.LLVMExec, marks=pytest.mark.llvm),
-                                      pytest.param(pnl.ExecutionMode.LLVMRun, marks=pytest.mark.llvm),
-                                      pytest.param(pnl.ExecutionMode.PTXExec, marks=[pytest.mark.llvm, pytest.mark.cuda]),
-                                      pytest.param(pnl.ExecutionMode.PTXRun, marks=[pytest.mark.llvm, pytest.mark.cuda]),
-                                     ])
     @pytest.mark.parametrize('timescale, expected',
                              [(TimeScale.TIME_STEP, [[0.5], [0.4375]]),
                               (TimeScale.PASS, [[0.5], [0.4375]]),
                               (TimeScale.TRIAL, [[1.5], [0.4375]]),
                               (TimeScale.RUN, [[1.5], [0.4375]])],
                               ids=lambda x: x if isinstance(x, TimeScale) else "")
-    def test_time_termination_measures(self, mode, timescale, expected):
+    # 'LLVM' mode is not supported, because synchronization of compiler and
+    # python values during execution is not implemented.
+    @pytest.mark.usefixtures("comp_mode_no_llvm")
+    def test_time_termination_measures(self, comp_mode, timescale, expected):
         in_one_pass = timescale in {TimeScale.TIME_STEP, TimeScale.PASS}
         attention = pnl.TransferMechanism(name='Attention',
                                  integrator_mode=True,
@@ -1533,23 +1526,14 @@ class TestFeedback:
         comp.scheduler.add_condition(response, pnl.WhenFinished(attention))
         comp.scheduler.add_condition(counter, pnl.Always())
         inputs = {attention: [[0.5]], counter: [[2.0]]}
-        result = comp.run(inputs=inputs, execution_mode=mode)
-        if mode is pnl.ExecutionMode.Python:
+        result = comp.run(inputs=inputs, execution_mode=comp_mode)
+        if comp_mode is pnl.ExecutionMode.Python:
             assert attention.execution_count == 3
             assert counter.execution_count == 1 if in_one_pass else 3
             assert response.execution_count == 1
         assert np.allclose(result, expected)
 
     @pytest.mark.composition
-    @pytest.mark.parametrize("mode", [pnl.ExecutionMode.Python,
-                                      # 'LLVM' mode is not supported, because
-                                      # synchronization of compiler and python
-                                      # values during execution is not implemented.
-                                      pytest.param(pnl.ExecutionMode.LLVMExec, marks=pytest.mark.llvm),
-                                      pytest.param(pnl.ExecutionMode.LLVMRun, marks=pytest.mark.llvm),
-                                      pytest.param(pnl.ExecutionMode.PTXExec, marks=[pytest.mark.llvm, pytest.mark.cuda]),
-                                      pytest.param(pnl.ExecutionMode.PTXRun, marks=[pytest.mark.llvm, pytest.mark.cuda]),
-                                     ])
     @pytest.mark.parametrize("condition,scale,expected_result",
                              [(pnl.BeforeNCalls, TimeScale.TRIAL, [[.05, .05]]),
                               (pnl.BeforeNCalls, TimeScale.PASS, [[.05, .05]]),
@@ -1570,7 +1554,10 @@ class TestFeedback:
                               (pnl.AtTrial, None, [[0.05, 0.05]]),
                               #(pnl.Never), #TODO: Find a good test case for this!
                             ])
-    def test_scheduler_conditions(self, mode, condition, scale, expected_result):
+    # 'LLVM' mode is not supported, because synchronization of compiler and
+    # python values during execution is not implemented.
+    @pytest.mark.usefixtures("comp_mode_no_llvm")
+    def test_scheduler_conditions(self, comp_mode, condition, scale, expected_result):
         decisionMaker = pnl.DDM(
                         function=pnl.DriftDiffusionIntegrator(starting_point=0,
                                                               threshold=1,
@@ -1619,9 +1606,9 @@ class TestFeedback:
         elif condition is pnl.AtTrial:
             comp.scheduler.add_condition(response, condition(0))
 
-        result = comp.run([0.05], execution_mode=mode)
+        result = comp.run([0.05], execution_mode=comp_mode)
         #HACK: The result is an object dtype in Python mode for some reason?
-        if mode is pnl.ExecutionMode.Python:
+        if comp_mode is pnl.ExecutionMode.Python:
             result = np.asfarray(result[0])
         assert np.allclose(result, expected_result)
 


### PR DESCRIPTION

This changes the order of generated tests slightly.
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>