### PR TITLE
llvm: Reduce the amount of data copied due to parameter modulation

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1375,6 +1375,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      "previous_w", "random_state", "is_finished_flag",
                      "num_executions_before_finished", "num_executions",
                      "variable", "value", "saved_values", "saved_samples",
+                     "integrator_function_value", "termination_measure_value",
+                     "execution_count",
                      # Invalid types
                      "input_port_variables", "results", "simulation_results",
                      "monitor_for_control", "state_feature_values", "simulation_ids",
@@ -1389,12 +1391,20 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      # autodiff specific types
                      "pytorch_representation", "optimizer",
                      # duplicate
-                     "allocation_samples", "control_allocation_search_space"}
+                     "allocation_samples", "control_allocation_search_space",
+                     # not used in computation
+                     "has_recurrent_input_port", "enable_learning",
+                     "enable_output_type_conversion", "changes_shape",
+                     "output_type", 'bounds' }
         # Mechanism's need few extra entires:
         # * matrix -- is never used directly, and is flatened below
         # * integration rate -- shape mismatch with param port input
         if hasattr(self, 'ports'):
             blacklist.update(["matrix", "integration_rate"])
+        else:
+            # Execute until finished is only used by mechanisms
+            blacklist.update(["execute_until_finished", "max_executions_before_finished"])
+
         def _is_compilation_param(p):
             if p.name not in blacklist and not isinstance(p, (ParameterAlias, SharedParameter)):
                 #FIXME: this should use defaults

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2289,10 +2289,10 @@ class Port_Base(Port):
         base_params = pnlvm.helpers.get_param_ptr(builder, self, params,
                                                   "function")
 
-        if len(self.mod_afferents) > 0:
-            # Create a local copy of the function parameters
-            # only if there are modulating projections
-            # LLVM is not eliminating the redundant copy
+        if any(a.sender.modulation != OVERRIDE for a in self.mod_afferents):
+            # Create a local copy of the function parameters only if
+            # there are modulating projections of type other than OVERRIDE.
+            # LLVM is not eliminating the redundant copy.
             f_params = builder.alloca(port_f.args[0].type.pointee,
                                       name="modulated_port_params")
             builder.store(builder.load(base_params), f_params)


### PR DESCRIPTION
Do not create a private copy of port parameters if there is no modulation other than override.
Drop more unused parameters from the binary parameter structure.