### PR TITLE
setup/coverage: Correct option name multiprocess -> multiprocessing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ match-dir = (?!Script)(?!bin)(?!docs).*
 
 [coverage:run]
 branch = True
-concurrency = multiprocess
+concurrency = multiprocessing
 source = psyneulink/
 
 [coverage:report]


### PR DESCRIPTION
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>