### PR TITLE
github-actions: Restrict main CI run to macos-10.15

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
         python-architecture: ['x64']
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-10.15, windows-latest]
         include:
           # add 32-bit build on windows
           - python-version: 3.8


### PR DESCRIPTION
Block macos-11 until
https://github.com/actions/virtual-environments/issues/4230 is fixed

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>