### PR TITLE
scheduling: account for floating point errors for absolute time

### DIFF
--- a/psyneulink/__init__.py
+++ b/psyneulink/__init__.py
@@ -29,6 +29,7 @@ import pint as _pint
 # reason for skipping E402 below
 _unit_registry = _pint.get_application_registry()
 _pint.set_application_registry(_unit_registry)
+_unit_registry.precision = 8  # TODO: remove when floating point issues resolved
 
 # starred imports to allow user imports from top level
 from . import core  # noqa: E402

--- a/psyneulink/core/scheduling/scheduler.py
+++ b/psyneulink/core/scheduling/scheduler.py
@@ -764,19 +764,21 @@ class Scheduler(JSONDumpable):
         else:
             termination_conds = self._combine_termination_conditions(termination_conds)
 
+        current_time = self.get_clock(context).time
+
         in_absolute_time_mode = len(self.get_absolute_conditions(termination_conds)) > 0
         if in_absolute_time_mode:
             # advance absolute clock time to first necessary time
-            self.get_clock(context).time.absolute = max(
-                self.get_clock(context).time.absolute,
+            current_time.absolute = max(
+                current_time.absolute,
                 min([
                     min(c.absolute_fixed_points)
                     if len(c.absolute_fixed_points) > 0 else 0
                     for c in self.get_absolute_conditions(termination_conds).values()
                 ])
             )
-            self.get_clock(context).time.absolute_interval = self._get_absolute_time_step_unit(termination_conds)
-        self.get_clock(context).time.absolute_enabled = in_absolute_time_mode
+            current_time.absolute_interval = self._get_absolute_time_step_unit(termination_conds)
+        current_time.absolute_enabled = in_absolute_time_mode
 
         self._init_counts(context.execution_id, base_context.execution_id)
         self._reset_counts_useable(context.execution_id)
@@ -839,7 +841,7 @@ class Scheduler(JSONDumpable):
                     self.execution_list[context.execution_id].append(cur_time_step_exec)
                     if in_absolute_time_mode:
                         self.execution_timestamps[context.execution_id].append(
-                            copy.copy(self.get_clock(context).time)
+                            copy.copy(current_time)
                         )
                     yield self.execution_list[context.execution_id][-1]
 

--- a/psyneulink/core/scheduling/time.py
+++ b/psyneulink/core/scheduling/time.py
@@ -296,6 +296,14 @@ class Time(types.SimpleNamespace):
             and time_scale is self.absolute_time_unit_scale
         ):
             self.absolute += self.absolute_interval
+            if (
+                self.absolute_interval < 1 * self.absolute.u
+                and isinstance(self.absolute.m, float)
+            ):
+                # only round for floating point interval increases,
+                # until pint fixes precision errors
+                # see https://github.com/hgrecco/pint/issues/1263
+                self.absolute = round(self.absolute, pnl._unit_registry.precision)
 
     def _reset_by_time_scale(self, time_scale):
         """

--- a/tests/scheduling/test_condition.py
+++ b/tests/scheduling/test_condition.py
@@ -907,6 +907,15 @@ class TestAbsolute:
                 {A: TimeInterval(repeat=1200), B: TimeInterval(repeat=1000)},
                 {TimeScale.TRIAL: AfterNCalls(A, 3)},
             ),
+            (
+                {A: TimeInterval(repeat=0.33333), B: TimeInterval(repeat=0.66666)},
+                {TimeScale.TRIAL: AfterNCalls(B, 3)},
+            ),
+            # smaller than default units cause floating point issue without mitigation
+            (
+                {A: TimeInterval(repeat=2 * _unit_registry.us), B: TimeInterval(repeat=4 * _unit_registry.us)},
+                {TimeScale.TRIAL: AfterNCalls(B, 3)},
+            ),
         ]
     )
     def test_TimeInterval_linear_everynms(self, conditions, termination_conds):


### PR DESCRIPTION
Conditions sometimes failed to be satisfied when they otherwise should have due to floating point precision issues. Times now avoid floats when possible but limit precision to 8 decimal points when not.