### PR TITLE
llvm: More descriptive variable names

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1399,7 +1399,7 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      "allocation_samples", "control_allocation_search_space",
                      # not used in computation
                      "auto", "hetero", "cost", "costs", "combined_costs",
-                     "control_signal", "intensity",
+                     "control_signal", "intensity", "competition",
                      "has_recurrent_input_port", "enable_learning",
                      "enable_output_type_conversion", "changes_shape",
                      "output_type", "bounds", "internal_only",

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1409,7 +1409,8 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
                      "adjustment_cost", "intensity_cost", "duration_cost",
                      "enabled_cost_functions", "control_signal_costs",
                      "default_allocation", "same_seed_for_all_allocations",
-                     "search_statefulness", "initial_seed", "combine"
+                     "search_statefulness", "initial_seed", "combine",
+                     "smoothing_factor",
                      }
         # Mechanism's need few extra entires:
         # * matrix -- is never used directly, and is flatened below

--- a/psyneulink/core/components/functions/stateful/integratorfunctions.py
+++ b/psyneulink/core/components/functions/stateful/integratorfunctions.py
@@ -2526,7 +2526,7 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
         time_step_size = self._gen_llvm_load_param(ctx, builder, params, index, TIME_STEP_SIZE)
 
         random_state = ctx.get_random_state_ptr(builder, self, state, params)
-        rand_val_ptr = builder.alloca(ctx.float_ty)
+        rand_val_ptr = builder.alloca(ctx.float_ty, name="random_out")
         rand_f = ctx.get_normal_dist_function_by_state(random_state)
         builder.call(rand_f, [random_state, rand_val_ptr])
         rand_val = builder.load(rand_val_ptr)

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -3397,19 +3397,19 @@ class OptimizationControlMechanism(ControlMechanism):
         param_is_zero = builder.icmp_unsigned("==", num_trials_per_estimate,
                                                     ctx.int32_ty(0))
         num_sims = builder.select(param_is_zero, ctx.int32_ty(1),
-                                  num_trials_per_estimate, "corrected_estimates")
+                                  num_trials_per_estimate, "corrected_trials per_estimate")
 
-        num_runs = builder.alloca(ctx.int32_ty, name="num_runs")
-        builder.store(num_sims, num_runs)
+        num_trials = builder.alloca(ctx.int32_ty, name="num_sim_trials")
+        builder.store(num_sims, num_trials)
 
         # We only provide one input
-        num_inputs = builder.alloca(ctx.int32_ty, name="num_inputs")
+        num_inputs = builder.alloca(ctx.int32_ty, name="num_sim_inputs")
         builder.store(num_inputs.type.pointee(1), num_inputs)
 
         # Simulations don't store output
         comp_output = sim_f.args[4].type(None)
         builder.call(sim_f, [comp_state, comp_params, comp_data, comp_input,
-                             comp_output, num_runs, num_inputs])
+                             comp_output, num_trials, num_inputs])
 
         # Extract objective mechanism value
         idx = self.agent_rep._get_node_index(self.objective_mechanism)

--- a/psyneulink/core/llvm/builtins.py
+++ b/psyneulink/core/llvm/builtins.py
@@ -640,8 +640,8 @@ def _setup_mt_rand_integer(ctx, state_ty):
     cond = builder.icmp_signed(">=", idx, ctx.int32_ty(_MERSENNE_N))
     with builder.if_then(cond, likely=False):
         mag01 = ir.ArrayType(array.type.pointee.element, 2)([0, 0x9908b0df])
-        pmag01 = builder.alloca(mag01.type, name="mag01")
-        builder.store(mag01, pmag01)
+        mag0 = builder.extract_value(mag01, [0])
+        mag1 = builder.extract_value(mag01, [1])
 
         with helpers.for_loop_zero_inc(builder,
                                        ctx.int32_ty(_MERSENNE_N - _MERSENNE_M),
@@ -653,9 +653,9 @@ def _setup_mt_rand_integer(ctx, state_ty):
             val_kk_1 = b.and_(b.load(pkk_1), pkk_1.type.pointee(0x7fffffff))
             val = b.or_(val_kk, val_kk_1)
 
-            val_1 = b.and_(val, val.type(1))
-            pval_mag = b.gep(pmag01, [ctx.int32_ty(0), val_1])
-            val_mag = b.load(pval_mag)
+            val_i1 = b.and_(val, val.type(1))
+            val_b = b.trunc(val_i1, ctx.bool_ty)
+            val_mag = b.select(val_b, mag1, mag0)
 
             val_shift = b.lshr(val, val.type(1))
 
@@ -681,9 +681,9 @@ def _setup_mt_rand_integer(ctx, state_ty):
             val_kk_1 = b.and_(b.load(pkk_1), pkk.type.pointee(0x7fffffff))
             val = b.or_(val_kk, val_kk_1)
 
-            val_1 = b.and_(val, val.type(1))
-            pval_mag = b.gep(pmag01, [ctx.int32_ty(0), val_1])
-            val_mag = b.load(pval_mag)
+            val_i1 = b.and_(val, val.type(1))
+            val_b = b.trunc(val_i1, ctx.bool_ty)
+            val_mag = b.select(val_b, mag1, mag0)
 
             val_shift = b.lshr(val, val.type(1))
 


### PR DESCRIPTION
Add missing name to alloca instruction.
Use more descriptive variable names when invoking simulation trials.
Use conditional select instead of a stack array in the initialization of Mersenne Twister.
