### PR TITLE
Reenable reportOutputPref 'params' option

### DIFF
--- a/psyneulink/core/globals/preferences/basepreferenceset.py
+++ b/psyneulink/core/globals/preferences/basepreferenceset.py
@@ -373,7 +373,9 @@ class BasePreferenceSet(PreferenceSet):
         :param setting:
         :return:
         """
-        self.set_preference(candidate_info=setting, pref_ivar_name=REPORT_OUTPUT_PREF)
+        # skip setting validation because default is bool but 'params'
+        # string should be accepted
+        self.set_preference(candidate_info=setting, pref_ivar_name=REPORT_OUTPUT_PREF, skip_validation=True)
 
     @property
     def logPref(self):

--- a/psyneulink/core/globals/preferences/preferenceset.py
+++ b/psyneulink/core/globals/preferences/preferenceset.py
@@ -504,7 +504,7 @@ class PreferenceSet(object):
 #                                          " must be a {2} or PreferenceLevel".
 #                                          format(pref_spec, pref_attrib_name, type(pref_spec).__name__))
 
-    def set_preference(self, candidate_info, pref_ivar_name, default_entry=None):
+    def set_preference(self, candidate_info, pref_ivar_name, default_entry=None, skip_validation=False):
         """Validate and assign PreferenceSet, setting, or level to a PreferenceSet preference attribute
 
         Validate candidate candidate_info and, if OK, assign to pref_ivar_name attribute; candidate_info can be a:
@@ -575,7 +575,7 @@ class PreferenceSet(object):
                 candidate_info = PreferenceEntry(candidate_info[0], candidate_info[1])
             setting_OK = self.validate_setting(candidate_info.setting, default_setting, pref_ivar_name)
             level_OK = isinstance(candidate_info.level, PreferenceLevel)
-            if level_OK and setting_OK:
+            if (level_OK and setting_OK) or skip_validation:
                 setattr(self, pref_ivar_name, candidate_info)
                 return_val = candidate_info
             else:
@@ -589,12 +589,12 @@ class PreferenceSet(object):
         # candidate_info is a presumed setting
         else:
             setting_OK = self.validate_setting(candidate_info, default_setting, pref_ivar_name)
-            if setting_OK:
+            if setting_OK or skip_validation:
                 setattr(self, pref_ivar_name, PreferenceEntry(candidate_info, default_level))
                 return_val = PreferenceEntry(setting=candidate_info, level=None)
 
         # All is OK, so return
-        if level_OK and setting_OK:
+        if (level_OK and setting_OK) or skip_validation:
             return return_val
 
         # Something's amiss, so raise exception

--- a/tests/composition/test_report.py
+++ b/tests/composition/test_report.py
@@ -1,3 +1,5 @@
+import contextlib
+import io
 import psyneulink as pnl
 from psyneulink.core.globals.keywords import DIVERT, FULL, TERSE
 
@@ -205,3 +207,38 @@ class TestReport():
     #     actual_output = ocomp.rich_diverted_reports
     #     expected_output = '\nocomp TRIAL 0 ====================\n Time Step 0 ---------\nicomp TRIAL 0 ====================\n Time Step 0 ---------\n Time Step 0 ---------\n Time Step 0 ---------\n Time Step 1 ---------\nocomp: Executed 1 of 1 trials\nocomp: Simulated 3 trials\nicomp: Executed 1 of 1 trials\nicomp: Simulated 4 trials\nicomp: Executed 1 of 1 trials\nicomp: Simulated 4 trials\nicomp: Executed 1 of 1 trials\nicomp: Simulated 4 trials\nicomp: Executed 1 of 1 trials\nicomp: Simulated 4 trials'
     #     assert actual_output == expected_output
+
+    def test_reportOutputPref_true(self):
+        t = pnl.TransferMechanism()
+        t.reportOutputPref = True
+
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            t.execute(1)
+        output = f.getvalue()
+
+        assert 'input: 1.0' in output
+        assert 'output: 1.0' in output
+        assert 'params' not in output
+
+    def test_reportOutputPref_params(self):
+        t = pnl.TransferMechanism()
+        t.reportOutputPref = 'params'
+
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            t.execute(1)
+        output = f.getvalue()
+
+        assert 'input: 1.0' in output
+        assert 'output: 1.0' in output
+        assert 'params' in output
+
+        # NOTE: parameters are not consistent in printed form with
+        # their underlying values (e.g. dimension brackets are removed)
+        # So, don't check output for all parameters and correct values
+        assert 'noise:' in output
+        assert 'integration_rate:' in output
+
+        assert 'Parameter(' not in output
+        assert 'pnl_internal=' not in output


### PR DESCRIPTION
- add tests to ensure `'params'` option does not break again
- add workaround to Preference validation to mimic pre- 8c0eecc2c674a481138420f703ee661d39239052 behavior (4460fe5ea499441d8f0a255b62c4840de9c2b568)