### PR TITLE
llvm: Implement multihreaded parallel evaluate

### DIFF
--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -1371,7 +1371,7 @@ class GridSearch(OptimizationFunction):
             s.reset()
         self.grid = itertools.product(*[s for s in self.search_space])
 
-    def _get_optimized_composition(self):
+    def _get_optimized_controller(self):
         # self.objective_function may be a bound method of
         # OptimizationControlMechanism
         return getattr(self.objective_function, '__self__', None)
@@ -1379,7 +1379,7 @@ class GridSearch(OptimizationFunction):
     def _gen_llvm_function(self, *, ctx:pnlvm.LLVMBuilderContext, tags:frozenset):
         if "select_min" in tags:
             return self._gen_llvm_select_min_function(ctx=ctx, tags=tags)
-        ocm = self._get_optimized_composition()
+        ocm = self._get_optimized_controller()
         if ocm is not None:
             # self.objective_function may be a bound method of
             # OptimizationControlMechanism
@@ -1421,7 +1421,7 @@ class GridSearch(OptimizationFunction):
 
     def _gen_llvm_select_min_function(self, *, ctx:pnlvm.LLVMBuilderContext, tags:frozenset):
         assert "select_min" in tags
-        ocm = self._get_optimized_composition()
+        ocm = self._get_optimized_controller()
         if ocm is not None:
             assert ocm.function is self
             sample_t = ocm._get_evaluate_alloc_struct_type(ctx)
@@ -1521,7 +1521,7 @@ class GridSearch(OptimizationFunction):
         return builder.function
 
     def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:frozenset):
-        ocm = self._get_optimized_composition()
+        ocm = self._get_optimized_controller()
         if ocm is not None:
             assert ocm.function is self
             obj_func = ctx.import_llvm_function(ocm, tags=tags.union({"evaluate"}))
@@ -1754,7 +1754,7 @@ class GridSearch(OptimizationFunction):
                     format(repr(DIRECTION), self.name, direction)
 
 
-            ocm = self._get_optimized_composition()
+            ocm = self._get_optimized_controller()
             if ocm is not None and \
                (ocm.parameters.comp_execution_mode._get(context) == "PTX"):
                     opt_sample, opt_value, all_values = self._run_cuda_grid(ocm, variable, context)

--- a/psyneulink/core/components/functions/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/optimizationfunctions.py
@@ -1589,7 +1589,7 @@ class GridSearch(OptimizationFunction):
 
         # Map allocations to values
         comp_exec = pnlvm.execution.CompExecution(ocm.agent_rep, [context.execution_id])
-        ct_values = comp_exec.cuda_evaluate(new_variable, self.search_space)
+        ct_values = comp_exec.cuda_evaluate(new_variable, num_evals)
 
         assert len(ct_values) == num_evals
         # Reduce array of values to min/max

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1127,6 +1127,70 @@ class OptimizationControlMechanism(ControlMechanism):
         builder.ret_void()
         return llvm_func
 
+    def _gen_llvm_evaluate_alloc_range_function(self, *, ctx:pnlvm.LLVMBuilderContext,
+                                                   tags=frozenset()):
+        assert "evaluate" in tags
+        assert "alloc_range" in tags
+        evaluate_f = ctx.import_llvm_function(self,
+                                              tags=tags - {"alloc_range"})
+
+
+        args = [*evaluate_f.type.pointee.args[:2],
+                ctx.int32_ty, ctx.int32_ty,
+                *evaluate_f.type.pointee.args[3:]]
+        builder = ctx.create_llvm_function(args, self, str(self) + "_evaluate_range")
+        llvm_func = builder.function
+
+        params, state, start, stop, arg_out, arg_in, data = llvm_func.args
+        for p in llvm_func.args:
+            if isinstance(p.type, (pnlvm.ir.PointerType)):
+                p.attributes.add('nonnull')
+
+        nodes_params = pnlvm.helpers.get_param_ptr(builder, self.composition,
+                                                   params, "nodes")
+        my_idx = self.composition._get_node_index(self)
+        my_params = builder.gep(nodes_params, [ctx.int32_ty(0),
+                                               ctx.int32_ty(my_idx)])
+        func_params = pnlvm.helpers.get_param_ptr(builder, self,
+                                                  my_params, "function")
+        search_space = pnlvm.helpers.get_param_ptr(builder, self.function,
+                                                   func_params, "search_space")
+
+        allocation = builder.alloca(evaluate_f.args[2].type.pointee)
+        with pnlvm.helpers.for_loop(builder, start, stop, stop.type(1), "alloc_loop") as (b, idx):
+
+            func_out = b.gep(arg_out, [idx])
+            # Construct allocation corresponding to this index
+            for i in reversed(range(len(search_space.type.pointee))):
+                slot_ptr = b.gep(allocation, [ctx.int32_ty(0), ctx.int32_ty(i)])
+
+                dim_ptr = b.gep(search_space, [ctx.int32_ty(0), ctx.int32_ty(i)])
+                # Iterators store {start, step, num}
+                if len(dim_ptr.type.pointee) == 3:
+                    iter_val = b.load(dim_ptr)
+                    dim_start = b.extract_value(iter_val, 0)
+                    dim_step = b.extract_value(iter_val, 1)
+                    dim_size = b.extract_value(iter_val, 2)
+                    dim_idx = b.urem(idx, dim_size)
+                    val = b.uitofp(dim_idx, dim_step.type)
+                    val = b.fmul(val, dim_step)
+                    val = b.fadd(val, dim_start)
+                else:
+                    # Otherwise it's just an array
+                    dim_size = ctx.int32_ty(len(dim_ptr.type.pointee))
+                    dim_idx = b.urem(idx, dim_size)
+                    val_ptr = b.gep(dim_ptr, [ctx.int32_ty(0), dim_idx])
+                    val = b.load(val_ptr)
+
+                idx = b.udiv(idx, dim_size)
+
+                b.store(val, slot_ptr)
+
+            b.call(evaluate_f, [params, state, allocation, func_out, arg_in, data])
+
+        builder.ret_void()
+        return llvm_func
+
     def _gen_llvm_evaluate_function(self, *, ctx:pnlvm.LLVMBuilderContext,
                                              tags=frozenset()):
         assert "evaluate" in tags
@@ -1250,6 +1314,8 @@ class OptimizationControlMechanism(ControlMechanism):
     def _gen_llvm_function(self, *, ctx:pnlvm.LLVMBuilderContext, tags:frozenset):
         if "net_outcome" in tags:
             return self._gen_llvm_net_outcome_function(ctx=ctx, tags=tags)
+        if "evaluate" in tags and "alloc_range" in tags:
+            return self._gen_llvm_evaluate_alloc_range_function(ctx=ctx, tags=tags)
         if "evaluate" in tags:
             return self._gen_llvm_evaluate_function(ctx=ctx, tags=tags)
 

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -625,7 +625,7 @@ class CompExecution(CUDAExecution):
         data_out = jit_engine.pycuda.driver.mem_alloc(output_size)
 
         # number of trials argument
-        runs_np = np.array([runs] * len(self._execution_contexts), dtype=np.int32)
+        runs_np = np.full(len(self._execution_contexts), runs, dtype=np.int32)
         runs_count = jit_engine.pycuda.driver.InOut(runs_np)
         self._uploaded_bytes['input'] += runs_np.nbytes
         self._downloaded_bytes['input'] += runs_np.nbytes

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -117,15 +117,10 @@ class CUDAExecution(Execution):
         # CUDA uses the same function for single and multi run
         return self._bin_func
 
-    def _get_ctype_bytes(self, data):
-        # Return dummy buffer. CUDA does not handle 0 size well.
-        if ctypes.sizeof(data) == 0:
-            return bytearray(b'aaaa')
-        return bytearray(data)
-
     def upload_ctype(self, data, name='other'):
         self._uploaded_bytes[name] += ctypes.sizeof(data)
-        return jit_engine.pycuda.driver.to_device(self._get_ctype_bytes(data))
+        assert ctypes.sizeof(data) != 0
+        return jit_engine.pycuda.driver.to_device(bytearray(data))
 
     def download_ctype(self, source, ty, name='other'):
         self._downloaded_bytes[name] += ctypes.sizeof(ty)

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -692,4 +692,4 @@ class CompExecution(CUDAExecution):
         bin_func.cuda_call(*cuda_args, threads=len(allocations))
         ct_results = self.download_ctype(cuda_args[3], out_ty, 'result')
 
-        return ct_allocations.contents, ct_results
+        return ct_results

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -174,6 +174,37 @@ def all_close(ctx, builder, arr1, arr2, rtol=1e-05, atol=1e-08):
 
     return builder.load(all_ptr)
 
+
+def create_allocation(builder, allocation, search_space, idx):
+    # Construct allocation corresponding to this index
+    for i in reversed(range(len(search_space.type.pointee))):
+        slot_ptr = builder.gep(allocation, [idx.type(0), idx.type(i)])
+
+        dim_ptr = builder.gep(search_space, [idx.type(0), idx.type(i)])
+        # Iterators store {start, step, num}
+        if isinstance(dim_ptr.type.pointee,  ir.LiteralStructType):
+            iter_val = builder.load(dim_ptr)
+            dim_start = builder.extract_value(iter_val, 0)
+            dim_step = builder.extract_value(iter_val, 1)
+            dim_size = builder.extract_value(iter_val, 2)
+            dim_idx = builder.urem(idx, dim_size)
+            val = builder.uitofp(dim_idx, dim_step.type)
+            val = builder.fmul(val, dim_step)
+            val = builder.fadd(val, dim_start)
+        elif isinstance(dim_ptr.type.pointee,  ir.ArrayType):
+            # Otherwise it's just an array
+            dim_size = idx.type(len(dim_ptr.type.pointee))
+            dim_idx = builder.urem(idx, dim_size)
+            val_ptr = builder.gep(dim_ptr, [idx.type(0), dim_idx])
+            val = builder.load(val_ptr)
+        else:
+            assert False, "Unknown dimension type: {}".format(dim_ptr.type)
+
+        idx = builder.udiv(idx, dim_size)
+
+        builder.store(val, slot_ptr)
+
+
 def is_pointer(x):
     type_t = getattr(x, "type", x)
     return isinstance(type_t, ir.PointerType)

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -1677,11 +1677,12 @@ class TestModelBasedOptimizationControlMechanisms:
     @pytest.mark.composition
     @pytest.mark.benchmark(group="Model Based OCM")
     @pytest.mark.parametrize("mode", pytest.helpers.get_comp_execution_modes() +
-                                     [pytest.helpers.cuda_param('Python-PTX')])
+                                     [pytest.helpers.cuda_param('Python-PTX'),
+                                      pytest.param('Python-LLVM', marks=pytest.mark.llvm)])
     def test_model_based_ocm_after(self, benchmark, mode):
-        if mode == 'Python-PTX':
+        if str(mode).startswith('Python-'):
+            ocm_mode = mode.split('-')[1]
             mode = pnl.ExecutionMode.Python
-            ocm_mode = 'PTX'
         else:
             # OCM default mode is Python
             ocm_mode = 'Python'
@@ -1724,11 +1725,12 @@ class TestModelBasedOptimizationControlMechanisms:
     @pytest.mark.composition
     @pytest.mark.benchmark(group="Model Based OCM")
     @pytest.mark.parametrize("mode", pytest.helpers.get_comp_execution_modes() +
-                                     [pytest.helpers.cuda_param('Python-PTX')])
+                                     [pytest.helpers.cuda_param('Python-PTX'),
+                                      pytest.param('Python-LLVM', marks=pytest.mark.llvm)])
     def test_model_based_ocm_before(self, benchmark, mode):
-        if mode == 'Python-PTX':
+        if str(mode).startswith('Python-'):
+            ocm_mode = mode.split('-')[1]
             mode = pnl.ExecutionMode.Python
-            ocm_mode = 'PTX'
         else:
             # OCM default mode is Python
             ocm_mode = 'Python'

--- a/tests/models/test_greedy_agent.py
+++ b/tests/models/test_greedy_agent.py
@@ -109,7 +109,8 @@ def test_simplified_greedy_agent_random(benchmark, comp_mode):
 @pytest.mark.model
 @pytest.mark.benchmark(group="Predator Prey")
 @pytest.mark.parametrize("mode", pytest.helpers.get_comp_execution_modes() +
-                                 [pytest.helpers.cuda_param('Python-PTX')])
+                                 [pytest.helpers.cuda_param('Python-PTX'),
+                                  pytest.param('Python-LLVM', marks=pytest.mark.llvm)])
 @pytest.mark.parametrize("samples", [[0,10],
     pytest.param([0,3,6,10], marks=pytest.mark.stress),
     pytest.param([0,2,4,6,8,10], marks=pytest.mark.stress),
@@ -119,11 +120,11 @@ def test_predator_prey(benchmark, mode, samples):
     if len(samples) > 10 and mode not in {pnl.ExecutionMode.LLVM,
                                           pnl.ExecutionMode.LLVMExec,
                                           pnl.ExecutionMode.LLVMRun,
-                                          "Python-PTX"}:
+                                          "Python-PTX", "Python-LLVM"}:
         pytest.skip("This test takes too long")
-    if mode == 'Python-PTX':
+    if str(mode).startswith('Python-'):
+        ocm_mode = mode.split('-')[1]
         mode = pnl.ExecutionMode.Python
-        ocm_mode = 'PTX'
     else:
         # OCM default mode is Python
         ocm_mode = 'Python'


### PR DESCRIPTION
Generate samples locally instead of preparing the entire array in Python.
Add evaluate range wrapper.
Split the total number of evaluations evenly across all cores.