### PR TITLE
github-actions: Use v0.0.0.0 as dummy tag to compare documentation on pull requests

### DIFF
--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -94,8 +94,10 @@ jobs:
     - name: Add git tag
       # The generated docs include PNL version,
       # set it to a fixed value to prevent polluting the diff
+      # This needs to be done after installing PNL
+      # to not interfere with dependency resolving
       if: github.event_name == 'pull_request'
-      run: git tag --force 'v999.999.999.999'
+      run: git tag --force 'v0.0.0.0'
 
     - name: Build Documentation
       run: make -C docs/ html -e SPHINXOPTS="-aE -j auto"
@@ -104,7 +106,7 @@ jobs:
       # The generated docs include PNL version,
       # This was set to a fixed value to prevent polluting the diff
       if: github.event_name == 'pull_request' && always()
-      run: git tag -d 'v999.999.999.999'
+      run: git tag -d 'v0.0.0.0'
 
     - name: Upload Documentation
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
When there are multiple tags pointing to the HEAD commit,
git describe returns the first in alphabetical order.
Use v0.0.0.0 to have deterministic description
even if there is another tag pointing to the HEAD commit.

Fixes: 65967d9e1f67891b4bbb771ed5670cea5ea2eac3
       ("ci: increase fetch depth and tags")

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>