### PR TITLE
Report: add _get_sim_number function

### DIFF
--- a/psyneulink/core/compositions/report.py
+++ b/psyneulink/core/compositions/report.py
@@ -127,6 +127,18 @@ trial_output_color = 'red'
 trial_panel_box = box.HEAVY
 
 
+def _get_sim_number(context):
+    try:
+        context = context.execution_id
+    except (AttributeError, TypeError):
+        pass
+
+    try:
+        return int(re.search(r'num: (\d+)', context).group(1))
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
 class ReportOutput(Enum):
     """
     Options used in the **report_output** argument of a `Composition`\'s `execution methods

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -1,9 +1,9 @@
-import re
-
 import numpy as np
 import pytest
 
 import psyneulink as pnl
+
+from psyneulink.core.compositions.report import _get_sim_number
 from psyneulink.core.globals.keywords import ALLOCATION_SAMPLES, PROJECTIONS
 from psyneulink.core.globals.log import LogCondition
 from psyneulink.core.globals.sampleiterator import SampleIterator, SampleIteratorError, SampleSpec
@@ -1810,18 +1810,18 @@ class TestModelBasedOptimizationControlMechanisms:
         # preprocess to ignore control allocations
         log_parsed = {}
         for key, value in log.items():
-            cleaned_key = re.sub(r'comp-sim.*num: (\d).*', r'\1', key)
+            cleaned_key = _get_sim_number(key)
             log_parsed[cleaned_key] = value
 
         # First round of simulations is only one trial.
         # (Even though the feature fn is a Buffer, there is no history yet)
         for i in range(0, 3):
-            assert len(log_parsed[str(i)]["Trial"]) == 1
+            assert len(log_parsed[i]["Trial"]) == 1
 
         # Second and third rounds of simulations are two trials.
         # (The buffer has history = 2)
         for i in range(3, 9):
-            assert len(log_parsed[str(i)]["Trial"]) == 2
+            assert len(log_parsed[i]["Trial"]) == 2
 
     def test_stability_flexibility_susan_and_sebastian(self):
 

--- a/tests/mechanisms/test_control_mechanism.py
+++ b/tests/mechanisms/test_control_mechanism.py
@@ -6,6 +6,8 @@ import pytest
 import psyneulink.core.components.functions.transferfunctions
 import psyneulink.core.llvm as pnlvm
 
+from psyneulink.core.compositions.report import _get_sim_number
+
 class TestLCControlMechanism:
 
     @pytest.mark.mechanism
@@ -296,3 +298,13 @@ class TestLCControlMechanism:
         assert m2.parameter_ports[pnl.SLOPE].value == [10]
         assert c2.control_signals[2].value == [10]
         assert m3.parameter_ports[pnl.SLOPE].value == [10]
+
+
+class TestSimulationIDs:
+    def test_sim_numbers(self):
+        cmech = pnl.ControlMechanism()
+        context = pnl.Context('comp')
+
+        for i in range(10):
+            sim_id = cmech.get_next_sim_id(context)
+            assert _get_sim_number(sim_id) == i


### PR DESCRIPTION
extracts the simulation number from a simulation context or execution_id