### PR TITLE
llvm, functions/OneHot: MAX_ABS_VAL should return absolute value of the greatest magnitude

### DIFF
--- a/psyneulink/core/components/functions/nonstateful/selectionfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/selectionfunctions.py
@@ -288,7 +288,7 @@ class OneHot(SelectionFunction):
                 cmp_op = ">="
                 cmp_prev = b1.call(fabs, [prev])
                 cmp_curr = b1.call(fabs, [current])
-                val = current
+                val = b1.call(fabs, [current])
             elif self.mode == MAX_INDICATOR:
                 cmp_op = ">="
                 cmp_prev = prev

--- a/tests/functions/test_selection.py
+++ b/tests/functions/test_selection.py
@@ -19,6 +19,7 @@ test_philox /= sum(test_philox)
 test_data = [
     (Functions.OneHot, test_var, {'mode':kw.MAX_VAL}, [0., 0., 0., 0., 0., 0., 0., 0., 0.92732552, 0.]),
     (Functions.OneHot, test_var, {'mode':kw.MAX_ABS_VAL}, [0., 0., 0., 0., 0., 0., 0., 0., 0.92732552, 0.]),
+    (Functions.OneHot, -test_var, {'mode':kw.MAX_ABS_VAL}, [0., 0., 0., 0., 0., 0., 0., 0., 0.92732552, 0.]),
     (Functions.OneHot, test_var, {'mode':kw.MAX_INDICATOR}, [0., 0., 0., 0., 0., 0., 0., 0., 1., 0.]),
     (Functions.OneHot, test_var, {'mode':kw.MAX_ABS_INDICATOR}, [0., 0., 0., 0., 0., 0., 0., 0., 1., 0.]),
     (Functions.OneHot, test_var, {'mode':kw.MIN_VAL}, [0., 0., 0., 0., 0., 0., 0., 0., 0., -0.23311696]),
@@ -35,6 +36,7 @@ test_data = [
 names = [
     "OneHot MAX_VAL",
     "OneHot MAX_ABS_VAL",
+    "OneHot MAX_ABS_VAL_NEG",
     "OneHot MAX_INDICATOR",
     "OneHot MAX_ABS_INDICATOR",
     "OneHot MIN_VAL",

--- a/tests/mechanisms/test_processing_mechanism.py
+++ b/tests/mechanisms/test_processing_mechanism.py
@@ -246,6 +246,7 @@ class TestProcessingMechanismStandardOutputPorts:
     @pytest.mark.parametrize("op, expected", [(MAX_ONE_HOT, [0, 2, 0]),
                                               (MAX_INDICATOR, [0, 1, 0]),
                                               (MAX_ABS_INDICATOR, [0, 0, 1]),
+                                              (MAX_ABS_ONE_HOT, [0, 0, 4]),
                                               (MAX_VAL, [2]),
                                              ],
                              ids=lambda x: x if isinstance(x, str) else "")
@@ -264,7 +265,6 @@ class TestProcessingMechanismStandardOutputPorts:
                                               (STANDARD_DEVIATION, [1.24721913]),
                                               (VARIANCE, [1.55555556]),
                                               (MAX_ABS_VAL, [4]),
-                                              (MAX_ABS_ONE_HOT, [0, 0, 4]),
                                               (PROB, [0, 2, 0]),
                                              ],
                              ids=lambda x: x if isinstance(x, str) else "")


### PR DESCRIPTION
Enable compiled test of MAX_ABS_ONE_HOT output port. (#1780)

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>