### PR TITLE
 tests/models/Predator-Prey: Use attractor/repeller forces to select the next move

### DIFF
--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -55,6 +55,7 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
         numpy_handlers = {
             'tanh': self.call_builtin_np_tanh,
             'exp': self.call_builtin_np_exp,
+            'sqrt': self.call_builtin_np_sqrt,
             'equal': get_np_cmp("=="),
             'not_equal': get_np_cmp("!="),
             'less': get_np_cmp("<"),
@@ -469,6 +470,10 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
     def call_builtin_np_exp(self, builder, x):
         x = self.get_rval(x)
         return self._do_unary_op(builder, x, lambda builder, x: helpers.exp(self.ctx, builder, x))
+
+    def call_builtin_np_sqrt(self, builder, x):
+        x = self.get_rval(x)
+        return self._do_unary_op(builder, x, lambda builder, x: helpers.sqrt(self.ctx, builder, x))
 
     def call_builtin_np_max(self, builder, x):
         # numpy max searches for the largest scalar and propagates NaNs be default.

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -136,6 +136,9 @@ def exp(ctx, builder, x):
     exp_f = ctx.get_builtin("exp", [x.type])
     return builder.call(exp_f, [x])
 
+def sqrt(ctx, builder, x):
+    sqrt_f = ctx.get_builtin("sqrt", [x.type])
+    return builder.call(sqrt_f, [x])
 
 def tanh(ctx, builder, x):
     tanh_f = ctx.get_builtin("tanh", [x.type])

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -476,6 +476,7 @@ def test_user_def_func_return(dtype, expected, func_mode, benchmark):
 @pytest.mark.parametrize("op,variable,expected", [ # parameter is string since compiled udf doesn't support closures as of present
                 ("TANH", [[1, 3]], [0.76159416, 0.99505475]),
                 ("EXP", [[1, 3]], [2.71828183, 20.08553692]),
+                ("SQRT", [[1, 3]], [1.0, 1.7320508075688772]),
                 ("SHAPE", [1, 2], [2]),
                 ("SHAPE", [[1, 3]], [1, 2]),
                 ("ASTYPE_FLOAT", [1], [1.0]),
@@ -504,6 +505,9 @@ def test_user_def_func_numpy(op, variable, expected, func_mode, benchmark):
     elif op == "EXP":
         def myFunction(variable):
             return np.exp(variable)
+    elif op == "SQRT":
+        def myFunction(variable):
+            return np.sqrt(variable)
     elif op == "SHAPE":
         def myFunction(variable):
             return variable.shape


### PR DESCRIPTION
Needs custom UDF to calculate the weighted move.
This also introduces new nodes to handle inputs, and a node to calculate the direction from real player to prey.
Add support for np.sqrt to the UDF compiler.