### PR TITLE
github-actions: Consolidate documentation jobs

### DIFF
--- a/.github/actions/on-branch/action.yml
+++ b/.github/actions/on-branch/action.yml
@@ -1,0 +1,28 @@
+name: 'Check commit in branch'
+description: 'Check if the current commit is included in the last n commits of the given branch'
+inputs:
+  branch:
+    description: 'Branch name to check against. Default: "master".'
+    required: true
+    default: 'master'
+  depth:
+    description: 'Check the last $depth commits. Default: 5.'
+    required: true
+    default: 5
+outputs:
+  on-branch:
+    description: 'Returns the branch name if the current commit is included in the branch, "" otherwise'
+    value: ${{ steps.on_branch.outputs.on_branch }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check if on ${{ inputs.branch }}
+      id: on_branch
+      shell: bash
+      run: |
+        git fetch origin ${{ inputs.branch }} --depth=${{ inputs.depth }}
+        git describe --always --tags
+        export ON_BRANCH=$(git branch -a --contains ${{ github.ref }} | grep -q '^  remotes/origin/${{ inputs.branch }}$' && echo "${{ inputs.branch }}" || echo "")
+        echo "Found out: ${ON_BRANCH}"
+        echo "::set-output name=on_branch::$ON_BRANCH"

--- a/.github/workflows/compare-comment.yml
+++ b/.github/workflows/compare-comment.yml
@@ -7,58 +7,75 @@ on:
       - completed
 
 jobs:
-  post-comment:
+  docs-compare:
     runs-on: ubuntu-latest
     if: >
       ${{ github.event.workflow_run.event == 'pull_request' &&
           github.event.workflow_run.conclusion == 'success' }}
+
     steps:
 
-      - name: 'Download artifact'
-        uses: actions/github-script@v4.0.2
-        with:
-          script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: ${{github.event.workflow_run.id }},
-            });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name.startsWith("compare")
-            }).slice(-1)[0];
+    - name: 'Download docs artifacts'
+      id: docs-artifacts
+      uses: actions/github-script@v4.0.2
+      with:
+        script: |
+          var artifacts = await github.actions.listWorkflowRunArtifacts({
+             owner: context.repo.owner,
+             repo: context.repo.repo,
+             run_id: ${{ github.event.workflow_run.id }},
+          });
+          const docsPrefix = 'docs-base-'
+          const docsSuffix = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name.startsWith(docsPrefix)
+          }).slice(-1)[0].name.slice(docsPrefix.length);
+
+          core.setOutput('DOCS_GEN_ENV', docsSuffix);
+
+          var docsArtifacts = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name.endsWith(docsSuffix) && artifact.name.startsWith('docs-')
+          });
+
+          // check that we got exactly 2 artifacts
+          console.assert(docsArtifacts.length == 2, docsSuffix, docsArtifacts, artifacts.data.artifacts);
+
+          var fs = require('fs');
+          for (artifact of docsArtifacts) {
+            console.log('Downloading: ' + artifact.name);
             var download = await github.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
+               artifact_id: artifact.id,
                archive_format: 'zip',
             });
-            var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+            fs.writeFileSync('${{ github.workspace }}/' + artifact.name + '.zip', Buffer.from(download.data));
+          }
 
-      - name: Unzip artifact
-        run: unzip pr.zip
+    - name: Unzip artifacts
+      shell: bash
+      run: |
+        unzip docs-base-*.zip -d docs-base/
+        unzip docs-merge-*.zip -d docs-head/
 
-      - name: Post comment with docs diff
-        uses: actions/github-script@v4.0.2
-        with:
-          script: |
-            var fs = require("fs");
-            var issue_number = Number(fs.readFileSync('./PR_NR'));
-            var os = fs.readFileSync('./PR_OS', 'utf8').trim();
-            var python = fs.readFileSync('./PR_PYTHON_VERSION', 'utf8').trim();
-            var text = fs.readFileSync("./result.diff").slice(0,16384);
+    - name: Compare
+      shell: bash
+      run: |
+        # Store the resulting diff, or 'No differences!' to and output file
+        # The 'or true' part is needed to workaround 'pipefail' flag used by github-actions
+        (diff -r docs-base docs-head && echo 'No differences!' || true) | tee ./result.diff
 
-            // basic input checks
-            console.assert(['ubuntu-latest', 'windows-latest', 'macos-latest'].includes(os), 'Unexpected os: %s', os);
-            console.assert(['3.7', '3.8', '3.9'].includes(python), 'Unexpected python: %s', python);
-            console.assert(!text.includes('```'), 'Invalid diff!');
+    - name: Post comment with docs diff
+      uses: actions/github-script@v4.0.2
+      with:
+        script: |
+          var fs = require('fs');
+          var text = fs.readFileSync("./result.diff").slice(0,16384);
 
-            console.log('Posting diff to PR:' + issue_number)
+          console.log('Posting diff to PR: ${{ github.event.workflow_run.pull_requests[0].number }}')
 
-            github.issues.createComment({
-              issue_number: issue_number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'This PR causes the following changes to the html docs (' + os + ', python-' + python + '):\n```\n' + text + '\n...\n```\nSee CI logs for the full diff.'
-            })
-
+          github.issues.createComment({
+            issue_number: ${{ github.event.workflow_run.pull_requests[0].number }},
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'This PR causes the following changes to the html docs (${{ steps.docs-artifacts.outputs.DOCS_GEN_ENV }}):\n```\n' + text + '\n...\n```\nSee CI logs for the full diff.'
+          })

--- a/.github/workflows/compare-comment.yml
+++ b/.github/workflows/compare-comment.yml
@@ -2,16 +2,15 @@ name: "Add doc diff to PR comment"
 
 on:
   workflow_run:
-    workflows: ["PsyNeuLink Docs Compare"]
+    workflows: ["PsyNeuLink Docs CI"]
     types:
       - completed
 
 jobs:
   docs-compare:
     runs-on: ubuntu-latest
-    if: >
-      ${{ github.event.workflow_run.event == 'pull_request' &&
-          github.event.workflow_run.conclusion == 'success' }}
+    if: github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.conclusion == 'success'
 
     steps:
 
@@ -25,7 +24,7 @@ jobs:
              repo: context.repo.repo,
              run_id: ${{ github.event.workflow_run.id }},
           });
-          const docsPrefix = 'docs-base-'
+          const docsPrefix = 'Documentation-base-'
           const docsSuffix = artifacts.data.artifacts.filter((artifact) => {
             return artifact.name.startsWith(docsPrefix)
           }).slice(-1)[0].name.slice(docsPrefix.length);
@@ -33,7 +32,7 @@ jobs:
           core.setOutput('DOCS_GEN_ENV', docsSuffix);
 
           var docsArtifacts = artifacts.data.artifacts.filter((artifact) => {
-            return artifact.name.endsWith(docsSuffix) && artifact.name.startsWith('docs-')
+            return artifact.name.endsWith(docsSuffix) && artifact.name.startsWith('Documentation-')
           });
 
           // check that we got exactly 2 artifacts
@@ -54,8 +53,8 @@ jobs:
     - name: Unzip artifacts
       shell: bash
       run: |
-        unzip docs-base-*.zip -d docs-base/
-        unzip docs-merge-*.zip -d docs-head/
+        unzip Documentation-base-*.zip -d docs-base/
+        unzip Documentation-head-*.zip -d docs-head/
 
     - name: Compare
       shell: bash

--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -1,16 +1,39 @@
 name: PsyNeuLink Docs CI
 
-on: push
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+    tags:
+      - 'v*'
+  pull_request:
 
 jobs:
   docs-build:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      # Matrix setup is a hacky way to include 'base' build in pull requests
+      # The entire matrix is set up and 'base' builds are pruned based
+      # on event name and final configuration (ubuntu, python3.7).
       matrix:
         python-version: [3.7, 3.8, 3.9]
         python-architecture: ['x64']
         os: [ubuntu-latest, macos-latest, windows-latest]
+        event:
+          - ${{ github.event_name }}
+        pnl-version: ['head', 'base']
+        exclude:
+          - event: 'push'
+            pnl-version: 'base'
+          - os: macos-latest
+            pnl-version: 'base'
+          - os: windows-latest
+            pnl-version: 'base'
+          - python-version: 3.8
+            pnl-version: 'base'
+          - python-version: 3.9
+            pnl-version: 'base'
 
     outputs:
       on_master: ${{ steps.on_master.outputs.on-branch }}
@@ -18,10 +41,20 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2.3.4
+      if: ${{ matrix.pnl-version == 'head' }}
       with:
-        fetch-depth: 0
+        fetch-depth: 10
+        ref: ${{ github.ref }}
+
+    - name: Checkout pull base
+      uses: actions/checkout@v2.3.4
+      if: ${{ matrix.pnl-version == 'base' }}
+      with:
+        fetch-depth: 10
+        ref: ${{ github.base_ref }}
 
     - name: Check if on master
+      if: ${{ github.event_name == 'push' }}
       id: on_master
       uses: ./.github/actions/on-branch
       with:
@@ -54,13 +87,19 @@ jobs:
       with:
         features: 'doc'
 
+    - name: Add git tag
+      # The generated docs include PNL version,
+      # set it to a fixed value to prevent polluting the diff
+      if: ${{ github.event_name == 'pull_request' }}
+      run: git tag 'v999.999.999.999'
+
     - name: Build Documentation
       run: sphinx-build -b html -aE -j auto docs/source pnl-html
 
     - name: Upload Documentation
       uses: actions/upload-artifact@v2.2.3
       with:
-        name: Documentation-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}
+        name: Documentation-${{matrix.pnl-version}}-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}
         retention-days: 1
         path: pnl-html
 
@@ -73,7 +112,12 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     needs: [docs-build]
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/docs' || (contains(github.ref, 'tags') && contains(needs.*.outputs.on_master, 'master'))
+    if: github.event_name == 'push' &&
+        (github.ref == 'refs/heads/master' ||
+         github.ref == 'refs/heads/devel' ||
+         github.ref == 'refs/heads/docs' ||
+         (contains(github.ref, 'tags') && contains(needs.*.outputs.on_master, 'master'))
+        )
 
     steps:
     - name: Checkout docs
@@ -84,7 +128,7 @@ jobs:
     - name: Download branch docs
       uses: actions/download-artifact@v2
       with:
-        name: Documentation-${{ matrix.os }}-${{ matrix.python-version }}-x64
+        name: Documentation-head-${{ matrix.os }}-${{ matrix.python-version }}-x64
         path: _built_docs/${{ github.ref }}
       if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/docs'
 
@@ -101,7 +145,7 @@ jobs:
     - name: Download main docs
       uses: actions/download-artifact@v2
       with:
-        name: Documentation-${{ matrix.os }}-${{ matrix.python-version }}-x64
+        name: Documentation-head-${{ matrix.os }}-${{ matrix.python-version }}-x64
         # This overwrites files in current directory
       if: contains(github.ref, 'tags') && contains(needs.*.outputs.on_master, 'master')
 

--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     outputs:
-      on_master: ${{ steps.on_master.outputs.on_master }}
+      on_master: ${{ steps.on_master.outputs.on-branch }}
 
     steps:
     - name: Checkout sources
@@ -23,13 +23,9 @@ jobs:
 
     - name: Check if on master
       id: on_master
-      shell: bash
-      run: |
-        git branch -a --contains $GITHUB_REF
-        git describe --always --tags
-        export ON_MASTER=$(git branch -a --contains $GITHUB_REF | grep -q '^  remotes/origin/master$' && echo "master" || echo "")
-        echo "Found out: ${ON_MASTER}"
-        echo ::set-output name=on_master::$ON_MASTER
+      uses: ./.github/actions/on-branch
+      with:
+        branch: master
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2.2.2

--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -116,7 +116,7 @@ jobs:
         (github.ref == 'refs/heads/master' ||
          github.ref == 'refs/heads/devel' ||
          github.ref == 'refs/heads/docs' ||
-         (contains(github.ref, 'tags') && contains(needs.*.outputs.on_master, 'master'))
+         (startsWith(github.ref, 'refs/tags/') && contains(needs.*.outputs.on_master, 'master'))
         )
 
     steps:
@@ -147,14 +147,14 @@ jobs:
       with:
         name: Documentation-head-${{ matrix.os }}-${{ matrix.python-version }}-x64
         # This overwrites files in current directory
-      if: contains(github.ref, 'tags') && contains(needs.*.outputs.on_master, 'master')
+      if: startsWith(github.ref, 'refs/tags/') && contains(needs.*.outputs.on_master, 'master')
 
     - name: Update main docs
       shell: bash
       run: |
         # Remove '.doctrees'
         rm -rf ".doctrees"
-      if: contains(github.ref, 'tags') && contains(needs.*.outputs.on_master, 'master')
+      if: startsWith(github.ref, 'refs/tags/') && contains(needs.*.outputs.on_master, 'master')
 
     - name: Commit docs changes
       shell: bash

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -17,13 +17,9 @@ jobs:
 
     - name: Check if on master
       id: on_master
-      shell: bash
-      run: |
-        git fetch origin master --depth=100
-        git describe --always --tags
-        export ON_MASTER=$(git branch -a --contains ${{ github.ref }} | grep -q '^  remotes/origin/master$' && echo "master" || echo "")
-        echo "Found out: ${ON_MASTER}"
-        echo ::set-output name=on_master::$ON_MASTER
+      uses: ./.github/actions/on-branch
+      with:
+        branch: master
 
     - name: Check for existing release with the reference tag
       uses: actions/github-script@v4
@@ -52,7 +48,7 @@ jobs:
 
     - name: Create Release
       uses: actions/github-script@v4
-      if: steps.on_master.outputs.on_master == 'master' && steps.exist_check.outputs.exists == 'no'
+      if: steps.on_master.outputs.on-branch == 'master' && steps.exist_check.outputs.exists == 'no'
       with:
         # We need custom token since the default one doesn't trigger actions
         github-token: ${{ secrets.CREATE_RELEASE_TOKEN }}


### PR DESCRIPTION
Unify documentation testing and comparison.
Switch the comment posting workflow to use generated documentation artifacts.
The old docs-compare workflow can be removed after the modified comment posting lands in the default branch.