### PR TITLE
Feat/content addressable memory 0 distance warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@
 Welcome to PsyNeuLink
 =====================
 
+(pronounced: /sīnyoolingk - sigh-new-link)
 Documentation is available at https://princetonuniversity.github.io/PsyNeuLink/
-Pronounced: /sīnyoolingk (sigh-new-link)
 
 Purpose
 -------
@@ -226,6 +226,12 @@ With substantial and greatly appreciated assistance from:
 * **Michael Shvartsman**, Princeton Neuroscience Institute, Princeton University
 * **Ben Singer**, Princeton Neuroscience Institute, Princeton University
 * **Ted Willke**, Intel Labs, Intel Corporation
+
+Support for the development of PsyNeuLink has been provided by:
+
+* The National Institute of Mental Health (R21-MH117548)
+* The John Templeton Foundation
+* The Templeton World Charitable Foundation
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,7 @@ Welcome to PsyNeuLink
 =====================
 
 Documentation is available at https://princetonuniversity.github.io/PsyNeuLink/
+Pronounced: /sīnyoolingk (sigh-new-link)
 
 Purpose
 -------

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -918,6 +918,9 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
                 if len(field_weights) not in {1, num_fields}:
                     return f"length ({fw_len}) must be same as number of fields " \
                            f"in entries of initializer ({num_fields})."
+                if not np.any(field_weights):
+                    warnings.warn(f"All weights in the 'distance_fields_weights' Parameter of {self._owner.name} "
+                                  f"are set to '0', so all entries of its memory will be treated as duplicates.")
 
         def _validate_equidistant_entries_select(self, equidistant_entries_select):
             if equidistant_entries_select not in equidistant_entries_select_keywords:

--- a/tests/functions/test_memory.py
+++ b/tests/functions/test_memory.py
@@ -1134,7 +1134,7 @@ class TestContentAddressableMemory:
                "must return a scalar if 'distance_field_weights' is not specified or is homogenous " \
                "(i.e., all elements are the same." in str(error_text.value)
 
-        # Test parameter assignment Parameter errors
+        # Test parameter assignment Parameter errors and warnings
 
         with pytest.raises(ParameterError) as error_text:
             clear_registry(FunctionRegistry)
@@ -1157,7 +1157,14 @@ class TestContentAddressableMemory:
                "ContentAddressableMemory Function-0).parameters is not valid: " \
                "must be a float in the interval [0,1]." in str(error_text.value)
 
-        # Test storage and retrieval Function errorsn
+        text = "All weights in the 'distance_fields_weights' Parameter of ContentAddressableMemory Function-0 " \
+               "are set to '0', so all entries of its memory will be treated as duplicates."
+        with pytest.warns(UserWarning, match=text):
+            clear_registry(FunctionRegistry)
+            c = ContentAddressableMemory(initializer=[[1,2],[1,2]],
+                                         distance_field_weights=[0,0])
+
+        # Test storage and retrieval Function errors
 
         with pytest.raises(FunctionError) as error_text:
             clear_registry(FunctionRegistry)


### PR DESCRIPTION
• memoryfunctions.py
  ContentAddressableMemory:  add warning for all zeros in distance_field_weights

• README.rst:  
  - added proununciation key
  - added statements of support