### PR TITLE
llvm: Update and refactor the UDF compiler

### DIFF
--- a/psyneulink/core/components/functions/userdefinedfunction.py
+++ b/psyneulink/core/components/functions/userdefinedfunction.py
@@ -590,11 +590,18 @@ class UserDefinedFunction(Function_Base):
 
         func_globals = self.custom_function.__globals__
         func_params = {param_id: pnlvm.helpers.get_param_ptr(builder, self, params, param_id) for param_id in self.llvm_param_ids}
-        pnlvm.codegen.UserDefinedFunctionVisitor(ctx, builder, func_globals, func_params, arg_in, arg_out).visit(func_ast)
+
+        udf_block = builder.append_basic_block(name="post_udf")
+        udf_builder = pnlvm.ir.IRBuilder(udf_block)
+
+        pnlvm.codegen.UserDefinedFunctionVisitor(ctx, builder, udf_builder, func_globals, func_params, arg_in, arg_out).visit(func_ast)
+        # After we're done with allocating variable stack space, jump to the code
+        builder.branch(udf_block)
+
         post_block = builder.append_basic_block(name="post_udf")
-        # If the function didn't include a return statement jump back to the outer one
-        if not builder.block.is_terminated:
-            builder.branch(post_block)
+        # If the function didn't use return as the last statement jump back to the outer block
+        if not udf_builder.block.is_terminated:
+            udf_builder.branch(post_block)
 
         builder.position_at_start(post_block)
         return builder

--- a/psyneulink/core/components/functions/userdefinedfunction.py
+++ b/psyneulink/core/components/functions/userdefinedfunction.py
@@ -591,5 +591,10 @@ class UserDefinedFunction(Function_Base):
         func_globals = self.custom_function.__globals__
         func_params = {param_id: pnlvm.helpers.get_param_ptr(builder, self, params, param_id) for param_id in self.llvm_param_ids}
         pnlvm.codegen.UserDefinedFunctionVisitor(ctx, builder, func_globals, func_params, arg_in, arg_out).visit(func_ast)
+        post_block = builder.append_basic_block(name="post_udf")
+        # If the function didn't include a return statement jump back to the outer one
+        if not builder.block.is_terminated:
+            builder.branch(post_block)
 
+        builder.position_at_start(post_block)
         return builder

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -383,9 +383,11 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
 
         # get position in arg_out if types differ
         if (helpers.is_scalar(ret_val) or helpers.is_vector(ret_val)) and helpers.is_2d_matrix(arg_out):
+            assert len(arg_out.type.pointee) == 1
             arg_out = self.builder.gep(arg_out, [self.ctx.int32_ty(0), self.ctx.int32_ty(0)])
 
         if helpers.is_scalar(ret_val) and helpers.is_vector(arg_out):
+            assert len(arg_out.type.pointee) == 1
             arg_out = self.builder.gep(arg_out, [self.ctx.int32_ty(0), self.ctx.int32_ty(0)])
 
         self.builder.store(ret_val, arg_out)

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -393,7 +393,13 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
 
     def visit_Subscript(self, node):
         node_val = self.visit(node.value)
-        node_slice_val = helpers.convert_type(self.builder, self.visit(node.slice), self.ctx.int32_ty)
+        index = self.visit(node.slice)
+        node_slice_val = helpers.convert_type(self.builder, index, self.ctx.int32_ty)
+        if not self.is_lval(node_val):
+            temp_node_val = self.builder.alloca(node_val.type)
+            self.builder.store(node_val, temp_node_val)
+            node_val = temp_node_val
+
         return self.builder.gep(node_val, [self.ctx.int32_ty(0), node_slice_val])
 
     def visit_Index(self, node):

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -160,6 +160,14 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
 
         return _add
 
+    def visit_Sub(self, node):
+        def _add(builder, x, y):
+            assert helpers.is_floating_point(x)
+            assert helpers.is_floating_point(y)
+            return builder.fsub(x, y)
+
+        return _add
+
     def visit_Mult(self, node):
         def _mul(builder, x, y):
             assert helpers.is_floating_point(x)

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -303,7 +303,7 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
 
     def visit_Or(self, node):
         def _or(builder, x, y):
-            # Python's 'and' takes the boolean value of the first operand and returns
+            # Python's 'or' takes the boolean value of the first operand and returns
             # LHS if bool(LHS) else RHS
             cond = helpers.convert_type(builder, x, self.ctx.bool_ty)
             return builder.select(cond, x, y)

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -92,15 +92,6 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
             else:
                 self.register[param.arg] = self.func_params[param.arg]
 
-    def _generate_binop(self, x, y, callback):
-        # unpack scalars from pointers
-        if helpers.is_floating_point(x) and helpers.is_pointer(x):
-            x = self.builder.load(x)
-        if helpers.is_floating_point(y) and helpers.is_pointer(y):
-            y = self.builder.load(y)
-
-        return callback(self.ctx, self.builder, x, y)
-
     def visit_Add(self, node):
         def _add(builder, x, y):
             assert helpers.is_floating_point(x)
@@ -141,12 +132,6 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
             return builder.call(pow_f, [x, y])
 
         return _div
-
-    def _generate_unop(self, x, callback):
-        if helpers.is_floating_point(x) and helpers.is_pointer(x):
-            x = self.builder.load(x)
-
-        return callback(self.ctx, self.builder, x)
 
     def visit_USub(self, node):
         def _usub(builder, x):

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -108,12 +108,12 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
         return _add
 
     def visit_Sub(self, node):
-        def _add(builder, x, y):
+        def _sub(builder, x, y):
             assert helpers.is_floating_point(x)
             assert helpers.is_floating_point(y)
             return builder.fsub(x, y)
 
-        return _add
+        return _sub
 
     def visit_Mult(self, node):
         def _mul(builder, x, y):

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -213,6 +213,15 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
 
         return _uadd
 
+    def visit_Not(self, node):
+        def _not(builder, x):
+            assert helpers.is_scalar(x)
+            # The result of 'not' is always bool even if the input is not
+            x_b = helpers.convert_type(builder, x, self.ctx.bool_ty)
+            return builder.not_(x_b)
+
+        return _not
+
     def visit_Name(self, node):
         return self.register[node.id]
 

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -428,6 +428,7 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
             arg_out = self.builder.gep(arg_out, [self.ctx.int32_ty(0), self.ctx.int32_ty(0)])
 
         self.builder.store(ret_val, arg_out)
+        self.builder.ret_void()
 
     def visit_Subscript(self, node):
         node_val = self.visit(node.value)

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -10,7 +10,6 @@
 import ast
 import warnings
 import numpy as np
-from functools import reduce
 
 from llvmlite import ir
 from contextlib import contextmanager

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -206,6 +206,13 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
 
         return _usub
 
+    def visit_UAdd(self, node):
+        def _uadd(builder, x):
+            assert helpers.is_floating_point(x)
+            return x
+
+        return _uadd
+
     def visit_Name(self, node):
         return self.register[node.id]
 

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -184,6 +184,15 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
 
         return _div
 
+    def visit_Pow(self, node):
+        def _div(builder, x, y):
+            assert helpers.is_floating_point(x)
+            assert helpers.is_floating_point(y)
+            pow_f = ctx.get_builtin("pow", [x.type, y.type])
+            return builder.call(pow_f, [x, y])
+
+        return _div
+
     def _generate_unop(self, x, callback):
         if helpers.is_floating_point(x) and helpers.is_pointer(x):
             x = self.builder.load(x)

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -569,7 +569,11 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
         return comp_val
 
     def visit_If(self, node):
-        predicate = self.visit(node.test)
+        cond_val = self.visit(node.test)
+        if helpers.is_pointer(cond_val):
+            cond_val = self.builder.load(cond_val)
+
+        predicate = helpers.convert_type(self.builder, cond_val, self.ctx.bool_ty)
         with self.builder.if_else(predicate) as (then, otherwise):
             with then:
                 for child in node.body:

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -31,12 +31,6 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
         self.arg_out = arg_out
 
         #setup default functions
-        def _len(builder, x):
-            x_ty = x.type
-            if helpers.is_pointer(x):
-                x_ty = x_ty.pointee
-            return ctx.float_ty(len(x_ty))
-
         # see: https://docs.python.org/3/library/functions.html#max
         def _max(builder, *args):
             if len(args) == 1 and helpers.is_vector(args[0]):
@@ -61,7 +55,7 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
             assert False, "Attempted to call max with invalid arguments!"
         self.register = {
             "sum": self.call_builtin_horizontal_sum,
-            "len": _len,
+            "len": self.call_builtin_len,
             "float": ctx.float_ty,
             "int": ctx.int32_ty,
             "max": _max,
@@ -490,6 +484,12 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
             tmp = self._do_bin_op(b, b.load(total_sum), b.load(curr_val), add_func)
             b.store(tmp, total_sum)
         return total_sum
+
+    def call_builtin_len(self, builder, x):
+        x_ty = x.type
+        if helpers.is_pointer(x):
+            x_ty = x_ty.pointee
+        return self.ctx.float_ty(len(x_ty))
 
     def call_builtin_np_tanh(self, builder, x):
         if helpers.is_pointer(x):

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -243,6 +243,7 @@ def convert_type(builder, val, t):
 
 def is_pointer(x):
     type_t = getattr(x, "type", x)
+    assert isinstance(type_t, ir.Type)
     return isinstance(type_t, ir.PointerType)
 
 def is_floating_point(x):

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -212,6 +212,11 @@ def convert_type(builder, val, t):
     if val.type == t:
         return val
 
+    if is_floating_point(val) and is_boolean(t):
+        # convert any scalar to bool by comparing to 0
+        # Python converts both 0.0 and -0.0 to False
+        return builder.fcmp_unordered("!=", val, val.type(0.0))
+
     if is_boolean(val) and is_floating_point(t):
         # float(True) == 1.0, float(False) == 0.0
         return builder.select(val, t(1.0), t(0.0))

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -533,8 +533,12 @@ def test_udf_in_mechanism(mech_mode, benchmark):
                 ("LEN", [1.0, 3.0], 2),
                 ("LEN", [[1.0], [3.0]], 2),
                 ("LEN_TUPLE", [0, 0], 2),
-                ("MAX_MULTI", [1,], 6),
+                ("MAX_MULTI", [1.0, 3.0, 2.0], 6),
+                ("MAX_TUPLE", [1.0, 3.0, 2.0], 6),
                 ("MAX", [1.0, 3.0, 2.0], 3.0),
+                ("MAX", [1.0, float("Inf"), 2.0], float("Inf")),
+                ("MAX", [1.0, float("NaN"), 2.0], 2.0),
+                ("MAX", [1.0, float("-Inf"), 2.0], 2.0),
                 ])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_func_builtin(op, variable, expected, func_mode, benchmark):
@@ -552,8 +556,11 @@ def test_user_def_func_builtin(op, variable, expected, func_mode, benchmark):
             return max(variable)
     elif op == "MAX_MULTI":
         # special cased, since passing in multiple variables without a closure is hard
-        def myFunction(_):
-            return max(1, 2, 3, 4, 5, 6, -1, -2)
+        def myFunction(variable):
+            return max(variable[0], variable[1], variable[2], -5, 6)
+    elif op == "MAX_TUPLE":
+        def myFunction(variable):
+            return max((variable[0], variable[1], variable[2], -5, 6))
 
     U = UserDefinedFunction(custom_function=myFunction, default_variable=variable)
     e = pytest.helpers.get_func_execution(U, func_mode)

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -430,7 +430,7 @@ def test_user_def_reward_func(func_mode, benchmark):
                     ("TUPLE_LIT", (1, 2, 3, 4)),
                     ])
 @pytest.mark.benchmark(group="Function UDF")
-def test_user_def_func_assign(dtype, expected, func_mode, benchmark):
+def test_user_def_func_return(dtype, expected, func_mode, benchmark):
     if dtype == "SCALAR_VAR":
         def myFunction(variable):
             var = 1.0

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -286,10 +286,20 @@ def condReturn(variable, param1, param2):
     return param2 + 0.3
 
 
+def condValReturn(variable, param1, param2):
+    if variable[0]:
+        val = param1 + 0.5
+    else:
+        val = param2 + 0.3
+    return val
+
+
 @pytest.mark.parametrize("func,var,params,expected", [
     (simpleFun, [1, 3], {"param1":None, "param2":3}, [5, 9]),
     (condReturn, [0], {"param1":1, "param2":2}, [2.3]),
     (condReturn, [1], {"param1":1, "param2":2}, [1.5]),
+    (condValReturn, [0], {"param1":1, "param2":2}, [2.3]),
+    (condValReturn, [1], {"param1":1, "param2":2}, [1.5]),
 ])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_func(func, var, params, expected, func_mode, benchmark):

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -280,8 +280,16 @@ def simpleFun(variable, param1, param2):
     return variable * 2 + param2
 
 
+def condReturn(variable, param1, param2):
+    if variable[0]:
+        return param1 + 0.5
+    return param2 + 0.3
+
+
 @pytest.mark.parametrize("func,var,params,expected", [
     (simpleFun, [1, 3], {"param1":None, "param2":3}, [5, 9]),
+    (condReturn, [0], {"param1":1, "param2":2}, [2.3]),
+    (condReturn, [1], {"param1":1, "param2":2}, [1.5]),
 ])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_func(func, var, params, expected, func_mode, benchmark):

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -45,6 +45,15 @@ def test_user_def_bin_arith(param1, param2, func, func_mode, benchmark):
     assert np.allclose(val, func(0, param1=param1, param2=param2))
 
 
+def unNot(variable):
+    var1 = False
+    # compiled UDFs don't support python bool type outputs
+    if not var1:
+        return 0.0
+    else:
+        return 1.0
+
+
 def binAnd(variable):
     var1 = True
     var2 = False
@@ -102,7 +111,16 @@ def varOr(var):
     return var[0] or var[1]
 
 
+def varNot(var):
+    # compiled UDFs don't support python bool type outputs
+    if not var[0]:
+        return 0.0
+    else:
+        return 1.0
+
+
 @pytest.mark.parametrize("op,var, expected", [
+    (unNot, 0, 0.0),
     (binAnd, 0, 1.0),
     (binOr, 0, 1.0),
     (triAnd, 0, 1.0),
@@ -116,6 +134,8 @@ def varOr(var):
     (varOr, [3.0, 0.0], 3.0),
     (varOr, [0.0, -3.0], -3.0),
     (varOr, [1.5, -1.0], 1.5),
+    (varNot, [1.5], 1.0),
+    (varNot, [0.0], 0.0),
     ])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_func_boolop(op, var, expected, func_mode, benchmark):

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -11,24 +11,26 @@ import psyneulink.core.llvm as pnlvm
 
 
 # default val is same shape as expected output
+# we only use param1 and param2 to avoid automatic shape changes of the variable
 def binAdd(_, param1, param2):
-    # we only use param1 and param2 to avoid automatic shape changes of the variable
     return param1 + param2
 
 
+def binSub(_, param1, param2):
+    return param1 - param2
+
+
 def binMul(_, param1, param2):
-    # we only use param1 and param2 to avoid automatic shape changes of the variable
     return param1 * param2
 
 
 def binDiv(_, param1, param2):
-    # we only use param1 and param2 to avoid automatic shape changes of the variable
     return param1 / param2
 
 
 @pytest.mark.parametrize("param1", [1, np.ones(2), np.ones((2, 2))], ids=['scalar', 'vector', 'matrix'])
 @pytest.mark.parametrize("param2", [2, np.ones(2) * 2, np.ones((2, 2)) * 2], ids=['scalar', 'vector', 'matrix'])
-@pytest.mark.parametrize("func", [binAdd, binMul, binDiv])
+@pytest.mark.parametrize("func", [binAdd, binSub, binMul, binDiv])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_bin_arith(param1, param2, func, func_mode, benchmark):
 

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -406,34 +406,50 @@ def test_user_def_reward_func(func_mode, benchmark):
 
 
 @pytest.mark.parametrize("dtype, expected", [ # parameter is string since compiled udf doesn't support closures as of present
-                    ("SCALAR", 1.0),
-                    ("VECTOR", [1,2]),
-                    ("MATRIX", [[1,2],[3,4]]),
-                    ("BOOL", 1.0),
-                    ("TUPLE", (1, 2, 3, 4))
+                    ("SCALAR_VAR", 1.0),
+                    ("VECTOR_VAR", [1,2]),
+                    ("MATRIX_VAR", [[1,2],[3,4]]),
+                    ("BOOL_VAR", 1.0),
+                    ("TUPLE_VAR", (1, 2, 3, 4)),
+                    ("SCALAR_LIT", 1.0),
+                    ("VECTOR_LIT", [1,2]),
+                    ("MATRIX_LIT", [[1,2],[3,4]]),
+                    ("TUPLE_LIT", (1, 2, 3, 4)),
                     ])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_func_assign(dtype, expected, func_mode, benchmark):
-    if dtype == "SCALAR":
+    if dtype == "SCALAR_VAR":
         def myFunction(variable):
             var = 1.0
             return var
-    elif dtype == "VECTOR":
+    elif dtype == "VECTOR_VAR":
         def myFunction(variable):
             var = [1,2]
             return var
-    elif dtype == "MATRIX":
+    elif dtype == "MATRIX_VAR":
         def myFunction(variable):
             var = [[1,2],[3,4]]
             return var
-    elif dtype == "BOOL":
+    elif dtype == "BOOL_VAR":
         def myFunction(variable):
             var = True
             return 1.0
-    elif dtype == "TUPLE":
+    elif dtype == "TUPLE_VAR":
         def myFunction(variable):
             var = (1, 2, 3, 4)
             return var
+    elif dtype == "SCALAR_LIT":
+        def myFunction(variable):
+            return 1.0
+    elif dtype == "VECTOR_LIT":
+        def myFunction(variable):
+            return [1,2]
+    elif dtype == "MATRIX_LIT":
+        def myFunction(variable):
+            return [[1,2],[3,4]]
+    elif dtype == "TUPLE_LIT":
+        def myFunction(variable):
+            return (1, 2, 3, 4)
 
     U = UserDefinedFunction(custom_function=myFunction, default_variable=0)
     e = pytest.helpers.get_func_execution(U, func_mode)

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -318,21 +318,28 @@ def test_user_def_func_variable_index(func_mode, benchmark):
     assert np.allclose(val, [[6, 10]])
 
 
-@pytest.mark.parametrize("variable", [
-                    (1),
-                    (np.ones((2))),
-                    (np.ones((2, 2)))
-                    ], ids=["scalar", "vec-2d", "mat"])
-@pytest.mark.benchmark(group="Function UDF")
-def test_user_def_func_usub(variable, func_mode, benchmark):
-    def myFunction(variable, param):
-        return -param
+def unarySubVar(variable, param):
+    return -variable
 
-    U = UserDefinedFunction(custom_function=myFunction, default_variable=variable, param=variable)
+
+def unarySubParam(variable, param):
+    return -param
+
+
+@pytest.mark.parametrize("variable", [
+                    1,
+                    np.ones(2),
+                    np.ones((2)),
+                    np.ones((2, 2))
+                    ], ids=["scalar", "vec", "vec-2d", "mat"])
+@pytest.mark.parametrize("func", [unarySubVar, unarySubParam])
+@pytest.mark.benchmark(group="Function UDF")
+def test_user_def_func_unary(func, variable, func_mode, benchmark):
+    U = UserDefinedFunction(custom_function=func, default_variable=variable, param=variable)
     e = pytest.helpers.get_func_execution(U, func_mode)
 
     val = benchmark(e, variable)
-    assert np.allclose(val, -variable)
+    assert np.allclose(val, func(variable, param=variable))
 
 
 @pytest.mark.benchmark(group="Function UDF")

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -325,6 +325,17 @@ def branchOnVarFloat(variable, param1, param2):
         return 0.0
 
 
+def swap(variable, param1, param2):
+    val = variable[0]
+    variable[0] = variable[1]
+    variable[1] = val
+    return variable
+
+
+def indexLit(variable, param1, param2):
+    return [1,2,3,4][variable[0] + 2]
+
+
 @pytest.mark.parametrize("func,var,expected", [
     (branchOnVarCmp, [[1, 3]], [[5, 9]]),
     (branchOnVarCmp, [[-1, 3]], [[5, -3]]),
@@ -336,6 +347,8 @@ def branchOnVarFloat(variable, param1, param2):
     (branchOnVarFloat, [float("-Inf")], [1.0]),
     (branchOnVarFloat, [float("NaN")], [1.0]),
     (branchOnVarFloat, [float("-NaN")], [1.0]),
+    (swap, [-1, 3], [3, -1]),
+    (indexLit, [0], [3]),
 ])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_func_branching(func, var, expected, func_mode, benchmark):

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -9,53 +9,29 @@ from psyneulink.core.compositions.composition import Composition
 
 import psyneulink.core.llvm as pnlvm
 
-class TestBinaryOperations:
-    @pytest.mark.parametrize("param1, param2", [
-                        (1, 2),
-                        (np.ones(2), 2),
-                        (2, np.ones(2)),
-                        (np.ones((2, 2)), 2),
-                        (2, np.ones((2, 2))),
-                        (np.ones(2), np.array([1, 2])),
-                        (np.ones((2, 2)), np.array([[1, 2], [3, 4]])),
-                        ], ids=["scalar-scalar", "vec-scalar", "scalar-vec", "mat-scalar", "scalar-mat", "vec-vec", "mat-mat"])
-    @pytest.mark.benchmark(group="Function UDF")
-    def test_user_def_func_add(self, param1, param2, func_mode, benchmark):
-        # default val is same shape as expected output
-        def myFunction(_, param1, param2):
-            # we only use param1 and param2 to avoid automatic shape changes of the variable
-            return param1 + param2
+@pytest.mark.parametrize("param1, param2", [
+                    (1, 2),
+                    (np.ones(2), 2),
+                    (2, np.ones(2)),
+                    (np.ones((2, 2)), 2),
+                    (2, np.ones((2, 2))),
+                    (np.ones(2), np.array([1, 2])),
+                    (np.ones((2, 2)), np.array([[1, 2], [3, 4]])),
+                    ], ids=["scalar-scalar", "vec-scalar", "scalar-vec", "mat-scalar", "scalar-mat", "vec-vec", "mat-mat"])
+@pytest.mark.benchmark(group="Function UDF")
+def test_user_def_func_add(param1, param2, func_mode, benchmark):
+    # default val is same shape as expected output
+    def myFunction(_, param1, param2):
+        # we only use param1 and param2 to avoid automatic shape changes of the variable
+        return param1 + param2
 
-        U = UserDefinedFunction(custom_function=myFunction, param1=param1, param2=param2)
-        e = pytest.helpers.get_func_execution(U, func_mode)
+    U = UserDefinedFunction(custom_function=myFunction, param1=param1, param2=param2)
+    e = pytest.helpers.get_func_execution(U, func_mode)
 
-        val = benchmark(e, 0)
-        assert np.allclose(val, param1 + param2)
+    val = benchmark(e, 0)
+    assert np.allclose(val, param1 + param2)
 
-    @pytest.mark.parametrize("param1, param2", [
-                        (1, 2),
-                        (np.ones(2), 2),
-                        (2, np.ones(2)),
-                        (np.ones((2, 2)), 2),
-                        (2, np.ones((2, 2))),
-                        (np.ones(2), np.array([1, 2])),
-                        (np.ones(2), np.array([2.])),
-                        (np.ones((2, 2)), np.array([[1, 2], [3, 4]])),
-                        ], ids=["scalar-scalar", "vec-scalar", "scalar-vec", "mat-scalar", "scalar-mat", "vec-vec", "vec-vec-differing", "mat-mat"])
-    @pytest.mark.benchmark(group="Function UDF")
-    def test_user_def_func_mul(self, param1, param2, func_mode, benchmark):
-        # default val is same shape as expected output
-        def myFunction(_, param1, param2):
-            # we only use param1 and param2 to avoid automatic shape changes of the variable
-            return param1 * param2
-
-        U = UserDefinedFunction(custom_function=myFunction, param1=param1, param2=param2)
-        e = pytest.helpers.get_func_execution(U, func_mode)
-
-        val = benchmark(e, 0)
-        assert np.allclose(val, param1 * param2)
-
-    @pytest.mark.parametrize("param1, param2", [
+@pytest.mark.parametrize("param1, param2", [
                     (1, 2),
                     (np.ones(2), 2),
                     (2, np.ones(2)),
@@ -65,175 +41,198 @@ class TestBinaryOperations:
                     (np.ones(2), np.array([2.])),
                     (np.ones((2, 2)), np.array([[1, 2], [3, 4]])),
                     ], ids=["scalar-scalar", "vec-scalar", "scalar-vec", "mat-scalar", "scalar-mat", "vec-vec", "vec-vec-differing", "mat-mat"])
-    @pytest.mark.benchmark(group="Function UDF")
-    def test_user_def_func_div(self, param1, param2, func_mode, benchmark):
-        # default val is same shape as expected output
-        def myFunction(_, param1, param2):
-            # we only use param1 and param2 to avoid automatic shape changes of the variable
-            return param1 / param2
+@pytest.mark.benchmark(group="Function UDF")
+def test_user_def_func_mul(param1, param2, func_mode, benchmark):
+    # default val is same shape as expected output
+    def myFunction(_, param1, param2):
+        # we only use param1 and param2 to avoid automatic shape changes of the variable
+        return param1 * param2
 
-        U = UserDefinedFunction(custom_function=myFunction, param1=param1, param2=param2)
-        e = pytest.helpers.get_func_execution(U, func_mode)
+    U = UserDefinedFunction(custom_function=myFunction, param1=param1, param2=param2)
+    e = pytest.helpers.get_func_execution(U, func_mode)
 
-        val = benchmark(e, 0)
-        assert np.allclose(val, np.divide(param1, param2))
+    val = benchmark(e, 0)
+    assert np.allclose(val, param1 * param2)
 
-    @pytest.mark.parametrize("op", [ # parameter is string since compiled udf doesn't support closures as of present
-                        "AND",
-                        "OR",
-                        ])
-    @pytest.mark.benchmark(group="Function UDF")
-    def test_user_def_func_boolop(self, op, func_mode, benchmark):
-        if op == "AND":
-            def myFunction(variable):
-                var1 = True
-                var2 = False
-                # compiled UDFs don't support python bool type outputs
-                if var1 and var2:
-                    return 0.0
-                else:
-                    return 1.0
-        elif op == "OR":
-            def myFunction(variable):
-                var1 = True
-                var2 = False
-                # compiled UDFs don't support python bool type outputs
-                if var1 or var2:
-                    return 1.0
-                else:
-                    return 0.0
+@pytest.mark.parametrize("param1, param2", [
+                (1, 2),
+                (np.ones(2), 2),
+                (2, np.ones(2)),
+                (np.ones((2, 2)), 2),
+                (2, np.ones((2, 2))),
+                (np.ones(2), np.array([1, 2])),
+                (np.ones(2), np.array([2.])),
+                (np.ones((2, 2)), np.array([[1, 2], [3, 4]])),
+                ], ids=["scalar-scalar", "vec-scalar", "scalar-vec", "mat-scalar", "scalar-mat", "vec-vec", "vec-vec-differing", "mat-mat"])
+@pytest.mark.benchmark(group="Function UDF")
+def test_user_def_func_div(param1, param2, func_mode, benchmark):
+    # default val is same shape as expected output
+    def myFunction(_, param1, param2):
+        # we only use param1 and param2 to avoid automatic shape changes of the variable
+        return param1 / param2
 
-        U = UserDefinedFunction(custom_function=myFunction, default_variable=[0])
-        e = pytest.helpers.get_func_execution(U, func_mode)
+    U = UserDefinedFunction(custom_function=myFunction, param1=param1, param2=param2)
+    e = pytest.helpers.get_func_execution(U, func_mode)
 
-        val = benchmark(e, [0])
-        assert val == 1.0
+    val = benchmark(e, 0)
+    assert np.allclose(val, np.divide(param1, param2))
 
-    @pytest.mark.parametrize("op,var1,var2,expected", [ # parameter is string since compiled udf doesn't support closures as of present
-                        ("Eq", 1.0, 2.0, 0.0),
-                        ("NotEq", 1.0, 2.0, 1.0),
-                        ("Lt", 1.0, 2.0, 1.0),
-                        ("LtE", 1.0, 2.0, 1.0),
-                        ("Gt", 1.0, 2.0, 0.0),
-                        ("GtE", 1.0, 2.0, 0.0),
-                        ])
-    @pytest.mark.benchmark(group="Function UDF")
-    def test_user_def_func_cmpop(self, op, var1, var2, expected, func_mode, benchmark):
-        # we explicitly use np here to ensure that the result is castable to float in the scalar-scalar case
-        if op == "Eq":
-            def myFunction(variable, var1, var2):
-                if var1 == var2:
-                    return 1.0
-                else:
-                    return 0.0
-        elif op == "NotEq":
-            def myFunction(variable, var1, var2):
-                if var1 != var2:
-                    return 1.0
-                else:
-                    return 0.0
-        elif op == "Lt":
-            def myFunction(variable, var1, var2):
-                if var1 < var2:
-                    return 1.0
-                else:
-                    return 0.0
-        elif op == "LtE":
-            def myFunction(variable, var1, var2):
-                if var1 <= var2:
-                    return 1.0
-                else:
-                    return 0.0
-        elif op == "Gt":
-            def myFunction(variable, var1, var2):
-                if var1 > var2:
-                    return 1.0
-                else:
-                    return 0.0
-        elif op == "GtE":
-            def myFunction(variable, var1, var2):
-                if var1 >= var2:
-                    return 1.0
-                else:
-                    return 0.0
+@pytest.mark.parametrize("op", [ # parameter is string since compiled udf doesn't support closures as of present
+                    "AND",
+                    "OR",
+                    ])
+@pytest.mark.benchmark(group="Function UDF")
+def test_user_def_func_boolop(op, func_mode, benchmark):
+    if op == "AND":
+        def myFunction(variable):
+            var1 = True
+            var2 = False
+            # compiled UDFs don't support python bool type outputs
+            if var1 and var2:
+                return 0.0
+            else:
+                return 1.0
+    elif op == "OR":
+        def myFunction(variable):
+            var1 = True
+            var2 = False
+            # compiled UDFs don't support python bool type outputs
+            if var1 or var2:
+                return 1.0
+            else:
+                return 0.0
 
-        U = UserDefinedFunction(custom_function=myFunction, default_variable=[0], var1=var1, var2=var2)
-        e = pytest.helpers.get_func_execution(U, func_mode)
+    U = UserDefinedFunction(custom_function=myFunction, default_variable=[0])
+    e = pytest.helpers.get_func_execution(U, func_mode)
 
-        val = benchmark(e, [0])
-        assert np.allclose(expected, val)
+    val = benchmark(e, [0])
+    assert val == 1.0
 
-    @pytest.mark.parametrize("op,var1,var2,expected", [ # parameter is string since compiled udf doesn't support closures as of present
-                        ("Eq", 1.0, 2.0, 0.0),
-                        ("Eq", [1.0, 2.0], [1.0, 2.0], [1.0, 1.0]),
-                        ("Eq", 1.0, [1.0, 2.0], [1.0, 0.0]),
-                        ("Eq", [2.0, 1.0], 1.0, [0.0, 1.0]),
-                        ("Eq", [[1.0, 2.0], [3.0, 4.0]], 1.0, [[1.0, 0.0], [0.0, 0.0]]),
-                        ("Eq", 1.0, [[1.0, 2.0], [3.0, 4.0]], [[1.0, 0.0], [0.0, 0.0]]),
-                        ("Eq", [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]], [[1.0, 1.0], [1.0, 1.0]]),
-                        ("NotEq", 1.0, 2.0, 1.0),
-                        ("NotEq", [1.0, 2.0], [1.0, 2.0], [0.0, 0.0]),
-                        ("NotEq", 1.0, [1.0, 2.0], [0.0, 1.0]),
-                        ("NotEq", [2.0, 1.0], 1.0, [1.0, 0.0]),
-                        ("NotEq", [[1.0, 2.0], [3.0, 4.0]], 1.0, [[0.0, 1.0], [1.0, 1.0]]),
-                        ("NotEq", 1.0, [[1.0, 2.0], [3.0, 4.0]], [[0.0, 1.0], [1.0, 1.0]]),
-                        ("NotEq", [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]], [[0.0, 0.0], [0.0, 0.0]]),
-                        ("Lt", 1.0, 2.0, 1.0),
-                        ("Lt", [1.0, 2.0], [1.0, 2.0], [0.0, 0.0]),
-                        ("Lt", 1.0, [1.0, 2.0], [0.0, 1.0]),
-                        ("Lt", [2.0, 1.0], 1.0, [0.0, 0.0]),
-                        ("Lt", [[1.0, 2.0], [3.0, 4.0]], 1.0, [[0.0, 0.0], [0.0, 0.0]]),
-                        ("Lt", 1.0, [[1.0, 2.0], [3.0, 4.0]], [[0.0, 1.0], [1.0, 1.0]]),
-                        ("Lt", [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]], [[0.0, 0.0], [0.0, 0.0]]),
-                        ("LtE", 1.0, 2.0, 1.0),
-                        ("LtE", [1.0, 2.0], [1.0, 2.0], [1.0, 1.0]),
-                        ("LtE", 1.0, [1.0, 2.0], [1.0, 1.0]),
-                        ("LtE", [2.0, 1.0], 1.0, [0.0, 1.0]),
-                        ("LtE", [[1.0, 2.0], [3.0, 4.0]], 1.0, [[1.0, 0.0], [0.0, 0.0]]),
-                        ("LtE", 1.0, [[1.0, 2.0], [3.0, 4.0]], [[1.0, 1.0], [1.0, 1.0]]),
-                        ("LtE", [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]], [[1.0, 1.0], [1.0, 1.0]]),
-                        ("Gt", 1.0, 2.0, 0.0),
-                        ("Gt", [1.0, 2.0], [1.0, 2.0], [0.0, 0.0]),
-                        ("Gt", 1.0, [1.0, 2.0], [0.0, 0.0]),
-                        ("Gt", [2.0, 1.0], 1.0, [1.0, 0.0]),
-                        ("Gt", [[1.0, 2.0], [3.0, 4.0]], 1.0, [[0.0, 1.0], [1.0, 1.0]]),
-                        ("Gt", 1.0, [[1.0, 2.0], [3.0, 4.0]], [[0.0, 0.0], [0.0, 0.0]]),
-                        ("Gt", [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]], [[0.0, 0.0], [0.0, 0.0]]),
-                        ("GtE", 1.0, 2.0, 0.0),
-                        ("GtE", [1.0, 2.0], [1.0, 2.0], [1.0, 1.0]),
-                        ("GtE", 1.0, [1.0, 2.0], [1.0, 0.0]),
-                        ("GtE", [2.0, 1.0], 1.0, [1.0, 1.0]),
-                        ("GtE", [[1.0, 2.0], [3.0, 4.0]], 1.0, [[1.0, 1.0], [1.0, 1.0]]),
-                        ("GtE", 1.0, [[1.0, 2.0], [3.0, 4.0]], [[1.0, 0.0], [0.0, 0.0]]),
-                        ("GtE", [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]], [[1.0, 1.0], [1.0, 1.0]]),
-                        ])
-    @pytest.mark.benchmark(group="Function UDF")
-    def test_user_def_func_cmpop_numpy(self, op, var1, var2, expected, func_mode, benchmark):
-        # we explicitly use np here to ensure that the result is castable to float in the scalar-scalar case
-        if op == "Eq":
-            def myFunction(variable, var1, var2):
-                return np.equal(var1, var2).astype(float)
-        elif op == "NotEq":
-            def myFunction(variable, var1, var2):
-                return np.not_equal(var1, var2).astype(float)
-        elif op == "Lt":
-            def myFunction(variable, var1, var2):
-                return np.less(var1, var2).astype(float)
-        elif op == "LtE":
-            def myFunction(variable, var1, var2):
-                return np.less_equal(var1, var2).astype(float)
-        elif op == "Gt":
-            def myFunction(variable, var1, var2):
-                return np.greater(var1, var2).astype(float)
-        elif op == "GtE":
-            def myFunction(variable, var1, var2):
-                return np.greater_equal(var1, var2).astype(float)
+@pytest.mark.parametrize("op,var1,var2,expected", [ # parameter is string since compiled udf doesn't support closures as of present
+                    ("Eq", 1.0, 2.0, 0.0),
+                    ("NotEq", 1.0, 2.0, 1.0),
+                    ("Lt", 1.0, 2.0, 1.0),
+                    ("LtE", 1.0, 2.0, 1.0),
+                    ("Gt", 1.0, 2.0, 0.0),
+                    ("GtE", 1.0, 2.0, 0.0),
+                    ])
+@pytest.mark.benchmark(group="Function UDF")
+def test_user_def_func_cmpop(op, var1, var2, expected, func_mode, benchmark):
+    # we explicitly use np here to ensure that the result is castable to float in the scalar-scalar case
+    if op == "Eq":
+        def myFunction(variable, var1, var2):
+            if var1 == var2:
+                return 1.0
+            else:
+                return 0.0
+    elif op == "NotEq":
+        def myFunction(variable, var1, var2):
+            if var1 != var2:
+                return 1.0
+            else:
+                return 0.0
+    elif op == "Lt":
+        def myFunction(variable, var1, var2):
+            if var1 < var2:
+                return 1.0
+            else:
+                return 0.0
+    elif op == "LtE":
+        def myFunction(variable, var1, var2):
+            if var1 <= var2:
+                return 1.0
+            else:
+                return 0.0
+    elif op == "Gt":
+        def myFunction(variable, var1, var2):
+            if var1 > var2:
+                return 1.0
+            else:
+                return 0.0
+    elif op == "GtE":
+        def myFunction(variable, var1, var2):
+            if var1 >= var2:
+                return 1.0
+            else:
+                return 0.0
 
-        U = UserDefinedFunction(custom_function=myFunction, default_variable=[0], var1=var1, var2=var2)
-        e = pytest.helpers.get_func_execution(U, func_mode)
+    U = UserDefinedFunction(custom_function=myFunction, default_variable=[0], var1=var1, var2=var2)
+    e = pytest.helpers.get_func_execution(U, func_mode)
 
-        val = benchmark(e, [0])
-        assert np.allclose(expected, val)
+    val = benchmark(e, [0])
+    assert np.allclose(expected, val)
+
+@pytest.mark.parametrize("op,var1,var2,expected", [ # parameter is string since compiled udf doesn't support closures as of present
+                    ("Eq", 1.0, 2.0, 0.0),
+                    ("Eq", [1.0, 2.0], [1.0, 2.0], [1.0, 1.0]),
+                    ("Eq", 1.0, [1.0, 2.0], [1.0, 0.0]),
+                    ("Eq", [2.0, 1.0], 1.0, [0.0, 1.0]),
+                    ("Eq", [[1.0, 2.0], [3.0, 4.0]], 1.0, [[1.0, 0.0], [0.0, 0.0]]),
+                    ("Eq", 1.0, [[1.0, 2.0], [3.0, 4.0]], [[1.0, 0.0], [0.0, 0.0]]),
+                    ("Eq", [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]], [[1.0, 1.0], [1.0, 1.0]]),
+                    ("NotEq", 1.0, 2.0, 1.0),
+                    ("NotEq", [1.0, 2.0], [1.0, 2.0], [0.0, 0.0]),
+                    ("NotEq", 1.0, [1.0, 2.0], [0.0, 1.0]),
+                    ("NotEq", [2.0, 1.0], 1.0, [1.0, 0.0]),
+                    ("NotEq", [[1.0, 2.0], [3.0, 4.0]], 1.0, [[0.0, 1.0], [1.0, 1.0]]),
+                    ("NotEq", 1.0, [[1.0, 2.0], [3.0, 4.0]], [[0.0, 1.0], [1.0, 1.0]]),
+                    ("NotEq", [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]], [[0.0, 0.0], [0.0, 0.0]]),
+                    ("Lt", 1.0, 2.0, 1.0),
+                    ("Lt", [1.0, 2.0], [1.0, 2.0], [0.0, 0.0]),
+                    ("Lt", 1.0, [1.0, 2.0], [0.0, 1.0]),
+                    ("Lt", [2.0, 1.0], 1.0, [0.0, 0.0]),
+                    ("Lt", [[1.0, 2.0], [3.0, 4.0]], 1.0, [[0.0, 0.0], [0.0, 0.0]]),
+                    ("Lt", 1.0, [[1.0, 2.0], [3.0, 4.0]], [[0.0, 1.0], [1.0, 1.0]]),
+                    ("Lt", [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]], [[0.0, 0.0], [0.0, 0.0]]),
+                    ("LtE", 1.0, 2.0, 1.0),
+                    ("LtE", [1.0, 2.0], [1.0, 2.0], [1.0, 1.0]),
+                    ("LtE", 1.0, [1.0, 2.0], [1.0, 1.0]),
+                    ("LtE", [2.0, 1.0], 1.0, [0.0, 1.0]),
+                    ("LtE", [[1.0, 2.0], [3.0, 4.0]], 1.0, [[1.0, 0.0], [0.0, 0.0]]),
+                    ("LtE", 1.0, [[1.0, 2.0], [3.0, 4.0]], [[1.0, 1.0], [1.0, 1.0]]),
+                    ("LtE", [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]], [[1.0, 1.0], [1.0, 1.0]]),
+                    ("Gt", 1.0, 2.0, 0.0),
+                    ("Gt", [1.0, 2.0], [1.0, 2.0], [0.0, 0.0]),
+                    ("Gt", 1.0, [1.0, 2.0], [0.0, 0.0]),
+                    ("Gt", [2.0, 1.0], 1.0, [1.0, 0.0]),
+                    ("Gt", [[1.0, 2.0], [3.0, 4.0]], 1.0, [[0.0, 1.0], [1.0, 1.0]]),
+                    ("Gt", 1.0, [[1.0, 2.0], [3.0, 4.0]], [[0.0, 0.0], [0.0, 0.0]]),
+                    ("Gt", [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]], [[0.0, 0.0], [0.0, 0.0]]),
+                    ("GtE", 1.0, 2.0, 0.0),
+                    ("GtE", [1.0, 2.0], [1.0, 2.0], [1.0, 1.0]),
+                    ("GtE", 1.0, [1.0, 2.0], [1.0, 0.0]),
+                    ("GtE", [2.0, 1.0], 1.0, [1.0, 1.0]),
+                    ("GtE", [[1.0, 2.0], [3.0, 4.0]], 1.0, [[1.0, 1.0], [1.0, 1.0]]),
+                    ("GtE", 1.0, [[1.0, 2.0], [3.0, 4.0]], [[1.0, 0.0], [0.0, 0.0]]),
+                    ("GtE", [[1.0, 2.0], [3.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]], [[1.0, 1.0], [1.0, 1.0]]),
+                    ])
+@pytest.mark.benchmark(group="Function UDF")
+def test_user_def_func_cmpop_numpy(op, var1, var2, expected, func_mode, benchmark):
+    # we explicitly use np here to ensure that the result is castable to float in the scalar-scalar case
+    if op == "Eq":
+        def myFunction(variable, var1, var2):
+            return np.equal(var1, var2).astype(float)
+    elif op == "NotEq":
+        def myFunction(variable, var1, var2):
+            return np.not_equal(var1, var2).astype(float)
+    elif op == "Lt":
+        def myFunction(variable, var1, var2):
+            return np.less(var1, var2).astype(float)
+    elif op == "LtE":
+        def myFunction(variable, var1, var2):
+            return np.less_equal(var1, var2).astype(float)
+    elif op == "Gt":
+        def myFunction(variable, var1, var2):
+            return np.greater(var1, var2).astype(float)
+    elif op == "GtE":
+        def myFunction(variable, var1, var2):
+            return np.greater_equal(var1, var2).astype(float)
+
+    U = UserDefinedFunction(custom_function=myFunction, default_variable=[0], var1=var1, var2=var2)
+    e = pytest.helpers.get_func_execution(U, func_mode)
+
+    val = benchmark(e, [0])
+    assert np.allclose(expected, val)
 
 class TestUserDefFunc:
 

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -223,14 +223,29 @@ def branchOnVarCmp(variable, param1, param2):
         return variable * -2 + param2
 
 
+def branchOnVarFloat(variable, param1, param2):
+    if variable[0]:
+        return 1.0
+    else:
+        return 0.0
+
+
 @pytest.mark.parametrize("func,var,expected", [
     (branchOnVarCmp, [[1, 3]], [[5, 9]]),
     (branchOnVarCmp, [[-1, 3]], [[5, -3]]),
+    (branchOnVarFloat, [0.0], [0.0]),
+    (branchOnVarFloat, [-0.0], [0.0]),
+    (branchOnVarFloat, [-1.5], [1.0]),
+    (branchOnVarFloat, [1.5], [1.0]),
+    (branchOnVarFloat, [float("Inf")], [1.0]),
+    (branchOnVarFloat, [float("-Inf")], [1.0]),
+    (branchOnVarFloat, [float("NaN")], [1.0]),
+    (branchOnVarFloat, [float("-NaN")], [1.0]),
 ])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_func_branching(func, var, expected, func_mode, benchmark):
 
-    U = UserDefinedFunction(custom_function=func, default_variable=[[0, 0]], param2=3)
+    U = UserDefinedFunction(custom_function=func, default_variable=var, param2=3)
     e = pytest.helpers.get_func_execution(U, func_mode)
 
     val = benchmark(e, var)

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -276,16 +276,21 @@ def test_user_def_func_cmpop_numpy(op, var1, var2, expected, func_mode, benchmar
     assert np.allclose(expected, val)
 
 
-@pytest.mark.benchmark(group="Function UDF")
-def test_user_def_func(func_mode, benchmark):
-    def myFunction(variable, param1, param2):
-        return variable * 2 + param2
+def simpleFun(variable, param1, param2):
+    return variable * 2 + param2
 
-    U = UserDefinedFunction(custom_function=myFunction, default_variable=[[0, 0]], param2=3)
+
+@pytest.mark.parametrize("func,var,params,expected", [
+    (simpleFun, [1, 3], {"param1":None, "param2":3}, [5, 9]),
+])
+@pytest.mark.benchmark(group="Function UDF")
+def test_user_def_func(func, var, params, expected, func_mode, benchmark):
+
+    U = UserDefinedFunction(custom_function=func, default_variable=var, **params)
     e = pytest.helpers.get_func_execution(U, func_mode)
 
-    val = benchmark(e, [1, 3])
-    assert np.allclose(val, [[5, 9]])
+    val = benchmark(e, var)
+    assert np.allclose(val, expected)
 
 
 def branchOnVarCmp(variable, param1, param2):

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -16,6 +16,16 @@ def binAdd(_, param1, param2):
     return param1 + param2
 
 
+def binMul(_, param1, param2):
+    # we only use param1 and param2 to avoid automatic shape changes of the variable
+    return param1 * param2
+
+
+def binDiv(_, param1, param2):
+    # we only use param1 and param2 to avoid automatic shape changes of the variable
+    return param1 / param2
+
+
 @pytest.mark.parametrize("param1, param2", [
                     (1, 2),
                     (np.ones(2), 2),
@@ -25,9 +35,9 @@ def binAdd(_, param1, param2):
                     (np.ones(2), np.array([1, 2])),
                     (np.ones((2, 2)), np.array([[1, 2], [3, 4]])),
                     ], ids=["scalar-scalar", "vec-scalar", "scalar-vec", "mat-scalar", "scalar-mat", "vec-vec", "mat-mat"])
-@pytest.mark.parametrize("func", [binAdd])
+@pytest.mark.parametrize("func", [binAdd, binMul, binDiv])
 @pytest.mark.benchmark(group="Function UDF")
-def test_user_def_func_add(param1, param2, func, func_mode, benchmark):
+def test_user_def_bin_arith(param1, param2, func, func_mode, benchmark):
 
     U = UserDefinedFunction(custom_function=func, param1=param1, param2=param2)
     e = pytest.helpers.get_func_execution(U, func_mode)
@@ -35,51 +45,6 @@ def test_user_def_func_add(param1, param2, func, func_mode, benchmark):
     val = benchmark(e, 0)
     assert np.allclose(val, func(0, param1=param1, param2=param2))
 
-@pytest.mark.parametrize("param1, param2", [
-                    (1, 2),
-                    (np.ones(2), 2),
-                    (2, np.ones(2)),
-                    (np.ones((2, 2)), 2),
-                    (2, np.ones((2, 2))),
-                    (np.ones(2), np.array([1, 2])),
-                    (np.ones(2), np.array([2.])),
-                    (np.ones((2, 2)), np.array([[1, 2], [3, 4]])),
-                    ], ids=["scalar-scalar", "vec-scalar", "scalar-vec", "mat-scalar", "scalar-mat", "vec-vec", "vec-vec-differing", "mat-mat"])
-@pytest.mark.benchmark(group="Function UDF")
-def test_user_def_func_mul(param1, param2, func_mode, benchmark):
-    # default val is same shape as expected output
-    def myFunction(_, param1, param2):
-        # we only use param1 and param2 to avoid automatic shape changes of the variable
-        return param1 * param2
-
-    U = UserDefinedFunction(custom_function=myFunction, param1=param1, param2=param2)
-    e = pytest.helpers.get_func_execution(U, func_mode)
-
-    val = benchmark(e, 0)
-    assert np.allclose(val, param1 * param2)
-
-@pytest.mark.parametrize("param1, param2", [
-                (1, 2),
-                (np.ones(2), 2),
-                (2, np.ones(2)),
-                (np.ones((2, 2)), 2),
-                (2, np.ones((2, 2))),
-                (np.ones(2), np.array([1, 2])),
-                (np.ones(2), np.array([2.])),
-                (np.ones((2, 2)), np.array([[1, 2], [3, 4]])),
-                ], ids=["scalar-scalar", "vec-scalar", "scalar-vec", "mat-scalar", "scalar-mat", "vec-vec", "vec-vec-differing", "mat-mat"])
-@pytest.mark.benchmark(group="Function UDF")
-def test_user_def_func_div(param1, param2, func_mode, benchmark):
-    # default val is same shape as expected output
-    def myFunction(_, param1, param2):
-        # we only use param1 and param2 to avoid automatic shape changes of the variable
-        return param1 / param2
-
-    U = UserDefinedFunction(custom_function=myFunction, param1=param1, param2=param2)
-    e = pytest.helpers.get_func_execution(U, func_mode)
-
-    val = benchmark(e, 0)
-    assert np.allclose(val, np.divide(param1, param2))
 
 @pytest.mark.parametrize("op", [ # parameter is string since compiled udf doesn't support closures as of present
                     "AND",

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -465,9 +465,20 @@ def test_user_def_func_assign(dtype, expected, func_mode, benchmark):
                 ("SHAPE", [[1, 3]], [1, 2]),
                 ("ASTYPE_FLOAT", [1], [1.0]),
                 ("ASTYPE_INT", [-1.5], [-1.0]),
+                ("NP_MAX", 5.0, 5.0),
                 ("NP_MAX", [0.0, 0.0], 0),
                 ("NP_MAX", [1.0, 2.0], 2),
+                ("NP_MAX", [1.0, 2.0, float("-Inf"), float("Inf"), float("NaN")], float("NaN")),
                 ("NP_MAX", [[2.0, 1.0], [6.0, 2.0]], 6),
+                ("NP_MAX", [[[-2.0, -1.0], [-6.0, -2.0]],[[2.0, 1.0], [6.0, 2.0]]], 6),
+                ("NP_MAX", [[float('-Inf'), 1.0], [6.0, 2.0]], 6),
+                ("NP_MAX", [[float('Inf'), 1.0], [6.0, 2.0]], float('Inf')),
+                ("NP_MAX", [[float('NaN'), 1.0], [6.0, 2.0]], float('NaN')),
+                ("NP_MAX", [[float('-NaN'), 1.0], [6.0, 2.0]], float('-NaN')),
+                ("NP_MAX", [[5.0, float('-Inf'), 1.0], [3.0, 6.0, 2.0]], 6),
+                ("NP_MAX", [[5.0, float('Inf'), 1.0], [3.0, 6.0, 2.0]], float('Inf')),
+                ("NP_MAX", [[5.0, float('NaN'), 1.0], [3.0, 6.0, 2.0]], float('NaN')),
+                ("NP_MAX", [[5.0, float('NaN'), 1.0], [3.0, 6.0, 2.0]], float('-NaN')),
                 ("FLATTEN", [[1.0, 2.0], [3.0, 4.0]], [1.0, 2.0, 3.0, 4.0])
                 ])
 @pytest.mark.benchmark(group="Function UDF")
@@ -499,7 +510,7 @@ def test_user_def_func_numpy(op, variable, expected, func_mode, benchmark):
     e = pytest.helpers.get_func_execution(U, func_mode)
 
     val = benchmark(e, variable)
-    assert np.allclose(val, expected)
+    assert np.allclose(val, expected, equal_nan=True)
 
 
 @pytest.mark.benchmark(group="UDF in Mechanism")

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -531,9 +531,8 @@ def test_udf_in_mechanism(mech_mode, benchmark):
                 ("SUM", [1.0, 3.0], 12),
                 ("SUM", [[1.0], [3.0]], [12.0]),
                 ("SUM", [[1.0, 2.0], [3.0, 4.0]], [12.0, 18.0]),
-                ("LEN", [1.0, 3.0], 2),
-                ("LEN", [[1.0], [3.0]], 2),
-                ("LEN_TUPLE", [0, 0], 2),
+                ("LEN", [1.0, 3.0], 8),
+                ("LEN", [[1.0], [3.0]], 8),
                 ("MAX_MULTI", [1.0, 3.0, 2.0], 6),
                 ("MAX_TUPLE", [1.0, 3.0, 2.0], 6),
                 ("MAX", [1.0, 3.0, 2.0], 3.0),
@@ -547,11 +546,8 @@ def test_user_def_func_builtin(op, variable, expected, func_mode, benchmark):
         def myFunction(var):
             return sum(var) + sum((var[0], var[1])) + sum([var[0], var[1]])
     elif op == "LEN":
-        def myFunction(variable):
-            return len(variable)
-    elif op == "LEN_TUPLE":
-        def myFunction(variable):
-            return len((1,2))
+        def myFunction(var):
+            return len(var) + len((var[0], var[1])) + len([var[0], var[1]]) + len((1.0, (1,2)))
     elif op == "MAX":
         def myFunction(variable):
             return max(variable)

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -95,15 +95,36 @@ def multiAndOr(variable):
         return 0.0
 
 
-@pytest.mark.parametrize("op", [binAnd, binOr, triAnd, triOr, multiAndOr])
-@pytest.mark.benchmark(group="Function UDF")
-def test_user_def_func_boolop(op, func_mode, benchmark):
+def varAnd(var):
+    return var[0] and var[1]
 
-    U = UserDefinedFunction(custom_function=op, default_variable=[0])
+
+def varOr(var):
+    return var[0] or var[1]
+
+
+@pytest.mark.parametrize("op,var, expected", [
+    (binAnd, 0, 1.0),
+    (binOr, 0, 1.0),
+    (triAnd, 0, 1.0),
+    (triOr, 0, 1.0),
+    (multiAndOr, 0, 1.0),
+    (varAnd, [0.0, 0.0], 0.0),
+    (varAnd, [5.0, -0.0], -0.0),
+    (varAnd, [0.0, -2.0], 0.0),
+    (varAnd, [5.0, -2.0], -2.0),
+    (varOr, [-0.0, 0.0], 0.0),
+    (varOr, [3.0, 0.0], 3.0),
+    (varOr, [0.0, -3.0], -3.0),
+    (varOr, [1.5, -1.0], 1.5),
+    ])
+@pytest.mark.benchmark(group="Function UDF")
+def test_user_def_func_boolop(op, var, expected, func_mode, benchmark):
+    U = UserDefinedFunction(custom_function=op, default_variable=var)
     e = pytest.helpers.get_func_execution(U, func_mode)
 
-    val = benchmark(e, [0])
-    assert val == 1.0
+    val = benchmark(e, var)
+    assert val == expected
 
 
 @pytest.mark.parametrize("op,var1,var2,expected", [ # parameter is string since compiled udf doesn't support closures as of present

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -46,36 +46,36 @@ def test_user_def_bin_arith(param1, param2, func, func_mode, benchmark):
     assert np.allclose(val, func(0, param1=param1, param2=param2))
 
 
-@pytest.mark.parametrize("op", [ # parameter is string since compiled udf doesn't support closures as of present
-                    "AND",
-                    "OR",
-                    ])
+def binAnd(variable):
+    var1 = True
+    var2 = False
+    # compiled UDFs don't support python bool type outputs
+    if var1 and var2:
+        return 0.0
+    else:
+        return 1.0
+
+
+def binOr(variable):
+    var1 = True
+    var2 = False
+    # compiled UDFs don't support python bool type outputs
+    if var1 or var2:
+        return 1.0
+    else:
+        return 0.0
+
+
+@pytest.mark.parametrize("op", [binAnd, binOr])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_func_boolop(op, func_mode, benchmark):
-    if op == "AND":
-        def myFunction(variable):
-            var1 = True
-            var2 = False
-            # compiled UDFs don't support python bool type outputs
-            if var1 and var2:
-                return 0.0
-            else:
-                return 1.0
-    elif op == "OR":
-        def myFunction(variable):
-            var1 = True
-            var2 = False
-            # compiled UDFs don't support python bool type outputs
-            if var1 or var2:
-                return 1.0
-            else:
-                return 0.0
 
-    U = UserDefinedFunction(custom_function=myFunction, default_variable=[0])
+    U = UserDefinedFunction(custom_function=op, default_variable=[0])
     e = pytest.helpers.get_func_execution(U, func_mode)
 
     val = benchmark(e, [0])
     assert val == 1.0
+
 
 @pytest.mark.parametrize("op,var1,var2,expected", [ # parameter is string since compiled udf doesn't support closures as of present
                     ("Eq", 1.0, 2.0, 0.0),

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -126,55 +126,58 @@ def test_user_def_func_boolop(op, var, expected, func_mode, benchmark):
     assert val == expected
 
 
-@pytest.mark.parametrize("op,var1,var2,expected", [ # parameter is string since compiled udf doesn't support closures as of present
-                    ("Eq", 1.0, 2.0, 0.0),
-                    ("NotEq", 1.0, 2.0, 1.0),
-                    ("Lt", 1.0, 2.0, 1.0),
-                    ("LtE", 1.0, 2.0, 1.0),
-                    ("Gt", 1.0, 2.0, 0.0),
-                    ("GtE", 1.0, 2.0, 0.0),
+def binEQ(variable, var1, var2):
+    if var1 == var2:
+        return 1.0
+    else:
+        return 0.0
+
+
+def binNE(variable, var1, var2):
+    if var1 != var2:
+        return 1.0
+    else:
+        return 0.0
+
+
+def binLT(variable, var1, var2):
+    if var1 < var2:
+        return 1.0
+    else:
+        return 0.0
+
+
+def binLE(variable, var1, var2):
+    if var1 <= var2:
+        return 1.0
+    else:
+        return 0.0
+
+
+def binGT(variable, var1, var2):
+    if var1 > var2:
+        return 1.0
+    else:
+        return 0.0
+
+
+def binGE(variable, var1, var2):
+    if var1 >= var2:
+        return 1.0
+    else:
+        return 0.0
+
+@pytest.mark.parametrize("func,var1,var2,expected", [
+                    (binEQ, 1.0, 2.0, 0.0),
+                    (binNE, 1.0, 2.0, 1.0),
+                    (binLT, 1.0, 2.0, 1.0),
+                    (binLE, 1.0, 2.0, 1.0),
+                    (binGT, 1.0, 2.0, 0.0),
+                    (binGE, 1.0, 2.0, 0.0),
                     ])
 @pytest.mark.benchmark(group="Function UDF")
-def test_user_def_func_cmpop(op, var1, var2, expected, func_mode, benchmark):
-    # we explicitly use np here to ensure that the result is castable to float in the scalar-scalar case
-    if op == "Eq":
-        def myFunction(variable, var1, var2):
-            if var1 == var2:
-                return 1.0
-            else:
-                return 0.0
-    elif op == "NotEq":
-        def myFunction(variable, var1, var2):
-            if var1 != var2:
-                return 1.0
-            else:
-                return 0.0
-    elif op == "Lt":
-        def myFunction(variable, var1, var2):
-            if var1 < var2:
-                return 1.0
-            else:
-                return 0.0
-    elif op == "LtE":
-        def myFunction(variable, var1, var2):
-            if var1 <= var2:
-                return 1.0
-            else:
-                return 0.0
-    elif op == "Gt":
-        def myFunction(variable, var1, var2):
-            if var1 > var2:
-                return 1.0
-            else:
-                return 0.0
-    elif op == "GtE":
-        def myFunction(variable, var1, var2):
-            if var1 >= var2:
-                return 1.0
-            else:
-                return 0.0
-
-    U = UserDefinedFunction(custom_function=myFunction, default_variable=[0], var1=var1, var2=var2)
+def test_user_def_func_cmpop(func, var1, var2, expected, func_mode, benchmark):
+    U = UserDefinedFunction(custom_function=func, default_variable=[0], var1=var1, var2=var2)
     e = pytest.helpers.get_func_execution(U, func_mode)
 
     val = benchmark(e, [0])

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -326,13 +326,21 @@ def unarySubParam(variable, param):
     return -param
 
 
+def unaryAddVar(variable, param):
+    return +variable
+
+
+def unaryAddParam(variable, param):
+    return +param
+
+
 @pytest.mark.parametrize("variable", [
                     1,
                     np.ones(2),
                     np.ones((2)),
                     np.ones((2, 2))
                     ], ids=["scalar", "vec", "vec-2d", "mat"])
-@pytest.mark.parametrize("func", [unarySubVar, unarySubParam])
+@pytest.mark.parametrize("func", [unarySubVar, unarySubParam, unaryAddVar, unaryAddParam])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_func_unary(func, variable, func_mode, benchmark):
     U = UserDefinedFunction(custom_function=func, default_variable=variable, param=variable)

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -28,9 +28,13 @@ def binDiv(_, param1, param2):
     return param1 / param2
 
 
+def binPow(_, param1, param2):
+    return param1 / param2
+
+
 @pytest.mark.parametrize("param1", [1, np.ones(2), np.ones((2, 2))], ids=['scalar', 'vector', 'matrix'])
 @pytest.mark.parametrize("param2", [2, np.ones(2) * 2, np.ones((2, 2)) * 2], ids=['scalar', 'vector', 'matrix'])
-@pytest.mark.parametrize("func", [binAdd, binSub, binMul, binDiv])
+@pytest.mark.parametrize("func", [binAdd, binSub, binMul, binDiv, binPow])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_bin_arith(param1, param2, func, func_mode, benchmark):
 

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -55,6 +55,15 @@ def binAnd(variable):
     else:
         return 1.0
 
+def triAnd(variable):
+    var1 = True
+    var2 = False
+    # compiled UDFs don't support python bool type outputs
+    if var1 and var2 and False:
+        return 0.0
+    else:
+        return 1.0
+
 
 def binOr(variable):
     var1 = True
@@ -66,7 +75,27 @@ def binOr(variable):
         return 0.0
 
 
-@pytest.mark.parametrize("op", [binAnd, binOr])
+def triOr(variable):
+    var1 = True
+    var2 = False
+    # compiled UDFs don't support python bool type outputs
+    if var1 or var2 or True:
+        return 1.0
+    else:
+        return 0.0
+
+
+def multiAndOr(variable):
+    var1 = True
+    var2 = False
+    # compiled UDFs don't support python bool type outputs
+    if var1 or var2 and True or True and var1:
+        return 1.0
+    else:
+        return 0.0
+
+
+@pytest.mark.parametrize("op", [binAnd, binOr, triAnd, triOr, multiAndOr])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_func_boolop(op, func_mode, benchmark):
 

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -528,8 +528,9 @@ def test_udf_in_mechanism(mech_mode, benchmark):
 
 
 @pytest.mark.parametrize("op,variable,expected", [ # parameter is string since compiled udf doesn't support closures as of present
-                ("SUM", [1.0, 3.0], 4),
-                ("SUM", [[1.0], [3.0]], [4.0]),
+                ("SUM", [1.0, 3.0], 12),
+                ("SUM", [[1.0], [3.0]], [12.0]),
+                ("SUM", [[1.0, 2.0], [3.0, 4.0]], [12.0, 18.0]),
                 ("LEN", [1.0, 3.0], 2),
                 ("LEN", [[1.0], [3.0]], 2),
                 ("LEN_TUPLE", [0, 0], 2),
@@ -543,8 +544,8 @@ def test_udf_in_mechanism(mech_mode, benchmark):
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_func_builtin(op, variable, expected, func_mode, benchmark):
     if op == "SUM":
-        def myFunction(variable):
-            return sum(variable)
+        def myFunction(var):
+            return sum(var) + sum((var[0], var[1])) + sum([var[0], var[1]])
     elif op == "LEN":
         def myFunction(variable):
             return len(variable)

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -26,15 +26,8 @@ def binDiv(_, param1, param2):
     return param1 / param2
 
 
-@pytest.mark.parametrize("param1, param2", [
-                    (1, 2),
-                    (np.ones(2), 2),
-                    (2, np.ones(2)),
-                    (np.ones((2, 2)), 2),
-                    (2, np.ones((2, 2))),
-                    (np.ones(2), np.array([1, 2])),
-                    (np.ones((2, 2)), np.array([[1, 2], [3, 4]])),
-                    ], ids=["scalar-scalar", "vec-scalar", "scalar-vec", "mat-scalar", "scalar-mat", "vec-vec", "mat-mat"])
+@pytest.mark.parametrize("param1", [1, np.ones(2), np.ones((2, 2))], ids=['scalar', 'vector', 'matrix'])
+@pytest.mark.parametrize("param2", [2, np.ones(2) * 2, np.ones((2, 2)) * 2], ids=['scalar', 'vector', 'matrix'])
 @pytest.mark.parametrize("func", [binAdd, binMul, binDiv])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_bin_arith(param1, param2, func, func_mode, benchmark):


### PR DESCRIPTION
Extend test parametrization to cover more corner cases.
Add support for expressions of non-boolean type in if condition.
Add support for non-boolean values in boolean expressions.
Add support for subtraction and power operators.
Add support for unary add and not.
Fix return statements to return from the function instead of just updating the return value.
Allocate variable space for variable storage, the type is derived from the first occurrence of the variable in code.
Fix the NaN behavior of Python and numpy max builtins.
Refactor expression generation to not use stack space for constructing temporary values (with the exception of subscript).
