### PR TITLE
github-actions: Allow RW permissions for jobs updating the online docs

### DIFF
--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -122,6 +122,8 @@ jobs:
         python-version: [3.7]
         os: [ubuntu-latest]
 
+    permissions:
+      contents: write
     runs-on: ${{ matrix.os }}
     needs: [docs-build]
     if: github.event_name == 'push' &&


### PR DESCRIPTION
Per [0] this should also work with dependabot triggered runs on devel.
Closes: https://github.com/PrincetonUniversity/PsyNeuLink/issues/2144

Tested by setting default GITHUB_TOKEN permissions to RO at repo scope.

[0] https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>