### PR TITLE
github-actions: Bump python-3.{8,9} to macos-latest.

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -22,8 +22,16 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
         python-architecture: ['x64']
-        os: [ubuntu-latest, macos-10.15, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          # 3.7 is broken on macos-11, https://github.com/actions/virtual-environments/issues/4230
+          - python-version: 3.7
+            os: macos-latest
         include:
+          # 3.7 is broken on macos-11, https://github.com/actions/virtual-environments/issues/4230
+          - python-version: 3.7
+            python-architecture: 'x64'
+            os: macos-10.15
           # add 32-bit build on windows
           - python-version: 3.8
             python-architecture: 'x86'


### PR DESCRIPTION
Keep python3.7 on macos-10.15.
See https://github.com/actions/virtual-environments/issues/4230 for
details.

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>