### PR TITLE
TransferMechanism: fix integration_rate validation

### DIFF
--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1410,8 +1410,11 @@ class TransferMechanism(ProcessingMechanism_Base):
         # Validate INTEGRATION_RATE:
         if INTEGRATION_RATE in target_set and target_set[INTEGRATION_RATE] is not None:
             integration_rate = np.array(target_set[INTEGRATION_RATE])
-            if (not np.isscalar(integration_rate.tolist())
-                    and integration_rate.shape != self.defaults.variable.squeeze().shape):
+            if (
+                not np.isscalar(integration_rate.tolist())
+                and integration_rate.shape != self.defaults.variable.shape
+                and integration_rate.shape != self.defaults.variable.squeeze().shape
+            ):
                 raise TransferError(f"{repr(INTEGRATION_RATE)} arg for {self.name} ({integration_rate}) "
                                     f"must be either an int or float, or have the same shape "
                                     f"as its {VARIABLE} ({self.defaults.variable}).")


### PR DESCRIPTION
shape of integration_rate should at least be checked against exact shape
of default variable otherwise some valid configs fail (ex. rate and
variable = [[0], [0]])