### PR TITLE
scheduling: add absolute time and exact time modes

### DIFF
--- a/psyneulink/__init__.py
+++ b/psyneulink/__init__.py
@@ -22,18 +22,25 @@ please contact psyneulinkhelp@princeton.edu.
 import logging as _logging
 
 import numpy as _numpy
+import pint as _pint
+
+# pint requires a package-specific unit registry, and to use it as
+# needed in psyneulink, it has to come before imports. This is the
+# reason for skipping E402 below
+_unit_registry = _pint.get_application_registry()
+_pint.set_application_registry(_unit_registry)
 
 # starred imports to allow user imports from top level
-from . import core
-from . import library
+from . import core  # noqa: E402
+from . import library  # noqa: E402
 
-from ._version import get_versions
-from .core import *
-from .library import *
+from ._version import get_versions  # noqa: E402
+from .core import *  # noqa: E402
+from .library import *  # noqa: E402
 
 
 _pnl_global_names = [
-    'primary_registries', 'System', 'Process'
+    'primary_registries', 'System', 'Process', '_unit_registry',
 ]
 # flag when run from pytest (see conftest.py)
 _called_from_pytest = False

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -2363,6 +2363,7 @@ from inspect import isgenerator, isgeneratorfunction
 
 import networkx
 import numpy as np
+import pint
 import typecheck as tc
 from PIL import Image
 
@@ -2419,7 +2420,7 @@ from psyneulink.core.globals.registry import register_category
 from psyneulink.core.globals.utilities import \
     ContentAddressableList, call_with_pruned_args, convert_to_list, convert_to_np_array
 from psyneulink.core.scheduling.condition import All, AllHaveRun, Always, Any, Condition, Never
-from psyneulink.core.scheduling.scheduler import Scheduler
+from psyneulink.core.scheduling.scheduler import Scheduler, SchedulingMode
 from psyneulink.core.scheduling.time import Time, TimeScale
 from psyneulink.library.components.mechanisms.modulatory.learning.autoassociativelearningmechanism import \
     AutoAssociativeLearningMechanism
@@ -3442,6 +3443,14 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     @termination_processing.setter
     def termination_processing(self, termination_conds):
         self.scheduler.termination_conds = termination_conds
+
+    @property
+    def scheduling_mode(self):
+        return self.scheduler.scheduling_mode
+
+    @scheduling_mode.setter
+    def scheduling_mode(self, scheduling_mode: SchedulingMode):
+        self.scheduler.scheduling_mode = scheduling_mode
 
     # ******************************************************************************************************************
     #                                              GRAPH
@@ -8040,7 +8049,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             animate=False,
             log=False,
             scheduler=None,
+            scheduling_mode: typing.Optional[SchedulingMode] = None,
             execution_mode:pnlvm.ExecutionMode = pnlvm.ExecutionMode.Python,
+            default_absolute_time_unit: typing.Optional[pint.Quantity] = None,
             context=None,
             base_context=Context(execution_id=None),
             ):
@@ -8207,12 +8218,22 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             the scheduler object that owns the conditions that will instruct the execution of the Composition.
             If not specified, the Composition will use its automatically generated scheduler.
 
+        scheduling_mode : SchedulingMode[STANDARD|EXACT_TIME] : default None
+            if specified, sets the `scheduling mode <SchedulingMode>`
+            for the current and all future runs of the Composition. See
+            `Scheduler_Execution`
+
         execution_mode : enum.Enum[Auto|LLVM|LLVMexec|LLVMRun|Python|PTXExec|PTXRun] : default Python
             specifies whether to run using the Python interpreter or a `compiled mode <Composition_Compilation>`.
             False is the same as ``Python``;  True tries LLVM compilation modes, in order of power, progressively
             reverting to less powerful modes (in the order of the options listed), and to Python if no compilation
             mode succeeds (see `Composition_Compilation` for explanation of modes). PTX modes are used for
             CUDA compilation.
+
+        default_absolute_time_unit : ``pint.Quantity`` : ``1ms``
+            if not otherwise determined by any absolute **conditions**,
+            specifies the absolute duration of a `TIME_STEP`. See
+            `Scheduler.default_absolute_time_unit`
 
         context : `execution_id <Context.execution_id>` : default `default_execution_id`
             context in which the `Composition` will be executed;  set to self.default_execution_id ifunspecified.
@@ -8265,6 +8286,12 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         if scheduler is None:
             scheduler = self.scheduler
+
+        if scheduling_mode is not None:
+            scheduler.mode = scheduling_mode
+
+        if default_absolute_time_unit is not None:
+            scheduler.default_absolute_time_unit = default_absolute_time_unit
 
         for node in self.nodes:
             num_execs = node.parameters.num_executions._get(context)
@@ -9303,6 +9330,12 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                     self._animate_execution(next_execution_set, context)
 
                 # EXECUTE EACH NODE IN EXECUTION SET ----------------------------------------------------------------------
+                if execution_scheduler.mode is SchedulingMode.EXACT_TIME:
+                    # sort flattened execution set by unflattened position
+                    next_execution_set = sorted(
+                        next_execution_set,
+                        key=lambda n: execution_scheduler.consideration_queue_indices[n]
+                    )
 
                 # execute each node with EXECUTING in context
                 for (node_idx, node) in enumerate(next_execution_set):

--- a/psyneulink/core/scheduling/condition.py
+++ b/psyneulink/core/scheduling/condition.py
@@ -625,12 +625,17 @@ class Never(Condition):
 #   - based on other Conditions
 ######################################################################
 
-# TODO: create this class to subclass All and Any from
-# class CompositeCondition(Condition):
-    # def
+
+class CompositeCondition(Condition):
+    @Condition.owner.setter
+    def owner(self, value):
+        for cond in self.args:
+            logger.debug('owner setter: Setting owner of {0} to ({1})'.format(cond, value))
+            if cond.owner is None:
+                cond.owner = value
 
 
-class All(Condition):
+class All(CompositeCondition):
     """All
 
     Parameters:
@@ -656,13 +661,6 @@ class All(Condition):
         args += tuple(*[v for k, v in dependencies.items()])
         super().__init__(self.satis, *args)
 
-    @Condition.owner.setter
-    def owner(self, value):
-        for cond in self.args:
-            logger.debug('owner setter: Setting owner of {0} to ({1})'.format(cond, value))
-            if cond.owner is None:
-                cond.owner = value
-
     def satis(self, *conds, **kwargs):
         for cond in conds:
             if not cond.is_satisfied(**kwargs):
@@ -670,7 +668,7 @@ class All(Condition):
         return True
 
 
-class Any(Condition):
+class Any(CompositeCondition):
     """Any
 
     Parameters:
@@ -695,13 +693,6 @@ class Any(Condition):
     def __init__(self, *args, **dependencies):
         args += tuple(*[v for k, v in dependencies.items()])
         super().__init__(self.satis, *args)
-
-    @Condition.owner.setter
-    def owner(self, value):
-        for cond in self.args:
-            logger.debug('owner setter: Setting owner of {0} to ({1})'.format(cond, value))
-            if cond.owner is None:
-                cond.owner = value
 
     def satis(self, *conds, **kwargs):
         for cond in conds:

--- a/psyneulink/core/scheduling/condition.py
+++ b/psyneulink/core/scheduling/condition.py
@@ -165,8 +165,15 @@ six types:
 
 .. _Conditions_Time_Based:
 
-**Time-Based Conditions** (based on the count of units of time at a specified `TimeScale`):
+**Time-Based Conditions** (based on the count of units of time at a
+specified `TimeScale` or `Time <Scheduler_Absolute_Time>`):
 
+    * `TimeInterval` ([`pint.Quantity`, `pint.Quantity`, `pint.Quantity`])
+      satisfied every time an optional amount of absolute time has
+      passed in between an optional specified range
+
+    * `TimeTermination` (`pint.Quantity`)
+      satisfied after the given absolute time
 
     * `BeforeTimeStep` (int[, TimeScale])
       satisfied any time before the specified `TIME_STEP` occurs.
@@ -295,8 +302,13 @@ Class Reference
 import collections
 import dill
 import inspect
+import itertools
 import logging
+import typing
 import warnings
+
+import pint
+import psyneulink as pnl
 
 from psyneulink.core.globals.json import JSONDumpable
 from psyneulink.core.globals.keywords import MODEL_SPEC_ID_TYPE
@@ -310,10 +322,42 @@ __all__ = [
     'AtNCalls','AtPass', 'AtRunStart', 'AtRunNStart', 'AtTimeStep', 'AtTrial',
     'AtTrialStart', 'AtTrialNStart', 'BeforeNCalls', 'BeforePass', 'BeforeTimeStep', 'BeforeTrial',
     'Condition','ConditionError', 'ConditionSet', 'EveryNCalls', 'EveryNPasses',
-    'JustRan', 'Never', 'Not', 'NWhen', 'Or', 'WhenFinished', 'WhenFinishedAll', 'WhenFinishedAny', 'While', 'WhileNot'
+    'JustRan', 'Never', 'Not', 'NWhen', 'Or', 'WhenFinished', 'WhenFinishedAll', 'WhenFinishedAny', 'While', 'WhileNot', 'TimeInterval', 'TimeTermination'
 ]
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_absolute_unit(n, unit=None):
+    if isinstance(n, pnl._unit_registry.Quantity):
+        return n
+
+    try:
+        # handle string representation of a unit
+        unit = getattr(pnl._unit_registry, unit)
+    except TypeError:
+        pass
+
+    if isinstance(n, str):
+        try:
+            full_quantity = pnl._unit_registry.Quantity(n)
+        except pint.errors.UndefinedUnitError:
+            pass
+        else:
+            # n is an actual full quantity (e.g. '1ms') not just a number ('1')
+            if full_quantity.u != pnl._unit_registry.Unit('dimensionless'):
+                return full_quantity
+            else:
+                try:
+                    n = int(n)
+                except ValueError:
+                    n = float(n)
+
+    assert unit is not None
+    if n is not None:
+        n = n * unit
+
+    return n
 
 
 class ConditionError(Exception):
@@ -526,6 +570,32 @@ class Condition(JSONDumpable):
             'kwargs': self.kwargs,
         }
 
+    @property
+    def absolute_intervals(self):
+        """
+        In absolute time, repeated intervals for satisfaction or
+        unsatisfaction of this Condition or those it contains
+        """
+        return []
+
+    @property
+    def absolute_fixed_points(self):
+        """
+        In absolute time, specific time points for satisfaction or
+        unsatisfaction of this Condition or those it contains
+        """
+        return []
+
+    @property
+    def is_absolute(self):
+        return False
+
+
+class AbsoluteCondition(Condition):
+    @property
+    def is_absolute(self):
+        return True
+
 
 class _DependencyValidation:
     @Condition.owner.setter
@@ -634,6 +704,24 @@ class CompositeCondition(Condition):
             logger.debug('owner setter: Setting owner of {0} to ({1})'.format(cond, value))
             if cond.owner is None:
                 cond.owner = value
+
+    @property
+    def absolute_intervals(self):
+        return list(itertools.chain.from_iterable([
+            c.absolute_intervals
+            for c in filter(lambda a: a.is_absolute, self.args)
+        ]))
+
+    @property
+    def absolute_fixed_points(self):
+        return list(itertools.chain.from_iterable([
+            c.absolute_fixed_points
+            for c in filter(lambda a: a.is_absolute, self.args)
+        ]))
+
+    @property
+    def is_absolute(self):
+        return any(a.is_absolute for a in self.args)
 
 
 class All(CompositeCondition):
@@ -775,8 +863,177 @@ class NWhen(Condition):
 
 ######################################################################
 # Time-based Conditions
-#   - satisfied based only on TimeScales
+#   - satisfied based only on time
 ######################################################################
+
+class TimeInterval(AbsoluteCondition):
+    """TimeInterval
+
+    Attributes:
+
+        repeat
+            the interval between *unit*s where this condition can be
+            satisfied
+
+        start
+            the time at/after which this condition can be
+            satisfied
+
+        end
+            the time at/fter which this condition can be
+            satisfied
+
+        unit
+            the `pint.Unit` to use for scalar values of *repeat*,
+            *start*, and *end*
+
+        start_inclusive
+            if True, *start* allows satisfaction exactly at the time
+            corresponding to *start*. if False, satisfaction can occur
+            only after *start*
+
+        end_inclusive
+            if True, *end* allows satisfaction exactly until the time
+            corresponding to *end*. if False, satisfaction can occur
+            only before *end*
+
+
+    Satisfied when:
+
+        Every *repeat* units of time at/after *start* and before/through
+        *end*
+
+    Notes:
+
+        Using a `TimeInterval` as a
+        `termination Condition <Scheduler_Termination_Conditions>` may
+        result in unexpected behavior. The user may be inclined to
+        create **TimeInterval(end=x)** to terminate at time **x**, but
+        this will do the opposite and be true only and always until time
+        **x**, terminating at any time before **x**. If in doubt, use
+        `TimeTermination` instead.
+
+        If the scheduler is not set to `exact_time_mode = True`,
+        *start_inclusive* and *end_inclusive* may not behave as
+        expected. See `Scheduler_Exact_Time` for more info.
+    """
+    def __init__(
+        self,
+        repeat: typing.Union[int, str, pint.Quantity] = None,
+        start: typing.Union[int, str, pint.Quantity] = None,
+        end: typing.Union[int, str, pint.Quantity] = None,
+        unit: typing.Union[str, pint.Unit] = pnl._unit_registry.ms,
+        start_inclusive: bool = True,
+        end_inclusive: bool = True
+    ):
+        if repeat is start is end is None:
+            raise ConditionError(
+                'At least one of "repeat", "start", "end" must be specified'
+            )
+
+        if start is not None and end is not None and start > end:
+            raise ConditionError(f'Start ({start}) is later than {end}')
+
+        repeat = _parse_absolute_unit(repeat, unit)
+        start = _parse_absolute_unit(start, unit)
+        end = _parse_absolute_unit(end, unit)
+
+        def func(scheduler, execution_id):
+            satisfied = True
+            clock = scheduler.get_clock(execution_id)
+
+            if scheduler._in_exact_time_mode and start is not None:
+                offset = start
+            else:
+                for i, cs in enumerate(scheduler.consideration_queue):
+                    if self.owner in cs:
+                        offset = i * clock.time.absolute_interval
+
+            if repeat is not None:
+                satisfied &= (clock.time.absolute - offset) % repeat == 0
+
+            if start is not None:
+                if start_inclusive:
+                    satisfied &= clock.time.absolute >= start
+                else:
+                    satisfied &= clock.time.absolute > start
+
+            if end is not None:
+                if end_inclusive:
+                    satisfied &= clock.time.absolute <= end
+                else:
+                    satisfied &= clock.time.absolute < end
+
+            return satisfied
+
+        super().__init__(
+            func,
+            repeat=repeat,
+            start=start,
+            end=end,
+            unit=unit,
+            start_inclusive=start_inclusive,
+            end_inclusive=end_inclusive
+        )
+
+    @property
+    def absolute_intervals(self):
+        return [self.repeat] if self.repeat is not None else []
+
+    @property
+    def absolute_fixed_points(self):
+        fp = []
+        if self.start_inclusive and self.start is not None:
+            fp.append(self.start)
+        if self.end_inclusive and self.end is not None:
+            fp.append(self.end)
+
+        return fp
+
+
+class TimeTermination(AbsoluteCondition):
+    """TimeTermination
+
+    Attributes:
+
+        t
+            the time at/after which this condition is satisfied
+
+        unit
+            the `pint.Unit` to use for scalar values of *t*, *start*,
+            and *end*
+
+        start_inclusive
+            if True, the condition is satisfied exactly at the time
+            corresponding to *t*. if False, satisfaction can occur
+            only after *t*
+
+    Satisfied when:
+
+        At/After time *t*
+    """
+    def __init__(
+        self,
+        t: typing.Union[int, str, pint.Quantity],
+        inclusive: bool = True,
+        unit: typing.Union[str, pint.Unit] = pnl._unit_registry.ms,
+    ):
+        t = _parse_absolute_unit(t, unit)
+
+        def func(scheduler, execution_id):
+            clock = scheduler.get_clock(execution_id)
+
+            if inclusive:
+                return clock.time.absolute >= t
+            else:
+                return clock.time.absolute > t
+
+        super().__init__(func, t=t, inclusive=inclusive)
+
+    @property
+    def absolute_fixed_points(self):
+        return [self.t] if self.inclusive else []
+
 
 class BeforeTimeStep(Condition):
     """BeforeTimeStep
@@ -1218,8 +1475,6 @@ class AfterNRuns(Condition):
                 raise ConditionError(f'{type(self).__name__}: scheduler must be supplied to is_satisfied: {e}.')
 
         super().__init__(func, n)
-
-
 
 ######################################################################
 # Component-based Conditions

--- a/psyneulink/core/scheduling/condition.py
+++ b/psyneulink/core/scheduling/condition.py
@@ -629,6 +629,7 @@ class Never(Condition):
 class CompositeCondition(Condition):
     @Condition.owner.setter
     def owner(self, value):
+        super(CompositeCondition, CompositeCondition).owner.__set__(self, value)
         for cond in self.args:
             logger.debug('owner setter: Setting owner of {0} to ({1})'.format(cond, value))
             if cond.owner is None:
@@ -726,6 +727,7 @@ class Not(Condition):
 
     @Condition.owner.setter
     def owner(self, value):
+        super(Not, Not).owner.__set__(self, value)
         self.condition.owner = value
 
 
@@ -751,6 +753,7 @@ class NWhen(Condition):
 
     @Condition.owner.setter
     def owner(self, value):
+        super(NWhen, NWhen).owner.__set__(self, value)
         self.condition.owner = value
 
     def satis(self, condition, n, *args, scheduler=None, execution_id=None, **kwargs):

--- a/psyneulink/core/scheduling/condition.py
+++ b/psyneulink/core/scheduling/condition.py
@@ -442,6 +442,9 @@ class Condition(JSONDumpable):
 
         self._owner = None
 
+        for k in kwargs:
+            setattr(self, k, kwargs[k])
+
     def __str__(self):
         return '{0}({1}{2})'.format(
             self.__class__.__name__,

--- a/psyneulink/core/scheduling/scheduler.py
+++ b/psyneulink/core/scheduling/scheduler.py
@@ -112,6 +112,12 @@ Pseudocode::
 Execution
 ---------
 
+.. note::
+    This section covers normal scheduler execution
+    (`Scheduler.mode = SchedulingMode.STANDARD`). See
+    `Scheduler_Exact_Time` below for a description of
+    `exact time mode <SchedulingMode.EXACT_TIME>`.
+
 When a Scheduler is run, it provides a set of Components that should be run next, based on their dependencies in the
 Composition or graph specification dictionary, and any `Conditions <Condition>`, specified in the Scheduler's
 constructor. For each call to the `run <Scheduler.run>` method, the Scheduler sequentially evaluates its
@@ -180,6 +186,65 @@ running a Composition, by passing a dictionary mapping `TimeScales <TimeScale>` 
         ...,
         termination_processing={TimeScale.TRIAL: WhenFinished(ddm)}
         )
+
+
+.. _Scheduler_Absolute_Time:
+
+Absolute Time
+-------------
+
+The scheduler supports scheduling of models of real-time systems in
+modes, both of which involve mapping real-time values to psyneulink
+`Time`. The default mode is is most compatible with standard PsyNeuLink
+scheduling, but can cause some unexpected behavior in certain cases
+because it is inexact. The consideration queue remains intact, but as a
+result, actions specified by fixed times of absolute-time-based
+conditions (`start <TimeInterval.start>` and `end <TimeInterval.end>` of
+`TimeInterval`, and `t` of `TimeTermination`) may not occur at exactly
+the time specified. The simplest example of this situation involves a
+linear composition with two nodes::
+
+    >>> import psyneulink as pnl
+
+    >>> A = pnl.TransferMechanism()
+    >>> B = pnl.TransferMechanism()
+
+    >>> comp = pnl.Composition()
+    >>> pway = comp.add_linear_processing_pathway([A, B])
+
+    >>> comp.scheduler.add_condition(A, pnl.TimeInterval(start=10))
+    >>> comp.scheduler.add_condition(B, pnl.TimeInterval(start=10))
+
+In standard mode, **A** and **B** are in different consideration sets,
+and so can never execute at the same time. At most one of **A** and
+**B** will start exactly at t=10ms, with the other starting at its next
+consideration after. There are many of these examples, and while it may
+be solveable in some cases, it is not a simple problem. So,
+`Exact Time Mode <Scheduler_Exact_Time>` exists as an alternative
+option for these cases, though it comes with its own drawbacks.
+
+.. _Scheduler_Exact_Time:
+
+Exact Time Mode
+~~~~~~~~~~~~~~~
+
+When `Scheduler.mode` is `SchedulingMode.EXACT_TIME`, the scheduler is
+capable of handling examples like the one
+`above <Scheduler_Absolute_Time>`. In this mode, all nodes in the
+scheduler's graph become members of the same consideration set, and may
+be executed at the same time for every time step, subject to the
+conditions specified. As a result, the guarantees in
+`standard scheduling <Scheduler_Execution>` may not apply - that is,
+that all parent nodes get a chance to execute before their children, and
+that there exist no data dependencies (Projections) between nodes in the
+same execution set. In exact time mode, all nodes will be in one
+[unordered] execution set. An ordering may be inferred by the original
+graph, however, using the `indices in the original consideration queue
+<Scheduler.consideration_queue_indices>`_. `Composition`\\ s will
+execute nodes in this order, however independent usages of the scheduler
+may not.  The user should be aware of this and set up defaults and
+inputs to nodes accordingly. Additionally, non-absolute conditions like
+`EveryNCalls` may behave unexpectedly in some cases.
 
 Examples
 --------
@@ -274,17 +339,24 @@ Class Reference
 
 import copy
 import datetime
+import enum
+import fractions
 import logging
+import typing
+
+import numpy as np
+import pint
+import psyneulink as pnl
 
 from toposort import toposort
 
 from psyneulink.core.globals.context import Context, handle_external_context
 from psyneulink.core.globals.json import JSONDumpable
-from psyneulink.core.scheduling.condition import All, AllHaveRun, Always, Condition, ConditionSet, EveryNCalls, Never
+from psyneulink.core.scheduling.condition import All, AllHaveRun, Always, Condition, ConditionSet, EveryNCalls, Never, _parse_absolute_unit
 from psyneulink.core.scheduling.time import Clock, TimeScale
 
 __all__ = [
-    'Scheduler', 'SchedulerError',
+    'Scheduler', 'SchedulerError', 'SchedulingMode',
 ]
 
 logger = logging.getLogger(__name__)
@@ -293,6 +365,19 @@ default_termination_conds = {
     TimeScale.RUN: Never(),
     TimeScale.TRIAL: AllHaveRun(),
 }
+
+
+class SchedulingMode(enum.Enum):
+    """
+        Attributes:
+            STANDARD
+                `Standard Mode <Scheduler_Execution>`
+
+            EXACT_TIME
+                `Exact time Mode <Scheduler_Exact_Time>`
+    """
+    STANDARD = enum.auto()
+    EXACT_TIME = enum.auto()
 
 
 class SchedulerError(Exception):
@@ -324,6 +409,14 @@ class Scheduler(JSONDumpable):
         and the value of each entry must be a set of zero or more objects that project directly to the key.
         or, a `Graph`
 
+    mode : SchedulingMode[STANDARD|EXACT_TIME] : SchedulingMode.STANDARD
+        sets the mode of scheduling: `standard <Scheduler_Execution>` or
+        `exact time <Scheduler_Exact_Time>`
+
+    default_absolute_time_unit : ``pint.Quantity`` : ``1ms``
+        if not otherwise determined by any absolute **conditions**,
+        specifies the absolute duration of a `TIME_STEP`
+
     Attributes
     ----------
 
@@ -341,6 +434,20 @@ class Scheduler(JSONDumpable):
         of the specified `TimeScale`. On set, update only for the
         `TimeScale`\\ s specified in the argument.
 
+    mode
+        sets the mode of scheduling: `standard <Scheduler_Execution>` or
+        `exact time <Scheduler_Exact_Time>`
+
+        :type: SchedulingMode
+        :default: `SchedulingMode.STANDARD`
+
+    default_absolute_time_unit
+        if not otherwise determined by any absolute **conditions**,
+        specifies the absolute duration of a `TIME_STEP`
+
+        :type: ``pint.Quantity``
+        :default: ``1ms``
+
     times : Dict[TimeScale: Dict[TimeScale: int]]
         a structure counting the number of occurrences of a certain `TimeScale` within the scope of another `TimeScale`.
         For example, `times[TimeScale.RUN][TimeScale.PASS]` is the number of `PASS`es that have occurred in the
@@ -357,6 +464,8 @@ class Scheduler(JSONDumpable):
         conditions=None,
         termination_conds=default_termination_conds,
         default_execution_id=None,
+        mode: SchedulingMode = SchedulingMode.STANDARD,
+        default_absolute_time_unit: typing.Union[str, pint.Quantity] = 1 * pnl._unit_registry.ms,
         **kwargs
     ):
         """
@@ -373,6 +482,8 @@ class Scheduler(JSONDumpable):
         self._termination_conds = self.default_termination_conds.copy()
 
         self.cycle_nodes = set()
+        self.mode = mode
+        self.default_absolute_time_unit = _parse_absolute_unit(default_absolute_time_unit)
 
         if composition is not None:
             self.nodes = [vert.component for vert in composition.graph_processing.vertices]
@@ -394,8 +505,11 @@ class Scheduler(JSONDumpable):
             raise SchedulerError('Must instantiate a Scheduler with either a Composition (kwarg composition) '
                                  'or a graph dependency dict (kwarg graph)')
 
+        self._generate_consideration_queue_indices()
+
         self.default_execution_id = default_execution_id
         self.execution_list = {self.default_execution_id: []}
+        self.execution_timestamps = {self.default_execution_id: []}
         self.clocks = {self.default_execution_id: Clock()}
         self.counts_total = {}
         self.counts_useable = {}
@@ -408,6 +522,13 @@ class Scheduler(JSONDumpable):
     def _init_consideration_queue_from_graph(self, graph):
         self.dependency_dict, self.removed_dependencies, self.structural_dependencies = graph.prune_feedback_edges()
         self.consideration_queue = list(toposort(self.dependency_dict))
+
+    def _generate_consideration_queue_indices(self):
+        self.consideration_queue_indices = {}
+        for i, cs in enumerate(self.consideration_queue):
+            self.consideration_queue_indices.update({
+                n: i for n in cs
+            })
 
     def _init_counts(self, execution_id=None, base_execution_id=None):
         """
@@ -617,7 +738,13 @@ class Scheduler(JSONDumpable):
     # Run methods
     ################################################################################
     @handle_external_context(fallback_default=True)
-    def run(self, termination_conds=None, context=None, base_context=Context(execution_id=None), skip_trial_time_increment=False):
+    def run(
+        self,
+        termination_conds=None,
+        context=None,
+        base_context=Context(execution_id=None),
+        skip_trial_time_increment=False,
+    ):
         """
         run is a python generator, that when iterated over provides the next `TIME_STEP` of
         executions at each iteration
@@ -626,10 +753,30 @@ class Scheduler(JSONDumpable):
                terminate the execution of the specified `TimeScale`
         """
         self._validate_run_state()
+
+        if self.mode is SchedulingMode.EXACT_TIME:
+            effective_consideration_queue = [set(self.nodes)]
+        else:
+            effective_consideration_queue = self.consideration_queue
+
         if termination_conds is None:
             termination_conds = self.termination_conds
         else:
-            termination_conds = self._combine_termination_conditions(Scheduler._parse_termination_conditions(termination_conds))
+            termination_conds = self._combine_termination_conditions(termination_conds)
+
+        in_absolute_time_mode = len(self.get_absolute_conditions(termination_conds)) > 0
+        if in_absolute_time_mode:
+            # advance absolute clock time to first necessary time
+            self.get_clock(context).time.absolute = max(
+                self.get_clock(context).time.absolute,
+                min([
+                    min(c.absolute_fixed_points)
+                    if len(c.absolute_fixed_points) > 0 else 0
+                    for c in self.get_absolute_conditions(termination_conds).values()
+                ])
+            )
+            self.get_clock(context).time.absolute_interval = self._get_absolute_time_step_unit(termination_conds)
+        self.get_clock(context).time.absolute_enabled = in_absolute_time_mode
 
         self._init_counts(context.execution_id, base_context.execution_id)
         self._reset_counts_useable(context.execution_id)
@@ -645,14 +792,15 @@ class Scheduler(JSONDumpable):
             cur_index_consideration_queue = 0
 
             while (
-                cur_index_consideration_queue < len(self.consideration_queue)
+                cur_index_consideration_queue < len(effective_consideration_queue)
                 and not termination_conds[TimeScale.TRIAL].is_satisfied(scheduler=self, context=context)
                 and not termination_conds[TimeScale.RUN].is_satisfied(scheduler=self, context=context)
             ):
                 # all nodes to be added during this time step
                 cur_time_step_exec = set()
                 # the current "layer/group" of nodes that MIGHT be added during this time step
-                cur_consideration_set = self.consideration_queue[cur_index_consideration_queue]
+                cur_consideration_set = effective_consideration_queue[cur_index_consideration_queue]
+
                 try:
                     iter(cur_consideration_set)
                 except TypeError as e:
@@ -687,8 +835,12 @@ class Scheduler(JSONDumpable):
                         break
 
                 # add a new time step at each step in a pass, if the time step would not be empty
-                if len(cur_time_step_exec) >= 1:
+                if len(cur_time_step_exec) >= 1 or in_absolute_time_mode:
                     self.execution_list[context.execution_id].append(cur_time_step_exec)
+                    if in_absolute_time_mode:
+                        self.execution_timestamps[context.execution_id].append(
+                            copy.copy(self.get_clock(context).time)
+                        )
                     yield self.execution_list[context.execution_id][-1]
 
                     self.get_clock(context)._increment_time(TimeScale.TIME_STEP)
@@ -696,7 +848,7 @@ class Scheduler(JSONDumpable):
                 cur_index_consideration_queue += 1
 
             # if an entire pass occurs with nothing running, add an empty time step
-            if not execution_list_has_changed:
+            if not execution_list_has_changed and not in_absolute_time_mode:
                 self.execution_list[context.execution_id].append(set())
                 yield self.execution_list[context.execution_id][-1]
 
@@ -711,6 +863,71 @@ class Scheduler(JSONDumpable):
             self.date_last_run_end = datetime.datetime.now()
 
         return self.execution_list[context.execution_id]
+
+    def _increment_time(self, time_scale, context):
+        self.get_clock(context)._increment_time(time_scale)
+
+    def _get_absolute_time_step_unit(self, termination_conds=None):
+        """Computes the time length of the gap between two time steps
+        """
+        if termination_conds is None:
+            termination_conds = self.termination_conds
+
+        # all of the units of time that must occur on a time step
+        intervals = []
+        for c in self.get_absolute_conditions(termination_conds).values():
+            intervals.extend(c.absolute_intervals)
+            if self.mode is SchedulingMode.EXACT_TIME:
+                intervals.extend(c.absolute_fixed_points)
+
+        if len(intervals) == 0:
+            return self.default_absolute_time_unit
+        else:
+            adjusted_intervals = []
+
+            for interval in intervals:
+                # change quantity to largest unit representable by integer
+                # (1000ms -> 1s)
+                adj = interval.to_compact()
+
+                if np.allclose(adj.m, int(adj.m)):
+                    adj = int(adj.m) * adj.u
+                else:
+                    adj = interval
+
+                adjusted_intervals.append(adj)
+
+            min_time_unit = min(adjusted_intervals, key=lambda x: x.u).u
+
+            # convert all intervals into the same unit
+            for i, a in enumerate(adjusted_intervals):
+                unit_conversion = round(np.log10((1 * a.u).to(min_time_unit).m))
+                adjusted_intervals[i] = (int(a.m) * 10 ** unit_conversion) * min_time_unit
+
+            # numerator is the largest possible length of a pass
+            # denominator evenly divides this length by number of time steps
+            numerator = np.gcd.reduce([interval.m for interval in adjusted_intervals])
+            if self.mode == SchedulingMode.STANDARD:
+                denominator = len(self.consideration_queue)
+            elif self.mode == SchedulingMode.EXACT_TIME:
+                denominator = 1
+
+            if denominator == 1:
+                res = numerator
+            else:
+                res = fractions.Fraction(numerator=numerator, denominator=denominator)
+            return res * min_time_unit
+
+    def get_absolute_conditions(self, termination_conds=None):
+        if termination_conds is None:
+            termination_conds = self.termination_conds
+
+        return {
+            owner: cond
+            for owner, cond
+            in [*self.conditions.conditions.items(), *termination_conds.items()]
+            if cond.is_absolute
+        }
 
     @property
     def _dict_summary(self):
@@ -736,6 +953,9 @@ class Scheduler(JSONDumpable):
             try:
                 return self.clocks[context.execution_id]
             except AttributeError:
+                if context not in self.clocks:
+                    self._init_clock(context)
+
                 return self.clocks[context]
         except KeyError:
             raise
@@ -763,3 +983,7 @@ class Scheduler(JSONDumpable):
             self._termination_conds = self._combine_termination_conditions(
                 termination_conds
             )
+
+    @property
+    def _in_exact_time_mode(self):
+        return self.mode is SchedulingMode.EXACT_TIME or len(self.consideration_queue) == 1

--- a/psyneulink/core/scheduling/time.py
+++ b/psyneulink/core/scheduling/time.py
@@ -26,6 +26,8 @@ import enum
 import functools
 import types
 
+import psyneulink as pnl
+
 __all__ = [
     'Clock', 'TimeScale', 'Time', 'SimpleTime', 'TimeHistoryTree', 'TimeScaleError'
 ]
@@ -209,6 +211,18 @@ class Time(types.SimpleNamespace):
         time_step : int : 0
             the `TimeScale.TIME_STEP` value
 
+        absolute : ``pint.Quantity`` : 0ms
+            the absolute time value
+
+        absolute_interval : ``pint.Quantity`` : 1ms
+            the interval between units of absolute time
+
+        absolute_time_unit_scale : `TimeScale` : TimeScale.TIME_STEP
+            the `TimeScale` that corresponds to an interval of absolute time
+
+        absolute_enabled : bool : False
+            whether absolute time is used for this Time object
+
     """
     _time_scale_attr_map = {
         TimeScale.TIME_STEP: 'time_step',
@@ -218,8 +232,33 @@ class Time(types.SimpleNamespace):
         TimeScale.LIFE: 'life'
     }
 
-    def __init__(self, time_step=0, pass_=0, trial=0, run=0, life=0):
-        super().__init__(time_step=time_step, pass_=pass_, trial=trial, run=run, life=life)
+    def __init__(
+        self,
+        time_step=0,
+        pass_=0,
+        trial=0,
+        run=0,
+        life=0,
+        absolute=0 * pnl._unit_registry.ms,
+        absolute_interval=1 * pnl._unit_registry.ms,
+        absolute_time_unit_scale=TimeScale.TIME_STEP,
+        absolute_enabled=False,
+    ):
+        super().__init__(
+            time_step=time_step,
+            pass_=pass_,
+            trial=trial,
+            run=run,
+            life=life,
+            absolute=0 * pnl._unit_registry.ms,
+            absolute_interval=1 * pnl._unit_registry.ms,
+            absolute_time_unit_scale=TimeScale.TIME_STEP,
+            absolute_enabled=False,
+        )
+
+    def __repr__(self):
+        abs_str = f'{self.absolute}, ' if self.absolute_enabled else ''
+        return f'Time({abs_str}run: {self.run}, trial: {self.trial}, pass: {self.pass_}, time_step: {self.time_step})'
 
     def _get_by_time_scale(self, time_scale):
         """
@@ -252,13 +291,19 @@ class Time(types.SimpleNamespace):
         self._set_by_time_scale(time_scale, self._get_by_time_scale(time_scale) + 1)
         self._reset_by_time_scale(time_scale)
 
+        if (
+            self.absolute_enabled
+            and time_scale is self.absolute_time_unit_scale
+        ):
+            self.absolute += self.absolute_interval
+
     def _reset_by_time_scale(self, time_scale):
         """
         Resets all the times for the time scale scope up to **time_scale**
         e.g. _reset_by_time_scale(TimeScale.TRIAL) will set the values for
         TimeScale.PASS and TimeScale.TIME_STEP to 0
         """
-        for relative_time_scale in TimeScale:
+        for relative_time_scale in sorted(self._time_scale_attr_map):
             # this works because the enum is set so that higher granularities of time have lower values
             if relative_time_scale >= time_scale:
                 continue
@@ -277,7 +322,12 @@ class SimpleTime:
     # override __repr__ because this class is used only for cosmetic simplicity
     # based on a Time object
     def __repr__(self):
-        return 'Time(run: {0}, trial: {1}, time_step: {2})'.format(self.run, self.trial, self.time_step)
+        abs_str = f'{self.absolute}, ' if self._time_ref.absolute_enabled else ''
+        return f'Time({abs_str}run: {self.run}, trial: {self.trial}, time_step: {self.time_step})'
+
+    @property
+    def absolute(self):
+        return self._time_ref.absolute
 
     @property
     def run(self):

--- a/psyneulink/core/scheduling/time.py
+++ b/psyneulink/core/scheduling/time.py
@@ -114,10 +114,13 @@ class Clock:
     ----------
         history : `TimeHistoryTree`
             a root `TimeHistoryTree` associated with this Clock
+
+        simple_time : `SimpleTime`
+            the current time in simple format
     """
     def __init__(self):
         self.history = TimeHistoryTree()
-        self._simple_time = SimpleTime()
+        self.simple_time = SimpleTime(self.time)
 
     def __repr__(self):
         return 'Clock({0})'.format(self.time.__repr__())
@@ -176,16 +179,6 @@ class Clock:
         the current time : `Time`
         """
         return self.history.current_time
-
-    @property
-    def simple_time(self):
-        """
-        the current time in simple format : `SimpleTime`
-        """
-        self._simple_time.run = self.time.run
-        self._simple_time.trial = self.time.trial
-        self._simple_time.time_step = self.time.time_step
-        return self._simple_time
 
     @property
     def previous_time(self):
@@ -273,18 +266,30 @@ class Time(types.SimpleNamespace):
             self._set_by_time_scale(relative_time_scale, 0)
 
 
-class SimpleTime(types.SimpleNamespace):
+class SimpleTime:
     """
     A subset class of `Time`, used to provide simple access to only
     `run <Time.run>`, `trial <Time.trial>`, and `time_step <Time.time_step>`
     """
-    def __init__(self, run=0, trial=0, time_step=0):
-        super().__init__(run=0, trial=0, time_step=0)
+    def __init__(self, time_ref):
+        self._time_ref = time_ref
 
     # override __repr__ because this class is used only for cosmetic simplicity
     # based on a Time object
     def __repr__(self):
         return 'Time(run: {0}, trial: {1}, time_step: {2})'.format(self.run, self.trial, self.time_step)
+
+    @property
+    def run(self):
+        return self._time_ref.run
+
+    @property
+    def trial(self):
+        return self._time_ref.trial
+
+    @property
+    def time_step(self):
+        return self._time_ref.time_step
 
 
 class TimeHistoryTree:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ matplotlib<3.3.4
 networkx<2.6
 numpy<1.20.4
 pillow<8.1.0
+pint<0.18
 toposort<1.7
 torch>=1.8.0, <1.9.0; (platform_machine == 'AMD64' or platform_machine == 'x86_64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
 typecheck-decorator<=1.2

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -32,9 +32,9 @@ from psyneulink.core.globals.keywords import \
     ADDITIVE, ALLOCATION_SAMPLES, BEFORE, DEFAULT, DISABLE, INPUT_PORT, INTERCEPT, LEARNING_MECHANISMS, \
     LEARNED_PROJECTIONS, \
     NAME, PROJECTIONS, RESULT, OBJECTIVE_MECHANISM, OUTPUT_MECHANISM, OVERRIDE, SLOPE, TARGET_MECHANISM, VARIANCE
-from psyneulink.core.scheduling.condition import AtTimeStep, AtTrial, Never
+from psyneulink.core.scheduling.condition import AtTimeStep, AtTrial, Never, TimeInterval
 from psyneulink.core.scheduling.condition import EveryNCalls
-from psyneulink.core.scheduling.scheduler import Scheduler
+from psyneulink.core.scheduling.scheduler import Scheduler, SchedulingMode
 from psyneulink.core.scheduling.time import TimeScale
 from psyneulink.library.components.mechanisms.modulatory.control.agt.lccontrolmechanism import LCControlMechanism
 from psyneulink.library.components.mechanisms.processing.transfer.recurrenttransfermechanism import \
@@ -2259,6 +2259,23 @@ class TestExecutionOrder:
 
         assert np.allclose(comp1.results[:3], [[[0.52497918747894]], [[0.5719961329315186]], [[0.6366838893983633]]])
 
+    @pytest.mark.composition
+    def test_exact_time(self):
+        A = ProcessingMechanism(name="A")
+        B = ProcessingMechanism(name="B")
+
+        comp = Composition(name="comp")
+        comp.add_linear_processing_pathway([A, B])
+
+        # these cannot run at same execution set unless in EXACT_TIME
+        comp.scheduler.add_condition(A, TimeInterval(start=1))
+        comp.scheduler.add_condition(B, TimeInterval(start=1))
+
+        comp.run(inputs={A: [1.0]}, scheduling_mode=SchedulingMode.EXACT_TIME)
+
+        assert comp.scheduler.mode == SchedulingMode.EXACT_TIME
+        assert comp.scheduler.execution_list[comp.default_execution_id] == [{A, B}]
+        assert comp.scheduler.execution_timestamps[comp.default_execution_id][0].absolute == 1 * pnl._unit_registry.ms
 
 class TestGetMechanismsByRole:
 

--- a/tests/scheduling/conftest.py
+++ b/tests/scheduling/conftest.py
@@ -1,3 +1,4 @@
+import psyneulink as pnl
 import pytest
 
 
@@ -21,3 +22,15 @@ def setify_expected_output(expected_output):
             except TypeError:
                 expected_output[i] = set([expected_output[i]])
     return expected_output
+
+
+@pytest.fixture
+def three_node_linear_composition():
+    A = pnl.TransferMechanism(name='A')
+    B = pnl.TransferMechanism(name='B')
+    C = pnl.TransferMechanism(name='C')
+
+    comp = pnl.Composition()
+    comp.add_linear_processing_pathway([A, B, C])
+
+    return comp.nodes, comp

--- a/tests/scheduling/test_condition.py
+++ b/tests/scheduling/test_condition.py
@@ -1,13 +1,19 @@
 import logging
 
 import pytest
-
+from psyneulink import _unit_registry
 from psyneulink.core.components.functions.nonstateful.transferfunctions import Linear
 from psyneulink.core.components.mechanisms.processing.transfermechanism import TransferMechanism
 from psyneulink.core.components.projections.pathway.mappingprojection import MappingProjection
 from psyneulink.core.compositions.composition import Composition
-from psyneulink.core.scheduling.condition import AfterCall, AfterNCalls, AfterNCallsCombined, AfterNPasses, AfterNTrials, AfterPass, AfterTrial, All, AllHaveRun, Always, Any, AtPass, AtTimeStep, AtTrial, AtTrialStart, BeforeNCalls, BeforePass, BeforeTimeStep, BeforeTrial, Condition, ConditionError, \
-    EveryNCalls, EveryNPasses, NWhen, Not, WhenFinished, WhenFinishedAll, WhenFinishedAny, WhileNot
+from psyneulink.core.scheduling.condition import (
+    AfterCall, AfterNCalls, AfterNCallsCombined, AfterNPasses, AfterNTrials,
+    AfterPass, AfterTrial, All, AllHaveRun, Always, Any, AtPass, AtTimeStep,
+    AtTrial, AtTrialStart, BeforeNCalls, BeforePass, BeforeTimeStep,
+    BeforeTrial, Condition, ConditionError, EveryNCalls, EveryNPasses, Not,
+    NWhen, TimeInterval, TimeTermination, WhenFinished, WhenFinishedAll,
+    WhenFinishedAny, WhileNot,
+)
 from psyneulink.core.scheduling.scheduler import Scheduler
 from psyneulink.core.scheduling.time import TimeScale
 
@@ -871,3 +877,154 @@ class TestWhenFinished:
             set([A, B]), C, set([A, B]), C, set([A, B]),
         ]
         assert output == pytest.helpers.setify_expected_output(expected_output)
+
+
+class TestAbsolute:
+    A = TransferMechanism(name='scheduler-pytests-A')
+    B = TransferMechanism(name='scheduler-pytests-B')
+    C = TransferMechanism(name='scheduler-pytests-C')
+
+    @pytest.mark.parametrize(
+        'conditions, termination_conds',
+        [
+            (
+                {A: TimeInterval(repeat=8), B: TimeInterval(repeat=4), C: TimeInterval(repeat=2)},
+                {TimeScale.TRIAL: AfterNCalls(A, 2)},
+            ),
+            (
+                {A: TimeInterval(repeat=5), B: TimeInterval(repeat=3), C: TimeInterval(repeat=1)},
+                {TimeScale.TRIAL: AfterNCalls(A, 2)},
+            ),
+            (
+                {A: TimeInterval(repeat=3), B: TimeInterval(repeat=2)},
+                {TimeScale.TRIAL: AfterNCalls(A, 2)},
+            ),
+            (
+                {A: TimeInterval(repeat=5), B: TimeInterval(repeat=7)},
+                {TimeScale.TRIAL: AfterNCalls(B, 2)},
+            ),
+            (
+                {A: TimeInterval(repeat=1200), B: TimeInterval(repeat=1000)},
+                {TimeScale.TRIAL: AfterNCalls(A, 3)},
+            ),
+        ]
+    )
+    def test_TimeInterval_linear_everynms(self, conditions, termination_conds):
+        comp = Composition()
+
+        comp.add_linear_processing_pathway([self.A, self.B, self.C])
+        comp.scheduler.add_condition_set(conditions)
+
+        list(comp.scheduler.run(termination_conds=termination_conds))
+
+        for node, cond in conditions.items():
+            executions = [
+                comp.scheduler.execution_timestamps[comp.default_execution_id][i].absolute
+                for i in range(len(comp.scheduler.execution_list[comp.default_execution_id]))
+                if node in comp.scheduler.execution_list[comp.default_execution_id][i]
+            ]
+
+            for i in range(1, len(executions)):
+                assert (executions[i] - executions[i - 1]) == cond.repeat
+
+    @pytest.mark.parametrize(
+        'conditions, termination_conds',
+        [
+            (
+                {
+                    A: TimeInterval(repeat=10, start=100),
+                    B: TimeInterval(repeat=10, start=300),
+                    C: TimeInterval(repeat=10, start=400)
+                },
+                {TimeScale.TRIAL: TimeInterval(start=500)}
+            ),
+            (
+                {
+                    A: TimeInterval(start=100),
+                    B: TimeInterval(start=300),
+                    C: TimeInterval(start=400)
+                },
+                {TimeScale.TRIAL: TimeInterval(start=500)}
+            ),
+            (
+                {
+                    A: TimeInterval(repeat=2, start=105),
+                    B: TimeInterval(repeat=7, start=317),
+                    C: TimeInterval(repeat=11, start=431)
+                },
+                {TimeScale.TRIAL: TimeInterval(start=597)}
+            ),
+        ]
+    )
+    def test_TimeInterval_no_dependencies(self, conditions, termination_conds):
+        comp = Composition()
+        comp.add_nodes([self.A, self.B, self.C])
+        comp.scheduler.add_condition_set(conditions)
+        time_step_abs_value = comp.scheduler._get_absolute_time_step_unit(termination_conds)
+
+        list(comp.scheduler.run(termination_conds=termination_conds))
+
+        for node, cond in conditions.items():
+            executions = [
+                comp.scheduler.execution_timestamps[comp.default_execution_id][i].absolute
+                for i in range(len(comp.scheduler.execution_list[comp.default_execution_id]))
+                if node in comp.scheduler.execution_list[comp.default_execution_id][i]
+            ]
+
+            for i in range(1, len(executions)):
+                interval = (executions[i] - executions[i - 1])
+
+                if cond.repeat is not None:
+                    assert interval == cond.repeat
+                else:
+                    assert interval == time_step_abs_value
+
+            if cond.start is not None:
+                if cond.start_inclusive:
+                    assert cond.start in executions
+                else:
+                    assert cond.start + time_step_abs_value in executions
+
+    @pytest.mark.parametrize(
+        'repeat, unit, expected_repeat',
+        [
+            (1, None, 1 * _unit_registry.ms),
+            ('1ms', None, 1 * _unit_registry.ms),
+            (1 * _unit_registry.ms, None, 1 * _unit_registry.ms),
+            (1, 'ms', 1 * _unit_registry.ms),
+            (1, _unit_registry.ms, 1 * _unit_registry.ms),
+            ('1', _unit_registry.ms, 1 * _unit_registry.ms),
+            (1 * _unit_registry.ms, _unit_registry.ns, 1 * _unit_registry.ms),
+            (1000 * _unit_registry.ms, None, 1000 * _unit_registry.ms),
+        ]
+    )
+    def test_TimeInterval_time_specs(self, repeat, unit, expected_repeat):
+        if unit is None:
+            c = TimeInterval(repeat=repeat)
+        else:
+            c = TimeInterval(repeat=repeat, unit=unit)
+
+        assert c.repeat == expected_repeat
+
+    @pytest.mark.parametrize(
+        'repeat, inclusive, last_time',
+        [
+            (10, True, 10 * _unit_registry.ms),
+            (10, False, 11 * _unit_registry.ms),
+        ]
+    )
+    def test_TimeTermination(
+        self,
+        three_node_linear_composition,
+        repeat,
+        inclusive,
+        last_time
+    ):
+        _, comp = three_node_linear_composition
+
+        comp.scheduler.termination_conds = {
+            TimeScale.TRIAL: TimeTermination(repeat, inclusive)
+        }
+        list(comp.scheduler.run())
+
+        assert comp.scheduler.clock.time.absolute == last_time

--- a/tests/scheduling/test_scheduler.py
+++ b/tests/scheduling/test_scheduler.py
@@ -1,8 +1,10 @@
+import fractions
 import logging
 import numpy as np
 import psyneulink as pnl
 import pytest
 
+from psyneulink import _unit_registry
 from psyneulink.core.components.functions.stateful.integratorfunctions import DriftDiffusionIntegrator
 from psyneulink.core.components.functions.nonstateful.transferfunctions import Linear
 from psyneulink.core.components.mechanisms.processing.integratormechanism import IntegratorMechanism
@@ -10,8 +12,7 @@ from psyneulink.core.components.mechanisms.processing.transfermechanism import T
 from psyneulink.core.components.projections.pathway.mappingprojection import MappingProjection
 from psyneulink.core.compositions.composition import Composition, EdgeType
 from psyneulink.core.globals.keywords import VALUE
-from psyneulink.core.scheduling.condition import AfterNCalls, AfterNPasses, AfterNTrials, AfterPass, All, AllHaveRun, Always, Any, AtPass, BeforeNCalls, BeforePass, \
-    EveryNCalls, EveryNPasses, JustRan, WhenFinished
+from psyneulink.core.scheduling.condition import AfterNCalls, AfterNPasses, AfterNTrials, AfterPass, All, AllHaveRun, Always, Any, AtPass, BeforeNCalls, BeforePass, EveryNCalls, EveryNPasses, JustRan, TimeInterval, WhenFinished
 from psyneulink.core.scheduling.scheduler import Scheduler
 from psyneulink.core.scheduling.time import TimeScale
 from psyneulink.library.components.mechanisms.processing.integrator.ddm import DDM
@@ -1633,3 +1634,27 @@ class TestFeedback:
         r = comp.run(inputs=[1], num_trials=5, execution_mode=mode)
         assert np.allclose(r, expected_result[-1])
         assert np.allclose(comp.results, expected_result)
+
+
+class TestAbsoluteTime:
+
+    @pytest.mark.parametrize(
+        'conditions, interval',
+        [
+            ({'A': TimeInterval(repeat=8), 'B': TimeInterval(repeat=4)}, fractions.Fraction(4, 3) * _unit_registry.ms),
+            ({'A': TimeInterval(repeat=1), 'B': TimeInterval(repeat=3)}, fractions.Fraction(1, 3) * _unit_registry.ms),
+            ({'A': Any(TimeInterval(repeat=2), TimeInterval(repeat=3))}, fractions.Fraction(1, 3) * _unit_registry.ms),
+            ({'A': TimeInterval(repeat=6), 'B': TimeInterval(repeat=3)}, 1 * _unit_registry.ms),
+            ({'A': TimeInterval(repeat=100 * _unit_registry.us), 'B': TimeInterval(repeat=2)}, fractions.Fraction(100, 3) * _unit_registry.us),
+            ({'A': Any(TimeInterval(repeat=1000 * _unit_registry.us), TimeInterval(repeat=2))}, fractions.Fraction(1, 3) * _unit_registry.ms),
+            ({'A': TimeInterval(repeat=1000 * _unit_registry.us), 'B': TimeInterval(repeat=2)}, fractions.Fraction(1, 3) * _unit_registry.ms),
+            ({'A': Any(TimeInterval(repeat=1000), TimeInterval(repeat=1500)), 'B': TimeInterval(repeat=2000)}, fractions.Fraction(500, 3) * _unit_registry.ms),
+        ]
+    )
+    def test_absolute_interval_linear(self, three_node_linear_composition, conditions, interval):
+        [A, B, C], comp = three_node_linear_composition
+
+        for node in conditions:
+            comp.scheduler.add_condition(eval(node), conditions[node])
+
+        assert comp.scheduler._get_absolute_time_step_unit() == interval


### PR DESCRIPTION
Supports basic absolute/real time scheduling using `TimeInterval` and `TimeTermination`, with fixed-length time steps in both standard mode using the topological scheduling order and exact-time mode in a flattened order

New requirement: `pint<0.18`