### PR TITLE
OCM: improve simulation context setup

### DIFF
--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1930,9 +1930,18 @@ class OptimizationControlMechanism(ControlMechanism):
 
         # freeze the values of current context, because they can be changed in between simulations,
         # and the simulations must start from the exact spot
-        self.agent_rep._initialize_from_context(self._get_frozen_context(context),
-                                                base_context=context,
-                                                override=True)
+        frozen_context = self._get_frozen_context(context)
+
+        alt_controller = None
+        if self.agent_rep.controller is None:
+            try:
+                alt_controller = context.composition.controller
+            except AttributeError:
+                pass
+
+        self.agent_rep._initialize_as_agent_rep(
+            frozen_context, base_context=context, alt_controller=alt_controller
+        )
 
         # Get control_allocation that optimizes net_outcome using OptimizationControlMechanism's function
         # IMPLEMENTATION NOTE: skip ControlMechanism._execute since it is a stub method that returns input_values
@@ -1945,7 +1954,7 @@ class OptimizationControlMechanism(ControlMechanism):
                                                 )
 
         # clean up frozen values after execution
-        self.agent_rep._delete_contexts(self._get_frozen_context(context))
+        self.agent_rep._clean_up_as_agent_rep(frozen_context, alt_controller=alt_controller)
 
         optimal_control_allocation = np.array(optimal_control_allocation).reshape((len(self.defaults.value), 1))
         if self.function.save_samples:
@@ -1959,7 +1968,12 @@ class OptimizationControlMechanism(ControlMechanism):
     def _get_frozen_context(self, context=None):
         return Context(execution_id=f'{context.execution_id}{EID_FROZEN}')
 
-    def _set_up_simulation(self, base_context=Context(execution_id=None), control_allocation=None):
+    def _set_up_simulation(
+        self,
+        base_context=Context(execution_id=None),
+        control_allocation=None,
+        alt_controller=None
+    ):
         sim_context = copy.copy(base_context)
         sim_context.execution_id = self.get_next_sim_id(base_context, control_allocation)
 
@@ -1968,13 +1982,17 @@ class OptimizationControlMechanism(ControlMechanism):
         except AttributeError:
             self.parameters.simulation_ids._set([sim_context.execution_id], base_context)
 
-        self.agent_rep._initialize_from_context(sim_context, self._get_frozen_context(base_context), override=False)
+        self.agent_rep._initialize_as_agent_rep(
+            sim_context,
+            base_context=self._get_frozen_context(base_context),
+            alt_controller=alt_controller
+        )
 
         return sim_context
 
-    def _tear_down_simulation(self, sim_context=None):
+    def _tear_down_simulation(self, sim_context, alt_controller=None):
         if not self.agent_rep.parameters.retain_old_simulation_data._get():
-            self.agent_rep._delete_contexts(sim_context, check_simulation_storage=True)
+            self.agent_rep._clean_up_as_agent_rep(sim_context, alt_controller=alt_controller)
 
     def evaluate_agent_rep(self, control_allocation, context=None, return_results=False):
         """Call `evaluate <Composition.evaluate>` method of `agent_rep <OptimizationControlMechanism.agent_rep>`
@@ -2008,11 +2026,17 @@ class OptimizationControlMechanism(ControlMechanism):
 
         # agent_rep is a Composition (since runs_simulations = True)
         if self.agent_rep.runs_simulations:
+            alt_controller = None
+            if self.agent_rep.controller is None:
+                try:
+                    alt_controller = context.composition.controller
+                except AttributeError:
+                    pass
             # KDM 5/20/19: crudely using default here because it is a stateless parameter
             # and there is a bug in setting parameter values on init, see TODO note above
             # call to self._instantiate_defaults around component.py:1115
             if self.defaults.search_statefulness:
-                new_context = self._set_up_simulation(context, control_allocation)
+                new_context = self._set_up_simulation(context, control_allocation, alt_controller)
             else:
                 new_context = context
 
@@ -2031,7 +2055,7 @@ class OptimizationControlMechanism(ControlMechanism):
                                               return_results=return_results)
             context.composition = old_composition
             if self.defaults.search_statefulness:
-                self._tear_down_simulation(new_context)
+                self._tear_down_simulation(new_context, alt_controller)
 
             # FIX: THIS SHOULD BE REFACTORED TO BE HANDLED THE SAME AS A Composition AS agent_rep
             # If results of the simulation should be returned then, do so. agent_rep's evaluate method will

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -10895,6 +10895,27 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             except AttributeError:
                 self.scheduler._delete_counts(c)
 
+    def _initialize_as_agent_rep(self, context, base_context, alt_controller=None):
+        assert self.controller is None or alt_controller is None
+
+        _initialized = set()  # avoid reinitializing shared dependencies below
+        self._initialize_from_context(
+            context, base_context=base_context, override=True, visited=_initialized
+        )
+        if alt_controller is not None:
+            # evaluation will be done with a controller from another composition
+            alt_controller._initialize_from_context(
+                context, base_context=base_context, override=True, visited=_initialized
+            )
+
+    def _clean_up_as_agent_rep(self, context, alt_controller=None):
+        _deleted = set()  # avoid traversing shared dependencies below
+        self._delete_contexts(context, visited=_deleted, check_simulation_storage=True)
+        if alt_controller is not None:
+            alt_controller._delete_contexts(
+                context, visited=_deleted, check_simulation_storage=True
+            )
+
     # endregion EXECUTION
 
     # ******************************************************************************************************************


### PR DESCRIPTION
- initialize context for when an agent_rep uses a controller other than
its self.controller
	(ex. test_nested_composition_as_agent_rep)

- add Composition._initialize_as_agent_rep and
Composition._clean_up_as_agent_rep