### PR TITLE
tests: small cleanup

### DIFF
--- a/tests/llvm/test_builtins_intrinsics.py
+++ b/tests/llvm/test_builtins_intrinsics.py
@@ -13,8 +13,8 @@ y = np.random.rand()
                          (np.log, (x,), "__pnl_builtin_log", np.log(x)),
                          (np.power, (x,y), "__pnl_builtin_pow", np.power(x, y)),
                          (np.tanh, (x,), "__pnl_builtin_tanh", np.tanh(x)),
-                         (lambda x: 1 / np.tanh(x), (x,), "__pnl_builtin_coth", 1 / np.tanh(x)),
-                         (lambda x: 1 / np.sinh(x), (x,), "__pnl_builtin_csch", 1 / np.sinh(x)),
+                         (lambda x: 1.0 / np.tanh(x), (x,), "__pnl_builtin_coth", 1 / np.tanh(x)),
+                         (lambda x: 1.0 / np.sinh(x), (x,), "__pnl_builtin_csch", 1 / np.sinh(x)),
                          ], ids=["EXP", "LOG", "POW", "TANH", "COTH", "CSCH"])
 def test_builtin_op(benchmark, op, args, builtin, result, func_mode):
     if func_mode == 'Python':

--- a/tests/llvm/test_builtins_matrix.py
+++ b/tests/llvm/test_builtins_matrix.py
@@ -9,6 +9,7 @@ from llvmlite import ir
 DIM_X = 1000
 DIM_Y = 2000
 u = np.random.rand(DIM_X, DIM_Y)
+trans_u = u.transpose()
 v = np.random.rand(DIM_X, DIM_Y)
 vector = np.random.rand(DIM_X)
 trans_vector = np.random.rand(DIM_Y)
@@ -24,7 +25,7 @@ mat_add_res = np.add(u,v)
 mat_sub_res = np.subtract(u,v)
 mat_mul_res = np.multiply(u, v)
 dot_res = np.dot(vector, u)
-trans_dot_res = np.dot(trans_vector, u.transpose())
+trans_dot_res = np.dot(trans_vector, trans_u)
 mat_sadd_res = np.add(u, scalar)
 mat_smul_res = np.multiply(u, scalar)
 
@@ -95,7 +96,8 @@ def test_mat_scalar(benchmark, op, builtin, result, func_mode):
 @pytest.mark.benchmark(group="Dot")
 def test_dot(benchmark, func_mode):
     if func_mode == 'Python':
-        ex = lambda : np.dot(vector, u)
+        def ex():
+            return np.dot(vector, u)
     elif func_mode == 'LLVM':
         bin_f = pnlvm.LLVMBinaryFunction.get("__pnl_builtin_vxm")
         def ex():
@@ -153,8 +155,8 @@ def test_dot_llvm_constant_dim(benchmark, mode):
 @pytest.mark.benchmark(group="Dot")
 def test_dot_transposed(benchmark, func_mode):
     if func_mode == 'Python':
-        trans_u = u.transpose()
-        ex = lambda : np.dot(trans_vector, trans_u)
+        def ex():
+            return np.dot(trans_vector, trans_u)
     elif func_mode == 'LLVM':
         bin_f = pnlvm.LLVMBinaryFunction.get("__pnl_builtin_vxm_transposed")
         def ex():

--- a/tests/mechanisms/test_episodic_memory.py
+++ b/tests/mechanisms/test_episodic_memory.py
@@ -209,14 +209,11 @@ def test_with_contentaddressablememory(name, func, func_params, mech_params, tes
     assert em.input_ports.names == input_port_names
     assert em.output_ports.names == output_port_names
 
-    if mech_mode == 'Python':
-        def EX(variable):
-            em.execute(variable)
-            return em.output_values
-    elif mech_mode == 'LLVM':
-        pytest.skip("LLVM not yet implemented for ContentAddressableMemory")
-    elif mech_mode == 'PTX':
+    if mech_mode != 'Python':
         pytest.skip("PTX not yet implemented for ContentAddressableMemory")
+
+    EX = pytest.helpers.get_mech_execution(em, mech_mode)
+
 
     # EX(test_var)
     actual_output = EX(test_var)

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -967,12 +967,7 @@ class TestTransferMechanismTimeConstant:
 
         T.noise.base = 10
 
-        if mech_mode == 'Python':
-            val = T.execute([1, 2, -3, 0])
-        elif mech_mode == 'LLVM':
-            val = e.execute([1, 2, -3, 0])
-        elif mech_mode == 'PTX':
-            val = e.cuda_execute([1, 2, -3, 0])
+        val = EX([1, 2, -3, 0])
         assert np.allclose(val, [[10.98, 11.78, 7.779999999999999, 10.18]]) # testing noise changes to an integrator
 
     # @pytest.mark.mechanism

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -988,17 +988,19 @@ class TestTransferMechanismTimeConstant:
     #     )
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
-    def test_transfer_mech_integration_rate_0_8_list(self):
+    def test_transfer_mech_integration_rate_0_8_list(self, mech_mode):
         T = TransferMechanism(
             name='T',
             default_variable=[0, 0, 0, 0],
             function=Linear(),
-            integration_rate=[0.8, 0.8, 0.8, 0.8],
+            integration_rate=[0.8, 0.7, 0.6, 0.5],
             integrator_mode=True
         )
-        T.execute([1, 1, 1, 1])
-        val = T.execute([1, 1, 1, 1])
-        assert np.allclose(val, [[ 0.96,  0.96,  0.96,  0.96]])
+        EX = pytest.helpers.get_mech_execution(T, mech_mode)
+
+        EX([1, 1, 1, 1])
+        val = EX([1, 1, 1, 1])
+        assert np.allclose(val, [[ 0.96,  0.91,  0.84,  0.75]])
 
 
     @pytest.mark.mechanism


### PR DESCRIPTION
Add a test modulating DDM seed in analytical mode.
Use helper function to select the right execution mode.
Small style cleanups.