### PR TITLE
Fix/content addressable memory/execute 1d 2d entries

### DIFF
--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -1064,7 +1064,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
             (must be done here rather than in validate_params as it is needed to initialize previous_value
         """
 
-        if initializer is None or np.array(initializer, dtype=object).size == 0:
+        if initializer is None or convert_all_elements_to_np_array(initializer).size == 0:
             return None
 
         # Enforce initializer to be shape of memory (2d for ragged fields or 3d for regular ones)
@@ -1161,7 +1161,17 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         value of entry that best matches `variable <ContentAddressableMemory.variable>`  : 1d array
         """
 
+        # # MODIFIED 4/20/21 OLD:
+        # variable = convert_all_elements_to_np_array(variable)
+        # MODIFIED 4/20/21 NEW:
+        # Enforce initializer to be shape of memory (2d for ragged fields or 3d for regular ones)
+        # - note: this also allows initializer to be specified with a single entry
+        #         (i.e., without enclosing it in an outer list or array)
         variable = convert_all_elements_to_np_array(variable)
+        variable = np.atleast_2d(variable)
+        if variable.dtype != object and variable.ndim==1:
+            variable = np.expand_dims(variable, axis=0)
+        # MODIFIED 4/20/21 END
 
         retrieval_prob = np.array(self._get_current_parameter_value(RETRIEVAL_PROB, context)).astype(float)
         storage_prob = np.array(self._get_current_parameter_value(STORAGE_PROB, context)).astype(float)

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -646,9 +646,9 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
     initializer : ndarray
         initial set of entries for `memory <ContentAddressableMemory.memory>`.  It should be either a 3d regular
         array or a 2d ragged array (if the fields of an entry have different lengths), but it can be specified
-        in the **initializer** argument of the contructor using some simpler forms for convenience.  Specifically,
-        scalars, 1d and regular 2d arrays are allowed, which are interpreted as a single entry with a single
-        field that is converted to a 3d array to initialize `memory <ContentAddressableMemory.memory>`.
+        in the **initializer** argument of the constructor using some simpler forms for convenience.  Specifically,
+        scalars, 1d and regular 2d arrays are allowed, which are interpreted as a single entry that is converted to
+        a 3d array to initialize `memory <ContentAddressableMemory.memory>`.
 
     memory : list
         list of entries in ContentAddressableMemory, each of which is an array of fields containing stored items;

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -1173,6 +1173,9 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         value of entry that best matches `variable <ContentAddressableMemory.variable>`  : 1d array
         """
 
+        # Enforce variable to be shape of an entry (1d for ragged fields or 2d for regular ones)
+        # - note: this allows entries with a single field to be specified as a 1d regular array
+        #         (i.e., without enclosing it in an outer list or array), which are converted to a 2d array
         variable = convert_all_elements_to_np_array(variable)
         if variable.dtype != object and variable.ndim==1:
             variable = np.expand_dims(variable, axis=0)
@@ -1229,11 +1232,6 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         if not len(entry) == num_fields:
             raise FunctionError(f"Attempt to store and/or retrieve entry in {self.__class__.__name__} ({entry}) "
                                 f"that has an incorrect number of fields ({len(entry)}; should be {num_fields}).")
-
-        # if not all((np.array(item).ndim == 1 and np.array(item).shape == field_shapes[i][0]
-        #             for i, item in enumerate(entry))):
-        #     raise FunctionError(f"Attempt to store and/or retrieve an entry in {self.__class__.__name__} that has one "
-        #                         f"or more fields with an incorrect shape (shapes should be {field_shapes}):\n{entry}.")
 
         owner_name = f'of {self.owner.name}' if self.owner else ''
         for i, field in enumerate(entry):

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -1145,12 +1145,8 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
 
         # otherwise, set previous_value to initializer
         else:
-            # MODIFIED 4/20/21 OLD:
-            # value = self._initialize_previous_value(previous_value, context=context)
-            # MODIFIED 4/20/21 NEW:
             value = self._initialize_previous_value(ContentAddressableMemory._enforce_memory_shape(previous_value),
                                                     context=context)
-            # MODIFIED 4/20/21 END
 
         self.parameters.value.set(value, context, override=True)
         return value

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -1163,12 +1163,19 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
 
         # # MODIFIED 4/20/21 OLD:
         # variable = convert_all_elements_to_np_array(variable)
-        # MODIFIED 4/20/21 NEW:
+        # # MODIFIED 4/20/21 NEW:
+        # # Enforce initializer to be shape of memory (2d for ragged fields or 3d for regular ones)
+        # # - note: this also allows initializer to be specified with a single entry
+        # #         (i.e., without enclosing it in an outer list or array)
+        # variable = convert_all_elements_to_np_array(variable)
+        # variable = np.atleast_2d(variable)
+        # if variable.dtype != object and variable.ndim==1:
+        #     variable = np.expand_dims(variable, axis=0)
+        # MODIFIED 4/20/21 NEWER:
         # Enforce initializer to be shape of memory (2d for ragged fields or 3d for regular ones)
         # - note: this also allows initializer to be specified with a single entry
         #         (i.e., without enclosing it in an outer list or array)
         variable = convert_all_elements_to_np_array(variable)
-        variable = np.atleast_2d(variable)
         if variable.dtype != object and variable.ndim==1:
             variable = np.expand_dims(variable, axis=0)
         # MODIFIED 4/20/21 END

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -1133,20 +1133,22 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         `value <ContentAddressableMemory.value>` takes on the same value as
         `previous_value <ContentAddressableMemory.previous_value>`.
         """
-        # no arguments were passed in -- use current values of initializer attributes
-        if previous_value is None:
-            previous_value = self._get_current_parameter_value("initializer", context)
 
-        # no initializer, so clear previous_value and set value to None
-        if previous_value is None:
-            self.parameters.previous_value._get(context).clear()
-            # value = np.ndarray(shape=(2, 0, len(self.defaults.variable[0])))
-            value = None
-
-        # otherwise, set previous_value to initializer
-        else:
+        if previous_value is not None:
             value = self._initialize_previous_value(ContentAddressableMemory._enforce_memory_shape(previous_value),
                                                     context=context)
+
+        else:
+            # no arguments were passed in -- use current values of initializer attributes
+            initializer = self._get_current_parameter_value("initializer", context)
+            if initializer is not None:
+                # set previous_value to initializer and get value
+                value = self._initialize_previous_value(ContentAddressableMemory._enforce_memory_shape(initializer),
+                                                        context=context)
+            else:
+                # no initializer, so clear previous_value and set value to None
+                self.parameters.previous_value._get(context).clear()
+                value = None
 
         self.parameters.value.set(value, context, override=True)
         return value

--- a/tests/functions/test_memory.py
+++ b/tests/functions/test_memory.py
@@ -1075,7 +1075,7 @@ class TestContentAddressableMemory:
 
     def test_ContentAddressableMemory_errors_and_warnings(self):
 
-        # Test constructor
+        # Test constructor warnings and errors
 
         text = "(the angle of scalars is not defined)."
         with pytest.warns(UserWarning, match=text):
@@ -1134,11 +1134,7 @@ class TestContentAddressableMemory:
                "must return a scalar if 'distance_field_weights' is not specified or is homogenous " \
                "(i.e., all elements are the same." in str(error_text.value)
 
-        clear_registry(FunctionRegistry)
-        c = ContentAddressableMemory()
-        c([[1,2,3],[4,5,6]])
-
-        # Test parameter and value assignments
+        # Test parameter assignment Parameter errors
 
         with pytest.raises(ParameterError) as error_text:
             clear_registry(FunctionRegistry)
@@ -1161,6 +1157,19 @@ class TestContentAddressableMemory:
                "ContentAddressableMemory Function-0).parameters is not valid: " \
                "must be a float in the interval [0,1]." in str(error_text.value)
 
+        # Test storage and retrieval Function errorsn
+
+        with pytest.raises(FunctionError) as error_text:
+            clear_registry(FunctionRegistry)
+            c = ContentAddressableMemory(initializer=[[1,1],[2,2]])
+            c([1,1])
+        assert 'Attempt to store and/or retrieve entry in ContentAddressableMemory ([[1 1]]) ' \
+               'that has an incorrect number of fields (1; should be 2).' in str(error_text.value)
+
+        clear_registry(FunctionRegistry)
+        c = ContentAddressableMemory()
+        c([[1,2,3],[4,5,6]])
+
         with pytest.raises(FunctionError) as error_text:
             c([[[1,2,3],[4,5,6]]])
         assert 'Attempt to store and/or retrieve an entry in ContentAddressableMemory ([[[1 2 3]\n  [4 5 6]]]) that ' \
@@ -1177,12 +1186,8 @@ class TestContentAddressableMemory:
                "'ContentAddressableMemory Function-0';  should be: (3,)." in str(error_text.value)
 
         with pytest.raises(FunctionError) as error_text:
-            # c = ContentAddressableMemory()
-            # c = ContentAddressableMemory(equidistant_entries_select='HELLO')
             c.duplicate_entries_allowed = True
             c([[1,2,3],[4,5,6]])
-            # c.equidistant_entries_select = 'HELLO'
-            # c([[1., 2., 3.],  [4.,5.,6.]])
             c.duplicate_entries_allowed = OVERWRITE
             c([[1,2,3],[4,5,6]])
         assert "Attempt to store item ([[1. 2. 3.]\n [4. 5. 6.]]) in ContentAddressableMemory Function-0 with " \

--- a/tests/functions/test_memory.py
+++ b/tests/functions/test_memory.py
@@ -1090,25 +1090,41 @@ class TestContentAddressableMemory:
             c = ContentAddressableMemory(retrieval_prob=32)
         assert 'Value (32) assigned to parameter \'retrieval_prob\' of (ContentAddressableMemory ' \
                'ContentAddressableMemory Function-0).parameters is not valid: ' \
-               'retrieval_prob must be a float in the interval [0,1].' in str(error_text.value)
+               'must be a float in the interval [0,1].' in str(error_text.value)
 
         with pytest.raises(ParameterError) as error_text:
             clear_registry(FunctionRegistry)
             c = ContentAddressableMemory(storage_prob=-1)
         assert 'Value (-1) assigned to parameter \'storage_prob\' of (ContentAddressableMemory ' \
                'ContentAddressableMemory Function-0).parameters is not valid: ' \
-               'storage_prob must be a float in the interval [0,1].' in str(error_text.value)
+               'must be a float in the interval [0,1].' in str(error_text.value)
+
+        with pytest.raises(ParameterError) as error_text:
+            clear_registry(FunctionRegistry)
+            c = ContentAddressableMemory(initializer=[[1,1]],
+                                         distance_field_weights=[[1]])
+        assert 'Value ([[1]]) assigned to parameter \'distance_field_weights\' of (ContentAddressableMemory ' \
+               'ContentAddressableMemory Function-0).parameters is not valid: ' \
+               'must be a scalar or list or 1d array of scalars' in str(error_text.value)
+
+        with pytest.raises(ParameterError) as error_text:
+            clear_registry(FunctionRegistry)
+            c = ContentAddressableMemory(initializer=[[1,1]],
+                                         distance_field_weights=[1,2])
+        assert 'Value ([1 2]) assigned to parameter \'distance_field_weights\' of (ContentAddressableMemory ' \
+               'ContentAddressableMemory Function-0).parameters is not valid: ' \
+               'length (2) must be same as number of fields in entries of initializer (1)' in str(error_text.value)
 
         with pytest.raises(ParameterError) as error_text:
             clear_registry(FunctionRegistry)
             c = ContentAddressableMemory(equidistant_entries_select='HELLO')
-        assert "parameters is not valid: 'equidistant_entries_select' must be random or oldest or newest."\
+        assert "parameters is not valid: must be random or oldest or newest."\
                in str(error_text.value)
 
         with pytest.raises(ParameterError) as error_text:
             clear_registry(FunctionRegistry)
             c = ContentAddressableMemory(duplicate_entries_allowed='HELLO')
-        assert "parameters is not valid: 'duplicate_entries_allowed' must be a bool or 'OVERWRITE'."\
+        assert "parameters is not valid: must be a bool or 'OVERWRITE'."\
                in str(error_text.value)
 
         with pytest.raises(FunctionError) as error_text:
@@ -1128,22 +1144,22 @@ class TestContentAddressableMemory:
             clear_registry(FunctionRegistry)
             c.parameters.retrieval_prob = 2
         assert "Value (2) assigned to parameter 'retrieval_prob' of (ContentAddressableMemory " \
-               "ContentAddressableMemory Function-0).parameters is not valid: retrieval_prob " \
+               "ContentAddressableMemory Function-0).parameters is not valid: " \
                "must be a float in the interval [0,1]." in str(error_text.value)
 
         with pytest.raises(ParameterError) as error_text:
             clear_registry(FunctionRegistry)
             c = ContentAddressableMemory(retrieval_prob=32)
         assert "Value (32) assigned to parameter 'retrieval_prob' of (ContentAddressableMemory " \
-               "ContentAddressableMemory Function-0).parameters is not valid: retrieval_prob must " \
-               "be a float in the interval [0,1]." in str(error_text.value)
+               "ContentAddressableMemory Function-0).parameters is not valid: " \
+               "must be a float in the interval [0,1]." in str(error_text.value)
 
         with pytest.raises(ParameterError) as error_text:
             clear_registry(FunctionRegistry)
             c = ContentAddressableMemory(storage_prob=-1)
         assert "Value (-1) assigned to parameter 'storage_prob' of (ContentAddressableMemory " \
-               "ContentAddressableMemory Function-0).parameters is not valid: storage_prob must " \
-               "be a float in the interval [0,1]." in str(error_text.value)
+               "ContentAddressableMemory Function-0).parameters is not valid: " \
+               "must be a float in the interval [0,1]." in str(error_text.value)
 
         with pytest.raises(FunctionError) as error_text:
             c([[[1,2,3],[4,5,6]]])


### PR DESCRIPTION
• memoryfunctions.py:
  ContentAddressableMemory:
  - allow initializer to be a single entry (i.e., 1d or 2d array)
  - allow variable (entry) to be 1d or regular 2d array
  - clean up np.array casting
  - add classmethod _enforce_memory_shape
  - add validation for distance_field_weights parameter
