### PR TITLE
llvm: Cleanup execution of compiled functions

### DIFF
--- a/psyneulink/core/llvm/debug.py
+++ b/psyneulink/core/llvm/debug.py
@@ -33,7 +33,6 @@ Compilation modifiers:
                   instead of loading them from the param argument
  * "const_state" -- hardcode base context values into generate code,
                  instead of laoding them from the context argument
- * "no_ref_pass" -- Don't pass arguments to llvm functions by reference
 
 Compiled code dump:
  * "llvm" -- dumps LLVM IR into a file (named after the dumped module).

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -18,6 +18,7 @@ import numpy as np
 from inspect import isgenerator
 import os
 import sys
+import time
 
 
 from psyneulink.core import llvm as pnlvm
@@ -75,11 +76,22 @@ class Execution:
             init_f = getattr(self._obj, init_method)
             if len(self._execution_contexts) > 1:
                 struct_ty = struct_ty * len(self._execution_contexts)
+                init_start = time.time()
                 initializer = (init_f(ex) for ex in self._execution_contexts)
             else:
+                init_start = time.time()
                 initializer = init_f(self._execution_contexts[0])
 
+            init_end = time.time()
             struct = struct_ty(*initializer)
+            struct_end = time.time()
+
+
+            if "time_stat" in self._debug_env:
+                print("Time to get initializer for struct:", name,
+                      "for", self._obj.name, ":", init_end - init_start)
+                print("Time to instantiate struct:", name,
+                      "for", self._obj.name, ":", struct_end - init_end)
             setattr(self, name, struct)
             if "stat" in self._debug_env:
                 print("Instantiated struct:", name, "( size:" ,

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -69,7 +69,7 @@ class Execution:
         self._debug_env = debug_env
 
     def _get_compilation_param(self, name, init_method, arg):
-        struct = getattr(self, name)
+        struct = getattr(self, name, None)
         if struct is None:
             struct_ty = self._bin_func.byref_arg_types[arg]
             init_f = getattr(self._obj, init_method)
@@ -188,9 +188,6 @@ class FuncExecution(CUDAExecution):
         ]
         self._component = component
 
-        self._param = None
-        self._state = None
-
         par_struct_ty, ctx_struct_ty, vi_ty, vo_ty = self._bin_func.byref_arg_types
 
         if len(execution_ids) > 1:
@@ -271,9 +268,6 @@ class CompExecution(CUDAExecution):
         self.__tags = frozenset(additional_tags)
 
         self.__conds = None
-        self._state = None
-        self._param = None
-        self._data = None
 
         if len(execution_ids) > 1:
             self._ct_len = ctypes.c_int(len(execution_ids))


### PR DESCRIPTION
Allow arbitrary attribute names for caching binary structures.
Report time to generate binary functions.
