### PR TITLE
Component: _initialize_parameters: always ensure None context set

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1157,6 +1157,14 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             self.defaults.variable = copy.deepcopy(default_variable)
             self.parameters.variable._user_specified = True
 
+        self.parameters.variable._set(
+            copy_parameter_value(default_variable),
+            context=context,
+            skip_log=True,
+            skip_history=True,
+            override=True
+        )
+
         # ASSIGN PREFS
         _assign_prefs(self, prefs, BasePreferenceSet)
 
@@ -2050,7 +2058,10 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             p.spec = copy_parameter_value(p.spec)
 
             # set default to None context to ensure it exists
-            if p.getter is None and p._get(context) is None:
+            if (
+                p._get(context) is None and p.getter is None
+                or context.execution_id not in p.values
+            ):
                 if p._user_specified:
                     val = param_defaults[p.name]
 

--- a/psyneulink/core/components/functions/nonstateful/learningfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/learningfunctions.py
@@ -1393,15 +1393,24 @@ class ContrastiveHebbian(LearningFunction):  # ---------------------------------
 
 
 def _activation_input_getter(owning_component=None, context=None):
-    return owning_component.parameters.variable._get(context)[LEARNING_ACTIVATION_INPUT]
+    try:
+        return owning_component.parameters.variable._get(context)[LEARNING_ACTIVATION_INPUT]
+    except (AttributeError, TypeError):
+        return None
 
 
 def _activation_output_getter(owning_component=None, context=None):
-    return owning_component.parameters.variable._get(context)[LEARNING_ACTIVATION_OUTPUT]
+    try:
+        return owning_component.parameters.variable._get(context)[LEARNING_ACTIVATION_OUTPUT]
+    except (AttributeError, TypeError):
+        return None
 
 
 def _error_signal_getter(owning_component=None, context=None):
-    return owning_component.parameters.variable._get(context)[LEARNING_ERROR_OUTPUT]
+    try:
+        return owning_component.parameters.variable._get(context)[LEARNING_ERROR_OUTPUT]
+    except (AttributeError, TypeError):
+        return None
 
 
 

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -1136,7 +1136,7 @@ class MechParamsDict(UserDict):
 def _input_port_variables_getter(owning_component=None, context=None):
     try:
         return [input_port.parameters.variable._get(context) for input_port in owning_component.input_ports]
-    except TypeError:
+    except (AttributeError, TypeError):
         return None
 
 

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -712,7 +712,7 @@ def _outcome_getter(owning_component=None, context=None):
     """Return array of values of outcome_input_ports"""
     try:
         return np.array([port.parameters.value._get(context) for port in owning_component.outcome_input_ports])
-    except TypeError:
+    except (AttributeError, TypeError):
         return None
 
 def _net_outcome_getter(owning_component=None, context=None):

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -880,7 +880,7 @@ class OptimizationControlMechanismError(Exception):
 
 def _control_allocation_search_space_getter(owning_component=None, context=None):
     search_space = owning_component.parameters.search_space._get(context)
-    if not search_space:
+    if search_space is None:
         return [c.parameters.allocation_samples._get(context) for c in owning_component.control_signals]
     else:
         return search_space
@@ -1290,7 +1290,12 @@ class OptimizationControlMechanism(ControlMechanism):
         num_trials_per_estimate = None
 
         # search_space = None
-        control_allocation_search_space = Parameter(None, read_only=True, getter=_control_allocation_search_space_getter)
+        control_allocation_search_space = Parameter(
+            None,
+            read_only=True,
+            getter=_control_allocation_search_space_getter,
+            dependencies='search_space'
+        )
 
         saved_samples = None
         saved_values = None

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -393,6 +393,9 @@ class ContrastiveHebbianError(Exception):
 
 def _CHM_output_activity_getter(owning_component=None, context=None):
     current_activity = owning_component.parameters.current_activity._get(context)
+    if current_activity is None:
+        return None
+
     if owning_component.target_size:
         return current_activity[owning_component.target_start:owning_component.target_end]
     else:
@@ -400,18 +403,27 @@ def _CHM_output_activity_getter(owning_component=None, context=None):
 
 def _CHM_input_activity_getter(owning_component=None, context=None):
     current_activity = owning_component.parameters.current_activity._get(context)
+    if current_activity is None:
+        return None
+
     return current_activity[:owning_component.input_size]
 
 
 def _CHM_hidden_activity_getter(owning_component=None, context=None):
     if owning_component.hidden_size:
         current_activity = owning_component.parameters.current_activity._get(context)
+        if current_activity is None:
+            return None
+
         return current_activity[owning_component.input_size:owning_component.target_start]
 
 
 def _CHM_target_activity_getter(owning_component=None, context=None):
     if owning_component.target_size:
         current_activity = owning_component.parameters.current_activity._get(context)
+        if current_activity is None:
+            return None
+
         return current_activity[owning_component.target_start:owning_component.target_end]
 
 
@@ -937,10 +949,10 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
         )
         max_passes = Parameter(1000, stateful=False)
 
-        output_activity = Parameter(None, read_only=True, getter=_CHM_output_activity_getter)
-        input_activity = Parameter(None, read_only=True, getter=_CHM_input_activity_getter)
-        hidden_activity = Parameter(None, read_only=True, getter=_CHM_hidden_activity_getter)
-        target_activity = Parameter(None, read_only=True, getter=_CHM_target_activity_getter)
+        output_activity = Parameter(None, read_only=True, getter=_CHM_output_activity_getter, dependencies='current_activity')
+        input_activity = Parameter(None, read_only=True, getter=_CHM_input_activity_getter, dependencies='current_activity')
+        hidden_activity = Parameter(None, read_only=True, getter=_CHM_hidden_activity_getter, dependencies='current_activity')
+        target_activity = Parameter(None, read_only=True, getter=_CHM_target_activity_getter, dependencies='current_activity')
 
         execution_phase = Parameter(None, read_only=True)
         # is_finished_ = Parameter(False, read_only=True)


### PR DESCRIPTION
parameters with getters would not be called during initialization due to
condition order, and as a result values would not be populated.

Component: set variable to default when determined in init