### PR TITLE
llvm/cuda: Optimize memory copies in memory execution

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1382,7 +1382,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      "monitor_for_control", "state_feature_values", "simulation_ids",
                      "input_labels_dict", "output_labels_dict", "num_estimates",
                      "modulated_mechanisms", "grid", "control_signal_params",
-                     "activation_derivative_fct", "input_specification", "state_feature_specs",
+                     "activation_derivative_fct", "input_specification",
+                     "state_feature_specs",
                      # Reference to other components
                      "objective_mechanism", "agent_rep", "projections",
                      # Shape mismatch
@@ -1395,7 +1396,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      # not used in computation
                      "has_recurrent_input_port", "enable_learning",
                      "enable_output_type_conversion", "changes_shape",
-                     "output_type", 'bounds' }
+                     "output_type", "bounds"}
         # Mechanism's need few extra entires:
         # * matrix -- is never used directly, and is flatened below
         # * integration rate -- shape mismatch with param port input

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1405,6 +1405,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         else:
             # Execute until finished is only used by mechanisms
             blacklist.update(["execute_until_finished", "max_executions_before_finished"])
+            # "has_initializers" is only used by RTM
+            blacklist.update(["has_initializers"])
 
         def _is_compilation_param(p):
             if p.name not in blacklist and not isinstance(p, (ParameterAlias, SharedParameter)):

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2971,7 +2971,8 @@ class Mechanism_Base(Mechanism):
 
         # Allocate a shadow structure to overload user supplied parameters
         params_out = builder.alloca(params_in.type.pointee, name="modulated_parameters")
-        builder = pnlvm.helpers.memcpy(builder, params_out, params_in)
+        if len(param_ports) != len(obj.llvm_param_ids):
+            builder = pnlvm.helpers.memcpy(builder, params_out, params_in)
 
         def _get_output_ptr(b, i):
             ptr = pnlvm.helpers.get_param_ptr(b, obj, params_out,

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1603,32 +1603,32 @@ class TransferMechanism(ProcessingMechanism_Base):
         cmp_str = self.parameters.termination_comparison_op.get(None)
         return builder.fcmp_ordered(cmp_str, cmp_val, threshold)
 
-    def _gen_llvm_mechanism_functions(self, ctx, builder, params, state, arg_in,
-                                      ip_out, *, tags:frozenset):
+    def _gen_llvm_mechanism_functions(self, ctx, builder, m_base_params, m_params,
+                                      m_state, arg_in, ip_out, *, tags:frozenset):
 
         if self.integrator_mode:
-            if_state = pnlvm.helpers.get_state_ptr(builder, self, state,
+            if_state = pnlvm.helpers.get_state_ptr(builder, self, m_state,
                                                    "integrator_function")
-            if_param_ptr = pnlvm.helpers.get_param_ptr(builder, self, params,
-                                                       "integrator_function")
+            if_base_params = pnlvm.helpers.get_param_ptr(builder, self, m_base_params,
+                                                         "integrator_function")
             if_params, builder = self._gen_llvm_param_ports_for_obj(
-                    self.integrator_function, if_param_ptr, ctx, builder,
-                    params, state, arg_in)
+                    self.integrator_function, if_base_params, ctx, builder,
+                    m_base_params, m_state, arg_in)
 
             mf_in, builder = self._gen_llvm_invoke_function(
                     ctx, builder, self.integrator_function, if_params, if_state, ip_out, tags=tags)
         else:
             mf_in = ip_out
 
-        mf_state = pnlvm.helpers.get_state_ptr(builder, self, state, "function")
-        mf_param_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, "function")
+        mf_state = pnlvm.helpers.get_state_ptr(builder, self, m_state, "function")
+        mf_base_params = pnlvm.helpers.get_param_ptr(builder, self, m_base_params, "function")
         mf_params, builder = self._gen_llvm_param_ports_for_obj(
-                self.function, mf_param_ptr, ctx, builder, params, state, arg_in)
+                self.function, mf_base_params, ctx, builder, m_base_params, m_state, arg_in)
 
         mf_out, builder = self._gen_llvm_invoke_function(ctx, builder,
                                                          self.function, mf_params, mf_state, mf_in, tags=tags)
 
-        clip_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, "clip")
+        clip_ptr = pnlvm.helpers.get_param_ptr(builder, self, m_params, "clip")
         if len(clip_ptr.type.pointee) != 0:
             assert len(clip_ptr.type.pointee) == 2
             clip_lo = builder.load(builder.gep(clip_ptr, [ctx.int32_ty(0),

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -132,7 +132,10 @@ class CUDAExecution(Execution):
 
     def upload_ctype(self, data, name='other'):
         self._uploaded_bytes[name] += ctypes.sizeof(data)
-        assert ctypes.sizeof(data) != 0
+        if ctypes.sizeof(data) == 0:
+            # 0-sized structures fail to upload
+            # provide a small device buffer instead
+            return jit_engine.pycuda.driver.mem_alloc(4)
         return jit_engine.pycuda.driver.to_device(bytearray(data))
 
     def download_ctype(self, source, ty, name='other'):


### PR DESCRIPTION
Restrict 'has_initializers' parameter to mechanisms. This leaves most functions with parameters that are modified by parameter ports.
Don't copy base parameters to private parameter space if all of them will be replaced by parameter port outputs.
Use mechanism base params structure in places that don't modify parameters via parameter ports (e.g. running input/output ports). Unlike the modified result, which is private per evaluation, the base structure is shared.
This improves cache performance and memory utilization for both CPUs and GPUs.