### PR TITLE
fix(OptimizationControlMechanism): don't immediately create shadowed projection for features

### DIFF
--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -444,7 +444,7 @@ from psyneulink.core.globals.context import handle_external_context
 from psyneulink.core.globals.defaults import defaultControlAllocation
 from psyneulink.core.globals.keywords import \
     DEFAULT_VARIABLE, EID_FROZEN, FUNCTION, INTERNAL_ONLY, NAME, \
-    OPTIMIZATION_CONTROL_MECHANISM, OUTCOME, PARAMS
+    OPTIMIZATION_CONTROL_MECHANISM, OUTCOME, PARAMS, PROJECTIONS
 from psyneulink.core.globals.parameters import Parameter
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.sampleiterator import SampleIterator, SampleSpec
@@ -1429,6 +1429,7 @@ class OptimizationControlMechanism(ControlMechanism):
         for spec in input_ports:
             spec = _parse_port_spec(owner=self, port_type=InputPort, port_spec=spec)    # returns InputPort dict
             spec[PARAMS][INTERNAL_ONLY] = True
+            spec[PARAMS][PROJECTIONS] = None
             if feature_function:
                 if isinstance(feature_function, Function):
                     feat_fct = copy.deepcopy(feature_function)


### PR DESCRIPTION
Fixes a problem in which an incorrect shadowed projection is created from an
OCM/controller to a node. Specifically, consider a composition O with a nested
composition I, containing a node A. If the controller of O has A as its feature,
the controller should only control A and receive shadowed input through the
parameter CIM of I. Prior to this commit, the controller of O received a
shadowed input projection directly from A, created during
_instantiate_input_ports during construction of the controller. This step is
unnecessary and incorrect as shadowed input projections are created during the
call to Composition.add_controller.