### PR TITLE
bug(ControlMechanism): ensure simulation data and execution_id is unique

### DIFF
--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -971,10 +971,7 @@ class OptimizationControlMechanism(ControlMechanism):
 
     def _set_up_simulation(self, base_context=Context(execution_id=None), control_allocation=None):
         sim_context = copy.copy(base_context)
-        sim_context.execution_id = self.get_next_sim_id(base_context)
-
-        if control_allocation is not None:
-            sim_context.execution_id += f'-{control_allocation}'
+        sim_context.execution_id = self.get_next_sim_id(base_context, control_allocation)
 
         try:
             self.parameters.simulation_ids._get(base_context).append(sim_context.execution_id)

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -1810,7 +1810,7 @@ class TestModelBasedOptimizationControlMechanisms:
         # preprocess to ignore control allocations
         log_parsed = {}
         for key, value in log.items():
-            cleaned_key = re.sub(r'comp-sim-(\d).*', r'\1', key)
+            cleaned_key = re.sub(r'comp-sim.*num: (\d).*', r'\1', key)
             log_parsed[cleaned_key] = value
 
         # First round of simulations is only one trial.


### PR DESCRIPTION
Make generated simulation execution_ids more verbose and unique, ensuring no
simulations reuse state.

If a Composition and one of its nested Compositions both run simulations,
execution ids may be inadvertently reused. See test_input_type_equivalence for
an example.

By default the outer Composition 'ocomp' runs with execution_id 'ocomp'. When it
simulates first, the generated execution_id will be 'ocomp-sim-0'. The inner
Composition 'icomp' will run during this simulation. Later, during
non-simulation running of ocomp, icomp will run under execution_id 'ocomp' and
simulate itself, also generating 'ocomp-sim-0'. Note that while in this case
there is no control allocation is directly specified for the simulation (hence
it not being included in the simulation execution_id), it can also happen when
the same allocation is specified in both situations.

The reuse of simulation execution_ids may cause reuse of state when not deleted.