### PR TITLE
fix(parameter ports): handle same name param on obj and its functions

### DIFF
--- a/tests/ports/test_parameter_ports.py
+++ b/tests/ports/test_parameter_ports.py
@@ -161,6 +161,23 @@ class TestParameterPortList:
         ):
             transfer_mech.parameter_ports['offset']
 
+    def test_duplicate_from_owner_class(self):
+        # no current example of duplicate modulable parameter exists on
+        # a mechanism and function, but they will
+        class NewMech(TransferMechanism):
+            class Parameters(TransferMechanism.Parameters):
+                offset = pnl.Parameter(0, modulable=True)
+
+        mech = NewMech()
+        assert mech.parameter_ports['offset-self'].source is mech.parameters.offset
+        assert mech.parameter_ports['offset-integrator_function'].source is mech.integrator_function.parameters.offset
+
+        with pytest.raises(
+            pnl.ParameterPortError,
+            match='Did you want offset-integrator_function or offset-self'
+        ):
+            mech.parameter_ports['offset']
+
     def test_duplicate_sources(self, transfer_mech):
         assert transfer_mech.parameter_ports['offset-function'].source is transfer_mech.function.parameters.offset
         assert transfer_mech.parameter_ports['offset-integrator_function'].source is transfer_mech.integrator_function.parameters.offset


### PR DESCRIPTION
A class might have a modulable Parameter with the same name as a modulable Parameter on one of its functions. Previously, this would silently only create a single ParameterPort for the function's parameter. These changes cause the creation of ParameterPorts for both, with each suffixed in a similar manner as when there is a conflict between ParameterPorts with the same name across multiple functions. The suffix for the main object's port is `self`.