### PR TITLE
Composition: delete scheduler data when deleting a context

### DIFF
--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -9852,6 +9852,11 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     def _get_parsed_variable(self, *args, **kwargs):
         raise TypeError(f'_get_parsed_variable unsupported for {self.__class__.__name__}')
 
+    def _delete_contexts(self, *contexts, check_simulation_storage=False, visited=None):
+        super()._delete_contexts(*contexts, check_simulation_storage=check_simulation_storage, visited=visited)
+
+        for c in contexts:
+            self.scheduler._delete_counts(c.execution_id)
 
     # ******************************************************************************************************************
     #                                           LLVM

--- a/psyneulink/core/scheduling/scheduler.py
+++ b/psyneulink/core/scheduling/scheduler.py
@@ -479,6 +479,13 @@ class Scheduler(JSONDumpable):
             else:
                 self.clocks[execution_id] = Clock()
 
+    def _delete_counts(self, execution_id=None):
+        for obj in [self.counts_useable, self.counts_total, self.clocks, self.execution_list]:
+            try:
+                del obj[execution_id]
+            except KeyError:
+                pass
+
     def _reset_counts_total(self, time_scale, execution_id=None):
         for ts in TimeScale:
             # only reset the values underneath the current scope


### PR DESCRIPTION
Scheduler clocks previously were never deleted regardless of `Composition.retain_old_simulation_data` setting