### PR TITLE
pnl-ci: build docs-only branches

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -10,9 +10,6 @@ on:
     tags-ignore:
       - 'v**'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'doc_requirements.txt'
 
 jobs:
   build:


### PR DESCRIPTION
now that jenkins builds are not produced and the required status is on
actions, we need actions to build these