### PR TITLE
functions: noise properties based on numeric or function

### DIFF
--- a/psyneulink/core/components/functions/nonstateful/distributionfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/distributionfunctions.py
@@ -30,7 +30,7 @@ import typecheck as tc
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.functions.function import (
     DEFAULT_SEED, Function_Base, FunctionError,
-    _random_state_getter, _seed_setter,
+    _random_state_getter, _seed_setter, _noise_setter
 )
 from psyneulink.core.globals.keywords import \
     ADDITIVE_PARAM, DIST_FUNCTION_TYPE, BETA, DIST_MEAN, DIST_SHAPE, DRIFT_DIFFUSION_ANALYTICAL_FUNCTION, \
@@ -1100,7 +1100,7 @@ class DriftDiffusionAnalytical(DistributionFunction):  # -----------------------
         drift_rate = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
         starting_point = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
         threshold = Parameter(1.0, modulable=True)
-        noise = Parameter(0.5, modulable=True)
+        noise = Parameter(0.5, modulable=True, setter=_noise_setter)
         t0 = Parameter(.200, modulable=True)
         bias = Parameter(0.5, read_only=True, getter=_DriftDiffusionAnalytical_bias_getter)
         # this is read only because conversion is disabled for this function

--- a/psyneulink/core/components/functions/stateful/integratorfunctions.py
+++ b/psyneulink/core/components/functions/stateful/integratorfunctions.py
@@ -36,7 +36,7 @@ from psyneulink.core.components.component import DefaultsFlexibility
 from psyneulink.core.components.functions.nonstateful.distributionfunctions import DistributionFunction
 from psyneulink.core.components.functions.function import (
     DEFAULT_SEED, FunctionError, _random_state_getter,
-    _seed_setter,
+    _seed_setter, _noise_setter
 )
 from psyneulink.core.components.functions.stateful.statefulfunction import StatefulFunction
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
@@ -214,7 +214,9 @@ class IntegratorFunction(StatefulFunction):  # ---------------------------------
                     :type: ``float``
         """
         rate = Parameter(1.0, modulable=True, function_arg=True)
-        noise = Parameter(0.0, modulable=True, function_arg=True)
+        noise = Parameter(
+            0.0, modulable=True, function_arg=True, setter=_noise_setter
+        )
         previous_value = Parameter(np.array([0]), initializer='initializer', pnl_internal=True)
         initializer = Parameter(np.array([0]), pnl_internal=True)
 

--- a/psyneulink/core/components/functions/stateful/memoryfunctions.py
+++ b/psyneulink/core/components/functions/stateful/memoryfunctions.py
@@ -35,7 +35,7 @@ import typecheck as tc
 
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.functions.function import (
-    DEFAULT_SEED, FunctionError, _random_state_getter, _seed_setter, is_function_type, EPSILON,
+    DEFAULT_SEED, FunctionError, _random_state_getter, _seed_setter, is_function_type, EPSILON, _noise_setter
 )
 from psyneulink.core.components.functions.nonstateful.objectivefunctions import Distance
 from psyneulink.core.components.functions.nonstateful.selectionfunctions import OneHot
@@ -201,7 +201,9 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
         """
         variable = Parameter([], pnl_internal=True, constructor_argument='default_variable')
         rate = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
-        noise = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
+        noise = Parameter(
+            0.0, modulable=True, aliases=[ADDITIVE_PARAM], setter=_noise_setter
+        )
         history = None
         initializer = Parameter(np.array([]), pnl_internal=True)
 
@@ -1091,7 +1093,9 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         duplicate_threshold = Parameter(EPSILON, stateful=False, modulable=True)
         equidistant_entries_select = Parameter(RANDOM)
         rate = Parameter(1.0, modulable=True)
-        noise = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
+        noise = Parameter(
+            0.0, modulable=True, aliases=[ADDITIVE_PARAM], setter=_noise_setter
+        )
         max_entries = Parameter(1000)
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
         seed = Parameter(DEFAULT_SEED, modulable=True, fallback_default=True, setter=_seed_setter)
@@ -2151,7 +2155,9 @@ class DictionaryMemory(MemoryFunction):  # -------------------------------------
         duplicate_keys = Parameter(False)
         equidistant_keys_select = Parameter(RANDOM)
         rate = Parameter(1.0, modulable=True)
-        noise = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
+        noise = Parameter(
+            0.0, modulable=True, aliases=[ADDITIVE_PARAM], setter=_noise_setter
+        )
         max_entries = Parameter(1000)
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
         seed = Parameter(DEFAULT_SEED, modulable=True, fallback_default=True, setter=_seed_setter)

--- a/psyneulink/core/components/functions/stateful/statefulfunction.py
+++ b/psyneulink/core/components/functions/stateful/statefulfunction.py
@@ -27,7 +27,7 @@ import typecheck as tc
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.component import DefaultsFlexibility, _has_initializers_setter, ComponentsMeta
 from psyneulink.core.components.functions.nonstateful.distributionfunctions import DistributionFunction
-from psyneulink.core.components.functions.function import Function_Base, FunctionError
+from psyneulink.core.components.functions.function import Function_Base, FunctionError, _noise_setter
 from psyneulink.core.globals.context import handle_external_context
 from psyneulink.core.globals.keywords import STATEFUL_FUNCTION_TYPE, STATEFUL_FUNCTION, NOISE, RATE
 from psyneulink.core.globals.parameters import Parameter
@@ -146,6 +146,12 @@ class StatefulFunction(Function_Base): #  --------------------------------------
             output, or a list or array of either of these, then noise is simply an offset that remains the same
             across all executions.
 
+        .. note::
+            A ParameterPort for noise will only be generated, and the
+            noise Parameter itself will only be stateful, if the value
+            of noise is entirely numeric (contains no functions) at the
+            time of Mechanism construction.
+
     owner : Component
         `component <Component>` to which the Function has been assigned.
 
@@ -191,7 +197,7 @@ class StatefulFunction(Function_Base): #  --------------------------------------
                     :default value: 1.0
                     :type: ``float``
         """
-        noise = Parameter(0.0, modulable=True)
+        noise = Parameter(0.0, modulable=True, setter=_noise_setter)
         rate = Parameter(1.0, modulable=True)
         previous_value = Parameter(np.array([0]), initializer='initializer', pnl_internal=True)
         initializer = Parameter(np.array([0]), pnl_internal=True)

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -1379,9 +1379,15 @@ class ContentAddressableList(UserList):
 
 
 def is_value_spec(spec):
+    from psyneulink.core.components.component import Component
+
     if isinstance(spec, (numbers.Number, np.ndarray)):
         return True
-    elif isinstance(spec, list) and is_numeric(spec):
+    elif (
+        isinstance(spec, list)
+        and is_numeric(spec)
+        and not contains_type(spec, (Component, types.FunctionType))
+    ):
         return True
     else:
         return False

--- a/tests/mechanisms/test_mechanisms.py
+++ b/tests/mechanisms/test_mechanisms.py
@@ -45,7 +45,7 @@ class TestMechanism:
         'noise',
         [pnl.GaussianDistort, pnl.NormalDist]
     )
-    def test_noise_variations(self, noise):
+    def test_noise_assignment_equivalence(self, noise):
         t1 = pnl.TransferMechanism(name='t1', size=2, noise=noise())
         t2 = pnl.TransferMechanism(name='t2', size=2)
         t2.integrator_function.parameters.noise.set(noise())
@@ -55,6 +55,80 @@ class TestMechanism:
 
         for _ in range(5):
             np.testing.assert_equal(t1.execute([1, 1]), t2.execute([1, 1]))
+
+    @pytest.mark.parametrize(
+        'noise, included_parameter_ports, excluded_parameter_ports, noise_statefulness',
+        [
+            (0, ['noise'], ['seed'], True),
+            ([0], ['noise'], ['seed'], True),
+            ([0, 0], ['noise'], ['seed'], True),
+            ([0, pnl.NormalDist()], [], ['noise', 'seed'], False),
+            (pnl.NormalDist, ['seed'], ['noise'], False),
+            ([pnl.NormalDist(), pnl.NormalDist()], [], ['noise', 'seed'], False),
+        ]
+    )
+    def test_numeric_noise_specifications(
+        self,
+        noise,
+        included_parameter_ports,
+        excluded_parameter_ports,
+        noise_statefulness
+    ):
+        try:
+            size = len(noise)
+        except TypeError:
+            size = 1
+
+        t = pnl.TransferMechanism(size=size, noise=noise)
+
+        assert all(p in t.parameter_ports for p in included_parameter_ports)
+        assert all(p not in t.parameter_ports for p in excluded_parameter_ports)
+
+        assert t.parameters.noise.stateful is noise_statefulness
+
+    @pytest.mark.parametrize(
+        'noise',
+        [
+            [0, pnl.NormalDist()],
+            pnl.NormalDist,
+            [pnl.NormalDist(), pnl.NormalDist()]
+        ]
+    )
+    def test_noise_change_warning_to_numeric(self, noise):
+        try:
+            size = len(noise)
+        except TypeError:
+            size = 1
+
+        t = pnl.TransferMechanism(size=size, noise=noise)
+
+        with pytest.warns(
+            UserWarning,
+            match='Setting noise to a numeric value after instantiation.*'
+        ):
+            t.parameters.noise.set(0)
+
+    @pytest.mark.parametrize(
+        'noise',
+        [
+            0,
+            [0],
+            [0, 0],
+        ]
+    )
+    def test_noise_change_warning_to_function(self, noise):
+        try:
+            size = len(noise)
+        except TypeError:
+            size = 1
+
+        t = pnl.TransferMechanism(size=size, noise=noise)
+
+        with pytest.warns(
+            UserWarning,
+            match='Setting noise to a value containing functions after instantiation.*'
+        ):
+            t.parameters.noise.set(pnl.NormalDist)
 
 
 class TestMechanismFunctionParameters:


### PR DESCRIPTION
Noise values are either numeric or contain functions. A ParameterPort is generated for noise only when the noise value is numeric at the time of mechanism construction. These changes make the noise parameter stateless when it contains functions and warn the user that the previously mentioned properties will not change if the user changes the value of noise after function construction.