### PR TITLE
Component: speed up noise generation for common cases

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -3199,6 +3199,10 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
 
         var = convert_all_elements_to_np_array(copy.deepcopy(var), cast_from=int, cast_to=float)
 
+        # ignore zero-length variables (e.g. empty Buffer)
+        if var.shape == (0, ):
+            return var
+
         # handle simple wrapping of a Component (e.g. from ParameterPort in
         # case of set after Component instantiation)
         if (
@@ -3224,6 +3228,15 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                 if param.shape == np.squeeze(var).shape:
                     param = param.reshape(var.shape)
         except AttributeError:
+            pass
+
+        try:
+            # try to broadcast param to variable if param is numeric and regular
+            param_arr = np.asarray(param)
+            if param_arr.dtype != object:
+                return np.broadcast_to(param_arr, var.shape)
+        except ValueError:
+            # param not directly compatible with variable, continue elementwise
             pass
 
         fill_recursively(var, param)


### PR DESCRIPTION
When noise is numeric (not generated at Component run time by functions), do not
apply it element-by-element, which can get very slow for large variables.