### PR TITLE
fix(json/mdf): crash on backprop learning compositions

### DIFF
--- a/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
@@ -337,6 +337,7 @@ class ComparatorMechanism(ObjectiveMechanism):
                  ):
 
         input_ports = kwargs.pop(INPUT_PORTS, {})
+        input_ports_spec = input_ports
         if input_ports:
             input_ports = {INPUT_PORTS: input_ports}
 
@@ -363,6 +364,8 @@ class ComparatorMechanism(ObjectiveMechanism):
 
         # Require Projection to TARGET InputPort (already required for SAMPLE as primary InputPort)
         self.input_ports[1].parameters.require_projection_in_composition.set(True, override=True)
+        # reset input ports spec to actual spec, not parsed
+        self.parameters.input_ports.spec = input_ports_spec
 
     def _validate_params(self, request_set, target_set=None, context=None):
         """If sample and target values are specified, validate that they are compatible

--- a/tests/json/model_backprop.py
+++ b/tests/json/model_backprop.py
@@ -1,0 +1,10 @@
+import psyneulink as pnl
+
+a = pnl.TransferMechanism()
+b = pnl.TransferMechanism()
+c = pnl.TransferMechanism()
+
+p = pnl.Pathway(pathway=[a, b, c])
+
+comp = pnl.Composition()
+comp.add_backpropagation_learning_pathway(pathway=p)

--- a/tests/json/test_json.py
+++ b/tests/json/test_json.py
@@ -29,7 +29,8 @@ json_results_parametrization = [
         'stroop_conflict_monitoring.py',
         'Stroop_model',
         str(stroop_stimuli).replace("'", '')
-    )
+    ),
+    ('model_backprop.py', 'comp', '{a: [1, 2, 3]}'),
 ]
 
 


### PR DESCRIPTION
Ensures that for `ComparatorMechanism`, the `spec` for `input_ports` is correctly assigned to the actual values passed in by the user. Due to unique parsing in `ComparatorMechanism.__init__`, the spec for `input_ports` is a fully parsed port specification dictionary, which is not supported as user-input and consequently is not supported in json methods. Fixes crash in #1997 