### PR TITLE
ci: fix missing PR number

### DIFF
--- a/.github/workflows/compare-comment.yml
+++ b/.github/workflows/compare-comment.yml
@@ -32,11 +32,14 @@ jobs:
           core.setOutput('DOCS_GEN_ENV', docsSuffix);
 
           var docsArtifacts = artifacts.data.artifacts.filter((artifact) => {
-            return artifact.name.endsWith(docsSuffix) && artifact.name.startsWith('Documentation-')
+            return (
+              (artifact.name.endsWith(docsSuffix) && artifact.name.startsWith('Documentation-'))
+              || artifact.name == 'pr_number'
+            )
           });
 
-          // check that we got exactly 2 artifacts
-          console.assert(docsArtifacts.length == 2, docsSuffix, docsArtifacts, artifacts.data.artifacts);
+          // check that we got exactly 3 artifacts
+          console.assert(docsArtifacts.length == 3, docsSuffix, docsArtifacts, artifacts.data.artifacts);
 
           var fs = require('fs');
           for (artifact of docsArtifacts) {
@@ -55,6 +58,7 @@ jobs:
       run: |
         unzip Documentation-base-*.zip -d docs-base/
         unzip Documentation-head-*.zip -d docs-head/
+        unzip pr_number.zip
 
     - name: Compare
       shell: bash
@@ -69,11 +73,12 @@ jobs:
         script: |
           var fs = require('fs');
           var text = fs.readFileSync("./result.diff").slice(0,16384);
+          var issue_number = Number(fs.readFileSync('./pr_number.txt'));
 
-          console.log('Posting diff to PR: ${{ github.event.workflow_run.pull_requests[0].number }}')
+          console.log('Posting diff to PR: ' + issue_number);
 
           github.issues.createComment({
-            issue_number: ${{ github.event.workflow_run.pull_requests[0].number }},
+            issue_number: issue_number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: 'This PR causes the following changes to the html docs (${{ steps.docs-artifacts.outputs.DOCS_GEN_ENV }}):\n```\n' + text + '\n...\n```\nSee CI logs for the full diff.'

--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -103,6 +103,18 @@ jobs:
         retention-days: 1
         path: docs/build/html
 
+    - name: Store PR number
+      if: ${{ github.event_name == 'pull_request' }}
+      run: echo ${{ github.event.pull_request.number }} > ./pr_number.txt
+
+    - name: Upload PR number for other workflows
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/upload-artifact@v2.2.4
+      with:
+          name: pr_number
+          path: ./pr_number.txt
+
+
   docs-deploy:
     strategy:
       fail-fast: false


### PR DESCRIPTION
workflows started by other workflows cannot access the PR
number of the original if the PR branch is from a fork. This causes
compare-comment to not be able to download pnl-ci-docs artifacts

See https://github.com/PrincetonUniversity/PsyNeuLink/runs/3317202966?check_suite_focus=true corresponding to #2103 