### PR TITLE
llvm: Drop redundant parameters from compiled structures

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1382,7 +1382,9 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      "auto", "hetero", "cost", "costs", "combined_costs",
                      "control_signal",
                      # autodiff specific types
-                     "pytorch_representation", "optimizer"}
+                     "pytorch_representation", "optimizer",
+                     # duplicate
+                     "allocation_samples"}
         # Mechanism's need few extra entires:
         # * matrix -- is never used directly, and is flatened below
         # * integration rate -- shape mismatch with param port input

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1320,6 +1320,11 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         # Only mechanisms use "value" state
         if not hasattr(self, 'ports'):
             blacklist.add("value")
+
+        # Only mechanisms and compositions need 'num_executions'
+        if not hasattr(self, 'ports') and not hasattr(self, 'nodes'):
+            blacklist.add("num_executions")
+
         def _is_compilation_state(p):
             #FIXME: This should use defaults instead of 'p.get'
             return p.name not in blacklist and \

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1389,7 +1389,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      # autodiff specific types
                      "pytorch_representation", "optimizer",
                      # duplicate
-                     "allocation_samples"}
+                     "allocation_samples", "control_allocation_search_space"}
         # Mechanism's need few extra entires:
         # * matrix -- is never used directly, and is flatened below
         # * integration rate -- shape mismatch with param port input


### PR DESCRIPTION
Drop 'allocation_samples' the values are replicated in 'search_space'.
Drop 'num_executions' from most components. It's only used by Composition and Mechanism