### PR TITLE
llvm/{cuda,}: Reduce and optimize data copies in model execution

### DIFF
--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2971,7 +2971,7 @@ class Mechanism_Base(Mechanism):
 
         # Allocate a shadow structure to overload user supplied parameters
         params_out = builder.alloca(params_in.type.pointee, name="modulated_parameters")
-        builder.store(builder.load(params_in), params_out)
+        builder = pnlvm.helpers.memcpy(builder, params_out, params_in)
 
         def _get_output_ptr(b, i):
             ptr = pnlvm.helpers.get_param_ptr(b, obj, params_out,

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -2912,7 +2912,7 @@ class OptimizationControlMechanism(ControlMechanism):
             const_state = self.agent_rep._get_state_initializer(None)
             builder.store(comp_state.type.pointee(const_state), comp_state)
         else:
-            builder.store(builder.load(base_comp_state), comp_state)
+            builder = pnlvm.helpers.memcpy(builder, comp_state, base_comp_state)
 
         # Create a simulation copy of composition data
         comp_data = builder.alloca(base_comp_data.type.pointee, name="data_copy")
@@ -2920,7 +2920,7 @@ class OptimizationControlMechanism(ControlMechanism):
             const_data = self.agent_rep._get_data_initializer(None)
             builder.store(comp_data.type.pointee(const_data), comp_data)
         else:
-            builder.store(builder.load(base_comp_data), comp_data)
+            builder = pnlvm.helpers.memcpy(builder, comp_data, base_comp_data)
 
         # Evaluate is called on composition controller
         assert self.composition.controller is self

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1549,7 +1549,7 @@ class TransferMechanism(ProcessingMechanism_Base):
                                                         ctx.int32_ty(0)])
 
         threshold = builder.load(threshold_ptr)
-        cmp_val_ptr = builder.alloca(threshold.type)
+        cmp_val_ptr = builder.alloca(threshold.type, name="is_finished_value")
         if self.termination_measure is max:
             assert self._termination_measure_num_items_expected == 1
             # Get inside of the structure
@@ -1578,7 +1578,7 @@ class TransferMechanism(ProcessingMechanism_Base):
             func = ctx.import_llvm_function(self.termination_measure)
             func_params = pnlvm.helpers.get_param_ptr(builder, self, params, "termination_measure")
             func_state = pnlvm.helpers.get_state_ptr(builder, self, state, "termination_measure")
-            func_in = builder.alloca(func.args[2].type.pointee)
+            func_in = builder.alloca(func.args[2].type.pointee, name="is_finished_func_in")
             # Populate input
             func_in_current_ptr = builder.gep(func_in, [ctx.int32_ty(0),
                                                         ctx.int32_ty(0)])

--- a/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
@@ -1152,9 +1152,10 @@ class ControlSignal(ModulatorySignal):
         assert self.cost_options & ~CostFunctions.INTENSITY == 0
 
         cfunc = ctx.import_llvm_function(self.function.combine_costs_fct)
-        cfunc_in = builder.alloca(cfunc.args[2].type.pointee)
+        cfunc_in = builder.alloca(cfunc.args[2].type.pointee,
+                                  name="combine_costs_func_in")
 
-        # Set to 0 be default
+        # Set to 0 by default
         builder.store(cfunc_in.type.pointee(None), cfunc_in)
 
         cost_funcs = 0
@@ -1189,7 +1190,8 @@ class ControlSignal(ModulatorySignal):
         cfunc_state = pnlvm.helpers.get_state_ptr(builder, self.function,
                                                   func_state,
                                                   "combine_costs_fct")
-        cfunc_out = builder.alloca(cfunc.args[3].type.pointee)
+        cfunc_out = builder.alloca(cfunc.args[3].type.pointee,
+                                   name="combine_costs_func_out")
         builder.call(cfunc, [cfunc_params, cfunc_state, cfunc_in, cfunc_out])
 
 

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2293,7 +2293,8 @@ class Port_Base(Port):
             # Create a local copy of the function parameters
             # only if there are modulating projections
             # LLVM is not eliminating the redundant copy
-            f_params = builder.alloca(port_f.args[0].type.pointee)
+            f_params = builder.alloca(port_f.args[0].type.pointee,
+                                      name="modulated_port_params")
             builder.store(builder.load(base_params), f_params)
         else:
             f_params = base_params

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -503,11 +503,6 @@ def _gen_cuda_kernel_wrapper_module(function):
         builder.ret_void()
         return module
 
-
-    # There are 6 arguments to evaluate:
-    # comp_param, comp_state, allocations, output, input, comp_data
-    is_grid_evaluate = len(args) == 6
-
     # Runs need special handling. data_in and data_out are one dimensional,
     # but hold entries for all parallel invocations.
     # comp_state, comp_params, comp_data, comp_in, comp_out, #trials, #inputs
@@ -528,10 +523,6 @@ def _gen_cuda_kernel_wrapper_module(function):
                     offset = builder.mul(global_id, runs_count)
                 elif i == 3:  # data_in
                     offset = builder.mul(global_id, input_count)
-            elif is_grid_evaluate:
-                # all but #2 and #3 are shared
-                if i != 2 and i != 3:
-                    offset = ir.IntType(32)(0)
 
             arg = builder.gep(arg, [offset])
 

--- a/psyneulink/core/llvm/builtins.py
+++ b/psyneulink/core/llvm/builtins.py
@@ -543,13 +543,13 @@ def _setup_mt_rand_init(ctx, state_ty, init_scalar):
     builder.call(init_scalar, [state, default_seed])
 
     # python considers everything to be an array
-    key_array = builder.alloca(ir.ArrayType(seed.type, 1))
+    key_array = builder.alloca(ir.ArrayType(seed.type, 1), name="key_array")
     key_p = builder.gep(key_array, [ctx.int32_ty(0), ctx.int32_ty(0)])
     builder.store(seed, key_p)
 
-    pi = builder.alloca(ctx.int32_ty)
+    pi = builder.alloca(ctx.int32_ty, name="pi_slot")
     builder.store(ctx.int32_ty(1), pi)
-    pj = builder.alloca(ctx.int32_ty)
+    pj = builder.alloca(ctx.int32_ty, name="pj_slot")
     builder.store(ctx.int32_ty(0), pj)
     array = builder.gep(state, [ctx.int32_ty(0), ctx.int32_ty(0)])
     a_0 = builder.gep(array, [ctx.int32_ty(0), ctx.int32_ty(0)])
@@ -640,7 +640,7 @@ def _setup_mt_rand_integer(ctx, state_ty):
     cond = builder.icmp_signed(">=", idx, ctx.int32_ty(_MERSENNE_N))
     with builder.if_then(cond, likely=False):
         mag01 = ir.ArrayType(array.type.pointee.element, 2)([0, 0x9908b0df])
-        pmag01 = builder.alloca(mag01.type)
+        pmag01 = builder.alloca(mag01.type, name="mag01")
         builder.store(mag01, pmag01)
 
         with helpers.for_loop_zero_inc(builder,
@@ -741,10 +741,10 @@ def _setup_mt_rand_float(ctx, state_ty, gen_int):
     builder = _setup_builtin_func_builder(ctx, "mt_rand_double", (state_ty.as_pointer(), ctx.float_ty.as_pointer()))
     state, out = builder.function.args
 
-    al = builder.alloca(gen_int.args[1].type.pointee)
+    al = builder.alloca(gen_int.args[1].type.pointee, name="al_gen_int")
     builder.call(gen_int, [state, al])
 
-    bl = builder.alloca(gen_int.args[1].type.pointee)
+    bl = builder.alloca(gen_int.args[1].type.pointee, name="bl_gen_int")
     builder.call(gen_int, [state, bl])
 
     a = builder.load(al)
@@ -802,7 +802,7 @@ def _setup_mt_rand_normal(ctx, state_ty, gen_float):
 
     builder.branch(loop_block)
     builder.position_at_end(loop_block)
-    tmp = builder.alloca(out.type.pointee)
+    tmp = builder.alloca(out.type.pointee, name="mt_rand_normal_tmp")
 
     # X1 is in (-1, 1)
     builder.call(gen_float, [state, tmp])
@@ -1085,7 +1085,7 @@ def _setup_philox_rand_int32(ctx, state_ty, gen_int64):
         builder.ret_void()
 
 
-    val_ptr = builder.alloca(gen_int64.args[1].type.pointee)
+    val_ptr = builder.alloca(gen_int64.args[1].type.pointee, name="rand_i64")
     builder.call(gen_int64, [state, val_ptr])
     val = builder.load(val_ptr)
 
@@ -1112,7 +1112,7 @@ def _setup_philox_rand_double(ctx, state_ty, gen_int64):
     rhs = double_ty(1.0 / 9007199254740992.0)
 
     # Generate random integer
-    lhs_ptr = builder.alloca(gen_int64.args[1].type.pointee)
+    lhs_ptr = builder.alloca(gen_int64.args[1].type.pointee, name="rand_int64")
     builder.call(gen_int64, [state, lhs_ptr])
 
     # convert to float
@@ -1138,7 +1138,7 @@ def _setup_philox_rand_float(ctx, state_ty, gen_int32):
     rhs = float_ty(1.0 / 8388608.0)
 
     # Generate random integer
-    lhs_ptr = builder.alloca(gen_int32.args[1].type.pointee)
+    lhs_ptr = builder.alloca(gen_int32.args[1].type.pointee, name="rand_int32")
     builder.call(gen_int32, [state, lhs_ptr])
 
     # convert to float
@@ -1880,8 +1880,8 @@ def _setup_philox_rand_normal(ctx, state_ty, gen_float, gen_int, wi_data, ki_dat
 
     # Allocate storage for calling int/float PRNG
     # outside of the loop
-    tmp_fptype = builder.alloca(fptype)
-    tmp_itype = builder.alloca(itype)
+    tmp_fptype = builder.alloca(fptype, name="tmp_fp")
+    tmp_itype = builder.alloca(itype, name="tmp_int")
 
     # Enter the main generation loop
     builder.branch(loop_block)

--- a/psyneulink/core/llvm/debug.py
+++ b/psyneulink/core/llvm/debug.py
@@ -34,6 +34,7 @@ Compilation modifiers:
  * "const_state" -- hardcode base context values into generate code,
                  instead of laoding them from the context argument
  * "opt" -- Set compiler optimization level (0,1,2,3)
+ * "unaligned_copy" -- Do not assume structures are 4B aligned
  * "cuda_max_regs" -- Set maximum allowed GPU arch registers
 
 Compiled code dump:

--- a/psyneulink/core/llvm/debug.py
+++ b/psyneulink/core/llvm/debug.py
@@ -19,7 +19,6 @@ Increased debug output:
  * "compile" -- prints information messages when modules are compiled
  * "stat" -- prints code generation and compilation statistics
  * "time_stat" -- print compilation and code generation times
- * "cuda_data" -- print data upload/download statistic (to GPU VRAM)
  * "comp_node_debug" -- print intermediate results after execution composition node wrapper.
  * "print_values" -- Enabled printfs in llvm code (from ctx printf helper)
 

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -110,7 +110,7 @@ class CUDAExecution(Execution):
         self._downloaded_bytes = Counter()
 
     def __del__(self):
-        if "cuda_data" in self._debug_env:
+        if "stat" in self._debug_env:
             try:
                 name = self._bin_func.name
             except AttributeError:

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -192,7 +192,7 @@ def is_close(ctx, builder, val1, val2, rtol=1e-05, atol=1e-08):
 
 def all_close(ctx, builder, arr1, arr2, rtol=1e-05, atol=1e-08):
     assert arr1.type == arr2.type
-    all_ptr = builder.alloca(ir.IntType(1))
+    all_ptr = builder.alloca(ir.IntType(1), name="all_close_slot")
     builder.store(all_ptr.type.pointee(1), all_ptr)
     with array_ptr_loop(builder, arr1, "all_close") as (b1, idx):
         val1_ptr = b1.gep(arr1, [idx.type(0), idx])

--- a/psyneulink/core/llvm/jit_engine.py
+++ b/psyneulink/core/llvm/jit_engine.py
@@ -356,6 +356,6 @@ class ptx_jit_engine(jit_engine):
             self.stage_compilation({wrapper_mod})
             self.compile_staged()
             kernel = self._engine._find_kernel(name + "_cuda_kernel")
-            kernel.set_cache_config(pycuda.driver.func_cache.PREFER_L1)
+#            kernel.set_cache_config(pycuda.driver.func_cache.PREFER_L1)
 
         return kernel

--- a/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
@@ -844,7 +844,7 @@ class LCControlMechanism(ControlMechanism):
         elements_ty = pnlvm.ir.LiteralStructType(elements)
 
         # allocate new output type
-        new_out = builder.alloca(elements_ty)
+        new_out = builder.alloca(elements_ty, name="function_out")
 
         # Load mechanism parameters
         params = builder.function.args[0]

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1082,7 +1082,7 @@ class DDM(ProcessingMechanism):
         mf_out, builder = super()._gen_llvm_invoke_function(ctx, builder, function, params, state, variable, tags=tags)
 
         mech_out_ty = ctx.convert_python_struct_to_llvm_ir(self.defaults.value)
-        mech_out = builder.alloca(mech_out_ty)
+        mech_out = builder.alloca(mech_out_ty, name="mech_out")
 
         if isinstance(self.function, IntegratorFunction):
             # Integrator version of the DDM mechanism converts the
@@ -1129,7 +1129,7 @@ class DDM(ProcessingMechanism):
             mech_state = builder.function.args[1]
             random_state = ctx.get_random_state_ptr(builder, self, mech_state, mech_params)
             random_f = ctx.get_uniform_dist_function_by_state(random_state)
-            random_val_ptr = builder.alloca(random_f.args[1].type.pointee)
+            random_val_ptr = builder.alloca(random_f.args[1].type.pointee, name="random_out")
             builder.call(random_f, [random_state, random_val_ptr])
             random_val = builder.load(random_val_ptr)
 

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1292,8 +1292,8 @@ class RecurrentTransferMechanism(TransferMechanism):
         reinit_func = ctx.import_llvm_function(self.function, tags=tags)
         reinit_params = pnlvm.helpers.get_param_ptr(builder, self, params, "function")
         reinit_state = pnlvm.helpers.get_state_ptr(builder, self, state, "function")
-        reinit_in = builder.alloca(reinit_func.args[2].type.pointee)
-        reinit_out = builder.alloca(reinit_func.args[3].type.pointee)
+        reinit_in = builder.alloca(reinit_func.args[2].type.pointee, name="reinit_in")
+        reinit_out = builder.alloca(reinit_func.args[3].type.pointee, name="reinit_out")
         builder.call(reinit_func, [reinit_params, reinit_state, reinit_in,
                                    reinit_out])
 
@@ -1301,8 +1301,8 @@ class RecurrentTransferMechanism(TransferMechanism):
         if self.integrator_mode:
             reinit_f = ctx.import_llvm_function(self.integrator_function,
                                                 tags=tags)
-            reinit_in = builder.alloca(reinit_f.args[2].type.pointee)
-            reinit_out = builder.alloca(reinit_f.args[3].type.pointee)
+            reinit_in = builder.alloca(reinit_f.args[2].type.pointee, name="integ_reinit_in")
+            reinit_out = builder.alloca(reinit_f.args[3].type.pointee, name="integ_reinit_out")
             reinit_params = pnlvm.helpers.get_param_ptr(builder, self, params, "integrator_function")
             reinit_state = pnlvm.helpers.get_state_ptr(builder, self, state, "integrator_function")
             builder.call(reinit_f, [reinit_params, reinit_state, reinit_in,

--- a/tests/llvm/test_debug_composition.py
+++ b/tests/llvm/test_debug_composition.py
@@ -9,7 +9,7 @@ from psyneulink.core.components.mechanisms.processing.integratormechanism import
 from psyneulink.core.components.mechanisms.processing.transfermechanism import TransferMechanism
 from psyneulink.core.compositions.composition import Composition
 
-debug_options=["const_input=[[[7]]]", "const_input", "const_data", "const_params", "const_data", "const_state", "stat", "time_stat"]
+debug_options=["const_input=[[[7]]]", "const_input", "const_data", "const_params", "const_data", "const_state", "stat", "time_stat", "unaligned_copy"]
 options_combinations = (";".join(("debug_info", *c)) for i in range(len(debug_options) + 1) for c in combinations(debug_options, i))
 
 @pytest.mark.composition


### PR DESCRIPTION
Do not create a copy of parameters if there are no parameter states.
Add memcopy helper to W/A heavy register usage by store(load(src), dst) idiom.
Upload base arguments to on-chip 'shared' memory for GPU evaluate (optional, default ON).
Add human-readable names to alloca instructions.
Drop unused 'evaluate' kernel wrapper code.
Drop 'cuda_data' debug switch.

Improves performance ~2.5x for both CPU and GPU execution (measured using predator-prey model with 101 levels of attention)