### PR TITLE
llvm, ports/ControlSignal: Add support for CostFunctions.NONE

### DIFF
--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1373,6 +1373,11 @@ class OptimizationControlMechanism(ControlMechanism):
                                                       ctx.int32_ty(i)])
             data_out = builder.gep(op_in, [ctx.int32_ty(0), ctx.int32_ty(0),
                                            ctx.int32_ty(0)])
+            if data_in.type != data_out.type:
+                warnings.warn("Shape mismatch: Allocation sample '{}' ({}) doesn't match input port input ({}).".format(i, self.parameters.control_allocation_search_space.get(), op.defaults.variable))
+                assert len(data_out.type.pointee) == 1
+                data_out = builder.gep(data_out, [ctx.int32_ty(0), ctx.int32_ty(0)])
+
             builder.store(builder.load(data_in), data_out)
 
             # Invoke cost function

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1497,11 +1497,21 @@ class OptimizationControlMechanism(ControlMechanism):
         # Construct input
         comp_input = builder.alloca(sim_f.args[3].type.pointee, name="sim_input")
 
+        input_initialized = [False] * len(comp_input.type.pointee)
         for src_idx, ip in enumerate(self.input_ports):
             if ip.shadow_inputs is None:
                 continue
+
+            # shadow inputs point to an input port of of a node.
+            # If that node takes direct input, it will have an associated
+            # (input_port, output_port) in the input_CIM.
+            # Take the former as an index to composition input variable.
             cim_in_port = self.agent_rep.input_CIM_ports[ip.shadow_inputs][0]
             dst_idx = self.agent_rep.input_CIM.input_ports.index(cim_in_port)
+
+            # Check that all inputs are unique
+            assert not input_initialized[dst_idx], "Double initialization of input {}".format(dst_idx)
+            input_initialized[dst_idx] = True
 
             src = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(src_idx)])
             # Destination is a struct of 2d arrays
@@ -1509,6 +1519,10 @@ class OptimizationControlMechanism(ControlMechanism):
                                            ctx.int32_ty(dst_idx),
                                            ctx.int32_ty(0)])
             builder.store(builder.load(src), dst)
+
+        # Assert that we have populated all inputs
+        assert all(input_initialized), \
+          "Not all inputs to the simulated composition are initialized: {}".format(input_initialized)
 
 
         # FIX: 11/3/21 ??REFACTOR EITHER:

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -1052,15 +1052,15 @@ class TestControlMechanisms:
     @pytest.mark.control
     @pytest.mark.composition
     @pytest.mark.parametrize("cost, expected, exp_values", [
-        (pnl.CostFunctions.NONE, 7.0, [1, 2, 3, 4, 5]),
-        (pnl.CostFunctions.INTENSITY, 3, [-1.71828183, -5.3890561, -17.08553692, -50.59815003, -143.4131591]),
-        (pnl.CostFunctions.ADJUSTMENT, 3, [1, 1, 1, 1, 1] ),
-        (pnl.CostFunctions.INTENSITY | pnl.CostFunctions.ADJUSTMENT, 3, [-1.71828183, -6.3890561, -19.08553692, -53.59815003, -147.4131591]),
-        (pnl.CostFunctions.DURATION, 3, [-19, -22., -25., -28., -31]),
+        (pnl.CostFunctions.NONE, 7.0, [3, 4, 5, 6, 7]),
+        (pnl.CostFunctions.INTENSITY, 3, [0.2817181715409549, -3.3890560989306495, -15.085536923187664, -48.59815003314423, -141.41315910257657]),
+        (pnl.CostFunctions.ADJUSTMENT, 3, [3, 3, 3, 3, 3] ),
+        (pnl.CostFunctions.INTENSITY | pnl.CostFunctions.ADJUSTMENT, 3, [0.2817181715409549, -4.389056098930649, -17.085536923187664, -51.59815003314423, -145.41315910257657]),
+        (pnl.CostFunctions.DURATION, 3, [-17, -20, -23, -26, -29]),
         # FIXME: combinations with DURATION are broken
         # (pnl.CostFunctions.DURATION | pnl.CostFunctions.ADJUSTMENT, ,),
         # (pnl.CostFunctions.ALL, ,),
-        pytest.param(pnl.CostFunctions.DEFAULTS, 7, [1, 2, 3, 4, 5], id="CostFunctions.DEFAULT")],
+        pytest.param(pnl.CostFunctions.DEFAULTS, 7, [3, 4, 5, 6, 7], id="CostFunctions.DEFAULT")],
         ids=lambda x: x if isinstance(x, pnl.CostFunctions) else "")
     def test_modulation_simple(self, cost, expected, exp_values):
         obj = pnl.ObjectiveMechanism()
@@ -1073,6 +1073,7 @@ class TestControlMechanisms:
         comp.add_controller(
             pnl.OptimizationControlMechanism(
                 objective_mechanism=obj,
+                state_features=[mech.input_port],
                 control_signals=pnl.ControlSignal(
                     modulates=('intercept', mech),
                     modulation=pnl.OVERRIDE,
@@ -1162,6 +1163,7 @@ class TestControlMechanisms:
 
         comp.add_controller(
             pnl.OptimizationControlMechanism(
+                state_features=[mech.input_port],
                 objective_mechanism=obj,
                 control_signals=pnl.ControlSignal(
                     modulates=('seed', mech),


### PR DESCRIPTION
Add necessary shape workarounds to support compiled CostFunctions.NONE.
Fix and enable tests.
Add extra check for simulation input construction.