### PR TITLE
json/mdf: ignore learning components when regenerating script

### DIFF
--- a/psyneulink/core/globals/json.py
+++ b/psyneulink/core/globals/json.py
@@ -650,7 +650,9 @@ def _generate_composition_string(composition_list, component_identifiers):
     implicit_types = (
         psyneulink.ObjectiveMechanism,
         psyneulink.ControlProjection,
-        psyneulink.AutoAssociativeProjection
+        psyneulink.AutoAssociativeProjection,
+        psyneulink.LearningMechanism,
+        psyneulink.LearningProjection,
     )
     output = []
 


### PR DESCRIPTION
it was not reliable/tested in json examples, and it's unclear if there are any
actual examples of manual learning pathways for psyneulink. (all learning
appears to be done via premade methods like
Composition.add_backpropagation_learning_pathway)