### PR TITLE
tests/predator-prey: Mark the 101 level test instance as 'stress' test

### DIFF
--- a/tests/models/test_greedy_agent.py
+++ b/tests/models/test_greedy_agent.py
@@ -116,7 +116,7 @@ def test_simplified_greedy_agent_random(benchmark, comp_mode):
 @pytest.mark.parametrize("samples", [[0,10],
     pytest.param([0,3,6,10], marks=pytest.mark.stress),
     pytest.param([0,2,4,6,8,10], marks=pytest.mark.stress),
-    pytest.param([a / 10.0 for a in range(0, 101)]),
+    pytest.param([a / 10.0 for a in range(0, 101)], marks=pytest.mark.stress),
 ], ids=lambda x: len(x))
 @pytest.mark.parametrize('prng', ['Default', 'Philox'])
 def test_predator_prey(benchmark, mode, prng, samples):


### PR DESCRIPTION
No reason to run this variant in regular testing.

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>