### PR TITLE
Composition: fix TERMINAL node detection

### DIFF
--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -4566,7 +4566,10 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         #   consideration set.  Identifying these assumes that graph_processing has been called/updated,
         #   which identifies and "breaks" cycles, and assigns FEEDBACK_SENDER to the appropriate consideration set(s).
         for node in self.nodes:
-            if not any([efferent for efferent in node.efferents if efferent.receiver.owner is not self.output_CIM]):
+            if not any([
+                efferent.is_active_in_composition(self) for efferent in node.efferents
+                if efferent.receiver.owner is not self.output_CIM
+            ]):
                 self._add_node_role(node, NodeRole.TERMINAL)
 
     def _add_node_aux_components(self, node, context=None):

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -7351,6 +7351,17 @@ class TestNodeRoles:
         assert comp.get_nodes_by_role(NodeRole.CONTROLLER) == [comp.controller]
         assert comp.nodes_to_roles[comp.controller] == {NodeRole.CONTROLLER}
 
+    def test_inactive_terminal_projection(self):
+        A = pnl.ProcessingMechanism(name='A')
+        B = pnl.ProcessingMechanism(name='B')
+        C = pnl.ProcessingMechanism(name='C')
+        D = pnl.ProcessingMechanism(name='D')
+
+        pnl.MappingProjection(sender=A, receiver=D)
+        comp = pnl.Composition([[A],[B,C]])
+
+        assert comp.nodes_to_roles[A] == {NodeRole.INPUT, NodeRole.OUTPUT, NodeRole.SINGLETON, NodeRole.ORIGIN, NodeRole.TERMINAL}
+
 
 class TestMisc:
 


### PR DESCRIPTION
if a TERMINAL node in a Composition that was not in the final
consideration set had an inactive projection to another node, the
TERMINAL role was not assigned because the active/inactive status was
not considered