### PR TITLE
github-actions/comment: Add PR write permission and use github.rest.* for rest API

### DIFF
--- a/.github/workflows/compare-comment.yml
+++ b/.github/workflows/compare-comment.yml
@@ -11,15 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' &&
         github.event.workflow_run.conclusion == 'success'
+    permissions:
+      actions: read
+      pull-requests: write
 
     steps:
-
     - name: 'Download docs artifacts'
       id: docs-artifacts
       uses: actions/github-script@v5
       with:
         script: |
-          var artifacts = await github.actions.listWorkflowRunArtifacts({
+          var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
              owner: context.repo.owner,
              repo: context.repo.repo,
              run_id: ${{ github.event.workflow_run.id }},
@@ -44,7 +46,7 @@ jobs:
           var fs = require('fs');
           for (artifact of docsArtifacts) {
             console.log('Downloading: ' + artifact.name);
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: artifact.id,
@@ -77,7 +79,7 @@ jobs:
 
           console.log('Posting diff to PR: ' + issue_number);
 
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: issue_number,
             owner: context.repo.owner,
             repo: context.repo.repo,


### PR DESCRIPTION
Follow up to 01f710683a7ff6c163fe990700666af047bf9473
("github-actions/release: rest API methods were moved to github.rest.*")
Fixes: 35cf6ecc792f0dd4bb024510b37b3ff825560ab0 ("github-actions(deps):
bump actions/github-script from 4.1 to 5 (#2125)")

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>