### PR TITLE
llvm: Cleanup

### DIFF
--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2284,12 +2284,12 @@ class Port_Base(Port):
         return pnlvm.ir.LiteralStructType(input_types)
 
     def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:frozenset):
-        state_f = ctx.import_llvm_function(self.function)
+        port_f = ctx.import_llvm_function(self.function)
 
         # Create a local copy of the function parameters
         base_params = pnlvm.helpers.get_param_ptr(builder, self, params,
                                                   "function")
-        f_params = builder.alloca(state_f.args[0].type.pointee)
+        f_params = builder.alloca(port_f.args[0].type.pointee)
         builder.store(builder.load(base_params), f_params)
 
         # FIXME: Handle and combine multiple afferents
@@ -2338,13 +2338,13 @@ class Port_Base(Port):
                 builder.store(param_val, f_mod_param_ptr)
 
         # OutputPort returns 1D array even for scalar functions
-        if arg_out.type != state_f.args[3].type:
+        if arg_out.type != port_f.args[3].type:
             assert len(arg_out.type.pointee) == 1
             arg_out = builder.gep(arg_out, [ctx.int32_ty(0), ctx.int32_ty(0)])
         # Extract the data part of input
         f_input = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(0)])
         f_state = pnlvm.helpers.get_state_ptr(builder, self, state, "function")
-        builder.call(state_f, [f_params, f_state, f_input, arg_out])
+        builder.call(port_f, [f_params, f_state, f_input, arg_out])
         return builder
 
     @staticmethod

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -354,8 +354,6 @@ class LLVMBuilderContext:
                 return ir.LiteralStructType(self.get_param_struct_type(x) for x in val)
             elif p.name == 'matrix':   # Flatten matrix
                 val = np.asfarray(val).flatten()
-            elif p.name == NUM_ESTIMATES:  # Should always be int
-                val = np.int32(0) if val is None else np.int32(val)
             elif p.name == 'num_trials_per_estimate':  # Should always be int
                 val = np.int32(0) if val is None else np.int32(val)
             elif np.ndim(val) == 0 and component._is_param_modulated(p):

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -179,15 +179,20 @@ class LLVMBuilderContext:
     def get_uniform_dist_function_by_state(self, state):
         if len(state.type.pointee) == 5:
             return self.import_llvm_function("__pnl_builtin_mt_rand_double")
-        if len(state.type.pointee) == 7:
+        elif len(state.type.pointee) == 7:
+            # we have different versions based on selected FP precision
             return self.import_llvm_function("__pnl_builtin_philox_rand_{}".format(str(self.float_ty)))
+        else:
+            assert False, "Unknown PRNG type!"
 
     def get_normal_dist_function_by_state(self, state):
         if len(state.type.pointee) == 5:
             return self.import_llvm_function("__pnl_builtin_mt_rand_normal")
-        if len(state.type.pointee) == 7:
+        elif len(state.type.pointee) == 7:
             # Normal exists only for self.float_ty
             return self.import_llvm_function("__pnl_builtin_philox_rand_normal")
+        else:
+            assert False, "Unknown PRNG type!"
 
     def get_builtin(self, name: str, args=[], function_type=None):
         if name in _builtin_intrinsics:
@@ -272,6 +277,8 @@ class LLVMBuilderContext:
                 reseed_f = self.get_builtin("mt_rand_init")
             elif seed_idx == 6:
                 reseed_f = self.get_builtin("philox_rand_init")
+            else:
+                assert False, "Unknown PRNG type!"
 
             builder.call(reseed_f, [random_state_ptr, new_seed])
 

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -163,13 +163,13 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
         return _div
 
     def visit_Pow(self, node):
-        def _div(builder, x, y):
+        def _pow(builder, x, y):
             assert helpers.is_floating_point(x)
             assert helpers.is_floating_point(y)
-            pow_f = ctx.get_builtin("pow", [x.type, y.type])
+            pow_f = self.ctx.get_builtin("pow", [x.type, y.type])
             return builder.call(pow_f, [x, y])
 
-        return _div
+        return _pow
 
     def visit_USub(self, node):
         def _usub(builder, x):

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -238,7 +238,7 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
         for t in node.targets:
             target = self.visit(t)
             if target is None: # Allocate space for new variable
-                target = self.var_builder.alloca(value.type)
+                target = self.var_builder.alloca(value.type, name=str(t.id) + '_local_variable')
                 self.register[t.id] = target
             assert self.is_lval(target)
             self.builder.store(value, target)

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -31,7 +31,7 @@ def binDiv(_, param1, param2):
 
 
 def binPow(_, param1, param2):
-    return param1 / param2
+    return param1 ** param2
 
 
 @pytest.mark.parametrize("param1", [1, np.ones(2), np.ones((2, 2))], ids=['scalar', 'vector', 'matrix'])


### PR DESCRIPTION
Rename port function tmp var to match the 'port' name.
Add human-readable stack slot names to UDF local variables.
Drop handling of unused parameter.
Add extra check when selecting Philox vs. Mersenne-Twister