### PR TITLE
github-actions: Reintroduce 32-bit windows job

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -23,6 +23,16 @@ runs:
           *) echo "Unsupported OS"; exit 1 ;;
         esac
 
+    - name: Drop pytorch on x86
+      shell: bash
+      run: |
+        if [ $(python -c 'import struct; print(struct.calcsize("P") * 8)') == 32 ]; then
+          sed -i /torch/d requirements.txt
+          # pywinpty is a transitive dependency and v1.0+ removed support
+          # for x86 wheels
+          [[ ${{ runner.os }} = Windows* ]] && pip install "pywinpty<1"
+        fi
+
     - name: Python dependencies
       shell: bash
       run: |

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -21,6 +21,11 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
         python-architecture: ['x64']
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          # add 32-bit build on windows
+          - python-version: 3.8
+            python-architecture: 'x86'
+            os: windows-latest
 
     steps:
     - name: Checkout sources


### PR DESCRIPTION
Drop pytorch from requirements when using 32-bit python.
Install older pywinpty when using 32-bit python.

This reverts commit 1ace7f9ff141345c7ed9c3a1a2811d883061a4b6.

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>