### PR TITLE
Docs/episodic memory mechanism/examples

### DIFF
--- a/docs/source/EpisodicMemoryMechanism.rst
+++ b/docs/source/EpisodicMemoryMechanism.rst
@@ -4,4 +4,4 @@ EpisodicMemoryMechanism
 .. automodule:: psyneulink.library.components.mechanisms.processing.integrator.episodicmemorymechanism
    :members:
    :private-members:
-   :exclude-members: random, Parameters, _instantiate_input_ports, _instantiate_output_ports, _parse_function_variable, memory
+   :exclude-members: random, Parameters

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -357,16 +357,17 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
     """
     ContentAddressableMemory(                        \
         default_variable=None,                       \
-        retrieval_prob=1.0                           \
-        storage_prob=1.0                             \
+        retrieval_prob=1.0,                          \
+        storage_prob=1.0,                            \
         rate=None,                                   \
         noise=0.0,                                   \
         initializer=None,                            \
         distance_field_weights=None,                 \
         distance_function=Distance(metric=COSINE),   \
         selection_function=OneHot(mode=MIN_VAL),     \
-        equidistant_entries_select=RANDOM,           \
         duplicate_entries_allowed=False,             \
+        duplicate_threshold=0,                       \
+        equidistant_entries_select=RANDOM,           \
         max_entries=None,                            \
         params=None,                                 \
         owner=None,                                  \
@@ -375,22 +376,50 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
 
     .. _ContentAddressableMemory:
 
+    **Sections**
+
+    - `Overview <ContentAddressableMemory_Overview>` \n
+        `Entries and Fields <ContentAddressableMemory_Entries_and_Fields>` \n
+        `Content-based Retrieval <ContentAddressableMemory_Retrieval>` \n
+        `Duplicate entries <ContentAddressableMemory_Duplicate_Entries>` \n
+    - `Structure <ContentAddressableMemory_Structure>`
+    - `Execution <ContentAddressableMemory_Execution>` \n
+        `Retrieval <ContentAddressableMemory_Execution_Retrieval>` \n
+        `Storage <ContentAddressableMemory_Execution_Storage>` \n
+    - `Examples <ContentAddressableMemory_Examples>`
+    - `Class Reference <ContentAddressableMemory_Class_Reference>`
+
+    .. _ContentAddressableMemory_Overview:
+
     **Overview**
 
-    Implement configurable, content-addressable storage and retrieval of entries from
-    `memory <ContentAddressableMemory.memory>`. Storage is determined by `storage_prob
+    The ContentAddressableMemory `Function` implements a configurable, content-addressable storage and retrieval of
+    entries from `memory <ContentAddressableMemory.memory>`. Storage is determined by `storage_prob
     <ContentAddressableMemory.storage_prob>`, and retrieval of entries is determined by
     `distance_function <ContentAddressableMemory.distance_function>`,
     `selection_function <ContentAddressableMemory.selection_function>`, and `retrieval_prob
     <ContentAddressableMemory.retrieval_prob>`.
 
-    *Entries and Fields*. The **default_variable** argument specifies the shape of an entry in `memory
+    .. _ContentAddressableMemory_Entries_and_Fields:
+
+    **Entries and Fields**. The **default_variable** argument specifies the shape of an entry in `memory
     <ContentAddressableMemory.storage_prob>`, each of which is a list or array of fields that are themselves lists or
     1d arrays (see `EpisodicMemoryMechanism_Memory_Fields`). An entry can have an arbitrary number of fields, and
     each field can have an arbitrary length.  However, all entries must have the same number of fields, and the
-    corresponding fields must all have the same length across entries.
+    corresponding fields must all have the same length across entries.  Fields can be weighted to determine the
+    influence they have on retrieval, using the `distance_field_weights <ContentAddressableMemory.memory>` `Parameter`
+    (see `retrieval <ContentAddressableMemory_Retrieval>` below).
 
-    *Retrieval*. Entries are retrieved from `memory <ContentAddressableMemory.memory>` based on their distance from
+    .. hint::
+        Entries in `memory <ContentAddressableMemory.memory>` can be assigned "labels" -- i.e., values
+        that are not used in the calculation of distance -- by assigning them a weight of 0 or None in
+        `distance_field_weights <ContentAddressableMemory.memory>`); either can be used for labels that
+        are numeric values; however, if non-numeric values are assigned to a field as labels, then None
+        must be specified for that field in `distance_field_weights <ContentAddressableMemory.memory>`.
+
+    .. _ContentAddressableMemory_Retrieval:
+
+    **Retrieval**. Entries are retrieved from `memory <ContentAddressableMemory.memory>` based on their distance from
     `variable <ContentAddressableMemory.variable>`, used as the cue for retrieval. The distance is computed using the
     `distance_function <ContentAddressableMemory.distance_function>`, which compares `variable
     <ContentAddressableMemory.variable>` with each entry in `memory <ContentAddressableMemory.storage_prob>` as full
@@ -406,7 +435,9 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
     <ContentAddressableMemory.distance>` and `distances_by_field <ContentAddressableMemory.distances_by_field>`, and
     `distances_to_entries <ContentAddressableMemory.distances_to_entries>` respectively.
 
-    *Duplicate Entries*. These can be allowed, disallowed, or overwritten during storage using
+    .. _ContentAddressableMemory_Duplicate_Entries:
+
+    **Duplicate Entries**. These can be allowed, disallowed, or overwritten during storage using
     `duplicate_entries_allowed <ContentAddressableMemory.duplicate_entries_allowed>`),
     and how selection is made among duplicate entries or ones indistinguishable by the
     `distance_function <ContentAddressableMemory.distance_function>` can be specified
@@ -455,7 +486,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
 
     .. _ContentAddressableMemory_Execution_Retrieval:
 
-    * *Retrieval:* first, with probability `retrieval_prob <ContentAddressableMemory.retrieval_prob>`,
+    * **Retrieval:** first, with probability `retrieval_prob <ContentAddressableMemory.retrieval_prob>`,
       the entry closest to `variable <ContentAddressableMemory.variable>` is retrieved from is retrieved from `memory
       <ContentAddressableMemory.memory>`.  The entry is chosen by calling, in order:
 
@@ -486,13 +517,6 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
                between `variable <ContentAddressableMemory.variable>` and entries for those fields are not included
                in the averaging of distances by field.
 
-            .. hint::
-               Entries in `memory <ContentAddressableMemory.memory>` can be assigned "labels" -- i.e., values
-               that are not used in the calculation of distance -- by assigning them a weight of 0 or None in
-               `distance_field_weights <ContentAddressableMemory.memory>`); either can be used for labels that
-               are numeric values; however, if non-numeric values are assigned to a field as labels, then None
-               must be specified for that field in `distance_field_weights <ContentAddressableMemory.memory>`.
-
         * `selection_function <ContentAddressableMemory.selection_function>`\: called with the list of distances
           to determine which entries to select for consideration. If more than on entry from `memory
           <ContentAddressableMemory.memory>` is identified, `equidistant_entries_select
@@ -505,13 +529,12 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         `distances_by_field <ContentAddressableMemory.distances_by_field>`, and the distances of `variable
         <ContentAddressableMemory.variable>` to all entries in `memory <ContentAddressableMemory.memory>` is assigned
         to `distances_to_entries <ContentAddressableMemory.distances_to_entries>`.
+
     .. _ContentAddressableMemory_Execution_Storage:
 
-    * *Storage:* after retrieval, an attempt is made to store `variable <ContentAddressableMemory.variable>` in `memory
-      memory <ContentAddressableMemory.memory>` with probability `storage_prob<ContentAddressableMemory.storage_prob>`;
-      if the attempt is made:
-
-      .. _ContentAddressableMemory_Duplicate_Entries:
+    * **Storage:** after retrieval, an attempt is made to store `variable <ContentAddressableMemory.variable>`
+      in `memory memory <ContentAddressableMemory.memory>` with probability `storage_prob
+      <ContentAddressableMemory.storage_prob>`;  if the attempt is made:
 
       * if `variable <ContentAddressableMemory.variable>` is identical to an entry already in `memory
         <ContentAddressableMemory.memory>`, as evaluated by
@@ -544,6 +567,52 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         <ContentAddressableMemory.max_entries>`, the first (oldest) entry is deleted.  The current number of entries
         in memory is contained in the `memory_num_entries <ContentAddressableMemory.memory_num_entries>` attribute.
 
+    .. _ContentAddressableMemory_Examples:
+
+    **Examples**
+
+    *Initialize memory with **default_variable**
+
+    The format for entries in `memory <ContentAddressableMemory.memory` can be specified using either the
+    **default_variable** or **initializer** arguments of the Function's constructor.  **default_variable** specifies
+    the shape of entries, without creating any entries::
+
+    >>> c = ContentAddressableMemory(default_variable=[[0,0],[0,0,0]])
+    >>> c([[1,2]])
+    [array([0, 0])]
+
+    Since `memory <ContentAddressableMemory.memory` was not intialized, the first call to the Function returns an
+    array of zeros, formatted as specified in **defaul_variable**.  However, the input in the call to the Function
+    (``[[1,2]]``) is stored as an entry in `memory <EpisodicMemoryMechanism.memory>`::
+
+    >>> c.memory
+    array([[[1., 2.]]])
+
+    and is returned on the next call::
+
+    >>> c([[2,5]])
+    array([[1., 2.]])
+
+    Note that even though **default_variable** and the inputs to the Function are specified as lists, the entries
+    returned are arrays; `memory <ContentAddressableMemory.memory>` and all of its entries are always formated as
+    arrays.
+
+    *Initialize memory with **initializer**
+
+    The **initializer** argument of a ContentAddressableMemory's constructor can be used to initialize its `memory
+    <ContentAddressableMemory.memory>`::
+
+        >>> c = ContentAddressableMemory(initializer=[[[1,2],[3,4,5]],
+        ...                                            [[10,9],[8,7,6]]])
+        >>> c([[1,2],[3,4,6]])
+        array([array([1., 2.]), array([3., 4., 5.])], dtype=object)
+        >>> c([[1,2],[3,4,6]])
+        array([array([1., 2.]), array([3., 4., 6.])], dtype=object)
+
+    Note that there was no need to use **default_variable**, and in fact it would overidden if specified.
+
+    .. _ContentAddressableMemory_Class_Reference:
+
     Arguments
     ---------
 
@@ -572,15 +641,15 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         specifies an initial set of entries for `memory <ContentAddressableMemory.memory>` (see
         `initializer <ContentAddressableMemory.initializer>` for additional details).
 
-    distance_function : Distance or function : default Distance(metric=COSINE)
-        specifies the function used during retrieval to compare `variable <ContentAddressableMemory.variable>` with
-        entries in `memory <ContentAddressableMemory.memory>`.
-
     distance_field_weights : 1d array : default None
         specifies the weight to use in computing the distance between each item of `variable
         <ContentAddressableMemory.variable>` and the corresponding `memory_field
         <EpisodicMemoryMechanism_Memory_Fields>` of each item in `memory <ContentAddressableMemory.memory>` (see
         `distance_field_weights <ContentAddressableMemory.distance_field_weights>` for additional details).
+
+    distance_function : Distance or function : default Distance(metric=COSINE)
+        specifies the function used during retrieval to compare `variable <ContentAddressableMemory.variable>` with
+        entries in `memory <ContentAddressableMemory.memory>`.
 
     selection_function : OneHot or function : default OneHot(mode=MIN_VAL)
         specifies the function used during retrieval to evaluate the distances returned by `distance_function
@@ -596,7 +665,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         be considered a duplicate (see `duplicate entries <ContentAddressableMemory_Duplicate_Entries>`
         for additional details).
 
-    equidistant_entries_select:  RANDOM | OLDEST | NEWEST : default RANDOM
+    equidistant_entries_select :  RANDOM | OLDEST | NEWEST : default RANDOM
         specifies which entry in `memory <ContentAddressableMemory.memory>` is chosen for retrieval if two or more
         have the same distance from `variable <ContentAddressableMemory.variable>`.
 
@@ -658,23 +727,27 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
     memory : list
         list of entries in ContentAddressableMemory, each of which is an array of fields containing stored items;
         the fields of an entry must be lists or arrays, each of which can be different shapes, but the corresponding
-        fields of all entries must have the same shape;  for example:
-            [[[field1],[field2],[field3]...], [[field1],[field2],[field3]...]...]
-        could be:
-            |---------------- entry 1 ---------------|---------------- entry 2 ---------------|
-            |-- field1 --|-- field2 --|--- field3 ---|-- field1 --|-- field2 --|--- field3 ---|
-            [[   [a],      [b,c,d],      [[e],[f]]  ],[    [u],      [v,w,x],     [[y],[z]]  ]]
+        fields of all entries must have the same shape;  for example, the following could be a pair of entries in
+        memory:
 
-    distance_function : Distance or function : default Distance(metric=COSINE)
-        function used during retrieval to compare `variable <ContentAddressableMemory.variable>` with entries in
-        `memory <ContentAddressableMemory.memory>`.
+        +-------------+------------------------------+--------------------------------------------+
+        |                entry 1                     |                  entry 2                   |
+        +-------------+--------------+---------------+-----------+--------------+-----------------+
+        |    field1   |    field2    |     field3    |   field1  |    field2    |    field3       |
+        +-------------+--------------+---------------+-----------+--------------+-----------------+
+        |  [[ [a],    |  [b,c,d],    |  [[e],[f]] ], | [  [u],   |   [v,w,x],   |  [[y],[z]]  ]]  |
+        +-------------+--------------+---------------+-----------+--------------+-----------------+
 
     distance_field_weights : 1d array : default None
         determines the weight used in computing the distance between each item of `variable
         <ContentAddressableMemory.variable>` and the corresponding `memory_field
-        <EpisodicMemoryMechanism_Memory_Fields>` of each entry in `memory <ContentAddressableMemory.memory>`;
-        if all elements are identical, it is treated as a scalar coefficient on `distance
-        <ContentAddressableMemory.distance>` (see `ContentAddressableMemory_Field_Weights` for additional details).
+        <EpisodicMemoryMechanism_Memory_Fields>` of each entry in `memory <ContentAddressableMemory.memory>`; if all
+        elements are identical, it is treated as a scalar coefficient on `distance <ContentAddressableMemory.distance>`
+        (see `ContentAddressableMemory_Distance_Field_Weights` for additional details).
+
+    distance_function : Distance or function : default Distance(metric=COSINE)
+        function used during retrieval to compare `variable <ContentAddressableMemory.variable>` with entries in
+        `memory <ContentAddressableMemory.memory>`.
 
     distance : float : default 0
         contains distance used for retrieval last cue to last entry returned in a given `context <Context>`.
@@ -763,17 +836,17 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
                     :default value: [[0], [0]]
                     :type: ``list``
 
-                distance_field_weights
-                    see `distance_field_weights <ContentAddressableMemory.distance_field_weights>`
-
-                    :default value: [1]
-                    :type: ``numpy.ndarray``
-
                 distance
                     see `distance <ContentAddressableMemory.distance>`
 
                     :default value: 0
                     :type: ``float``
+
+                distance_field_weights
+                    see `distance_field_weights <ContentAddressableMemory.distance_field_weights>`
+
+                    :default value: [1]
+                    :type: ``numpy.ndarray``
 
                  distance_function
                     see `distance_function <ContentAddressableMemory.distance_function>`
@@ -946,29 +1019,43 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
                 initializer = ContentAddressableMemory._enforce_memory_shape(initializer)
             return initializer
 
+    @tc.typecheck
     def __init__(self,
-                 default_variable=None,
-                 retrieval_prob: Optional[Union[int, float]]=None,
-                 storage_prob: Optional[Union[int, float]]=None,
-                 noise: Optional[Union[int, float, list, np.ndarray, callable]]=None,
-                 rate: Optional[Union[int, float, list, np.ndarray]]=None,
-                 initializer:Optional[Union[list, np.ndarray]]=None,
-                 distance_field_weights:Optional[Union[list, np.ndarray]]=None,
-                 distance_function:Optional[Union[Distance, is_function_type]]=None,
-                 selection_function:Optional[Union[OneHot, is_function_type]]=None,
-                 duplicate_entries_allowed=None,
+                 # FIX: REINSTATE WHEN 3.6 IS RETIRED:
+                 # default_variable=None,
+                 # retrieval_prob: Optional[Union[int, float]]=None,
+                 # storage_prob: Optional[Union[int, float]]=None,
+                 # rate: Optional[Union[int, float, list, np.ndarray]]=None,
+                 # noise: Optional[Union[int, float, list, np.ndarray, callable]]=None,
+                 # initializer:Optional[Union[list, np.ndarray]]=None,
+                 # distance_field_weights:Optional[Union[list, np.ndarray]]=None,
+                 # distance_function:Optional[Union[Distance, is_function_type]]=None,
+                 # selection_function:Optional[Union[OneHot, is_function_type]]=None,
                  # duplicate_entries_allowed:Optional[Union[(bool, Literal[OVERWRITE]]]=None,
-                 duplicate_threshold:Optional[int]=None,
+                 # duplicate_threshold:Optional[int]=None,
                  # equidistant_entries_select:Optional[Literal[Union[RANDOM, OLDEST, NEWEST]]]=None,
+                 # max_entries:Optional[int]=None,
+                 # seed:Optional[int]=None,
+                 # params:Optional[Union[list, np.ndarray]]=None,
+                 # owner=None,
+                 # prefs:tc.optional(is_pref_set)=None):
+                 default_variable=None,
+                 retrieval_prob=None,
+                 storage_prob=None,
+                 rate=None,
+                 noise=None,
+                 initializer=None,
+                 distance_field_weights=None,
+                 distance_function=None,
+                 selection_function=None,
+                 duplicate_entries_allowed=None,
+                 duplicate_threshold=None,
                  equidistant_entries_select=None,
-                 max_entries:Optional[int]=None,
-                 seed:Optional[int]=None,
-                 params:Optional[Union[list, np.ndarray]] = None,
+                 max_entries=None,
+                 seed=None,
+                 params=None,
                  owner=None,
-                 prefs: tc.optional(is_pref_set) = None):
-
-        # if initializer is None:
-        #     initializer = []
+                 prefs:tc.optional(is_pref_set)=None):
 
         if seed is None:
             seed = get_global_seed()
@@ -1620,7 +1707,7 @@ VALS = 1
 
 class DictionaryMemory(MemoryFunction):  # ---------------------------------------------------------------------
     """
-    DictionaryMemory(                        \
+    DictionaryMemory(                                \
         default_variable=None,                       \
         retrieval_prob=1.0                           \
         storage_prob=1.0                             \
@@ -1689,12 +1776,12 @@ class DictionaryMemory(MemoryFunction):  # -------------------------------------
       `function <DictionaryMemory.function>`.
     ..
     * After retrieval, the key-value pair in the call (`variable <DictionaryMemory.variable>`) is stored in
-     `memory <DictionaryMemory.memory>` with probability `storage_prob <DictionaryMemory.storage_prob>`.
+      `memory <DictionaryMemory.memory>` with probability `storage_prob <DictionaryMemory.storage_prob>`.
       If the key (`variable <DictionaryMemory.variable>`\\[0]) is identical to one already in `memory
       <DictionaryMemory.memory>` and `duplicate_keys <DictionaryMemory.duplicate_keys>`
       is set to False, storage is skipped; if it is set to *OVERWRITE*, the value of the key in memory is replaced
       with the one in the call.  If **rate** and/or **noise** arguments are specified in the
-      construtor, it is applied to the key before storing, as follows:
+      constructor, it is applied to the key before storing, as follows:
 
     .. math::
         variable[1] * rate + noise

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -716,8 +716,8 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
 
         >>> c.duplicate_entries_allowed=OVERWRITE
         >>> c([[1, 2.1], [3, 4]])
-        array([[[1., 2.],
-                [3., 4.]]])
+        array([[1., 2.],
+               [3., 4.]])
         >>> c.memory
         array([[[1. , 2.1],
                 [3. , 4. ]]])

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -581,7 +581,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         >>> c([[1,2]])
         [array([0, 0])]
 
-    Since `memory <ContentAddressableMemory.memory` was not intialized, the first call to the Function returns an
+    Since `memory <ContentAddressableMemory.memory>` was not intialized, the first call to the Function returns an
     array of zeros, formatted as specified in **defaul_variable**.  However, the input in the call to the Function
     (``[[1,2]]``) is stored as an entry in `memory <EpisodicMemoryMechanism.memory>`::
 
@@ -616,9 +616,9 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
     *Weighting fields*
 
     The **distance_field_weights** argument can be used to differentially weight memory fields to modify their
-    influence on retrieval (see `ContentAddressableMemory_Distance_Field_Weights`).  For example, this can be
-    used to configure the Function as dictionary, using the first field for keys (on which retrieval is based)
-    and the second for values (that are retrieved with a matching key), as follows:
+    influence on retrieval (see `distance_field_weights <ContentAddressableMemory_Distance_Field_Weights>`).  For
+    example, this can be used to configure the Function as dictionary, using the first field for keys (on which
+    retrieval is based) and the second for values (that are retrieved with a matching key), as follows:
 
         >>> c = ContentAddressableMemory(initializer=[[[1,2],[3,4]],
         ...                                            [[1,5],[10,11]]],
@@ -639,12 +639,14 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         array([[ 1.,  5.],
                [10., 11.]])
 
+    COMMENT:
     # FIX: ADD EXAMPLES FOR ENTRIES WITH DIFFERENT SHAPES
-    # FIX: ADD EXAMPLES FOR DUPLICATE ENTRIES
+    COMMENT
+
     *Duplicate entries*
 
-    By default, duplicate entries are precluded from a ContentAddressableMechanism's `memory
-    <ContentAddressableMechanism.memory>`.  So, for an initializer with identical entries, only one copy of
+    By default, duplicate entries are precluded from a ContentAddressableMemory's `memory
+    <ContentAddressableMemory.memory>`.  So, for an initializer with identical entries, only one copy of
     the duplicates will be stored::
 
         >>> c = ContentAddressableMemory(initializer=[[[1,2],[3,4]],
@@ -662,7 +664,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         array([[[1., 2.],
                 [3., 4.]]])
 
-    Only fields with non-zero weights in `distance_field_weights <ContentAddressableMechanism.distance_field_weights>`
+    Only fields with non-zero weights in `distance_field_weights <ContentAddressableMemory.distance_field_weights>`
     are considered when evaluating whether entries are duplicates. So, in the following example, where the weight
     for the second field is 0, the two entries are considered duplicates and only the first is stored::
 
@@ -674,7 +676,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
                 [3., 4.]]])
 
     Duplicates can be allowed by setting the **duplicate_entries_allowed** argument to True or *OVERWRITE*.  Setting
-    it to True allows duplicate entries to accumulate in `memory <ContentAddressableMechanism.memory>`, as shown
+    it to True allows duplicate entries to accumulate in `memory <ContentAddressableMemory.memory>`, as shown
     here::
 
         >>> c = ContentAddressableMemory(initializer=[[[1,2],[3,4]],
@@ -694,10 +696,10 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
                 [ 3.,  4.]]])
 
     Duplicates are determined by comparing entries using the functions `distance_function
-    <ContentAddressableMechanism.distance_function>`;  if the `distance <ContentAddressableMechanism.distance>`
-    is less than `duplicate_threshold <ContentAddressableMechanism.duplicate_threshold>`, they are considered to be
+    <ContentAddressableMemory.distance_function>`;  if the `distance <ContentAddressableMemory.distance>`
+    is less than `duplicate_threshold <ContentAddressableMemory.duplicate_threshold>`, they are considered to be
     duplicates;  otherwise they are treated a distinct entries.  By default, `duplicate_threshold
-    <ContentAddressableMechanism.duplicate_threshold>` is 0.  In the folloiwng example it is increased, so that
+    <ContentAddressableMemory.duplicate_threshold>` is 0.  In the folloiwng example it is increased, so that
     two very similar, but non-identical entries, are nonetheless treated as duplicates::
 
         >>> c = ContentAddressableMemory(initializer=[[[1, 2.0], [3, 4]],
@@ -721,13 +723,15 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
                 [3. , 4. ]]])
 
     Note that the entry considered to be the duplicate (``[[1, 2.1], [3, 4]]``) is returned, and then replaced in
-    `memory <ContentAddressableMechanism.memory>`.  Finally, if `duplicate_entries_allowed
-    <ContentAddressableMechanism.duplicate_entries_allowed>` is True, and duplicates have accumulated, the
+    `memory <ContentAddressableMemory.memory>`.  Finally, if `duplicate_entries_allowed
+    <ContentAddressableMemory.duplicate_entries_allowed>` is True, and duplicates have accumulated, the
     `equidistant_entries_select <ContentAddressableMemory.equidistant_entries_select>` attribute can be used to
     specify how to select among them for retrieval, either by chosing randomly (*RANDOM*) or selecting either the
     first one (*OLDEST*) or last one (*NEWEST*) stored.
 
     .. _ContentAddressableMemory_Class_Reference:
+
+    **Class Reference**
 
     Arguments
     ---------

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -639,6 +639,93 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         array([[ 1.,  5.],
                [10., 11.]])
 
+    # FIX: ADD EXAMPLES FOR ENTRIES WITH DIFFERENT SHAPES
+    # FIX: ADD EXAMPLES FOR DUPLICATE ENTRIES
+    *Duplicate entries*
+
+    By default, duplicate entries are precluded from a ContentAddressableMechanism's `memory
+    <ContentAddressableMechanism.memory>`.  So, for an initializer with identical entries, only one copy of
+    the duplicates will be stored::
+
+        >>> c = ContentAddressableMemory(initializer=[[[1,2],[3,4]],
+        ...                                           [[1,2],[3,4]]])
+        >>> c.memory
+        array([[[1., 2.],
+                [3., 4.]]])
+
+    and using the same array as input to the function will retrieve that array but not store another copy::
+
+        >>> c([[1,2],[3,4]])
+        array([[1., 2.],
+               [3., 4.]])
+        >>> c.memory
+        array([[[1., 2.],
+                [3., 4.]]])
+
+    Only fields with non-zero weights in `distance_field_weights <ContentAddressableMechanism.distance_field_weights>`
+    are considered when evaluating whether entries are duplicates. So, in the following example, where the weight
+    for the second field is 0, the two entries are considered duplicates and only the first is stored::
+
+        >>> c = ContentAddressableMemory(initializer=[[[1,2],[3,4]],
+        ...                                           [[1,2],[5,6]]],
+        ...                              distance_field_weights=[1,0])
+        >>> c.memory
+        array([[[1., 2.],
+                [3., 4.]]])
+
+    Duplicates can be allowed by setting the **duplicate_entries_allowed** argument to True or *OVERWRITE*.  Setting
+    it to True allows duplicate entries to accumulate in `memory <ContentAddressableMechanism.memory>`, as shown
+    here::
+
+        >>> c = ContentAddressableMemory(initializer=[[[1,2],[3,4]],
+        ...                                            [[1,5],[10,11]]],
+        ...                              duplicate_entries_allowed=True)
+        >>> c([[1,2],[3,4]])
+        array([[1., 2.],
+               [3., 4.]])
+        >>> c.memory
+        array([[[ 1.,  2.],
+                [ 3.,  4.]],
+        <BLANKLINE>
+               [[ 1.,  5.],
+                [10., 11.]],
+        <BLANKLINE>
+               [[ 1.,  2.],
+                [ 3.,  4.]]])
+
+    Duplicates are determined by comparing entries using the functions `distance_function
+    <ContentAddressableMechanism.distance_function>`;  if the `distance <ContentAddressableMechanism.distance>`
+    is less than `duplicate_threshold <ContentAddressableMechanism.duplicate_threshold>`, they are considered to be
+    duplicates;  otherwise they are treated a distinct entries.  By default, `duplicate_threshold
+    <ContentAddressableMechanism.duplicate_threshold>` is 0.  In the folloiwng example it is increased, so that
+    two very similar, but non-identical entries, are nonetheless treated as duplicates::
+
+        >>> c = ContentAddressableMemory(initializer=[[[1, 2.0], [3, 4]],
+        ...                                           [[1, 2.5], [3, 4]]],
+        ...                              duplicate_entries_allowed=False,
+        ...                              duplicate_threshold=0.2)
+
+        >>> c.memory
+        array([[[1., 2.],
+                [3., 4.]]])
+
+    Setting **duplicate_entries_allowed** argument to *OVERWRITE* allows an entry to replace one that is considered
+    duplicate, even if it is not identical, as in the following example::
+
+        >>> c.duplicate_entries_allowed=OVERWRITE
+        >>> c([[1, 2.1], [3, 4]])
+        array([[[1., 2.],
+                [3., 4.]]])
+        >>> c.memory
+        array([[[1. , 2.1],
+                [3. , 4. ]]])
+
+    Note that the entry considered to be the duplicate (``[[1, 2.1], [3, 4]]``) is returned, and then replaced in
+    `memory <ContentAddressableMechanism.memory>`.  Finally, if `duplicate_entries_allowed
+    <ContentAddressableMechanism.duplicate_entries_allowed>` is True, and duplicates have accumulated, the
+    `equidistant_entries_select <ContentAddressableMemory.equidistant_entries_select>` attribute can be used to
+    specify how to select among them for retrieval, either by chosing randomly (*RANDOM*) or selecting either the
+    first one (*OLDEST*) or last one (*NEWEST*) stored.
 
     .. _ContentAddressableMemory_Class_Reference:
 

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -571,33 +571,33 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
 
     **Examples**
 
-    *Initialize memory with **default_variable**
+    *Initialize memory with **default_variable*
 
     The format for entries in `memory <ContentAddressableMemory.memory` can be specified using either the
     **default_variable** or **initializer** arguments of the Function's constructor.  **default_variable** specifies
     the shape of entries, without creating any entries::
 
-    >>> c = ContentAddressableMemory(default_variable=[[0,0],[0,0,0]])
-    >>> c([[1,2]])
-    [array([0, 0])]
+        >>> c = ContentAddressableMemory(default_variable=[[0,0],[0,0,0]])
+        >>> c([[1,2]])
+        [array([0, 0])]
 
     Since `memory <ContentAddressableMemory.memory` was not intialized, the first call to the Function returns an
     array of zeros, formatted as specified in **defaul_variable**.  However, the input in the call to the Function
     (``[[1,2]]``) is stored as an entry in `memory <EpisodicMemoryMechanism.memory>`::
 
-    >>> c.memory
-    array([[[1., 2.]]])
+        >>> c.memory
+        array([[[1., 2.]]])
 
     and is returned on the next call::
 
-    >>> c([[2,5]])
-    array([[1., 2.]])
+        >>> c([[2,5]])
+        array([[1., 2.]])
 
     Note that even though **default_variable** and the inputs to the Function are specified as lists, the entries
     returned are arrays; `memory <ContentAddressableMemory.memory>` and all of its entries are always formated as
     arrays.
 
-    *Initialize memory with **initializer**
+    *Initialize memory with **initializer*
 
     The **initializer** argument of a ContentAddressableMemory's constructor can be used to initialize its `memory
     <ContentAddressableMemory.memory>`::
@@ -610,6 +610,35 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         array([array([1., 2.]), array([3., 4., 6.])], dtype=object)
 
     Note that there was no need to use **default_variable**, and in fact it would overidden if specified.
+
+    .. _ContentAddressableMemory_Examples_Weighting_Fields:
+
+    *Weighting fields*
+
+    The **distance_field_weights** argument can be used to differentially weight memory fields to modify their
+    influence on retrieval (see `ContentAddressableMemory_Distance_Field_Weights`).  For example, this can be
+    used to configure the Function as dictionary, using the first field for keys (on which retrieval is based)
+    and the second for values (that are retrieved with a matching key), as follows:
+
+        >>> c = ContentAddressableMemory(initializer=[[[1,2],[3,4]],
+        ...                                            [[1,5],[10,11]]],
+        ...                              distance_field_weights=[1,0])
+        >>> c([[1,2.5],[10,11]])
+        array([[1., 2.],
+               [3., 4.]])
+
+    Note that the first entry ``[[1,2],[3,4]]`` in `memory <ContentAddressableMemory.memory>` was retrieved,
+    even though the cue used in the call (``[[1,2.5],[10,11]]``) was an exact match to the second field of the
+    second entry (``[[1,5],[10,11]]``).  However, since that field was assigned 0 in **distance_field_weights**,
+    it was ignored and, using only the first entry, the cue was closer to the first entry. This is confirmed by
+    repeating the example without specifying **distance_field_weights**::
+
+        >>> c = ContentAddressableMemory(initializer=[[[1,2],[3,4]],
+        ...                                            [[1,5],[10,11]]])
+        >>> c([[1,2.5],[10,11]])
+        array([[ 1.,  5.],
+               [10., 11.]])
+
 
     .. _ContentAddressableMemory_Class_Reference:
 

--- a/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
+++ b/psyneulink/core/components/functions/statefulfunctions/memoryfunctions.py
@@ -35,7 +35,7 @@ import typecheck as tc
 
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.functions.function import \
-    FunctionError, is_function_type
+    FunctionError, is_function_type, EPSILON
 from psyneulink.core.components.functions.objectivefunctions import Distance
 from psyneulink.core.components.functions.selectionfunctions import OneHot
 from psyneulink.core.components.functions.statefulfunctions.integratorfunctions import StatefulFunction
@@ -894,7 +894,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         # FIX: --------------------
         distance_field_weights = Parameter([1], stateful=True, modulable=True, dependencies='initializer')
         duplicate_entries_allowed = Parameter(False, stateful=True)
-        duplicate_threshold = Parameter(0, stateful=False, modulable=True)
+        duplicate_threshold = Parameter(EPSILON, stateful=False, modulable=True)
         equidistant_entries_select = Parameter(RANDOM)
         rate = Parameter(1.0, modulable=True)
         noise = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])

--- a/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
+++ b/psyneulink/core/components/functions/statefulfunctions/statefulfunction.py
@@ -57,8 +57,8 @@ class StatefulFunction(Function_Base): #  --------------------------------------
     COMMENT:
     NARRATIVE HERE THAT EXPLAINS:
     A) initializers and stateful_attributes
-    B) initializer (note singular) is a prespecified member of initializers
-       that contains the value with which to initiailzer previous_value
+    B) initializer (note singular) is a pre-specified member of initializers
+       that contains the value with which to initialize previous_value
     COMMENT
 
 

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -491,7 +491,7 @@ dependents can be scheduled to execute).
 Examples
 --------
 
-The examples below focus on the specificaiton of the `objective_mechanism <ControlMechanism.objective_mechanism>`
+The examples below focus on the specification of the `objective_mechanism <ControlMechanism.objective_mechanism>`
 for a ControlMechanism.  See `Control Signal Examples <ControlSignal_Examples>` for examples of how to specify the
 ControlSignals for a ControlMechanism.
 

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -281,7 +281,7 @@ as in the following example::
     >>> my_mech.execute([0.5, 1])
     array([[0.4375, 0.875 ]])
 
-Notice that every call to the ``my_execute`` produces a single step of integration (at the default `rate
+Notice that every call to ``my_mech.execute`` produces a single step of integration (at the default `rate
 <TransferMechanism.rate>` of 0.5), by executing its `integrator_function <TransferMechanism.integrator_function>`
 once.  A single step is also executed if the Mechanism's `execute_until_finished <Component.execute_until_finished>`
 attribute is set to False, even if **termination_threshold** is specified. In both cases, the

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -449,12 +449,11 @@ accepts a single argument that is a 2d array with two entries.
     ``stim_percept``executes, followed by ``decision``.  However, the latter carries out only one step of integration,
     since its **execute_until_finished** is set to False.  If its output does not meet its termination condition after
     that one step of integration, then ``response`` does not execute, since it has been assigned a condition that
-    requires ``deciions`` to terminate before it does so. As a result, since ``response`` has not executed, the trial
-    continues (see XXX for a full description of XXX). On the next pass, ``attention`` carries out only one step of
-    integration, since its termination condition has already been met, as does ``decision`` since its termination
-    condition has *not* yet been met.  If it is met, then ``response`` executes and the trial ends (since all
-    Mechanisms have now had an opportunity to execute). The value of the ``attention`` and ``decision`` Mechanisms
-    after each execution are shown below::
+    requires ``decision`` to terminate before it does so. As a result, since ``response`` has not executed, the trial
+    continues. On the next pass, ``attention`` carries out only one step of integration, since its termination
+    condition has already been met, as does ``decision`` since its termination condition has *not* yet been met.  If
+    it is met, then ``response`` executes and the trial ends (since all Mechanisms have now had an opportunity to
+    execute). The value of the ``attention`` and ``decision`` Mechanisms after each execution are shown below::
 
         >>> attention.log.print_entries(display=[pnl.TIME, pnl.VALUE]) #doctest: +SKIP
         Log for Attention:

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -229,15 +229,73 @@ the following operations:
          however, the order of storage and retrieval is determined by the EpisodicMemoryMechanism's
          `function <EpisodicMemoryMechanism.function>`.
 
+.. _EpisodicMemoryMechanism_Examples:
+
 Examples
 --------
 
-.. _EpisodicMemoryMechanism_Examples:
+.. _EpisodicMemoryMechanism_Examples_Default:
 
-The following example creates a default EpisodicMemoryMechanism with no initial memory::
+*Default EpisodicMemoryMechanism*
+
+The following example creates a default EpisodicMemoryMechanism (with no initial memory)::
 
     >>> my_em = EpisodicMemoryMechanism()
-    >>> my_em.execute([[1,2,3]])
+    >>> my_em.execute([[1,2]])
+    [array([0, 0])]
+    >>> my_em.execute([[2,5]])
+    array([[1., 2.]])
+
+The `default_variable <EpisodicMemoryMechanism_Default_Variable>` for an EpisodicMemoryMechanism is [[0,0]], so the
+format of an entry in `memory <EpisodicMemoryMechanism.memory>` is a single field with two elements. Note that, since
+it was not assigned any initial memory, the first execution returns an entry comprised of zeros.  However, the input
+to the Mechanism in that execution (``[[1,2]]``) is stored as an entry in `memory <EpisodicMemoryMechanism.memory>`,
+and on the second execution, since that is now the only entry in `memory <EpisodicMemoryMechanism.memory>`,
+that is what is returned.
+
+.. _EpisodicMemoryMechanism_Examples_Default_Variable:
+
+*Format entries using* **default_variable**
+
+In this example, the **default_variable** argument is used to format the entries of `memory
+<EpisodicMemoryMechanism.memory>` to have two fields, one with two elements and the other with three::
+
+    >>> my_em = EpisodicMemoryMechanism(default_variable=[[0,0],[0,0,0]])
+    >>> my_em.execute([[1,2],[3,4,5]])
+    [array([0, 0]), array([0, 0, 0])]
+
+As in the previous example, the first execution returns zeros since `memory <EpisodicMemoryMechanism.memory>` as not
+been initialized;  however, notice that in this case they are formated as specified in **default_variable**.  Note
+also that even though a list is specified for **default_variable**, the entry returned is an array; `memory
+<EpisodicMemoryMechanism.memory>` and all of its entries are always formated at arrays.
+
+.. _EpisodicMemoryMechanism_Examples_Memory_Init:
+
+*Initialize memory**
+
+Here, the **memory** argument is used to initialize `memory <EpisodicMemoryMechanism.memory>`::
+
+    >>> my_em = EpisodicMemoryMechanism(memory=[[[1,2],[3,4,5]], [[10,9],[8,7,6]]])
+    >>> my_em.execute([[1,2],[3,4,6]])
+    array([array([1., 2.]), array([3., 4., 5.])], dtype=object)
+    >>> my_em.execute([[1,2],[3,4,6]])
+    array([array([1., 2.]), array([3., 4., 6.])], dtype=object)
+
+In this case, since `memory <EpisodicMemoryMechanism.memory>` was initialized, the first execution returns the closest
+value to the input, which is used as the retrieval cue.  In the second execution, the input from the first execution
+is returned, since it was stored after the retrieval in that call. The current contents of memory can be inspected
+using the `memory <EpisodicMemoryMechanism.memory>` attribute::
+
+    >>> my_em.memory
+    array([[array([1., 2.]), array([3., 4., 5.])],
+           [array([10.,  9.]), array([8., 7., 6.])],
+           [array([1., 2.]), array([3., 4., 6.])],
+           [array([1., 2.]), array([3., 4., 6.])]], dtype=object)
+
+Notice also that there is no need to use **default_variable** to format entries;  it can be specified, but if it is,
+its shape must be the same as the entries specified in **memory**.
+
+
 
 .. _EpisodicMemoryMechanism_Class_Reference:
 
@@ -289,6 +347,11 @@ class EpisodicMemoryMechanism(ProcessingMechanism_Base):
 
     Arguments
     ---------
+
+    .. _EpisodicMemoryMechanism_Default_Variable:
+
+    default_variable : list or ndarray
+        specifies the format used for entries in `memory <EpisodicMemoryMechanism.memory>`.
 
     memory : list or ndarray
         initial set of entries for `memory <EpisodicMemory.memory>`.  It should be either a 3d regular

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -101,8 +101,8 @@ the constructor; the number of these must equal the number of fields specified i
 
 .. _EpisodicMemoryMechanism_Creation_Function_Parameters:
 
-*Function Parameters
-~~~~~~~~~~~~~~~~~~~~
+*Function Parameters*
+~~~~~~~~~~~~~~~~~~~~~
 
 Parameters that govern the storage and retrieval process are specified as arguments to the `MemoryFunction` specified
 in the **function** of the constructor (for example, see `ContentAddressableMemory` for parameters of the default
@@ -219,7 +219,7 @@ the following operations:
       shaped zero-valued array is returned.
     ..
     * store the `value <InputPort.value>` of its `input_ports <EpisodicMemoryMechanism.input_ports>` as an entry in
-      <EpisodicMemoryMechanism.function>` memory.
+      `memory <EpisodicMemoryMechanism.function>`.
     ..
     * assign the value of the entry retrieved to its `output_ports <EpisodicMemoryMechanism.output_ports>`,
       based on how the latter are configured (see `EpisodicMemoryMechanism_Creation_OutputPorts`).
@@ -304,7 +304,8 @@ class EpisodicMemoryMechanism(ProcessingMechanism_Base):
         additional information).
 
     memory : 3d array
-        contains entries stored in the `function <EpisodicMemoryMechanism.function>'\\s `memory` attribute.
+        contains entries stored in the `function <EpisodicMemoryMechanism.function>`\\s ``memory`` attribute
+        (for example, `memory <ContentAddressableMemory.memory>`).
 
     output_ports : ContentAddressableList[str, OutputPort]
         a list of the Mechanism's `OutputPorts <Mechanism_OutputPorts>`, the number of which is, by default, equal to

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -75,6 +75,8 @@ An EpisodicMemoryMechanism is created by calling its constructor with specificat
 is determined by the number of `fields <EpisodicMemoryMechanism_Memory_Fields>` and shape of each in an entry.
 These can be specified using any of the following arguments:
 
+  .. __EpisodicMemoryMechanism_Creation_Default_Variable_and_Size:
+
   * **default_variable** or **size** -- these are specified in the standard way that the `variable
     <Mechanism_Base.variable>` is specified for any  `Component` (see `default_variable <Component_Variable>`,
     `size <Component_Size>`, respectively);  the specified value is passed to the constructor for the
@@ -286,12 +288,16 @@ The **size** argument can also be used to format entries::
     >>> my_em.execute([[1,2],[3,4,5]])
     [array([0, 0]), array([0, 0, 0])]
 
+Note that each element of **size** specifies the length of a field
+(see `EpisodicMemoryMechanism_Creation_Default_Variable_and_Size` for additional details).
+
 .. _EpisodicMemoryMechanism_Examples_Memory_Init:
 
 *Initialize memory*
 ~~~~~~~~~~~~~~~~~~~
 
-Here, the **memory** argument is used to initialize `memory <EpisodicMemoryMechanism.memory>`::
+The **memory** argument of an EpisodicMemoryMechanism's constructor can be used to initialize its `memory
+<EpisodicMemoryMechanism.memory>`::
 
     >>> my_em = EpisodicMemoryMechanism(memory=[[[1,2],[3,4,5]],
     ...                                         [[10,9],[8,7,6]]])
@@ -353,15 +359,15 @@ in `memory <ContentAddressableMemory.memory>` (see `EpisodicMemoryMechanism_Inpu
 By default, an EpisodicMemoryMechanims also has the same number of `output_ports <EpisodicMemoryMechanism.output_ports>`
 as `input_ports <EpisodicMemoryMechanism.input_ports>`, named correspondingly ``RETRIEVED_FIELD_n``::
 
-    >>> my_em.input_ports.names
-    ['RETRIEVED_FIELD_0', 'RETRIEVED_FIELD_1']
+    >>> my_em.output_ports.names
+    ['RETREIVED_FIELD_0', 'RETREIVED_FIELD_1']
 
 These are assigned the values of the fields of the entry retrieved from `memory <ContentAddressableMemory.memory>`.
 
 The names of `input_ports <EpisodicMemoryMechanism.input_ports>` can be customized by specifying a list of names in
 the **input_ports** argument of the Mechanism's constructor::
 
-    >>> my_em = EpisodicMemoryMechanism(size=[3,2],
+    >>> my_em = EpisodicMemoryMechanism(size=[2,2,2],
     ...                                 input_ports=['KEY', 'VALUE', 'LABEL'])
     >>> my_em.input_ports.names
     ['KEY', 'VALUE', 'LABEL']
@@ -371,9 +377,9 @@ The number of names must be equal to the number of fields in an entry (in this c
 there can be fewer items specified, in which the number of fields reported will be limited by the number of items
 in the argument (see `OutputPort_Customization` for additional information about customizing OutputPorts)::
 
-    >>> my_em = EpisodicMemoryMechanism(size=[3,2],
+    >>> my_em = EpisodicMemoryMechanism(size=[2,2,2],
     ...                                 input_ports=['KEY', 'VALUE', 'LABEL'],
-    ...                                 output_ports=['VALUE_RETRIEVED', 'LABEL_RETRIEVED')
+    ...                                 output_ports=['VALUE_RETRIEVED', 'LABEL_RETRIEVED'])
     >>> my_em.output_ports.names
     ['VALUE_RETRIEVED', 'LABEL_RETRIEVED']
 

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -23,6 +23,10 @@ Contents
       - `EpisodicMemoryMechanism_Function`
       - `EpisodicMemoryMechanism_Output`
   * `EpisodicMemoryMechanism_Execution`
+  * `EpisodicMemoryMechanism_Examples`
+      - `Formatting entries in memory <EpisodicMemoryMechanism_Examples_Default>`
+      - `Initializing memory <EpisodicMemoryMechanism_Examples_Memory_Init>`
+      - `Naming InputPorts and OutputPorts EpisodicMemoryMechanism_Examples_Port_Naming>`
   * `EpisodicMemoryMechanism_Class_Reference`
 
 .. _EpisodicMemoryMechanism_Overview:
@@ -237,6 +241,7 @@ Examples
 .. _EpisodicMemoryMechanism_Examples_Default:
 
 *Default EpisodicMemoryMechanism*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following example creates a default EpisodicMemoryMechanism (with no initial memory)::
 
@@ -255,7 +260,8 @@ that is what is returned.
 
 .. _EpisodicMemoryMechanism_Examples_Default_Variable:
 
-*Format entries using* **default_variable*
+*Format entries using* **default_variable**
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In this example, the **default_variable** argument is used to format the entries of `memory
 <EpisodicMemoryMechanism.memory>` to have two fields, one with two elements and the other with three::
@@ -272,6 +278,7 @@ also that even though a list is specified for **default_variable**, the entry re
 .. _EpisodicMemoryMechanism_Examples_Size:
 
 *Format entries using* **size**
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The **size** argument can also be used to format entries::
 
@@ -282,6 +289,7 @@ The **size** argument can also be used to format entries::
 .. _EpisodicMemoryMechanism_Examples_Memory_Init:
 
 *Initialize memory*
+~~~~~~~~~~~~~~~~~~~
 
 Here, the **memory** argument is used to initialize `memory <EpisodicMemoryMechanism.memory>`::
 
@@ -292,12 +300,12 @@ Here, the **memory** argument is used to initialize `memory <EpisodicMemoryMecha
     >>> my_em.execute([[1,2],[3,4,6]])
     array([array([1., 2.]), array([3., 4., 6.])], dtype=object)
 
-Note that there was no need to use **default_variable** to format entries here, since those are specified by the
-entries in the **memory** argument.  If  **default_variable** is specified, its shape must be the same as the entries
-specified in **memory**.  In this example, since `memory <EpisodicMemoryMechanism.memory>` was initialized, the first
-execution returns the closest value to the input, which is used as the retrieval cue.  In the second execution, the
-input from the first execution is returned, since it was stored after the first retrieval. The current contents of
-memory can be inspected using the `memory <EpisodicMemoryMechanism.memory>` attribute::
+Note that there was no need to use **default_variable** or **size** to format entries here, since that is determined
+by the entries in the **memory** argument.  If  **default_variable** or **size** is specified, its shape must be the
+same as the entries specified in **memory**.  In this example, since `memory <EpisodicMemoryMechanism.memory>` was
+initialized, the first execution returns the closest value to the input, which is used as the retrieval cue.  In the
+second execution, the input from the first execution is returned, since it was stored after the first retrieval. The
+current contents of memory can be inspected using the `memory <EpisodicMemoryMechanism.memory>` attribute::
 
     >>> my_em.memory
     array([[array([1., 2.]), array([3., 4., 5.])],
@@ -314,6 +322,7 @@ of different sizes).
 .. _EpisodicMemoryMechanism_Examples_Memory_Init_Function:
 
 *Initialize memory in function*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The contents of `memory <EpisodicMemoryMechanism.memory>` can also be initialized using the **initializer** argument
 in the constructor for the EpisodicMemoryMechanism's `function <EpisodicMemoryMechanism.function>`::
@@ -329,7 +338,21 @@ in the constructor for the EpisodicMemoryMechanism's `function <EpisodicMemoryMe
            [array([10.,  9.]), array([8., 7., 6.])]], dtype=object)
 
 Notice `memory <EpisodicMemoryMechanism.memory>` actually refers to the contents of the `function
-<EpisodicMemoryMechanism.function>`//s `memory <ContentAddressableMemory.memory>` attribute.
+<EpisodicMemoryMechanism.function>`'s `memory <ContentAddressableMemory.memory>` attribute.
+
+COMMENT:
+.. _EpisodicMemoryMechanism_Examples_Port_Naming:
+
+FIX: InputPort and OutputPort noming (defaults and custom)
+     retrieved values (in OutputPorts)
+
+*Name InputPorts*
+~~~~~~~~~~~~~~~~~
+
+*Name OutputPorts*
+~~~~~~~~~~~~~~~~~
+
+COMMENT
 
 .. _EpisodicMemoryMechanism_Class_Reference:
 

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -269,6 +269,16 @@ been initialized;  however, notice that in this case they are formated as specif
 also that even though a list is specified for **default_variable**, the entry returned is an array; `memory
 <EpisodicMemoryMechanism.memory>` and all of its entries are always formated at arrays.
 
+.. _EpisodicMemoryMechanism_Examples_Size:
+
+*Format entries using* **size**
+
+The **size** argument can also be used to format entries::
+
+    >>> my_em = EpisodicMemoryMechanism(size=[2,3])
+    >>> my_em.execute([[1,2],[3,4,5]])
+    [array([0, 0]), array([0, 0, 0])]
+
 .. _EpisodicMemoryMechanism_Examples_Memory_Init:
 
 *Initialize memory*

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -275,7 +275,7 @@ In this example, the **default_variable** argument is used to format the entries
 As in the previous example, the first execution returns zeros since `memory <EpisodicMemoryMechanism.memory>` as not
 been initialized;  however, notice that in this case they are formated as specified in **default_variable**.  Note
 also that even though a list is specified for **default_variable**, the entry returned is an array; `memory
-<EpisodicMemoryMechanism.memory>` and all of its entries are always formated at arrays.
+<EpisodicMemoryMechanism.memory>` and all of its entries are always formated as arrays.
 
 .. _EpisodicMemoryMechanism_Examples_Size:
 

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -26,7 +26,7 @@ Contents
   * `EpisodicMemoryMechanism_Examples`
       - `Formatting entries in memory <EpisodicMemoryMechanism_Examples_Default>`
       - `Initializing memory <EpisodicMemoryMechanism_Examples_Memory_Init>`
-      - `Naming InputPorts and OutputPorts EpisodicMemoryMechanism_Examples_Port_Naming>`
+      - `Naming InputPorts and OutputPorts <EpisodicMemoryMechanism_Examples_Port_Naming>`
   * `EpisodicMemoryMechanism_Class_Reference`
 
 .. _EpisodicMemoryMechanism_Overview:
@@ -75,7 +75,7 @@ An EpisodicMemoryMechanism is created by calling its constructor with specificat
 is determined by the number of `fields <EpisodicMemoryMechanism_Memory_Fields>` and shape of each in an entry.
 These can be specified using any of the following arguments:
 
-  .. __EpisodicMemoryMechanism_Creation_Default_Variable_and_Size:
+  .. _EpisodicMemoryMechanism_Creation_Default_Variable_and_Size:
 
   * **default_variable** or **size** -- these are specified in the standard way that the `variable
     <Mechanism_Base.variable>` is specified for any  `Component` (see `default_variable <Component_Variable>`,
@@ -253,12 +253,12 @@ The following example creates a default EpisodicMemoryMechanism (with no initial
     >>> my_em.execute([[2,5]])
     array([[1., 2.]])
 
-The `default_variable <EpisodicMemoryMechanism_Default_Variable>` for an EpisodicMemoryMechanism is [[0,0]], so the
+The `default_variable <EpisodicMemoryMechanism_Default_Variable>` for an EpisodicMemoryMechanism is ``[[0,0]]``, so the
 format of an entry in `memory <EpisodicMemoryMechanism.memory>` is a single field with two elements. Note that, since
-it was not assigned any initial memory, the first execution returns an entry comprised of zeros.  However, the input
-to the Mechanism in that execution (``[[1,2]]``) is stored as an entry in `memory <EpisodicMemoryMechanism.memory>`,
-and on the second execution, since that is now the only entry in `memory <EpisodicMemoryMechanism.memory>`,
-that is what is returned.
+it was not assigned any initial memory, the first execution returns an entry comprised of zeros.  However, the input to
+the Mechanism in that execution (``[[1,2]]``) is stored as an entry in `memory <EpisodicMemoryMechanism.memory>`, and on
+the second execution, since that is now the only entry in `memory <EpisodicMemoryMechanism.memory>`, that is what is
+returned.
 
 .. _EpisodicMemoryMechanism_Examples_Default_Variable:
 
@@ -318,8 +318,8 @@ current contents of memory can be inspected using the `memory <EpisodicMemoryMec
            [array([10.,  9.]), array([8., 7., 6.])],
            [array([1., 2.]), array([3., 4., 6.])]], dtype=object)
 
-Notice that there is only one entry for [array([1., 2.]), array([3., 4., 6.])], even though it was provided as input
-to execute twice.  This is because the default `function <EpisodicMemoryMechanism.function>` is
+Notice that there is only one entry for ``[array([1., 2.]), array([3., 4., 6.])]``, even though it was provided
+as input to execute twice.  This is because the default `function <EpisodicMemoryMechanism.function>` is
 `ContentAddressableMemory`, and the default value of its `duplicate_entries_allowed
 <ContentAddressableMemory.duplicate_entries_allowed>` attribute is False. Notice also that that the dtype of the
 `memory <EpisodicMemoryMechanism.memory>` array is object, since its entries are ragged arrays (i.e., ones with fields
@@ -346,7 +346,6 @@ in the constructor for the EpisodicMemoryMechanism's `function <EpisodicMemoryMe
 Notice `memory <EpisodicMemoryMechanism.memory>` actually refers to the contents of the `function
 <EpisodicMemoryMechanism.function>`'s `memory <ContentAddressableMemory.memory>` attribute.
 
-COMMENT:
 .. _EpisodicMemoryMechanism_Examples_Port_Naming:
 
 The `input_ports <EpisodicMemoryMechanism.input_ports>` of an EpisodicMemoryMechanims correspond to fields of entries
@@ -382,9 +381,6 @@ in the argument (see `OutputPort_Customization` for additional information about
     ...                                 output_ports=['VALUE_RETRIEVED', 'LABEL_RETRIEVED'])
     >>> my_em.output_ports.names
     ['VALUE_RETRIEVED', 'LABEL_RETRIEVED']
-
-
-COMMENT
 
 .. _EpisodicMemoryMechanism_Class_Reference:
 

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -255,7 +255,7 @@ that is what is returned.
 
 .. _EpisodicMemoryMechanism_Examples_Default_Variable:
 
-*Format entries using* **default_variable**
+*Format entries using* **default_variable*
 
 In this example, the **default_variable** argument is used to format the entries of `memory
 <EpisodicMemoryMechanism.memory>` to have two fields, one with two elements and the other with three::
@@ -271,31 +271,55 @@ also that even though a list is specified for **default_variable**, the entry re
 
 .. _EpisodicMemoryMechanism_Examples_Memory_Init:
 
-*Initialize memory**
+*Initialize memory*
 
 Here, the **memory** argument is used to initialize `memory <EpisodicMemoryMechanism.memory>`::
 
-    >>> my_em = EpisodicMemoryMechanism(memory=[[[1,2],[3,4,5]], [[10,9],[8,7,6]]])
+    >>> my_em = EpisodicMemoryMechanism(memory=[[[1,2],[3,4,5]],
+    ...                                         [[10,9],[8,7,6]]])
     >>> my_em.execute([[1,2],[3,4,6]])
     array([array([1., 2.]), array([3., 4., 5.])], dtype=object)
     >>> my_em.execute([[1,2],[3,4,6]])
     array([array([1., 2.]), array([3., 4., 6.])], dtype=object)
 
-In this case, since `memory <EpisodicMemoryMechanism.memory>` was initialized, the first execution returns the closest
-value to the input, which is used as the retrieval cue.  In the second execution, the input from the first execution
-is returned, since it was stored after the retrieval in that call. The current contents of memory can be inspected
-using the `memory <EpisodicMemoryMechanism.memory>` attribute::
+Note that there was no need to use **default_variable** to format entries here, since those are specified by the
+entries in the **memory** argument.  If  **default_variable** is specified, its shape must be the same as the entries
+specified in **memory**.  In this example, since `memory <EpisodicMemoryMechanism.memory>` was initialized, the first
+execution returns the closest value to the input, which is used as the retrieval cue.  In the second execution, the
+input from the first execution is returned, since it was stored after the first retrieval. The current contents of
+memory can be inspected using the `memory <EpisodicMemoryMechanism.memory>` attribute::
 
     >>> my_em.memory
     array([[array([1., 2.]), array([3., 4., 5.])],
            [array([10.,  9.]), array([8., 7., 6.])],
-           [array([1., 2.]), array([3., 4., 6.])],
            [array([1., 2.]), array([3., 4., 6.])]], dtype=object)
 
-Notice also that there is no need to use **default_variable** to format entries;  it can be specified, but if it is,
-its shape must be the same as the entries specified in **memory**.
+Notice that there is only one entry for [array([1., 2.]), array([3., 4., 6.])], even though it was provided as input
+to execute twice.  This is because the default `function <EpisodicMemoryMechanism.function>` is
+`ContentAddressableMemory`, and the default value of its `duplicate_entries_allowed
+<ContentAddressableMemory.duplicate_entries_allowed>` attribute is False. Notice also that that the dtype of the
+`memory <EpisodicMemoryMechanism.memory>` array is object, since its entries are ragged arrays (i.e., ones with fields
+of different sizes).
 
+.. _EpisodicMemoryMechanism_Examples_Memory_Init_Function:
 
+*Initialize memory in function*
+
+The contents of `memory <EpisodicMemoryMechanism.memory>` can also be initialized using the **initializer** argument
+in the constructor for the EpisodicMemoryMechanism's `function <EpisodicMemoryMechanism.function>`::
+
+    >>> my_em = EpisodicMemoryMechanism(
+    ...                        function=ContentAddressableMemory(initializer=[[[1,2],[3,4,5]],
+    ...                                                                      [[10,9],[8,7,6]]]))
+    >>> my_em.function.memory
+    array([[array([1., 2.]), array([3., 4., 5.])],
+           [array([10.,  9.]), array([8., 7., 6.])]], dtype=object)
+    >>> my_em.memory
+    array([[array([1., 2.]), array([3., 4., 5.])],
+           [array([10.,  9.]), array([8., 7., 6.])]], dtype=object)
+
+Notice `memory <EpisodicMemoryMechanism.memory>` actually refers to the contents of the `function
+<EpisodicMemoryMechanism.function>`//s `memory <ContentAddressableMemory.memory>` attribute.
 
 .. _EpisodicMemoryMechanism_Class_Reference:
 

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -372,15 +372,24 @@ the **input_ports** argument of the Mechanism's constructor::
     ['KEY', 'VALUE', 'LABEL']
 
 The number of names must be equal to the number of fields in an entry (in this case, 3).  Similarly, the `output_ports
-<EpisodicMemoryMechanism.output_ports>` can names in the **output_ports** argument of the constructor.  In this case,
-there can be fewer items specified, in which the number of fields reported will be limited by the number of items
-in the argument (see `OutputPort_Customization` for additional information about customizing OutputPorts)::
+<EpisodicMemoryMechanism.output_ports>` can be named in the **output_ports** argument of the constructor.  In this case,
+there can be fewer items specified, in which case the number of fields assigned to OutputPorts will be limited by the
+number of OutputPorts specified in the argument::
 
-    >>> my_em = EpisodicMemoryMechanism(size=[2,2,2],
+    >>> my_em = EpisodicMemoryMechanism(memory=[[[1,2],[3,4,5],[6,7]],
+    ...                                         [[7,6],[5,4,3],[2,1]]],
     ...                                 input_ports=['KEY', 'VALUE', 'LABEL'],
     ...                                 output_ports=['VALUE_RETRIEVED', 'LABEL_RETRIEVED'])
-    >>> my_em.output_ports.names
-    ['VALUE_RETRIEVED', 'LABEL_RETRIEVED']
+    >>> my_em.execute([[1,2],[3,4,5],[6,7]])
+    array([array([1., 2.]), array([3., 4., 5.]), array([6., 7.])],
+          dtype=object)
+    >>> my_em.output_ports
+    [(OutputPort VALUE_RETRIEVED), (OutputPort LABEL_RETRIEVED)]
+    >>> my_em.output_ports.values
+    [array([1., 2.]), array([3., 4., 5.])]
+
+Notice that the first two fields of the retrieved entry are assigned to the two OutputPorts, and the third is not
+assigned to an OutputPort (see `OutputPort_Customization` for additional information about customizing OutputPorts).
 
 .. _EpisodicMemoryMechanism_Class_Reference:
 

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -229,6 +229,16 @@ the following operations:
          however, the order of storage and retrieval is determined by the EpisodicMemoryMechanism's
          `function <EpisodicMemoryMechanism.function>`.
 
+Examples
+--------
+
+.. _EpisodicMemoryMechanism_Examples:
+
+The following example creates a default EpisodicMemoryMechanism with no initial memory::
+
+    >>> my_em = EpisodicMemoryMechanism()
+    >>> my_em.execute([[1,2,3]])
+
 .. _EpisodicMemoryMechanism_Class_Reference:
 
 Class Reference
@@ -326,7 +336,7 @@ class EpisodicMemoryMechanism(ProcessingMechanism_Base):
                 variable
                     see `variable <EpisodicMemoryMechanism.variable>`
 
-                    :default value: [[0]]
+                    :default value: [[0,0]]
                     :type: ``list``
 
                 function
@@ -336,7 +346,7 @@ class EpisodicMemoryMechanism(ProcessingMechanism_Base):
                     :type: `Function`
 
         """
-        variable = Parameter([[0]], pnl_internal=True, constructor_argument='default_variable')
+        variable = Parameter([[0,0]], pnl_internal=True, constructor_argument='default_variable')
         function = Parameter(ContentAddressableMemory, stateful=False, loggable=False)
 
     def __init__(self,

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -240,6 +240,10 @@ the following operations:
 Examples
 --------
 
+(See `ContentAddressableMemory <ContentAddressableMemory_Examples>` for additional examples of how to use that
+Function, including how it can be configured to implement a `key-value dictionary
+<ContentAddressableMemory_Examples_Weighting_Fields>`.)
+
 .. _EpisodicMemoryMechanism_Examples_Default:
 
 *Default EpisodicMemoryMechanism*

--- a/tests/documentation/test_mod_docs.py
+++ b/tests/documentation/test_mod_docs.py
@@ -17,8 +17,10 @@ import psyneulink as pnl
                                  pnl.core.components.mechanisms.processing.integratormechanism,
                                  pnl.core.components.mechanisms.processing.objectivemechanism,
                                  pnl.core.components.mechanisms.modulatory.control.controlmechanism,
-                                 # Function
+                                 # Functions
                                  pnl.core.components.functions.function,
+                                 pnl.core.components.functions.statefulfunctions.memoryfunctions
+
                                 ])
 def test_core_docs(mod, capsys):
     fail, total = doctest.testmod(mod)

--- a/tests/documentation/test_mod_docs.py
+++ b/tests/documentation/test_mod_docs.py
@@ -30,6 +30,7 @@ def test_core_docs(mod, capsys):
 @pytest.mark.parametrize("mod", [# Mechanisms
                                  pnl.library.components.mechanisms.processing.integrator.ddm,
                                  pnl.library.components.mechanisms.processing.objective.comparatormechanism,
+                                 pnl.library.components.mechanisms.processing.integrator.episodicmemorymechanism,
                                  # Scheduling
                                  pnl.core.scheduling.scheduler,
                                  # Logs

--- a/tests/functions/test_memory.py
+++ b/tests/functions/test_memory.py
@@ -1003,6 +1003,56 @@ class TestContentAddressableMemory:
         assert "Field 1 of entry ([array([1, 2, 3]) array([200, 201, 202, 203])]) has incorrect shape ((4,)) " \
                "for memory of 'ContentAddressableMemory Function-0';  should be: (3,)." in str(error_text.value)
 
+    def test_ContentAddressableMemory_duplicate_entries(self):
+
+        c = ContentAddressableMemory(
+            initializer=[[[1,2,3], [4,5,6]],
+                         [[7,8,9], [10,11,12]],
+                         [[7,8,9], [10,11,12]]],
+            duplicate_entries_allowed=False,
+        )
+
+        expected_memory = [[[ 1,  2,  3],[ 4,  5,  6]],
+                           [[ 7,  8,  9],[10, 11, 12]]]
+        assert np.allclose(c.memory, expected_memory)
+
+        c.add_to_memory([[ 1,  2,  3],[ 4,  5,  6]])
+        assert np.allclose(c.memory, expected_memory)
+
+        c.execute([[ 1,  2,  3],[ 4,  5,  6]])
+        assert np.allclose(c.memory, expected_memory)
+
+        c.duplicate_threshold = 0
+        c.add_to_memory([[ 1,  2,  3],[ 4,  5,  7]])
+        expected_memory = [[[ 1,  2,  3],[ 4,  5,  6]],
+                           [[ 7,  8,  9],[10, 11, 12]],
+                           [[ 1,  2,  3],[ 4,  5,  7]]]
+        assert np.allclose(c.memory, expected_memory)
+
+        c.duplicate_threshold = .1
+        c.add_to_memory([[ 1,  2,  3],[ 4,  5,  8]])
+        expected_memory = [[[ 1,  2,  3],[ 4,  5,  6]],
+                           [[ 7,  8,  9],[10, 11, 12]],
+                           [[ 1,  2,  3],[ 4,  5,  7]]]
+        assert np.allclose(c.memory, expected_memory)
+
+        c = ContentAddressableMemory(
+            initializer=[[[1,2,3], [4,5,6]],
+                         [[7,8,9], [10,11,12]],
+                         [[7,8,9], [10,11,12]]],
+            duplicate_entries_allowed=True,
+        )
+        expected_memory = [[[ 1,  2,  3],[ 4,  5,  6]],
+                           [[ 7,  8,  9],[10, 11, 12]],
+                           [[7,8,9], [10,11,12]]],
+        assert np.allclose(c.memory, expected_memory)
+        c.add_to_memory([[ 1,  2,  3],[ 4,  5,  6]])
+        expected_memory = [[[ 1,  2,  3],[ 4,  5,  6]],
+                           [[ 7,  8,  9],[10, 11, 12]],
+                           [[7,8,9], [10,11,12]],
+                           [[ 1,  2,  3],[ 4,  5,  6]]],
+        assert np.allclose(c.memory, expected_memory)
+
     def test_ContentAddressableMemory_overwrite_mode(self):
 
         c = ContentAddressableMemory(

--- a/tests/functions/test_memory.py
+++ b/tests/functions/test_memory.py
@@ -1022,14 +1022,14 @@ class TestContentAddressableMemory:
         c.execute([[ 1,  2,  3],[ 4,  5,  6]])
         assert np.allclose(c.memory, expected_memory)
 
-        c.duplicate_threshold = 0
+        c.duplicate_threshold = 0  # <- Low threshold allows new entry to be considered distinct
         c.add_to_memory([[ 1,  2,  3],[ 4,  5,  7]])
         expected_memory = [[[ 1,  2,  3],[ 4,  5,  6]],
                            [[ 7,  8,  9],[10, 11, 12]],
                            [[ 1,  2,  3],[ 4,  5,  7]]]
         assert np.allclose(c.memory, expected_memory)
 
-        c.duplicate_threshold = .1
+        c.duplicate_threshold = .1  # <- Higher threshold means new entry is considered duplicate
         c.add_to_memory([[ 1,  2,  3],[ 4,  5,  8]])
         expected_memory = [[[ 1,  2,  3],[ 4,  5,  6]],
                            [[ 7,  8,  9],[10, 11, 12]],

--- a/tests/mechanisms/test_episodic_memory.py
+++ b/tests/mechanisms/test_episodic_memory.py
@@ -71,6 +71,24 @@ def test_with_dictionary_memory(variable, func, params, expected, benchmark, mec
 test_data = [
     (
         # name
+        "ContentAddressableMemory Default",
+        # func
+        ContentAddressableMemory,
+        # func_params
+        {},
+        # mech_params
+        {},
+        # test_var
+        [[10.,10.]],
+        # expected input_port names
+        ['FIELD_0_INPUT'],
+        # expected output_port names
+        ['RETREIVED_FIELD_0'],
+        # expected output
+        [[0,0]]
+    ),
+    (
+        # name
         "ContentAddressableMemory Func Default Variable Mech Size Init",
         # func
         ContentAddressableMemory,


### PR DESCRIPTION
• episodicmemorymechanism.py
    - Parameters:  changed default_variable to [0,0] (to avoid warning with Distance(metric=COSINE)
    - Examples added to docstring

• test_episodic_memory.py:  added test for default constructor

• test_memory.py:  added explicit tests for duplicate_entries_allowed and duplicate_threshold