### PR TITLE
tests: Add and use new execution wrapper helpers

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -121,6 +121,20 @@ def get_func_execution(func, func_mode):
         assert False, "Unknown function mode: {}".format(mode)
 
 @pytest.helpers.register
+def get_mech_execution(mech, mech_mode):
+    if mech_mode == 'LLVM':
+        return pnlvm.execution.MechExecution(mech).execute
+    elif mech_mode == 'PTX':
+        return pnlvm.execution.MechExecution(mech).cuda_execute
+    elif mech_mode == 'Python':
+        def mech_wrapper(x):
+            mech.execute(x)
+            return mech.output_values
+        return mech_wrapper
+    else:
+        assert False, "Unknown mechanism mode: {}".format(mode)
+
+@pytest.helpers.register
 def expand_np_ndarray(arr):
     # this will fail on an input containing a float (not np.ndarray)
     try:

--- a/conftest.py
+++ b/conftest.py
@@ -110,6 +110,17 @@ def cuda_param(val):
     return pytest.param(val, marks=[pytest.mark.llvm, pytest.mark.cuda])
 
 @pytest.helpers.register
+def get_func_execution(func, func_mode):
+    if func_mode == 'LLVM':
+        return pnlvm.execution.FuncExecution(func).execute
+    elif func_mode == 'PTX':
+        return pnlvm.execution.FuncExecution(func).cuda_execute
+    elif func_mode == 'Python':
+        return func.function
+    else:
+        assert False, "Unknown function mode: {}".format(mode)
+
+@pytest.helpers.register
 def expand_np_ndarray(arr):
     # this will fail on an input containing a float (not np.ndarray)
     try:

--- a/tests/functions/test_combination.py
+++ b/tests/functions/test_combination.py
@@ -213,15 +213,7 @@ def test_reduce_function(variable, operation, exponents, weights, scale, offset,
             pytest.xfail("vector offset is not supported")
         raise e from None
 
-    if func_mode == 'Python':
-        EX = f.function
-    elif func_mode == 'LLVM':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.execute
-    elif func_mode == 'PTX':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.cuda_execute
-
+    EX = pytest.helpers.get_func_execution(f, func_mode)
     res = benchmark(EX, variable)
 
     scale = 1.0 if scale is None else scale
@@ -259,15 +251,7 @@ def test_linear_combination_function(variable, operation, exponents, weights, sc
                               weights=weights,
                               scale=scale,
                               offset=offset)
-    if func_mode == 'Python':
-        EX = f.function
-    elif func_mode == 'LLVM':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.execute
-    elif func_mode == 'PTX':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.cuda_execute
-
+    EX = pytest.helpers.get_func_execution(f, func_mode)
     res = benchmark(EX, variable)
 
     scale = 1.0 if scale is None else scale

--- a/tests/functions/test_combination.py
+++ b/tests/functions/test_combination.py
@@ -275,18 +275,11 @@ def test_linear_combination_function(variable, operation, exponents, weights, sc
 @pytest.mark.parametrize("input, input_ports", [ ([[1,2,3,4]], ["hi"]), ([[1,2,3,4], [5,6,7,8], [9,10,11,12]], ['1','2','3']), ([[1, 2, 3, 4], [5, 6, 7, 8], [0, 0, 1, 2]], ['1','2','3']) ], ids=["1S", "2S", "3S"])
 @pytest.mark.parametrize("scale", [None, 2.5, [1,2.5,0,0]], ids=["S_NONE", "S_SCALAR", "S_VECTOR"])
 @pytest.mark.parametrize("offset", [None, 1.5, [1,2.5,0,0]], ids=["O_NONE", "O_SCALAR", "O_VECTOR"])
-def test_linear_combination_function_in_mechanism(operation, input, input_ports, scale, offset, benchmark, func_mode):
+def test_linear_combination_function_in_mechanism(operation, input, input_ports, scale, offset, benchmark, mech_mode):
     f = pnl.LinearCombination(default_variable=input, operation=operation, scale=scale, offset=offset)
     p = pnl.ProcessingMechanism(size=[len(input[0])] * len(input), function=f, input_ports=input_ports)
 
-    if func_mode == 'Python':
-        EX = p.execute
-    elif func_mode == 'LLVM':
-        e = pnlvm.execution.MechExecution(p)
-        EX = e.execute
-    elif func_mode == 'PTX':
-        e = pnlvm.execution.MechExecution(p)
-        EX = e.cuda_execute
+    EX = pytest.helpers.get_mech_execution(p, mech_mode)
 
     res = benchmark(EX, input)
 

--- a/tests/functions/test_default_allocation.py
+++ b/tests/functions/test_default_allocation.py
@@ -10,14 +10,7 @@ from psyneulink.core.components.mechanisms.modulatory.control.controlmechanism i
 def test_basic(benchmark, func_mode):
     variable = np.random.rand(1)
     f = DefaultAllocationFunction()
-    if func_mode == 'Python':
-        EX = f.function
-    elif func_mode == 'LLVM':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.execute
-    elif func_mode == 'PTX':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.cuda_execute
+    EX = pytest.helpers.get_func_execution(f, func_mode)
 
     res = benchmark(EX, variable)
     assert np.allclose(res, variable)

--- a/tests/functions/test_distance.py
+++ b/tests/functions/test_distance.py
@@ -73,14 +73,7 @@ def test_basic(variable, metric, normalize, fail, expected, benchmark, func_mode
 
     benchmark.group = "DistanceFunction " + metric + ("-normalized" if normalize else "")
     f = Functions.Distance(default_variable=variable, metric=metric, normalize=normalize)
-    if func_mode == 'Python':
-        EX = f.function
-    elif func_mode == 'LLVM':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.execute
-    elif func_mode == 'PTX':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.cuda_execute
+    EX = pytest.helpers.get_func_execution(f, func_mode)
 
     res = benchmark(EX, variable)
 

--- a/tests/functions/test_distribution.py
+++ b/tests/functions/test_distribution.py
@@ -47,13 +47,9 @@ def test_execute(func, variable, params, llvm_skip, expected, benchmark, func_mo
     if func_mode != 'Python' and llvm_skip:
         pytest.skip(llvm_skip)
     f = func(default_variable=variable, **params)
-    if func_mode == 'Python':
-        ex = f
-    elif func_mode == 'LLVM':
-        ex = pnlvm.execution.FuncExecution(f).execute
-    elif func_mode == 'PTX':
-        ex = pnlvm.execution.FuncExecution(f).cuda_execute
+    ex = pytest.helpers.get_func_execution(f, func_mode)
     res = ex(variable)
+
     assert np.allclose(res, expected)
     if benchmark.enabled:
         benchmark(f.function, variable)

--- a/tests/functions/test_distribution.py
+++ b/tests/functions/test_distribution.py
@@ -52,4 +52,4 @@ def test_execute(func, variable, params, llvm_skip, expected, benchmark, func_mo
 
     assert np.allclose(res, expected)
     if benchmark.enabled:
-        benchmark(f.function, variable)
+        benchmark(ex, variable)

--- a/tests/functions/test_fhn_integrator.py
+++ b/tests/functions/test_fhn_integrator.py
@@ -63,4 +63,4 @@ def test_basic(func, variable, integration_method, params, expected, benchmark, 
     assert np.allclose(res[2], expected[2])
 
     if benchmark.enabled:
-        benchmark(f, variable)
+        benchmark(EX, variable)

--- a/tests/functions/test_fhn_integrator.py
+++ b/tests/functions/test_fhn_integrator.py
@@ -52,14 +52,7 @@ names = [
 @pytest.mark.parametrize("func, variable, integration_method, params, expected", test_data, ids=names)
 def test_basic(func, variable, integration_method, params, expected, benchmark, func_mode):
     f = func(default_variable=variable, integration_method=integration_method, params=params)
-    if func_mode == 'Python':
-        EX = f.function
-    elif func_mode == 'LLVM':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.execute
-    elif func_mode == 'PTX':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.cuda_execute
+    EX = pytest.helpers.get_func_execution(f, func_mode)
 
     res = EX(variable)
     res = EX(variable)

--- a/tests/functions/test_identity.py
+++ b/tests/functions/test_identity.py
@@ -11,12 +11,7 @@ import psyneulink.core.llvm as pnlvm
 def test_basic(size, benchmark, func_mode):
     variable = np.random.rand(size)
     f = Functions.Identity(default_variable=variable)
-    if func_mode == 'Python':
-        EX = f.function
-    elif func_mode == 'LLVM':
-        EX = pnlvm.execution.FuncExecution(f).execute
-    elif func_mode == 'PTX':
-        EX = pnlvm.execution.FuncExecution(f).cuda_execute
+    EX = pytest.helpers.get_func_execution(f, func_mode)
 
     res = benchmark(EX, variable)
     assert np.allclose(res, variable)

--- a/tests/functions/test_integrator.py
+++ b/tests/functions/test_integrator.py
@@ -171,13 +171,8 @@ def test_execute(func, func_mode, variable, noise, params, benchmark):
             params.pop('dimension')
 
     f = func[0](default_variable=variable, noise=noise, **params)
+    ex = pytest.helpers.get_func_execution(f, func_mode)
 
-    if func_mode == 'Python':
-        ex = f
-    elif func_mode == 'LLVM':
-        ex = pnlvm.execution.FuncExecution(f).execute
-    elif func_mode == 'PTX':
-        ex = pnlvm.execution.FuncExecution(f).cuda_execute
     ex(variable)
     ex(variable)
     res = ex(variable)

--- a/tests/functions/test_memory.py
+++ b/tests/functions/test_memory.py
@@ -97,16 +97,10 @@ def test_basic(func, variable, params, expected, benchmark, func_mode):
     if func is Functions.ContentAddressableMemory and func_mode != 'Python':
         pytest.skip("Not implemented")
 
-    f = func(default_variable=variable, **params)
     benchmark.group = func.componentName
-    if func_mode == 'Python':
-        EX = f.function
-    elif func_mode == 'LLVM':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.execute
-    elif func_mode == 'PTX':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.cuda_execute
+    f = func(default_variable=variable, **params)
+    EX = pytest.helpers.get_func_execution(f, func_mode)
+
     EX(variable)
     res = EX(variable)
     assert np.allclose(res[0], expected[0])

--- a/tests/functions/test_memory.py
+++ b/tests/functions/test_memory.py
@@ -106,7 +106,7 @@ def test_basic(func, variable, params, expected, benchmark, func_mode):
     assert np.allclose(res[0], expected[0])
     assert np.allclose(res[1], expected[1])
     if benchmark.enabled:
-        benchmark(f, variable)
+        benchmark(EX, variable)
 
 #endregion
 

--- a/tests/functions/test_optimization.py
+++ b/tests/functions/test_optimization.py
@@ -91,4 +91,4 @@ def test_grid_search(obj_func, metric, normalize, direction, selection, benchmar
         assert np.allclose(res[3], result[3])
 
     if benchmark.enabled:
-        benchmark(f.function, variable)
+        benchmark(EX, variable)

--- a/tests/functions/test_optimization.py
+++ b/tests/functions/test_optimization.py
@@ -80,14 +80,7 @@ def test_grid_search(obj_func, metric, normalize, direction, selection, benchmar
                                 search_space=search_space, direction=direction,
                                 select_randomly_from_optimal_values=(selection=='RANDOM'),
                                 seed=0)
-    if func_mode == 'Python':
-        EX = f.function
-    elif func_mode == 'LLVM':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.execute
-    elif func_mode == 'PTX':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.cuda_execute
+    EX = pytest.helpers.get_func_execution(f, func_mode)
 
     res = EX(variable)
 

--- a/tests/functions/test_selection.py
+++ b/tests/functions/test_selection.py
@@ -44,14 +44,10 @@ GROUP_PREFIX="SelectionFunction "
 @pytest.mark.benchmark
 @pytest.mark.parametrize("func, variable, params, expected", test_data, ids=names)
 def test_basic(func, variable, params, expected, benchmark, func_mode):
-    f = func(default_variable=variable, **params)
     benchmark.group = GROUP_PREFIX + func.componentName + params['mode']
-    if func_mode == 'Python':
-        EX = f
-    elif func_mode == 'LLVM':
-        EX = pnlvm.execution.FuncExecution(f).execute
-    elif func_mode == 'PTX':
-        EX = pnlvm.execution.FuncExecution(f).cuda_execute
+
+    f = func(default_variable=variable, **params)
+    EX = pytest.helpers.get_func_execution(f, func_mode)
 
     EX(variable)
     res = EX(variable)

--- a/tests/functions/test_stability.py
+++ b/tests/functions/test_stability.py
@@ -37,14 +37,7 @@ names = [
 @pytest.mark.parametrize("variable", [test_var, test_var.astype(np.float32)], ids=["float", "float32"] )
 def test_basic(variable, metric, normalize, expected, benchmark, func_mode):
     f = Functions.Stability(default_variable=variable, metric=metric, normalize=normalize)
-    if func_mode == 'Python':
-        EX = f.function
-    elif func_mode == 'LLVM':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.execute
-    elif func_mode == 'PTX':
-        e = pnlvm.execution.FuncExecution(f)
-        EX = e.cuda_execute
+    EX = pytest.helpers.get_func_execution(f, func_mode)
 
     benchmark.group = "DistanceFunction " + metric + ("-normalized" if normalize else "")
     res = benchmark(EX, variable)

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -100,15 +100,11 @@ derivative_names = [
 @pytest.mark.parametrize("func, variable, params, fail, expected", test_data, ids=names)
 def test_execute(func, variable, params, fail, expected, benchmark, func_mode):
     if 'Angle' in func.componentName and func_mode != 'Python':
-        pytest.skip('Angle not yet supported by LLV or PTX')
-    f = func(default_variable=variable, **params)
+        pytest.skip('Angle not yet supported by LLVM or PTX')
     benchmark.group = "TransferFunction " + func.componentName
-    if func_mode == 'Python':
-        ex = f
-    elif func_mode == 'LLVM':
-        ex = pnlvm.execution.FuncExecution(f).execute
-    elif func_mode == 'PTX':
-        ex = pnlvm.execution.FuncExecution(f).cuda_execute
+    f = func(default_variable=variable, **params)
+    ex = pytest.helpers.get_func_execution(f, func_mode)
+
     res = ex(variable)
     assert np.allclose(res, expected)
     if benchmark.enabled:

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -124,10 +124,9 @@ def test_execute_derivative(func, variable, params, expected, benchmark, func_mo
         ex = pnlvm.execution.FuncExecution(f, tags=frozenset({"derivative"})).execute
     elif func_mode == 'PTX':
         ex = pnlvm.execution.FuncExecution(f, tags=frozenset({"derivative"})).cuda_execute
-    res = ex(variable)
+
+    res = benchmark(ex, variable)
     assert np.allclose(res, expected)
-    if benchmark.enabled:
-        benchmark(ex, variable)
 
 
 def test_transfer_with_costs_function():

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -108,7 +108,7 @@ def test_execute(func, variable, params, fail, expected, benchmark, func_mode):
     res = ex(variable)
     assert np.allclose(res, expected)
     if benchmark.enabled:
-        benchmark(f.function, variable)
+        benchmark(ex, variable)
 
 
 @pytest.mark.function

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -391,12 +391,8 @@ class TestUserDefFunc:
         myMech = ProcessingMechanism(function=myFunction, size=4, name='myMech')
         # assert 'param1' in myMech.parameter_ports.names # <- FIX reinstate when problem with function params is fixed
         # assert 'param2' in myMech.parameter_ports.names # <- FIX reinstate when problem with function params is fixed
-        if mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(myMech).execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(myMech).cuda_execute
-        else:
-            e = myMech.execute
+        e = pytest.helpers.get_mech_execution(myMech, mech_mode)
+
         val = benchmark(e, [-1, 2, 3, 4])
         assert np.allclose(val, [[10]])
 

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -27,12 +27,8 @@ class TestBinaryOperations:
             return param1 + param2
 
         U = UserDefinedFunction(custom_function=myFunction, param1=param1, param2=param2)
-        if func_mode == 'LLVM':
-            e = pnlvm.execution.FuncExecution(U).execute
-        elif func_mode == 'PTX':
-            e = pnlvm.execution.FuncExecution(U).cuda_execute
-        else:
-            e = U
+        e = pytest.helpers.get_func_execution(U, func_mode)
+
         val = benchmark(e, 0)
         assert np.allclose(val, param1 + param2)
 
@@ -54,12 +50,8 @@ class TestBinaryOperations:
             return param1 * param2
 
         U = UserDefinedFunction(custom_function=myFunction, param1=param1, param2=param2)
-        if func_mode == 'LLVM':
-            e = pnlvm.execution.FuncExecution(U).execute
-        elif func_mode == 'PTX':
-            e = pnlvm.execution.FuncExecution(U).cuda_execute
-        else:
-            e = U
+        e = pytest.helpers.get_func_execution(U, func_mode)
+
         val = benchmark(e, 0)
         assert np.allclose(val, param1 * param2)
 
@@ -81,12 +73,8 @@ class TestBinaryOperations:
             return param1 / param2
 
         U = UserDefinedFunction(custom_function=myFunction, param1=param1, param2=param2)
-        if func_mode == 'LLVM':
-            e = pnlvm.execution.FuncExecution(U).execute
-        elif func_mode == 'PTX':
-            e = pnlvm.execution.FuncExecution(U).cuda_execute
-        else:
-            e = U
+        e = pytest.helpers.get_func_execution(U, func_mode)
+
         val = benchmark(e, 0)
         assert np.allclose(val, np.divide(param1, param2))
 
@@ -116,12 +104,8 @@ class TestBinaryOperations:
                     return 0.0
 
         U = UserDefinedFunction(custom_function=myFunction, default_variable=[0])
-        if func_mode == 'LLVM':
-            e = pnlvm.execution.FuncExecution(U).execute
-        elif func_mode == 'PTX':
-            e = pnlvm.execution.FuncExecution(U).cuda_execute
-        else:
-            e = U
+        e = pytest.helpers.get_func_execution(U, func_mode)
+
         val = benchmark(e, [0])
         assert val == 1.0
 
@@ -174,12 +158,8 @@ class TestBinaryOperations:
                     return 0.0
 
         U = UserDefinedFunction(custom_function=myFunction, default_variable=[0], var1=var1, var2=var2)
-        if func_mode == 'LLVM':
-            e = pnlvm.execution.FuncExecution(U).execute
-        elif func_mode == 'PTX':
-            e = pnlvm.execution.FuncExecution(U).cuda_execute
-        else:
-            e = U
+        e = pytest.helpers.get_func_execution(U, func_mode)
+
         val = benchmark(e, [0])
         assert np.allclose(expected, val)
 
@@ -250,12 +230,8 @@ class TestBinaryOperations:
                 return np.greater_equal(var1, var2).astype(float)
 
         U = UserDefinedFunction(custom_function=myFunction, default_variable=[0], var1=var1, var2=var2)
-        if func_mode == 'LLVM':
-            e = pnlvm.execution.FuncExecution(U).execute
-        elif func_mode == 'PTX':
-            e = pnlvm.execution.FuncExecution(U).cuda_execute
-        else:
-            e = U
+        e = pytest.helpers.get_func_execution(U, func_mode)
+
         val = benchmark(e, [0])
         assert np.allclose(expected, val)
 
@@ -267,12 +243,8 @@ class TestUserDefFunc:
             return variable * 2 + param2
 
         U = UserDefinedFunction(custom_function=myFunction, default_variable=[[0, 0]], param2=3)
-        if func_mode == 'LLVM':
-            e = pnlvm.execution.FuncExecution(U).execute
-        elif func_mode == 'PTX':
-            e = pnlvm.execution.FuncExecution(U).cuda_execute
-        else:
-            e = U
+        e = pytest.helpers.get_func_execution(U, func_mode)
+
         val = benchmark(e, [1, 3])
         assert np.allclose(val, [[5, 9]])
 
@@ -285,12 +257,8 @@ class TestUserDefFunc:
                 return variable * -2 + param2
 
         U = UserDefinedFunction(custom_function=myFunction, default_variable=[[0, 0]], param2=3)
-        if func_mode == 'LLVM':
-            e = pnlvm.execution.FuncExecution(U).execute
-        elif func_mode == 'PTX':
-            e = pnlvm.execution.FuncExecution(U).cuda_execute
-        else:
-            e = U
+        e = pytest.helpers.get_func_execution(U, func_mode)
+
         val = benchmark(e, [[1, 3]])
         assert np.allclose(val, [[5, 9]])
         val2 = e([[-1, 3]])
@@ -304,12 +272,8 @@ class TestUserDefFunc:
             return variable
 
         U = UserDefinedFunction(custom_function=myFunction, default_variable=[[0, 0]])
-        if func_mode == 'LLVM':
-            e = pnlvm.execution.FuncExecution(U).execute
-        elif func_mode == 'PTX':
-            e = pnlvm.execution.FuncExecution(U).cuda_execute
-        else:
-            e = U
+        e = pytest.helpers.get_func_execution(U, func_mode)
+
         val = benchmark(e, [[1, 3]])
         assert np.allclose(val, [[6, 10]])
 
@@ -324,12 +288,8 @@ class TestUserDefFunc:
             return -param
 
         U = UserDefinedFunction(custom_function=myFunction, default_variable=variable, param=variable)
-        if func_mode == 'LLVM':
-            e = pnlvm.execution.FuncExecution(U).execute
-        elif func_mode == 'PTX':
-            e = pnlvm.execution.FuncExecution(U).cuda_execute
-        else:
-            e = U
+        e = pytest.helpers.get_func_execution(U, func_mode)
+
         val = benchmark(e, variable)
         assert np.allclose(val, -variable)
 
@@ -339,12 +299,8 @@ class TestUserDefFunc:
         def myFunction(x,t0=0.48):
             return (x[0][0]>0).astype(float) * (x[0][2]>0).astype(float) / (np.max([x[0][1],x[0][3]]) + t0)
         U = UserDefinedFunction(custom_function=myFunction, default_variable=variable, param=variable)
-        if func_mode == 'LLVM':
-            e = pnlvm.execution.FuncExecution(U).execute
-        elif func_mode == 'PTX':
-            e = pnlvm.execution.FuncExecution(U).cuda_execute
-        else:
-            e = U
+        e = pytest.helpers.get_func_execution(U, func_mode)
+
         val = benchmark(e, variable)
         assert np.allclose(val, 0.2232142857142857)
 
@@ -379,12 +335,8 @@ class TestUserDefFunc:
                 return var
 
         U = UserDefinedFunction(custom_function=myFunction, default_variable=0)
-        if func_mode == 'LLVM':
-            e = pnlvm.execution.FuncExecution(U).execute
-        elif func_mode == 'PTX':
-            e = pnlvm.execution.FuncExecution(U).cuda_execute
-        else:
-            e = U
+        e = pytest.helpers.get_func_execution(U, func_mode)
+
         val = benchmark(e, 0)
         assert np.allclose(val, expected)
 
@@ -424,13 +376,10 @@ class TestUserDefFunc:
         elif op == "FLATTEN":
             def myFunction(variable):
                 return variable.flatten()
+
         U = UserDefinedFunction(custom_function=myFunction, default_variable=variable)
-        if func_mode == 'LLVM':
-            e = pnlvm.execution.FuncExecution(U).execute
-        elif func_mode == 'PTX':
-            e = pnlvm.execution.FuncExecution(U).cuda_execute
-        else:
-            e = U
+        e = pytest.helpers.get_func_execution(U, func_mode)
+
         val = benchmark(e, variable)
         assert np.allclose(val, expected)
 
@@ -480,12 +429,8 @@ class TestUserDefFunc:
                 return max(1, 2, 3, 4, 5, 6, -1, -2)
 
         U = UserDefinedFunction(custom_function=myFunction, default_variable=variable)
-        if func_mode == 'LLVM':
-            e = pnlvm.execution.FuncExecution(U).execute
-        elif func_mode == 'PTX':
-            e = pnlvm.execution.FuncExecution(U).cuda_execute
-        else:
-            e = U
+        e = pytest.helpers.get_func_execution(U, func_mode)
+
         val = benchmark(e, variable)
         assert np.allclose(val, expected)
 

--- a/tests/mechanisms/test_control_mechanism.py
+++ b/tests/mechanisms/test_control_mechanism.py
@@ -81,16 +81,7 @@ class TestLCControlMechanism:
             scaling_factor_gain=0.5,
             default_variable = 10.0
         )
-        if mech_mode == 'Python':
-            def EX(variable):
-                LC.execute(variable)
-                return LC.output_values
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(LC)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(LC)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(LC, mech_mode)
 
         val = EX([10.0])
         # All values are the same because LCControlMechanism assigns all of its ControlSignals to the same value

--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -116,12 +116,7 @@ class TestThreshold:
     def test_threshold_stops_accumulation(self, mech_mode, variable, expected, benchmark):
         D = DDM(name='DDM',
                 function=DriftDiffusionIntegrator(threshold=5.0))
-        if mech_mode == 'Python':
-            ex = D.execute
-        elif mech_mode == 'LLVM':
-            ex = pnlvm.execution.MechExecution(D).execute
-        elif mech_mode == 'PTX':
-            ex = pnlvm.execution.MechExecution(D).cuda_execute
+        ex = pytest.helpers.get_mech_execution(D, mech_mode)
 
         decision_variables = []
         time_points = []
@@ -245,12 +240,8 @@ def test_DDM_Integrator_Bogacz(benchmark, mech_mode):
         name='DDM',
         function=DriftDiffusionAnalytical()
     )
-    if mech_mode == 'Python':
-        ex = T.execute
-    elif mech_mode == 'LLVM':
-        ex = pnlvm.execution.MechExecution(T).execute
-    elif mech_mode == 'PTX':
-        ex = pnlvm.execution.MechExecution(T).cuda_execute
+    ex = pytest.helpers.get_mech_execution(T, mech_mode)
+
     val = ex(stim)[0]
     assert np.allclose(val, [1.0])
     if benchmark.enabled:
@@ -297,12 +288,7 @@ def test_DDM_noise(mech_mode, benchmark, noise, expected):
             time_step_size=1.0
         )
     )
-    if mech_mode == 'Python':
-        ex = T.execute
-    elif mech_mode == 'LLVM':
-        ex = pnlvm.execution.MechExecution(T).execute
-    elif mech_mode == 'PTX':
-        ex = pnlvm.execution.MechExecution(T).cuda_execute
+    ex = pytest.helpers.get_mech_execution(T, mech_mode)
 
     val = ex([10])
     assert np.allclose(val[0][0], expected)
@@ -430,12 +416,8 @@ def test_DDM_rate(benchmark, rate, expected, mech_mode):
             time_step_size=1.0
         ),
     )
-    if mech_mode == 'Python':
-        ex = T.execute
-    elif mech_mode == 'LLVM':
-        ex = pnlvm.execution.MechExecution(T).execute
-    elif mech_mode == 'PTX':
-        ex = pnlvm.execution.MechExecution(T).cuda_execute
+    ex = pytest.helpers.get_mech_execution(T, mech_mode)
+
     val = float(ex(stim)[0][0])
     assert val == expected
     if benchmark.enabled:

--- a/tests/mechanisms/test_episodic_memory.py
+++ b/tests/mechanisms/test_episodic_memory.py
@@ -49,14 +49,7 @@ names = [
 def test_with_dictionary_memory(variable, func, params, expected, benchmark, mech_mode):
     f = func(seed=0, **params)
     m = EpisodicMemoryMechanism(content_size=len(variable[0]), assoc_size=len(variable[1]), function=f)
-    if mech_mode == 'Python':
-        def EX(variable):
-            m.execute(variable)
-            return m.output_values
-    elif mech_mode == 'LLVM':
-        EX = pnlvm.execution.MechExecution(m).execute
-    elif mech_mode == 'PTX':
-        EX = pnlvm.execution.MechExecution(m).cuda_execute
+    EX = pytest.helpers.get_mech_execution(m, mech_mode)
 
     EX(variable)
     res = EX(variable)

--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -364,19 +364,6 @@ class TestReset:
 
 VECTOR_SIZE=4
 
-def _get_mechanism_execution(mech, mech_mode):
-    if mech_mode == 'Python':
-        def ex(variable):
-            mech.execute(variable)
-            return mech.output_values
-        return ex
-    elif mech_mode == 'LLVM':
-        return pnlvm.execution.MechExecution(mech).execute
-    elif mech_mode == 'PTX':
-        return pnlvm.execution.MechExecution(mech).cuda_execute
-    else:
-        assert False, "Unknown execution mode: {}".format(mech_mode)
-
 class TestIntegratorFunctions:
 
     @pytest.mark.mechanism
@@ -403,7 +390,7 @@ class TestIntegratorFunctions:
             default_variable=[[1], [2]],
             input_ports=['a', 'b'],
         )
-        ex = _get_mechanism_execution(I, mech_mode)
+        ex = pytest.helpers.get_mech_execution(I, mech_mode)
 
         val = ex([[1], [2]])
         assert np.allclose(val, [[3]])
@@ -419,7 +406,7 @@ class TestIntegratorFunctions:
             default_variable=[5],
             output_ports=[{pnl.VARIABLE: (pnl.OWNER_VALUE, 0)}, 'c'],
         )
-        ex = _get_mechanism_execution(I, mech_mode)
+        ex = pytest.helpers.get_mech_execution(I, mech_mode)
 
         val = ex([5])
         assert np.allclose(val, [[2.5], [2.5]])
@@ -438,7 +425,7 @@ class TestIntegratorFunctions:
             output_ports=[{pnl.VARIABLE: (pnl.OWNER_VALUE, 1)},
                           {pnl.VARIABLE: (pnl.OWNER_VALUE, 0)}],
         )
-        ex = _get_mechanism_execution(I, mech_mode)
+        ex = pytest.helpers.get_mech_execution(I, mech_mode)
 
         val = ex([[1], [2]])
         assert np.allclose(val, [[5], [3]])
@@ -453,7 +440,7 @@ class TestIntegratorFunctions:
         I = IntegratorMechanism(name="I",
                                 default_variable=[var],
                                 function=FitzHughNagumoIntegrator())
-        ex = _get_mechanism_execution(I, mech_mode)
+        ex = pytest.helpers.get_mech_execution(I, mech_mode)
 
         val = ex(var)
         assert np.allclose(val[0], [0.05127053])
@@ -468,7 +455,7 @@ class TestIntegratorFunctions:
         I = IntegratorMechanism(name="I",
                                 default_variable=var,
                                 function=FitzHughNagumoIntegrator)
-        ex = _get_mechanism_execution(I, mech_mode)
+        ex = pytest.helpers.get_mech_execution(I, mech_mode)
 
         val = ex(var)
         assert np.allclose(val[0], [0.05127053, 0.15379818])
@@ -482,7 +469,7 @@ class TestIntegratorFunctions:
         I = IntegratorMechanism(
             default_variable=[0 for i in range(VECTOR_SIZE)],
             function=Linear(slope=5.0))
-        ex = _get_mechanism_execution(I, mech_mode)
+        ex = pytest.helpers.get_mech_execution(I, mech_mode)
 
         val = benchmark(ex, [1.0 for i in range(VECTOR_SIZE)])
         assert np.allclose(val, [[5.0 for i in range(VECTOR_SIZE)]])
@@ -613,7 +600,7 @@ class TestIntegratorFunctions:
     @pytest.mark.benchmark(group="IntegratorMechanism")
     def test_integrator_no_function(self, benchmark, mech_mode):
         I = IntegratorMechanism()
-        ex = _get_mechanism_execution(I, mech_mode)
+        ex = pytest.helpers.get_mech_execution(I, mech_mode)
 
         val = ex([10])
         assert np.allclose(val, [[5.0]])

--- a/tests/mechanisms/test_objective_mechanism.py
+++ b/tests/mechanisms/test_objective_mechanism.py
@@ -18,15 +18,7 @@ class TestObjectiveMechanism:
             name='O',
             default_variable=[0 for i in range(VECTOR_SIZE)],
         )
-        if mech_mode == 'Python':
-            EX = O.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(O)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(O)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(O, mech_mode)
 
         val = benchmark(EX, [10.0 for i in range(VECTOR_SIZE)])
-
         assert np.allclose(val, [[10.0 for i in range(VECTOR_SIZE)]])

--- a/tests/mechanisms/test_processing_mechanism.py
+++ b/tests/mechanisms/test_processing_mechanism.py
@@ -42,12 +42,8 @@ class TestProcessingMechanismFunctions:
                              ])
     def test_processing_mechanism_default_function(self, mech_mode, variable, benchmark):
         PM = ProcessingMechanism(default_variable=[0, 0, 0, 0])
-        if mech_mode == "Python":
-            ex = PM.execute
-        elif mech_mode == "LLVM":
-            ex = pnlvm.MechExecution(PM).execute
-        elif mech_mode == "PTX":
-            ex = pnlvm.MechExecution(PM).cuda_execute
+        ex = pytest.helpers.get_mech_execution(PM, mech_mode)
+
         res = benchmark(ex, variable)
         assert np.allclose(res, [[1., 2., 3., 4.]])
 
@@ -256,14 +252,9 @@ class TestProcessingMechanismStandardOutputPorts:
         benchmark.group = "Output Port Op: {}".format(op)
         PM1 = ProcessingMechanism(default_variable=[0, 0, 0], output_ports=[op])
         var = [1, 2, 4] if op in {MEAN, MEDIAN, STANDARD_DEVIATION, VARIANCE} else [1, 2, -4]
-        if mech_mode == "Python":
-            ex = PM1.execute
-        elif mech_mode == "LLVM":
-            ex = pnlvm.MechExecution(PM1).execute
-        elif mech_mode == "PTX":
-            ex = pnlvm.MechExecution(PM1).cuda_execute
+        ex = pytest.helpers.get_mech_execution(PM1, mech_mode)
+
         res = benchmark(ex, var)
-        res = PM1.output_ports[0].value if mech_mode == "Python" else res
         assert np.allclose(res, expected)
 
     # FIXME: These variants don't compile (use UDFs)

--- a/tests/mechanisms/test_recurrent_transfer_mechanism.py
+++ b/tests/mechanisms/test_recurrent_transfer_mechanism.py
@@ -104,14 +104,7 @@ class TestRecurrentTransferMechanismInputs:
             name='R',
             default_variable=[0, 0, 0, 0]
         )
-        if mech_mode == 'Python':
-            EX = R.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(R)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(R)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(R, mech_mode)
 
         val1 = EX([10, 12, 0, -1])
         val2 = EX([1, 2, 3, 0])
@@ -131,14 +124,7 @@ class TestRecurrentTransferMechanismInputs:
             name='R',
             size=4
         )
-        if mech_mode == 'Python':
-            EX = R.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(R)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(R)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(R, mech_mode)
 
         val = benchmark(EX, [10.0, 10.0, 10.0, 10.0])
         np.testing.assert_allclose(val, [[10.0, 10.0, 10.0, 10.0]])
@@ -153,14 +139,7 @@ class TestRecurrentTransferMechanismInputs:
                                        integrator_mode=True,
                                        integration_rate=0.01,
                                        output_ports = [RESULT])
-        if mech_mode == 'Python':
-            EX = R.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(R)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(R)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(R, mech_mode)
 
         val1 = EX([[1.0, 2.0]])
         val2 = EX([[1.0, 2.0]])
@@ -184,14 +163,7 @@ class TestRecurrentTransferMechanismInputs:
                                        integrator_mode=True,
                                        integrator_function=LCI,
                                        output_ports = [RESULT])
-        if mech_mode == 'Python':
-            EX = R.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(R)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(R)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(R, mech_mode)
 
         val1 = EX([[1.0, 2.0]])
         val2 = EX([[1.0, 2.0]])
@@ -226,14 +198,7 @@ class TestRecurrentTransferMechanismInputs:
             name='R'
         )
         np.testing.assert_allclose(R.defaults.variable, [[0]])
-        if mech_mode == 'Python':
-            EX = R.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(R)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(R)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(R, mech_mode)
 
         val = EX([10])
         np.testing.assert_allclose(val, [[10.]])

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -59,14 +59,7 @@ class TestTransferMechanismInputs:
         )
         T.reset_stateful_function_when = Never()
         var = [10.0 for i in range(VECTOR_SIZE)]
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         val = EX(var)
         assert np.allclose(val, [[10.0 for i in range(VECTOR_SIZE)]])
@@ -158,14 +151,7 @@ class TestTransferMechanismNoise:
             integrator_mode=True
         )
         T.reset_stateful_function_when = Never()
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         var = [0 for i in range(VECTOR_SIZE)]
         val = EX(var)
@@ -220,14 +206,7 @@ class TestTransferMechanismNoise:
             integrator_mode=True
         )
         T.reset_stateful_function_when = Never()
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         var = [0 for i in range(VECTOR_SIZE)]
         val = EX(var)
@@ -437,14 +416,7 @@ class TestTransferMechanismFunctions:
             integration_rate=1.0,
             integrator_mode=True
         )
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         var = [0 for i in range(VECTOR_SIZE)]
         val = EX(var)
@@ -464,14 +436,7 @@ class TestTransferMechanismFunctions:
             integration_rate=1.0,
             integrator_mode=True
         )
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         val1 = EX([0 for i in range(VECTOR_SIZE)])
         val2 = EX([1 for i in range(VECTOR_SIZE)])
@@ -496,14 +461,7 @@ class TestTransferMechanismFunctions:
             integration_rate=1.0,
             integrator_mode=True
         )
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         var = [0 for i in range(VECTOR_SIZE)]
         val = EX(var)
@@ -523,14 +481,7 @@ class TestTransferMechanismFunctions:
             integration_rate=1.0,
             integrator_mode=True
         )
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         var = [0 for i in range(VECTOR_SIZE)]
         val = EX(var)
@@ -617,14 +568,7 @@ class TestTransferMechanismIntegratorFunctionParams:
             integrator_function=AdaptiveIntegrator,
             integration_rate=[i / 10 for i in range(VECTOR_SIZE)]
         )
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         var = [1 for i in range(VECTOR_SIZE)]
         EX(var)
@@ -644,14 +588,7 @@ class TestTransferMechanismIntegratorFunctionParams:
             integrator_mode=True,
             integrator_function=AdaptiveIntegrator(rate=[i / 10 for i in range(VECTOR_SIZE)])
         )
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         var = [1 for i in range(VECTOR_SIZE)]
         EX(var)
@@ -672,14 +609,7 @@ class TestTransferMechanismIntegratorFunctionParams:
                 integrator_function=AdaptiveIntegrator(rate=[i / 20 for i in range(VECTOR_SIZE)]),
                 integration_rate=[i / 10 for i in range(VECTOR_SIZE)]
         )
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         var = [1 for i in range(VECTOR_SIZE)]
         EX(var)
@@ -728,14 +658,7 @@ class TestTransferMechanismIntegratorFunctionParams:
             integrator_mode=True,
             initial_value=[i / 10 for i in range(VECTOR_SIZE)]
         )
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         var = [1 for i in range(VECTOR_SIZE)]
         EX(var)
@@ -758,15 +681,7 @@ class TestTransferMechanismIntegratorFunctionParams:
                     initializer=[i / 10 for i in range(VECTOR_SIZE)]
             ),
         )
-        if mech_mode == 'Python':
-            EX = T.execute
-            assert True
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         var = [1 for i in range(VECTOR_SIZE)]
         EX(var)
@@ -790,14 +705,7 @@ class TestTransferMechanismIntegratorFunctionParams:
             ),
             initial_value=[i / 10 for i in range(VECTOR_SIZE)]
         )
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         var = [1 for i in range(VECTOR_SIZE)]
         EX(var)
@@ -889,14 +797,7 @@ class TestTransferMechanismIntegratorFunctionParams:
             integrator_function=AdaptiveIntegrator,
             noise=[i / 10 for i in range(VECTOR_SIZE)]
         )
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         var = [1 for i in range(VECTOR_SIZE)]
         EX(var)
@@ -917,14 +818,7 @@ class TestTransferMechanismIntegratorFunctionParams:
             integrator_mode=True,
             integrator_function=AdaptiveIntegrator(noise=[i / 10 for i in range(VECTOR_SIZE)])
         )
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         var = [1 for i in range(VECTOR_SIZE)]
         EX(var)
@@ -946,14 +840,7 @@ class TestTransferMechanismIntegratorFunctionParams:
                 integrator_function=AdaptiveIntegrator(noise=[i / 20 for i in range(VECTOR_SIZE)]),
                 noise=[i / 10 for i in range(VECTOR_SIZE)]
         )
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         var = [1 for i in range(VECTOR_SIZE)]
         EX(var)
@@ -1009,14 +896,7 @@ class TestTransferMechanismTimeConstant:
             integration_rate=0.8,
             integrator_mode=True
         )
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         val1 = T.execute([1 for i in range(VECTOR_SIZE)])
         val2 = T.execute([1 for i in range(VECTOR_SIZE)])
@@ -1038,15 +918,9 @@ class TestTransferMechanismTimeConstant:
             integration_rate=1.0,
             integrator_mode=True
         )
-        if mech_mode == 'Python':
-            val = benchmark(T.execute, [1 for i in range(VECTOR_SIZE)])
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            val = benchmark(e.execute, [1 for i in range(VECTOR_SIZE)])
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            val = benchmark(e.cuda_execute, [1 for i in range(VECTOR_SIZE)])
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
+        val = benchmark(EX, [1 for i in range(VECTOR_SIZE)])
         assert np.allclose(val, [[1.0 for i in range(VECTOR_SIZE)]])
 
     @pytest.mark.mechanism
@@ -1060,14 +934,9 @@ class TestTransferMechanismTimeConstant:
             integration_rate=0.0,
             integrator_mode=True
         )
-        if mech_mode == 'Python':
-            val = benchmark(T.execute, [1 for i in range(VECTOR_SIZE)])
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            val = benchmark(e.execute, [1 for i in range(VECTOR_SIZE)])
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            val = benchmark(e.cuda_execute, [1 for i in range(VECTOR_SIZE)])
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
+
+        val = benchmark(EX, [1 for i in range(VECTOR_SIZE)])
         assert np.allclose(val, [[0.0 for i in range(VECTOR_SIZE)]])
 
     @pytest.mark.mechanism
@@ -1081,14 +950,9 @@ class TestTransferMechanismTimeConstant:
             initial_value=np.array([[.5, .5, .5, .5]]),
             integrator_mode=True
         )
-        if mech_mode == 'Python':
-            val = T.execute([1, 1, 1, 1])
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            val = e.execute([1, 1, 1, 1])
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            val = e.cuda_execute([1, 1, 1, 1])
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
+
+        val = EX([1, 1, 1, 1])
         assert np.allclose(val, [[0.9, 0.9, 0.9, 0.9]])
 
         # FIXME: The code bellow modifies parameter value.
@@ -1490,14 +1354,9 @@ class TestTransferMechanismMultipleInputPorts:
             function=Linear(slope=2.0, intercept=1.0),
             default_variable=[[0.0, 0.0], [0.0, 0.0]],
         )
-        if mech_mode == 'Python':
-            val = benchmark(T.execute, [[1.0, 2.0], [3.0, 4.0]])
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            val = benchmark(e.execute, [[1.0, 2.0], [3.0, 4.0]])
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            val = benchmark(e.cuda_execute, [[1.0, 2.0], [3.0, 4.0]])
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
+
+        val = benchmark(EX, [[1.0, 2.0], [3.0, 4.0]])
         assert np.allclose(val, [[3., 5.], [7., 9.]])
 
     @pytest.mark.mechanism
@@ -1518,19 +1377,12 @@ class TestTransferMechanismMultipleInputPorts:
     @pytest.mark.benchmark(group="MIMO")
     def test_multiple_output_ports_for_multiple_input_ports(self, benchmark, mech_mode):
         T = TransferMechanism(input_ports=['a','b','c'])
-        if mech_mode == 'Python':
-            val = benchmark(T.execute, [[1], [2], [3]])
-            assert all(a==b for a,b in zip(T.output_values,val))
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(T)
-            val = benchmark(e.execute, [[1], [2], [3]])
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(T)
-            val = benchmark(e.cuda_execute, [[1], [2], [3]])
+        assert len(T.variable) == 3
+        assert len(T.output_ports) == 3
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
-        assert len(T.variable)==3
-        assert all(a==b for a,b in zip(val, [[ 1.],[ 2.],[ 3.]]))
-        assert len(T.output_ports)==3
+        val = benchmark(EX, [[1], [2], [3]])
+        assert all(a == b for a,b in zip(val, [[ 1.],[ 2.],[ 3.]]))
 
     # @pytest.mark.mechanism
     # @pytest.mark.transfer_mechanism
@@ -1966,12 +1818,7 @@ class TestClip:
     @pytest.mark.transfer_mechanism
     def test_clip_float(self, mech_mode):
         T = TransferMechanism(clip=[-2.0, 2.0])
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            EX = pnlvm.execution.MechExecution(T).execute
-        elif mech_mode == 'PTX':
-            EX = pnlvm.execution.MechExecution(T).cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         assert np.allclose(EX(3.0), 2.0)
         assert np.allclose(EX(1.0), 1.0)
@@ -1982,12 +1829,8 @@ class TestClip:
     def test_clip_array(self, mech_mode):
         T = TransferMechanism(default_variable=[[0.0, 0.0, 0.0]],
                               clip=[-2.0, 2.0])
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            EX = pnlvm.execution.MechExecution(T).execute
-        elif mech_mode == 'PTX':
-            EX = pnlvm.execution.MechExecution(T).cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
+
         assert np.allclose(EX([3.0, 0.0, -3.0]), [2.0, 0.0, -2.0])
 
     @pytest.mark.mechanism
@@ -1995,12 +1838,7 @@ class TestClip:
     def test_clip_2d_array(self, mech_mode):
         T = TransferMechanism(default_variable=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                               clip=[-2.0, 2.0])
-        if mech_mode == 'Python':
-            EX = T.execute
-        elif mech_mode == 'LLVM':
-            EX = pnlvm.execution.MechExecution(T).execute
-        elif mech_mode == 'PTX':
-            EX = pnlvm.execution.MechExecution(T).cuda_execute
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
         assert np.allclose(EX([[-5.0, -1.0, 5.0], [5.0, -5.0, 1.0], [1.0, 5.0, 5.0]]),
                            [[-2.0, -1.0, 2.0], [2.0, -2.0, 1.0], [1.0, 2.0, 2.0]])

--- a/tests/ports/test_output_ports.py
+++ b/tests/ports/test_output_ports.py
@@ -22,20 +22,12 @@ class TestOutputPorts:
         expected = [[3.],[2.],[1.],[[1.],[2.],[3.]], [0]]
         for i, e in zip(mech.output_values, expected):
             assert np.array_equal(i, e)
-        if mech_mode == 'Python':
-            EX = mech.execute
-        elif mech_mode == 'LLVM':
-            e = pnlvm.execution.MechExecution(mech)
-            EX = e.execute
-        elif mech_mode == 'PTX':
-            e = pnlvm.execution.MechExecution(mech)
-            EX = e.cuda_execute
+        EX = pytest.helpers.get_mech_execution(mech, mech_mode)
+
         EX([[1.],[2.],[3.]])
         EX([[1.],[2.],[3.]])
         EX([[1.],[2.],[3.]])
         res = EX([[1.],[2.],[3.]])
-        if mech_mode == 'Python':
-            res = mech.output_values
         expected = [[3.],[2.],[1.],[[1.],[2.],[3.]], [4]]
         for i, e in zip(res, expected):
             assert np.array_equal(i, e)


### PR DESCRIPTION
Provide a helper to construct and select the right execution wrapper for compiled functions.
Provide a helper to construct and select the right execution wrapper for compiled mechanisms.

Pass the execution correct wrapper to the benchmark fixture.