### PR TITLE
github-actions: Drop maxprocesses settings

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -80,7 +80,7 @@ jobs:
 
     - name: Test with pytest
       timeout-minutes: 80
-      run: pytest --junit-xml=tests_out.xml --verbosity=0 -n auto --maxprocesses=2
+      run: pytest --junit-xml=tests_out.xml --verbosity=0 -n auto
 
     - name: Upload test results
       uses: actions/upload-artifact@v2.2.4


### PR DESCRIPTION
all cloud hosted runners should be able to run one test worker per core.
(see
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources )
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>