### PR TITLE
jenkins: copy actual build script used, to be target

### DIFF
--- a/bin/jenkins_build.sh
+++ b/bin/jenkins_build.sh
@@ -1,104 +1,27 @@
-#!/bin/bash
-# you must run this script in the top level dir
-source ~/.bashrc
+#!/bin/bash -l
+# Make sure the above line is #!/bin/bash -l. If the -l is missing this script
+# will not be executed as a login shell and /usr/local/bin will not be on the
+# path. This will lead to issues with missing graphviz (dot) expected to be on
+# the PATH by psyneulink.
 
-while getopts ":e:" opt; do
-	case $opt in
-		e) env_name="$OPTARG"
-		;;
-		\?) echo "Invalid argument -$OPTARG" >&2
-		;;
-	esac
-done
+cd $WORKSPACE
+toxenvs=$(grep envlist tox.ini | sed "s;envlist = ;;")
+USAGE="Usage: "$(basename "$0")" [$toxenvs]"
 
-if [ -z $env_name ]; then
-	echo "No python environment specified, set with -e" >&2
-	exit 1
+if [ $# -ne 1 ]; then
+	echo "$USAGE"
+	exit 0
 fi
 
-# setting the path
-PYTHONPATH=$PYTHONPATH:$WORKSPACE
+toxenv="$1"
 
-PNL_DIR=$WORKSPACE
-PYTEST_TEST_DIR=tests/
-
-JUNIT_DIR=$PNL_DIR'/jenkins/junit-reports'
-JUNIT_BACKUP_DIR=~/jenkins/junit-reports/$JOB_BASE_NAME
-
-echo 'Copying junit reports to workspace from' $JUNIT_BACKUP_DIR
-mkdir -p $JUNIT_DIR
-cp -rp $JUNIT_BACKUP_DIR/*.xml $JUNIT_DIR/
-
-cd $PNL_DIR
-
-# echo 'Cleaning Working dir '$PNL_DIR
-# git clean -xdf -e jenkins/junit-reports
-# git remote prune origin
-
-BRANCH='no_branch'
-if [ $GIT_BRANCH ]; then
-        BRANCH=$(echo $GIT_BRANCH | sed 's;/;_;g')
-        echo 'On branch' $BRANCH
+export GIT_BRANCH_NO_SLASH="no_branch"
+if [ $GIT_BRANCH ]
+then
+	GIT_BRANCH_NO_SLASH=`echo $GIT_BRANCH | sed 's;/;_;g'`
+	echo 'On branch' $BRANCH
 else
-        echo 'No current branch'
+	echo 'No current branch'
 fi
 
-BUILD='no-build'
-
-if [ $BUILD_NUMBER ]; then
-        BUILD=$BUILD_NUMBER
-        echo 'Running build' $BUILD
-else
-        echo 'No current build'
-fi
-
-
-echo "Building branch $BRANCH"
-
-echo "Activating PsyNeuLink environment ($env_name)..."
-# activate the environment
-# source activate $env_name
-pyenv activate $env_name
-
-# If multiple jobs on this machine are running,
-# the environment may fail to change due to a bug
-# in pyenv
-while [ $? -eq 1 ]; do
-	sleep 1
-	pyenv activate $env_name
-done
-
-echo 'Reinstalling environment...'
-# install all necessary dependencies
-
-# removing this below as the environments on this machine are messed up
-# on other machines fresh installs work fine but..not here
-# pip freeze | xargs pip uninstall -y
-
-pip install --no-cache-dir --upgrade $PNL_DIR[dev]
-
-if [ $? -eq 1 ]; then
-    echo 'pip install failed'
-    exit 1
-fi
-
-echo 'Running pytest on '$PYTEST_TEST_DIR
-#gtimeout --foreground -k 6 10m python -m pytest --junit-xml=$JUNIT_DIR/$BRANCH-$BUILD.xml $PYTEST_TEST_DIR
-python -m pytest -p no:logging --junit-xml=$JUNIT_DIR/$BRANCH-$BUILD.xml $PYTEST_TEST_DIR
-
-PYTEST_EXIT_CODE=$?
-
-if [ $PYTEST_EXIT_CODE -eq 124 ]; then
-	echo
-	echo 'pytest timed out'
-fi
-
-echo 'Backing up junit reports to' $JUNIT_BACKUP_DIR
-cp -rp $JUNIT_DIR/*.xml $JUNIT_BACKUP_DIR/
-
-echo 'Deactivating environment...'
-# deactivate the environment
-source deactivate
-
-exit $PYTEST_EXIT_CODE
-
+time tox -e "$toxenv"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,44 @@
+[tox]
+envlist = py36, py37
+skipsdist = true
+
+[testenv]
+whitelist_externals =
+  cp
+  rsync
+  echo
+  mkdir
+  dot
+  which
+
+passenv =
+  GIT_BRANCH_NO_SLASH
+  BUILD_NUMBER
+  JOB_BASE_NAME
+  WORKSPACE
+  HOME
+  PATH
+
+setenv =
+  JUNIT_DIR = jenkins/junit-reports
+  JUNIT_BACKUP_DIR = {env:HOME}/jenkins/junit-reports/{env:JOB_BASE_NAME}
+  JUNIT_XML_FILE = jenkins/junit-reports/{env:GIT_BRANCH_NO_SLASH}-{env:BUILD_NUMBER:no-build}.xml
+
+deps =
+  -rrequirements.txt
+  -rdev_requirements.txt
+
+commands_pre =
+  echo 'Copying junit reports to workspace from' {env:JUNIT_BACKUP_DIR}
+  mkdir -p {env:JUNIT_DIR}
+  rsync -a {env:JUNIT_BACKUP_DIR}/ {env:JUNIT_DIR}/
+
+commands =
+  python -V
+  pip install .[dev]
+  pip install git+https://github.com/benureau/leabra
+  pytest -n auto -p no:logging {env:WARN_LEVEL:-pno:warnings} --junit-xml={env:JUNIT_XML_FILE}
+
+commands_post =
+  echo 'Backing up junit reports to' {env:JUNIT_BACKUP_DIR}
+  rsync -a {env:JUNIT_DIR}/ {env:JUNIT_BACKUP_DIR}/


### PR DESCRIPTION
`jenkins_build.sh` contains a slightly modified version of the script jenkins actually uses for the psyneulink_test_py* jobs. This can be called instead, so any changes to the script or the tox config can be tracked. This is working on the pnl36-copy job, that can be removed when this PR is merged or closed. 

My only concern is about tests automatically running on jenkins on a PR without admin approval. It looks like this is enabled by default for the [pull request builder plugin](https://plugins.jenkins.io/ghprb/), and it doesn't look overridden to me, but it would be good for someone else to double check. 

This is a followup to #2044 
