### PR TITLE
llvm: Add generic conversion helper.

### DIFF
--- a/.github/workflows/compare-comment.yml
+++ b/.github/workflows/compare-comment.yml
@@ -50,7 +50,7 @@ jobs:
 
             // basic input checks
             console.assert(['ubuntu-latest', 'windows-latest', 'macos-latest'].includes(os), 'Unexpected os: %s', os);
-            console.assert(['3.6', '3.7', '3.8'].includes(python), 'Unexpected python: %s', python);
+            console.assert(['3.6', '3.7', '3.8', '3.9'].includes(python), 'Unexpected python: %s', python);
             console.assert(!text.includes('```'), 'Invalid diff!');
 
             console.log('Posting diff to PR:' + issue_number)

--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         python-architecture: ['x64']
         os: [ubuntu-latest, macos-latest, windows-latest]
 

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         python-architecture: ['x64']
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, macos-latest, windows-latest]
         dist: [wheel, sdist]
         exclude:

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -398,14 +398,7 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
                 def _convert(ctx, builder, x):
                     if helpers.is_pointer(x):
                         x = builder.load(x)
-                    if helpers.is_integer(x) and ty is ctx.float_ty:
-                        if helpers.is_boolean(x):
-                            return builder.uitofp(x, ty)
-                        return builder.sitofp(x, ty)
-                    elif helpers.is_floating_point(x) and ty is self.register["int"]:
-                        return builder.fptosi(x, ty)
-                    elif (helpers.is_floating_point(x) and ty is ctx.float_ty):
-                        return x
+                    return helpers.convert_type(builder, x, ty)
                 if helpers.is_scalar(val):
                     return _convert(self.ctx, self.builder, val)
                 else:

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -611,11 +611,16 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
 
     def visit_Subscript(self, node):
         node_val = self.visit(node.value)
-        node_slice_val = self.visit(node.slice)
+        node_slice_val = helpers.convert_type(self.builder, self.visit(node.slice), self.ctx.int32_ty)
         return self.builder.gep(node_val, [self.ctx.int32_ty(0), node_slice_val])
 
     def visit_Index(self, node):
-        return self.builder.fptoui(self.visit(node.value), self.ctx.int32_ty)
+        """
+        Returns the wrapped value.
+
+        Deprecated in python 3.9+.
+        """
+        return self.visit(node.value)
 
 def gen_node_wrapper(ctx, composition, node, *, tags:frozenset):
     assert "node_wrapper" in tags

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -207,6 +207,27 @@ def create_allocation(builder, allocation, search_space, idx):
         builder.store(val, slot_ptr)
 
 
+def convert_type(builder, val, t):
+    assert isinstance(t, ir.Type)
+    if val.type == t:
+        return val
+
+    if is_integer(val) and is_integer(t):
+        if val.type.width > t.width:
+            return builder.trunc(val, t)
+        elif val.type.width < t.width:
+            # Python integers are signed
+            return builder.sext(val, t)
+        else:
+            assert False, "Unknown integer conversion: {} -> {}".format(val.type, t)
+
+    if is_floating_point(val) and is_integer(t):
+        # Python integers are signed
+        return builder.fptosi(val, t)
+
+    assert False, "Unknown type conversion: {} -> {}".format(val.type, t)
+
+
 def is_pointer(x):
     type_t = getattr(x, "type", x)
     return isinstance(type_t, ir.PointerType)

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -212,6 +212,10 @@ def convert_type(builder, val, t):
     if val.type == t:
         return val
 
+    if is_boolean(val) and is_floating_point(t):
+        # float(True) == 1.0, float(False) == 0.0
+        return builder.select(val, t(1.0), t(0.0))
+
     if is_integer(val) and is_integer(t):
         if val.type.width > t.width:
             return builder.trunc(val, t)
@@ -220,6 +224,10 @@ def convert_type(builder, val, t):
             return builder.sext(val, t)
         else:
             assert False, "Unknown integer conversion: {} -> {}".format(val.type, t)
+
+    if is_integer(val) and is_floating_point(t):
+        # Python integers are signed
+        return builder.sitofp(val, t)
 
     if is_floating_point(val) and is_integer(t):
         # Python integers are signed


### PR DESCRIPTION
Use the helper to convert array indices and as_type.
Move float->int conversion from Index to Subscript.
Enable python3.9 CI jobs.