### PR TITLE
Parameter default specification improvements

### DIFF
--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -159,7 +159,7 @@ from psyneulink.core.globals.keywords import (
     IDENTITY_MATRIX, INVERSE_HOLLOW_MATRIX, NAME, PREFERENCE_SET_NAME, RANDOM_CONNECTIVITY_MATRIX, VALUE, VARIABLE,
     MODEL_SPEC_ID_METADATA, MODEL_SPEC_ID_MDF_VARIABLE
 )
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import REPORT_OUTPUT_PREF, is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
 from psyneulink.core.globals.registry import register_category
@@ -605,6 +605,7 @@ class Function_Base(Function):
     # Note: the following enforce encoding as 1D np.ndarrays (one array per variable)
     variableEncodingDim = 1
 
+    @check_user_specified
     @abc.abstractmethod
     def __init__(
         self,
@@ -995,6 +996,7 @@ class ArgumentTherapy(Function_Base):
     # These are used both to type-cast the params, and as defaults if none are assigned
     #  in the initialization call or later (using either _instantiate_defaults or during a function call)
 
+    @check_user_specified
     def __init__(self,
                  default_variable=None,
                  propensity=10.0,
@@ -1145,6 +1147,7 @@ class EVCAuxiliaryFunction(Function_Base):
         REPORT_OUTPUT_PREF: PreferenceEntry(False, PreferenceLevel.INSTANCE),
        }
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  function,

--- a/psyneulink/core/components/functions/nonstateful/combinationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/combinationfunctions.py
@@ -45,7 +45,7 @@ from psyneulink.core.globals.keywords import \
     PREFERENCE_SET_NAME, VARIABLE
 from psyneulink.core.globals.utilities import convert_to_np_array, is_numeric, np_array_less_than_2d, parameter_spec
 from psyneulink.core.globals.context import ContextFlags
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import \
     REPORT_OUTPUT_PREF, is_pref_set, PreferenceEntry, PreferenceLevel
 
@@ -201,6 +201,7 @@ class Concatenate(CombinationFunction):  # -------------------------------------
         offset = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
         changes_shape = Parameter(True, stateful=False, loggable=False, pnl_internal=True)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -420,6 +421,7 @@ class Rearrange(CombinationFunction):  # ---------------------------------------
         scale = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
         offset = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -723,6 +725,7 @@ class Reduce(CombinationFunction):  # ------------------------------------------
         offset = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
         changes_shape = Parameter(True, stateful=False, loggable=False, pnl_internal=True)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  # weights: tc.optional(parameter_spec)=None,
@@ -1165,6 +1168,7 @@ class LinearCombination(
         scale = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
         offset = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -1689,6 +1693,7 @@ class CombineMeans(CombinationFunction):  # ------------------------------------
         scale = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
         offset = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -1948,6 +1953,7 @@ class PredictionErrorDeltaFunction(CombinationFunction):
         variable = Parameter(np.array([[1], [1]]), pnl_internal=True, constructor_argument='default_variable')
         gamma = Parameter(1.0, modulable=True)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/core/components/functions/nonstateful/distributionfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/distributionfunctions.py
@@ -39,7 +39,7 @@ from psyneulink.core.globals.keywords import \
 from psyneulink.core.globals.utilities import convert_to_np_array, parameter_spec
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 
 __all__ = [
     'DistributionFunction', 'DRIFT_RATE', 'DRIFT_RATE_VARIABILITY', 'DriftDiffusionAnalytical', 'ExponentialDist',
@@ -159,6 +159,7 @@ class NormalDist(DistributionFunction):
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
         seed = Parameter(DEFAULT_SEED, modulable=True, fallback_default=True, setter=_seed_setter)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -341,6 +342,7 @@ class UniformToNormalDist(DistributionFunction):
         mean = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
         standard_deviation = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -467,6 +469,7 @@ class ExponentialDist(DistributionFunction):
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
         seed = Parameter(DEFAULT_SEED, modulable=True, fallback_default=True, setter=_seed_setter)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -593,6 +596,7 @@ class UniformDist(DistributionFunction):
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
         seed = Parameter(DEFAULT_SEED, modulable=True, fallback_default=True, setter=_seed_setter)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -750,6 +754,7 @@ class GammaDist(DistributionFunction):
         scale = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
         dist_shape = Parameter(1.0, modulable=True, aliases=[ADDITIVE_PARAM])
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -884,6 +889,7 @@ class WaldDist(DistributionFunction):
         scale = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
         mean = Parameter(1.0, modulable=True, aliases=[ADDITIVE_PARAM])
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -1120,6 +1126,7 @@ class DriftDiffusionAnalytical(DistributionFunction):  # -----------------------
             read_only=True
         )
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/core/components/functions/nonstateful/learningfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/learningfunctions.py
@@ -39,7 +39,7 @@ from psyneulink.core.globals.keywords import \
     CONTRASTIVE_HEBBIAN_FUNCTION, TDLEARNING_FUNCTION, LEARNING_FUNCTION_TYPE, LEARNING_RATE, \
     KOHONEN_FUNCTION, GAUSSIAN, LINEAR, EXPONENTIAL, HEBBIAN_FUNCTION, RL_FUNCTION, BACKPROPAGATION_FUNCTION, MATRIX, \
     MSE, SSE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.utilities import is_numeric, scalar_distance, convert_to_np_array
 
@@ -448,6 +448,7 @@ class BayesGLM(LearningFunction):
         gamma_size_n = 1
         gamma_size_prior = 1
 
+    @check_user_specified
     def __init__(self,
                  default_variable=None,
                  mu_0=None,
@@ -774,6 +775,7 @@ class Kohonen(LearningFunction):  # --------------------------------------------
 
     default_learning_rate = 0.05
 
+    @check_user_specified
     def __init__(self,
                  default_variable=None,
                  # learning_rate: tc.optional(tc.optional(parameter_spec)) = None,
@@ -1045,6 +1047,7 @@ class Hebbian(LearningFunction):  # --------------------------------------------
                                   modulable=True)
     default_learning_rate = 0.05
 
+    @check_user_specified
     def __init__(self,
                  default_variable=None,
                  learning_rate=None,
@@ -1278,6 +1281,7 @@ class ContrastiveHebbian(LearningFunction):  # ---------------------------------
 
     default_learning_rate = 0.05
 
+    @check_user_specified
     def __init__(self,
                  default_variable=None,
                  # learning_rate: tc.optional(tc.optional(parameter_spec)) = None,
@@ -1585,6 +1589,7 @@ class Reinforcement(LearningFunction):  # --------------------------------------
             read_only=True
         )
 
+    @check_user_specified
     def __init__(self,
                  default_variable=None,
                  # learning_rate: tc.optional(tc.optional(parameter_spec)) = None,
@@ -1934,6 +1939,7 @@ class BackPropagation(LearningFunction):
 
     default_learning_rate = 1.0
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -2175,6 +2181,7 @@ class TDLearning(Reinforcement):
     """
     componentName = TDLEARNING_FUNCTION
 
+    @check_user_specified
     def __init__(self,
                  default_variable=None,
                  learning_rate=None,

--- a/psyneulink/core/components/functions/nonstateful/objectivefunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/objectivefunctions.py
@@ -33,7 +33,7 @@ from psyneulink.core.globals.keywords import \
     DEFAULT_VARIABLE, DIFFERENCE, DISTANCE_FUNCTION, DISTANCE_METRICS, DistanceMetrics, \
     ENERGY, ENTROPY, EUCLIDEAN, HOLLOW_MATRIX, MATRIX, MAX_ABS_DIFF, \
     NORMED_L0_SIMILARITY, OBJECTIVE_FUNCTION_TYPE, SIZE, STABILITY_FUNCTION
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.utilities import is_distance_metric, safe_len, convert_to_np_array
 from psyneulink.core.globals.utilities import is_iterable
@@ -206,6 +206,7 @@ class Stability(ObjectiveFunction):
         transfer_fct = Parameter(None, stateful=False, loggable=False)
         normalize = Parameter(False, stateful=False)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -558,6 +559,7 @@ class Energy(Stability):
         specifies the `PreferenceSet` for the Function (see `prefs <Function_Base.prefs>` for details).
     """
 
+    @check_user_specified
     def __init__(self,
                  default_variable=None,
                  size=None,
@@ -667,6 +669,7 @@ class Entropy(Stability):
         specifies the `PreferenceSet` for the Function (see `prefs <Function_Base.prefs>` for details).
     """
 
+    @check_user_specified
     def __init__(self,
                  default_variable=None,
                  normalize:bool=None,
@@ -779,6 +782,7 @@ class Distance(ObjectiveFunction):
         variable = Parameter(np.array([[0], [0]]), read_only=True, pnl_internal=True, constructor_argument='default_variable')
         metric = Parameter(DIFFERENCE, stateful=False)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
@@ -48,7 +48,7 @@ from psyneulink.core.globals.defaults import MPI_IMPLEMENTATION
 from psyneulink.core.globals.keywords import \
     BOUNDS, GRADIENT_OPTIMIZATION_FUNCTION, GRID_SEARCH_FUNCTION, GAUSSIAN_PROCESS_FUNCTION, \
     OPTIMIZATION_FUNCTION_TYPE, OWNER, VALUE, VARIABLE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.sampleiterator import SampleIterator
 from psyneulink.core.globals.utilities import call_with_pruned_args
 
@@ -404,6 +404,7 @@ class OptimizationFunction(Function_Base):
         saved_samples = Parameter([], read_only=True, pnl_internal=True)
         saved_values = Parameter([], read_only=True, pnl_internal=True)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(
         self,
@@ -1084,6 +1085,7 @@ class GradientOptimization(OptimizationFunction):
             else:
                 return -1
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -1486,6 +1488,7 @@ class GridSearch(OptimizationFunction):
 
     # TODO: should save_values be in the constructor if it's ignored?
     # is False or True the correct value?
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -2198,6 +2201,7 @@ class GaussianProcess(OptimizationFunction):
 
     # TODO: should save_values be in the constructor if it's ignored?
     # is False or True the correct value?
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -2458,6 +2462,7 @@ class ParamEstimationFunction(OptimizationFunction):
         save_samples = True
         save_values = True
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  priors,

--- a/psyneulink/core/components/functions/nonstateful/selectionfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/selectionfunctions.py
@@ -36,7 +36,7 @@ from psyneulink.core.components.functions.function import (
 from psyneulink.core.globals.keywords import \
     MAX_VAL, MAX_ABS_VAL, MAX_INDICATOR, MAX_ABS_INDICATOR, MIN_VAL, MIN_ABS_VAL, MIN_INDICATOR, MIN_ABS_INDICATOR, \
     MODE, ONE_HOT_FUNCTION, PROB, PROB_INDICATOR, SELECTION_FUNCTION_TYPE, PREFERENCE_SET_NAME
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import \
     REPORT_OUTPUT_PREF, PreferenceEntry, PreferenceLevel, is_pref_set
 
@@ -201,6 +201,7 @@ class OneHot(SelectionFunction):
                 # returns error message
                 return 'not one of {0}'.format(options)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/core/components/functions/nonstateful/transferfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/transferfunctions.py
@@ -70,7 +70,7 @@ from psyneulink.core.globals.keywords import \
     RATE, RECEIVER, RELU_FUNCTION, SCALE, SLOPE, SOFTMAX_FUNCTION, STANDARD_DEVIATION, SUM, \
     TRANSFER_FUNCTION_TYPE, TRANSFER_WITH_COSTS_FUNCTION, VARIANCE, VARIABLE, X_0, PREFERENCE_SET_NAME
 from psyneulink.core.globals.parameters import \
-    FunctionParameter, Parameter, get_validator_by_function
+    FunctionParameter, Parameter, get_validator_by_function, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import \
     REPORT_OUTPUT_PREF, PreferenceEntry, PreferenceLevel, is_pref_set
 from psyneulink.core.globals.utilities import parameter_spec, safe_len
@@ -197,6 +197,7 @@ class Identity(TransferFunction):  # -------------------------------------------
         REPORT_OUTPUT_PREF: PreferenceEntry(False, PreferenceLevel.INSTANCE),
     }
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -364,6 +365,7 @@ class Linear(TransferFunction):  # ---------------------------------------------
         slope = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
         intercept = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -625,6 +627,7 @@ class Exponential(TransferFunction):  # ----------------------------------------
         offset = Parameter(0.0, modulable=True)
         bounds = (0, None)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -915,6 +918,7 @@ class Logistic(TransferFunction):  # -------------------------------------------
         scale = Parameter(1.0, modulable=True)
         bounds = (0, 1)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -1233,6 +1237,7 @@ class Tanh(TransferFunction):  # -----------------------------------------------
         scale = Parameter(1.0, modulable=True)
         bounds = (0, 1)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -1497,6 +1502,7 @@ class ReLU(TransferFunction):  # -----------------------------------------------
         leak = Parameter(0.0, modulable=True)
         bounds = (None, None)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -1705,6 +1711,7 @@ class Angle(TransferFunction):  # ----------------------------------------------
             if variable.ndim != 1 or len(variable) < 2:
                 return f"must be list or 1d array of length 2 or greater."
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -1970,6 +1977,7 @@ class Gaussian(TransferFunction):  # -------------------------------------------
         offset = Parameter(0.0, modulable=True)
         bounds = (None, None)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -2243,6 +2251,7 @@ class GaussianDistort(TransferFunction):  #-------------------------------------
         seed = Parameter(DEFAULT_SEED, modulable=True, fallback_default=True, setter=_seed_setter)
         bounds = (None, None)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -2523,6 +2532,7 @@ class SoftMax(TransferFunction):
             else:
                 return 'not one of {0}'.format(options)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -2925,6 +2935,7 @@ class LinearMatrix(TransferFunction):  # ---------------------------------------
     #         return True
     #     return False
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -3926,6 +3937,7 @@ class TransferWithCosts(TransferFunction):
             function_parameter_name=ADDITIVE_PARAM,
         )
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/core/components/functions/stateful/integratorfunctions.py
+++ b/psyneulink/core/components/functions/stateful/integratorfunctions.py
@@ -48,7 +48,7 @@ from psyneulink.core.globals.keywords import \
     INTERACTIVE_ACTIVATION_INTEGRATOR_FUNCTION, LEAKY_COMPETING_INTEGRATOR_FUNCTION, \
     MULTIPLICATIVE_PARAM, NOISE, OFFSET, OPERATION, ORNSTEIN_UHLENBECK_INTEGRATOR_FUNCTION, OUTPUT_PORTS, PRODUCT, \
     RATE, REST, SIMPLE_INTEGRATOR_FUNCTION, SUM, TIME_STEP_SIZE, THRESHOLD, VARIABLE, MODEL_SPEC_ID_MDF_VARIABLE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.utilities import parameter_spec, all_within_range, \
     convert_all_elements_to_np_array
@@ -220,6 +220,7 @@ class IntegratorFunction(StatefulFunction):  # ---------------------------------
         previous_value = Parameter(np.array([0]), initializer='initializer')
         initializer = Parameter(np.array([0]), pnl_internal=True)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -550,6 +551,7 @@ class AccumulatorIntegrator(IntegratorFunction):  # ----------------------------
         rate = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM], function_arg=True)
         increment = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM], function_arg=True)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -826,6 +828,7 @@ class SimpleIntegrator(IntegratorFunction):  # ---------------------------------
         rate = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM], function_arg=True)
         offset = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM], function_arg=True)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -1061,6 +1064,7 @@ class AdaptiveIntegrator(IntegratorFunction):  # -------------------------------
         rate = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM], function_arg=True)
         offset = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM], function_arg=True)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -1573,6 +1577,7 @@ class DualAdaptiveIntegrator(IntegratorFunction):  # ---------------------------
         long_term_logistic = None
 
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -2014,6 +2019,7 @@ class InteractiveActivationIntegrator(IntegratorFunction):  # ------------------
         max_val = Parameter(1.0, function_arg=True)
         min_val = Parameter(-1.0, function_arg=True)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -2418,6 +2424,7 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
             else:
                 return initializer
 
+    @check_user_specified
     @tc.typecheck
     def __init__(
         self,
@@ -2933,6 +2940,7 @@ class DriftOnASphereIntegrator(IntegratorFunction):  # -------------------------
                 noise = np.array(noise)
             return noise
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -3439,6 +3447,7 @@ class OrnsteinUhlenbeckIntegrator(IntegratorFunction):  # ----------------------
             read_only=True
         )
 
+    @check_user_specified
     @tc.typecheck
     def __init__(
         self,
@@ -3733,6 +3742,7 @@ class LeakyCompetingIntegrator(IntegratorFunction):  # -------------------------
         offset = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM], function_arg=True)
         time_step_size = Parameter(0.1, modulable=True, function_arg=True)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,
@@ -4414,6 +4424,7 @@ class FitzHughNagumoIntegrator(IntegratorFunction):  # -------------------------
             read_only=True
         )
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/core/components/functions/stateful/memoryfunctions.py
+++ b/psyneulink/core/components/functions/stateful/memoryfunctions.py
@@ -45,7 +45,7 @@ from psyneulink.core.globals.keywords import \
     ADDITIVE_PARAM, BUFFER_FUNCTION, MEMORY_FUNCTION, COSINE, \
     ContentAddressableMemory_FUNCTION, DictionaryMemory_FUNCTION, \
     MIN_INDICATOR, MULTIPLICATIVE_PARAM, NEWEST, NOISE, OLDEST, OVERWRITE, RATE, RANDOM, VARIABLE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.utilities import \
     all_within_range, convert_to_np_array, convert_to_list, convert_all_elements_to_np_array
@@ -225,6 +225,7 @@ class Buffer(MemoryFunction):  # -----------------------------------------------
         changes_shape = Parameter(True, stateful=False, loggable=False, pnl_internal=True)
 
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  # FIX: 12/11/18 JDC - NOT SAFE TO SPECIFY A MUTABLE TYPE AS DEFAULT
@@ -1152,6 +1153,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
                 initializer = ContentAddressableMemory._enforce_memory_shape(initializer)
             return initializer
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  # FIX: REINSTATE WHEN 3.6 IS RETIRED:
@@ -2173,6 +2175,7 @@ class DictionaryMemory(MemoryFunction):  # -------------------------------------
         selection_function = Parameter(OneHot(mode=MIN_INDICATOR), stateful=False, loggable=False)
 
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/core/components/functions/stateful/statefulfunction.py
+++ b/psyneulink/core/components/functions/stateful/statefulfunction.py
@@ -30,7 +30,7 @@ from psyneulink.core.components.functions.nonstateful.distributionfunctions impo
 from psyneulink.core.components.functions.function import Function_Base, FunctionError, _noise_setter
 from psyneulink.core.globals.context import handle_external_context
 from psyneulink.core.globals.keywords import STATEFUL_FUNCTION_TYPE, STATEFUL_FUNCTION, NOISE, RATE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.utilities import iscompatible, convert_to_np_array, contains_type
 
@@ -213,6 +213,7 @@ class StatefulFunction(Function_Base): #  --------------------------------------
                 return 'functions in a list must be instantiated and have the desired noise variable shape'
 
     @handle_external_context()
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/core/components/functions/userdefinedfunction.py
+++ b/psyneulink/core/components/functions/userdefinedfunction.py
@@ -18,7 +18,7 @@ from psyneulink.core.components.functions.function import FunctionError, Functio
 from psyneulink.core.globals.keywords import \
     CONTEXT, CUSTOM_FUNCTION, OWNER, PARAMS, \
     SELF, USER_DEFINED_FUNCTION, USER_DEFINED_FUNCTION_TYPE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences import is_pref_set
 from psyneulink.core.globals.utilities import _is_module_class, iscompatible
 
@@ -450,6 +450,7 @@ class UserDefinedFunction(Function_Base):
             pnl_internal=True,
         )
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  custom_function=None,

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -1109,7 +1109,7 @@ from psyneulink.core.globals.keywords import \
     NAME, OUTPUT, OUTPUT_LABELS_DICT, OUTPUT_PORT, OUTPUT_PORT_PARAMS, OUTPUT_PORTS, OWNER_EXECUTION_COUNT, OWNER_VALUE, \
     PARAMETER_PORT, PARAMETER_PORT_PARAMS, PARAMETER_PORTS, PROJECTIONS, REFERENCE_VALUE, RESULT, \
     TARGET_LABELS_DICT, VALUE, VARIABLE, WEIGHT, MODEL_SPEC_ID_MDF_VARIABLE, MODEL_SPEC_ID_INPUT_PORT_COMBINATION_FUNCTION
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.registry import register_category, remove_instance_from_registry
 from psyneulink.core.globals.utilities import \
@@ -1680,6 +1680,7 @@ class Mechanism_Base(Mechanism):
 
     @tc.typecheck
     @abc.abstractmethod
+    @check_user_specified
     def __init__(self,
                  default_variable=None,
                  size=None,

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -607,7 +607,7 @@ from psyneulink.core.globals.keywords import \
     MECHANISM, MULTIPLICATIVE, MODULATORY_SIGNALS, MONITOR_FOR_CONTROL, MONITOR_FOR_MODULATION, \
     OBJECTIVE_MECHANISM, OUTCOME, OWNER_VALUE, PARAMS, PORT_TYPE, PRODUCT, PROJECTION_TYPE, PROJECTIONS, \
     SEPARATE, SIZE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import ContentAddressableList, convert_to_list, convert_to_np_array, is_iterable
@@ -1213,6 +1213,7 @@ class ControlMechanism(ModulatoryMechanism_Base):
             # method?
             # validate_monitored_port_spec(self._owner, input_ports)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/core/components/mechanisms/modulatory/control/defaultcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/defaultcontrolmechanism.py
@@ -40,6 +40,7 @@ from psyneulink.core.components.mechanisms.modulatory.control.controlmechanism i
 from psyneulink.core.components.mechanisms.processing.objectivemechanism import ObjectiveMechanism
 from psyneulink.core.globals.defaults import defaultControlAllocation
 from psyneulink.core.globals.keywords import CONTROL, INPUT_PORTS, NAME
+from psyneulink.core.globals.parameters import check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import ContentAddressableList
@@ -87,6 +88,7 @@ class DefaultControlMechanism(ControlMechanism):
     #     PREFERENCE_SET_NAME: 'DefaultControlMechanismCustomClassPreferences',
     #     PREFERENCE_KEYWORD<pref>: <setting>...}
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  objective_mechanism:tc.optional(tc.any(ObjectiveMechanism, list))=None,

--- a/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
@@ -190,7 +190,7 @@ from psyneulink.core.globals.defaults import defaultGatingAllocation
 from psyneulink.core.globals.keywords import \
     CONTROL, CONTROL_SIGNALS, GATE, GATING_PROJECTION, GATING_SIGNAL, GATING_SIGNALS, \
     INIT_EXECUTE_METHOD_ONLY, MONITOR_FOR_CONTROL, PORT_TYPE, PROJECTIONS, PROJECTION_TYPE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import ContentAddressableList, convert_to_list
@@ -433,6 +433,7 @@ class GatingMechanism(ControlMechanism):
             constructor_argument='gate'
         )
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_gating_allocation=None,

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1099,7 +1099,7 @@ from psyneulink.core.globals.keywords import \
     ALL, COMPOSITION, COMPOSITION_FUNCTION_APPROXIMATOR, CONCATENATE, DEFAULT_INPUT, DEFAULT_VARIABLE, EID_FROZEN, \
     FUNCTION, INPUT_PORT, INTERNAL_ONLY, NAME, OPTIMIZATION_CONTROL_MECHANISM, NODE, OWNER_VALUE, PARAMS, PORT, \
     PROJECTIONS, SHADOW_INPUTS, VALUE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.registry import rename_instance_in_registry
 from psyneulink.core.globals.sampleiterator import SampleIterator, SampleSpec
@@ -1741,6 +1741,7 @@ class OptimizationControlMechanism(ControlMechanism):
                        f"with a shape appropriate for all of the INPUT Nodes or InputPorts to which it will be applied."
 
     @handle_external_context()
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  agent_rep=None,

--- a/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
@@ -545,7 +545,7 @@ from psyneulink.core.globals.keywords import \
     ADDITIVE, AFTER, ASSERT, ENABLED, INPUT_PORTS, \
     LEARNED_PARAM, LEARNING, LEARNING_MECHANISM, LEARNING_PROJECTION, LEARNING_SIGNAL, LEARNING_SIGNALS, \
     MATRIX, NAME, ONLINE, OUTPUT_PORT, OWNER_VALUE, PARAMS, PROJECTIONS, SAMPLE, PORT_TYPE, VARIABLE
-from psyneulink.core.globals.parameters import FunctionParameter, Parameter
+from psyneulink.core.globals.parameters import FunctionParameter, Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import ContentAddressableList, convert_to_np_array, is_numeric, parameter_spec, \
@@ -999,6 +999,7 @@ class LearningMechanism(ModulatoryMechanism_Base):
             structural=True,
         )
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  # default_variable:tc.any(list, np.ndarray),

--- a/psyneulink/core/components/mechanisms/modulatory/modulatorymechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/modulatorymechanism.py
@@ -140,6 +140,7 @@ Class Reference
 
 from psyneulink.core.components.mechanisms.mechanism import Mechanism_Base
 from psyneulink.core.globals.keywords import ADAPTIVE_MECHANISM
+from psyneulink.core.globals.parameters import check_user_specified
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 
 __all__ = [
@@ -191,6 +192,7 @@ class ModulatoryMechanism_Base(Mechanism_Base):
     #     PREFERENCE_SET_NAME: 'ModulatoryMechanismClassPreferences',
     #     PREFERENCE_KEYWORD<pref>: <setting>...}
 
+    @check_user_specified
     def __init__(self,
                  default_variable,
                  size,

--- a/psyneulink/core/components/mechanisms/processing/compositioninterfacemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/compositioninterfacemechanism.py
@@ -122,7 +122,7 @@ from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import COMPOSITION_INTERFACE_MECHANISM, INPUT_PORTS, OUTPUT_PORTS, \
     PREFERENCE_SET_NAME
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set, REPORT_OUTPUT_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
 
@@ -174,6 +174,7 @@ class CompositionInterfaceMechanism(ProcessingMechanism_Base):
         """
         function = Parameter(Identity, stateful=False, loggable=False)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/core/components/mechanisms/processing/defaultprocessingmechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/defaultprocessingmechanism.py
@@ -18,7 +18,7 @@ import typecheck as tc
 from psyneulink.core.components.mechanisms.mechanism import Mechanism_Base
 from psyneulink.core.globals.defaults import SystemDefaultInputValue
 from psyneulink.core.globals.keywords import DEFAULT_PROCESSING_MECHANISM
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 
@@ -53,6 +53,7 @@ class DefaultProcessingMechanism_Base(Mechanism_Base):
     class Parameters(Mechanism_Base.Parameters):
         variable = Parameter(np.array([SystemDefaultInputValue]), constructor_argument='default_variable')
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/core/components/mechanisms/processing/integratormechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/integratormechanism.py
@@ -92,7 +92,7 @@ from psyneulink.core.components.mechanisms.mechanism import Mechanism
 from psyneulink.core.globals.json import _substitute_expression_args
 from psyneulink.core.globals.keywords import \
     DEFAULT_VARIABLE, INTEGRATOR_MECHANISM, VARIABLE, PREFERENCE_SET_NAME
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set, REPORT_OUTPUT_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
 from psyneulink.core.globals.utilities import parse_valid_identifier
@@ -152,6 +152,7 @@ class IntegratorMechanism(ProcessingMechanism_Base):
         function = Parameter(AdaptiveIntegrator(rate=0.5), stateful=False, loggable=False)
 
         #
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
@@ -378,7 +378,7 @@ from psyneulink.core.globals.context import ContextFlags, handle_external_contex
 from psyneulink.core.globals.keywords import \
     CONTROL, EXPONENT, EXPONENTS, LEARNING, MATRIX, NAME, OBJECTIVE_MECHANISM, OUTCOME, OWNER_VALUE, \
     PARAMS, PREFERENCE_SET_NAME, PROJECTION, PROJECTIONS, PORT_TYPE, VARIABLE, WEIGHT, WEIGHTS
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set, REPORT_OUTPUT_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
 from psyneulink.core.globals.utilities import ContentAddressableList
@@ -562,6 +562,7 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
     standard_output_port_names.extend([OUTCOME])
 
     # FIX:  TYPECHECK MONITOR TO LIST OR ZIP OBJECT
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  monitor=None,

--- a/psyneulink/core/components/mechanisms/processing/processingmechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/processingmechanism.py
@@ -99,6 +99,7 @@ from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.globals.keywords import \
     FUNCTION, MAX_ABS_INDICATOR, MAX_ABS_ONE_HOT, MAX_ABS_VAL, MAX_INDICATOR, MAX_ONE_HOT, MAX_VAL, MEAN, MEDIAN, \
     NAME, PROB, PROCESSING_MECHANISM, PREFERENCE_SET_NAME, STANDARD_DEVIATION, VARIANCE
+from psyneulink.core.globals.parameters import check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set, REPORT_OUTPUT_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
 
@@ -168,6 +169,7 @@ class ProcessingMechanism_Base(Mechanism_Base):
                                    FUNCTION: SoftMax(output=PROB)}])
     standard_output_port_names = [i['name'] for i in standard_output_ports]
 
+    @check_user_specified
     def __init__(self,
                  default_variable=None,
                  size=None,
@@ -282,6 +284,7 @@ class ProcessingMechanism(ProcessingMechanism_Base):
         PREFERENCE_SET_NAME: 'ProcessingMechanismCustomClassPreferences',
         REPORT_OUTPUT_PREF: PreferenceEntry(False, PreferenceLevel.INSTANCE)}
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -848,7 +848,7 @@ from psyneulink.core.globals.keywords import \
     CURRENT_VALUE, LESS_THAN_OR_EQUAL, MAX_ABS_DIFF, \
     NAME, NOISE, NUM_EXECUTIONS_BEFORE_FINISHED, OWNER_VALUE, RESET, RESULT, RESULTS, \
     SELECTION_FUNCTION_TYPE, TRANSFER_FUNCTION_TYPE, TRANSFER_MECHANISM, VARIABLE
-from psyneulink.core.globals.parameters import Parameter, FunctionParameter
+from psyneulink.core.globals.parameters import Parameter, FunctionParameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import \
@@ -1283,6 +1283,7 @@ class TransferMechanism(ProcessingMechanism_Base):
                 return f"must be boolean comparison operator or one of the following strings:" \
                        f" {','.join(comparison_operators.keys())}."
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/core/components/ports/inputport.py
+++ b/psyneulink/core/components/ports/inputport.py
@@ -589,7 +589,7 @@ from psyneulink.core.globals.keywords import \
     LEARNING_SIGNAL, MAPPING_PROJECTION, MATRIX, NAME, OPERATION, OUTPUT_PORT, OUTPUT_PORTS, OWNER, \
     PARAMS, PRODUCT, PROJECTIONS, REFERENCE_VALUE, \
     SENDER, SHADOW_INPUTS, SHADOW_INPUT_NAME, SIZE, PORT_TYPE, SUM, VALUE, VARIABLE, WEIGHT
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import \
@@ -874,6 +874,7 @@ class InputPort(Port_Base):
     #endregion
 
     @handle_external_context()
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  owner=None,

--- a/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
@@ -421,7 +421,8 @@ from psyneulink.core.globals.keywords import \
     OUTPUT_PORT, OUTPUT_PORTS, OUTPUT_PORT_PARAMS, \
     PARAMETER_PORT, PARAMETER_PORTS, PROJECTIONS, \
     RECEIVER, FUNCTION
-from psyneulink.core.globals.parameters import FunctionParameter, Parameter, get_validator_by_function
+from psyneulink.core.globals.parameters import FunctionParameter, Parameter, get_validator_by_function, \
+    check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.sampleiterator import SampleSpec, SampleIterator
@@ -792,6 +793,7 @@ class ControlSignal(ModulatorySignal):
 
     #endregion
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  owner=None,

--- a/psyneulink/core/components/ports/modulatorysignals/gatingsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/gatingsignal.py
@@ -252,7 +252,7 @@ from psyneulink.core.globals.defaults import defaultGatingAllocation
 from psyneulink.core.globals.keywords import \
     GATE, GATING_PROJECTION, GATING_SIGNAL, INPUT_PORT, INPUT_PORTS, \
     MODULATES, OUTPUT_PORT, OUTPUT_PORTS, OUTPUT_PORT_PARAMS, PROJECTIONS, RECEIVER
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 
@@ -417,6 +417,7 @@ class GatingSignal(ControlSignal):
 
     #endregion
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  owner=None,

--- a/psyneulink/core/components/ports/modulatorysignals/learningsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/learningsignal.py
@@ -194,7 +194,7 @@ from psyneulink.core.components.ports.modulatorysignals.modulatorysignal import 
 from psyneulink.core.components.ports.outputport import PRIMARY
 from psyneulink.core.globals.keywords import \
     LEARNING_PROJECTION, LEARNING_SIGNAL, OUTPUT_PORT_PARAMS, PARAMETER_PORT, PARAMETER_PORTS, RECEIVER
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import parameter_spec
@@ -333,6 +333,7 @@ class LearningSignal(ModulatorySignal):
         value = Parameter(np.array([0]), read_only=True, aliases=['learning_signal'], pnl_internal=True)
         learning_rate = None
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  owner=None,

--- a/psyneulink/core/components/ports/modulatorysignals/modulatorysignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/modulatorysignal.py
@@ -412,6 +412,7 @@ from psyneulink.core.globals.defaults import defaultModulatoryAllocation
 from psyneulink.core.globals.keywords import \
     ADDITIVE_PARAM, CONTROL, DISABLE, MAYBE, MECHANISM, MODULATION, MODULATORY_SIGNAL, MULTIPLICATIVE_PARAM, \
     OVERRIDE, PROJECTIONS, VARIABLE
+from psyneulink.core.globals.parameters import check_user_specified
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 
 __all__ = [
@@ -562,6 +563,7 @@ class ModulatorySignal(OutputPort):
     #     PREFERENCE_SET_NAME: 'OutputPortCustomClassPreferences',
     #     PREFERENCE_KEYWORD<pref>: <setting>...}
 
+    @check_user_specified
     def __init__(self,
                  owner=None,
                  size=None,

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -631,7 +631,7 @@ from psyneulink.core.globals.keywords import \
     OWNER_VALUE, PARAMS, PARAMS_DICT, PROJECTION, PROJECTIONS, RECEIVER, REFERENCE_VALUE, STANDARD_OUTPUT_PORTS, PORT, \
     VALUE, VARIABLE, \
     output_port_spec_to_parameter_name, INPUT_PORT_VARIABLES
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import \
@@ -905,6 +905,7 @@ class OutputPort(Port_Base):
 
     #endregion
 
+    @check_user_specified
     @tc.typecheck
     @handle_external_context()
     def __init__(self,

--- a/psyneulink/core/components/ports/parameterport.py
+++ b/psyneulink/core/components/ports/parameterport.py
@@ -382,7 +382,7 @@ from psyneulink.core.globals.keywords import \
     CONTEXT, CONTROL_PROJECTION, CONTROL_SIGNAL, CONTROL_SIGNALS, FUNCTION, FUNCTION_PARAMS, \
     LEARNING_SIGNAL, LEARNING_SIGNALS, MECHANISM, NAME, PARAMETER_PORT, PARAMETER_PORT_PARAMS, PATHWAY_PROJECTION, \
     PROJECTION, PROJECTIONS, PROJECTION_TYPE, REFERENCE_VALUE, SENDER, VALUE
-from psyneulink.core.globals.parameters import ParameterBase, ParameterAlias, SharedParameter
+from psyneulink.core.globals.parameters import ParameterBase, ParameterAlias, SharedParameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities \
@@ -701,6 +701,7 @@ class ParameterPort(Port_Base):
     #endregion
 
     tc.typecheck
+    @check_user_specified
     def __init__(self,
                  owner,
                  reference_value=None,

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -797,7 +797,7 @@ from psyneulink.core.globals.keywords import \
     RECEIVER, REFERENCE_VALUE, REFERENCE_VALUE_NAME, SENDER, STANDARD_OUTPUT_PORTS, \
     PORT, PORT_COMPONENT_CATEGORY, PORT_CONTEXT, Port_Name, port_params, PORT_PREFS, PORT_TYPE, port_value, \
     VALUE, VARIABLE, WEIGHT
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import VERBOSE_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.registry import register_category
@@ -1004,6 +1004,7 @@ class Port_Base(Port):
 
     classPreferenceLevel = PreferenceLevel.CATEGORY
 
+    @check_user_specified
     @tc.typecheck
     @abc.abstractmethod
     def __init__(self,

--- a/psyneulink/core/components/projections/modulatory/controlprojection.py
+++ b/psyneulink/core/components/projections/modulatory/controlprojection.py
@@ -120,7 +120,7 @@ from psyneulink.core.components.shellclasses import Mechanism, Process_Base
 from psyneulink.core.globals.context import ContextFlags
 from psyneulink.core.globals.keywords import \
     CONTROL, CONTROL_PROJECTION, CONTROL_SIGNAL, INPUT_PORT, OUTPUT_PORT, PARAMETER_PORT
-from psyneulink.core.globals.parameters import Parameter, SharedParameter
+from psyneulink.core.globals.parameters import Parameter, SharedParameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 
@@ -237,6 +237,7 @@ class ControlProjection(ModulatoryProjection_Base):
 
     projection_sender = ControlMechanism
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  sender=None,

--- a/psyneulink/core/components/projections/modulatory/gatingprojection.py
+++ b/psyneulink/core/components/projections/modulatory/gatingprojection.py
@@ -112,7 +112,7 @@ from psyneulink.core.globals.context import ContextFlags
 from psyneulink.core.globals.keywords import \
     FUNCTION_OUTPUT_TYPE, GATE, GATING_MECHANISM, GATING_PROJECTION, GATING_SIGNAL, \
     INPUT_PORT, OUTPUT_PORT
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 
@@ -238,6 +238,7 @@ class GatingProjection(ModulatoryProjection_Base):
 
     projection_sender = GatingMechanism
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  sender=None,

--- a/psyneulink/core/components/projections/modulatory/learningprojection.py
+++ b/psyneulink/core/components/projections/modulatory/learningprojection.py
@@ -202,7 +202,7 @@ from psyneulink.core.globals.context import ContextFlags
 from psyneulink.core.globals.keywords import \
     LEARNING, LEARNING_PROJECTION, LEARNING_SIGNAL, \
     MATRIX, PARAMETER_PORT, PROJECTION_SENDER, ONLINE, AFTER
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import iscompatible, parameter_spec
@@ -440,6 +440,7 @@ class LearningProjection(ModulatoryProjection_Base):
 
     projection_sender = LearningMechanism
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  sender:tc.optional(tc.any(LearningSignal, LearningMechanism))=None,

--- a/psyneulink/core/components/projections/pathway/mappingprojection.py
+++ b/psyneulink/core/components/projections/pathway/mappingprojection.py
@@ -299,7 +299,7 @@ from psyneulink.core.globals.keywords import \
     MAPPING_PROJECTION, MATRIX, \
     OUTPUT_PORT, VALUE
 from psyneulink.core.globals.log import ContextFlags
-from psyneulink.core.globals.parameters import FunctionParameter, Parameter
+from psyneulink.core.globals.parameters import FunctionParameter, Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 
@@ -442,6 +442,7 @@ class MappingProjection(PathwayProjection_Base):
 
     projection_sender = OutputPort
 
+    @check_user_specified
     def __init__(self,
                  sender=None,
                  receiver=None,

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -418,7 +418,7 @@ from psyneulink.core.globals.keywords import \
     NAME, OUTPUT_PORT, OUTPUT_PORTS, PARAMS, PATHWAY, PROJECTION, PROJECTION_PARAMS, PROJECTION_SENDER, PROJECTION_TYPE, \
     RECEIVER, SENDER, STANDARD_ARGS, PORT, PORTS, WEIGHT, ADD_INPUT_PORT, ADD_OUTPUT_PORT, \
     PROJECTION_COMPONENT_CATEGORY
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.registry import register_category, remove_instance_from_registry
 from psyneulink.core.globals.socket import ConnectionInfo
@@ -631,6 +631,7 @@ class Projection_Base(Projection):
 
     classPreferenceLevel = PreferenceLevel.CATEGORY
 
+    @check_user_specified
     @abc.abstractmethod
     def __init__(self,
                  receiver,

--- a/psyneulink/core/components/shellclasses.py
+++ b/psyneulink/core/components/shellclasses.py
@@ -28,6 +28,7 @@ TBI:
 """
 
 from psyneulink.core.components.component import Component
+from psyneulink.core.globals.parameters import check_user_specified
 
 __all__ = [
     'Function', 'Mechanism', 'Process_Base', 'Projection', 'ShellClass', 'ShellClassError', 'Port', 'System_Base',
@@ -73,6 +74,7 @@ class Process_Base(ShellClass):
 
 class Mechanism(ShellClass):
 
+    @check_user_specified
     def __init__(self,
                  default_variable=None,
                  size=None,

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -2782,7 +2782,7 @@ from psyneulink.core.globals.keywords import \
     SAMPLE, SENDER, SHADOW_INPUTS, SOFT_CLAMP, SSE, \
     TARGET, TARGET_MECHANISM, TEXT, VARIABLE, WEIGHT, OWNER_MECH
 from psyneulink.core.globals.log import CompositionLog, LogCondition
-from psyneulink.core.globals.parameters import Parameter, ParametersBase
+from psyneulink.core.globals.parameters import Parameter, ParametersBase, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import BasePreferenceSet
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel, _assign_prefs
 from psyneulink.core.globals.registry import register_category
@@ -3743,6 +3743,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
     class _CompilationData(ParametersBase):
         execution = None
 
+    @check_user_specified
     def __init__(
             self,
             pathways=None,

--- a/psyneulink/core/compositions/compositionfunctionapproximator.py
+++ b/psyneulink/core/compositions/compositionfunctionapproximator.py
@@ -59,6 +59,8 @@ from psyneulink.core.globals.keywords import COMPOSITION_FUNCTION_APPROXIMATOR
 
 __all__ = ['CompositionFunctionApproximator']
 
+from psyneulink.core.globals.parameters import check_user_specified
+
 
 class CompositionFunctionApproximatorError(Exception):
     def __init__(self, error_value):
@@ -105,6 +107,7 @@ class CompositionFunctionApproximator(Composition):
 
     componentCategory = COMPOSITION_FUNCTION_APPROXIMATOR
 
+    @check_user_specified
     def __init__(self, name=None, **param_defaults):
        # self.function = function
         super().__init__(name=name, **param_defaults)

--- a/psyneulink/core/compositions/parameterestimationcomposition.py
+++ b/psyneulink/core/compositions/parameterestimationcomposition.py
@@ -150,7 +150,7 @@ from psyneulink.core.components.ports.modulatorysignals.controlsignal import Con
 from psyneulink.core.compositions.composition import Composition
 from psyneulink.core.globals.context import Context, ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import BEFORE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 
 __all__ = ['ParameterEstimationComposition']
 
@@ -431,6 +431,7 @@ class ParameterEstimationComposition(Composition):
                                                              setter=_same_seed_for_all_parameter_combinations_setter)
 
     @handle_external_context()
+    @check_user_specified
     def __init__(self,
                  parameters, # OCM control_signals
                  outcome_variables,  # OCM monitor_for_control

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -814,6 +814,12 @@ class Parameter(ParameterBase):
 
             :default: None
 
+        specify_none
+            if True, a user-specified value of None for this Parameter
+            will set the _user_specified flag to True
+
+            :default: False
+
     """
     # The values of these attributes will never be inherited from parent Parameters
     # KDM 7/12/18: consider inheriting ONLY default_value?
@@ -878,6 +884,7 @@ class Parameter(ParameterBase):
         initializer=None,
         port=None,
         mdf_name=None,
+        specify_none=False,
         _owner=None,
         _inherited=False,
         # this stores a reference to the Parameter object that is the
@@ -942,6 +949,7 @@ class Parameter(ParameterBase):
             initializer=initializer,
             port=port,
             mdf_name=mdf_name,
+            specify_none=specify_none,
             _inherited=_inherited,
             _inherited_source=_inherited_source,
             _user_specified=_user_specified,

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -99,7 +99,10 @@ To create new Parameters, reference this example of a new class *B*
     class B(A):
         class Parameters(A.Parameters):
             p = 1.0
-            q = Parameter(1.0, modulable=True)
+            q = Parameter()
+
+        def __init__(p=None, q=1.0):
+            super(p=p, q=q)
 
 
 - create an inner class Parameters on the Component, inheriting from the parent Component's Parameters class
@@ -108,6 +111,8 @@ To create new Parameters, reference this example of a new class *B*
     - as with *p*, specifying only a value uses default values for the attributes of the Parameter
     - as with *q*, specifying an explicit instance of the Parameter class allows you to modify the
       `Parameter attributes <Parameter_Attributes_Table>`
+- default values for the parameters can be specified in the Parameters class body, or in the
+  arguments for *B*.__init__. If both are specified and the values differ, an exception will be raised
 - if you want assignments to parameter *p* to be validated, add a method _validate_p(value),
   that returns None if value is a valid assignment, or an error string if value is not a valid assignment
 - if you want all values set to *p* to be parsed beforehand, add a method _parse_p(value) that returns the parsed value
@@ -295,6 +300,7 @@ Class Reference
 
 import collections
 import copy
+import inspect
 import itertools
 import logging
 import types
@@ -307,7 +313,7 @@ from psyneulink.core.globals.context import Context, ContextError, ContextFlags,
 from psyneulink.core.globals.context import time as time_object
 from psyneulink.core.globals.log import LogCondition, LogEntry, LogError
 from psyneulink.core.globals.utilities import call_with_pruned_args, copy_iterable_with_shared, \
-    get_alias_property_getter, get_alias_property_setter, get_deepcopy_with_shared, unproxy_weakproxy, create_union_set
+    get_alias_property_getter, get_alias_property_setter, get_deepcopy_with_shared, unproxy_weakproxy, create_union_set, safe_equals, get_function_sig_default_value
 from psyneulink.core.rpc.graph_pb2 import Entry, ndArray
 
 __all__ = [
@@ -390,6 +396,19 @@ def copy_parameter_value(value, shared_types=None, memo=None):
             return copy.deepcopy(value, memo)
         else:
             return value
+
+
+def get_init_signature_default_value(obj, parameter):
+    """
+        Returns:
+            the default value of the **parameter** argument of
+            the __init__ method of **obj** if it exists, or inspect._empty
+    """
+    # only use the signature if it's on the owner class, not a parent
+    if '__init__' in obj.__dict__:
+        return get_function_sig_default_value(obj.__init__, parameter)
+    else:
+        return inspect._empty
 
 
 class ParametersTemplate:
@@ -1028,20 +1047,34 @@ class Parameter(ParameterBase):
             Resets *default_value* to the value specified in its `Parameters` class declaration, or
             inherits from parent `Parameters` classes if it is not explicitly specified.
         """
-        try:
-            self.default_value = self._owner.__class__.__dict__[self.name].default_value
-        except (AttributeError, KeyError):
+        # check for default in Parameters class
+        cls_param_value = inspect._empty
+        if self._owner._param_is_specified_in_class(self.name):
             try:
-                self.default_value = self._owner.__class__.__dict__[self.name]
+                cls_param_value = self._owner.__class__.__dict__[self.name]
             except KeyError:
-                if self._parent is not None:
-                    self._inherited = True
-                else:
-                    raise ParameterError(
-                        'Parameter {0} cannot be reset, as it does not have a default specification '
-                        'or a parent. This may occur if it was added dynamically rather than in an'
-                        'explict Parameters inner class on a Component'
-                    )
+                pass
+            else:
+                try:
+                    cls_param_value = cls_param_value.default_value
+                except AttributeError:
+                    pass
+
+        # check for default in __init__ signature
+        value = self._owner._reconcile_value_with_init_default(self.name, cls_param_value)
+        if value is not inspect._empty:
+            self.default_value = value
+            return
+
+        # no default specified, must be inherited or invalid
+        if self._parent is not None:
+            self._inherited = True
+        else:
+            raise ParameterError(
+                'Parameter {0} cannot be reset, as it does not have a default specification '
+                'or a parent. This may occur if it was added dynamically rather than in an'
+                'explict Parameters inner class on a Component'
+            )
 
     def _register_alias(self, name):
         if self.aliases is None:
@@ -1951,16 +1984,20 @@ class ParametersBase(ParametersTemplate):
     _validation_method_prefix = '_validate_'
 
     def __init__(self, owner, parent=None):
+        self._initializing = True
+
         super().__init__(owner=owner, parent=parent)
 
         aliases_to_create = set()
         for param_name, param_value in self.values(show_all=True).items():
+            constructor_default = get_init_signature_default_value(self._owner, param_name)
+
             if (
-                param_name in self.__class__.__dict__
-                and (
-                    param_name not in self._parent.__class__.__dict__
-                    or self._parent.__class__.__dict__[param_name] is not self.__class__.__dict__[param_name]
+                (
+                    constructor_default is not None
+                    and constructor_default is not inspect._empty
                 )
+                or self._param_is_specified_in_class(param_name)
             ):
                 # KDM 6/25/18: NOTE: this may need special handling if you're creating a ParameterAlias directly
                 # in a class's Parameters class
@@ -1985,6 +2022,8 @@ class ParametersBase(ParametersTemplate):
 
         for param, value in self.values(show_all=True).items():
             self._validate(param, value.default_value)
+
+        self._initializing = False
 
     def __getattr__(self, attr):
         def throw_error():
@@ -2024,10 +2063,20 @@ class ParametersBase(ParametersTemplate):
             super().__setattr__(attr, value)
         else:
             if isinstance(value, Parameter):
+                if value._owner is None:
+                    value._owner = self
+                elif value._owner is not self and self._initializing:
+                    # case where no Parameters class defined on subclass
+                    # but default value overridden in __init__
+                    value = copy.deepcopy(value)
+                    value._owner = self
+
                 if value.name is None:
                     value.name = attr
 
-                value._owner = self
+                if self._initializing and not value._inherited:
+                    value.default_value = self._reconcile_value_with_init_default(attr, value.default_value)
+
                 super().__setattr__(attr, value)
 
                 if value.aliases is not None:
@@ -2079,6 +2128,9 @@ class ParametersBase(ParametersTemplate):
                 except AttributeError:
                     current_value = None
 
+                if self._initializing:
+                    value = self._reconcile_value_with_init_default(attr, value)
+
                 # assign value to default_value
                 if isinstance(current_value, (Parameter, ParameterAlias)):
                     # construct a copy because the original may be used as a base for reset()
@@ -2098,6 +2150,39 @@ class ParametersBase(ParametersTemplate):
 
             self._validate(attr, getattr(self, attr).default_value)
             self._register_parameter(attr)
+
+    def _reconcile_value_with_init_default(self, attr, value):
+        constructor_default = get_init_signature_default_value(self._owner, attr)
+        if constructor_default is not None and constructor_default is not inspect._empty:
+            if (
+                value is None
+                or not self._param_is_specified_in_class(attr)
+                or (
+                    type(constructor_default) == type(value)
+                    and safe_equals(constructor_default, value)
+                )
+            ):
+                # TODO: consider placing a developer-focused warning here?
+                return constructor_default
+            else:
+                assert False, (
+                    'PROGRAM ERROR: '
+                    f'Conflicting default parameter values assigned for Parameter {attr} of {self._owner} in:'
+                    f'\n\t{self._owner}.Parameters: {value}'
+                    f'\n\t{self._owner}.__init__: {constructor_default}'
+                    f'\nRemove one of these assignments. Prefer removing the default_value of {attr} in {self._owner}.Parameters'
+                )
+
+        return value
+
+    def _param_is_specified_in_class(self, param_name):
+        return (
+            param_name in self.__class__.__dict__
+            and (
+                param_name not in self._parent.__class__.__dict__
+                or self._parent.__class__.__dict__[param_name] is not self.__class__.__dict__[param_name]
+            )
+        )
 
     def _get_prefixed_method(
         self,

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -144,6 +144,8 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
+# TODO: consider combining with _unused_args_sig_cache
+_signature_cache = weakref.WeakKeyDictionary()
 
 
 class UtilitiesError(Exception):
@@ -1943,3 +1945,24 @@ def _is_module_class(class_: type, module: types.ModuleType) -> bool:
             pass
 
     return False
+
+
+def get_function_sig_default_value(
+    function: typing.Union[types.FunctionType, types.MethodType],
+    parameter: str
+):
+    """
+        Returns:
+            the default value of the **parameter** argument of
+            **function** if it exists, or inspect._empty
+    """
+    try:
+        sig = _signature_cache[function]
+    except KeyError:
+        sig = inspect.signature(function)
+        _signature_cache[function] = sig
+
+    try:
+        return sig.parameters[parameter].default
+    except KeyError:
+        return inspect._empty

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -144,7 +144,6 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
-# TODO: consider combining with _unused_args_sig_cache
 _signature_cache = weakref.WeakKeyDictionary()
 
 
@@ -1674,9 +1673,6 @@ def _get_arg_from_stack(arg_name:str):
     return arg_val
 
 
-_unused_args_sig_cache = weakref.WeakKeyDictionary()
-
-
 def prune_unused_args(func, args=None, kwargs=None):
     """
         Arguments
@@ -1697,10 +1693,10 @@ def prune_unused_args(func, args=None, kwargs=None):
     """
     # use the func signature to filter out arguments that aren't compatible
     try:
-        sig = _unused_args_sig_cache[func]
+        sig = _signature_cache[func]
     except KeyError:
         sig = inspect.signature(func)
-        _unused_args_sig_cache[func] = sig
+        _signature_cache[func] = sig
 
     has_args_param = False
     has_kwargs_param = False

--- a/psyneulink/library/components/mechanisms/modulatory/control/agt/agtcontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/control/agt/agtcontrolmechanism.py
@@ -169,6 +169,7 @@ from psyneulink.core.components.shellclasses import Mechanism
 from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.globals.keywords import \
     INIT_EXECUTE_METHOD_ONLY, MECHANISM, OBJECTIVE_MECHANISM
+from psyneulink.core.globals.parameters import check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 
@@ -244,6 +245,7 @@ class AGTControlMechanism(ControlMechanism):
     #     PREFERENCE_SET_NAME: 'ControlMechanismClassPreferences',
     #     PREFERENCE_KEYWORD<pref>: <setting>...}
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  monitored_output_ports=None,

--- a/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
@@ -307,7 +307,7 @@ from psyneulink.core.components.shellclasses import Mechanism
 from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.globals.keywords import \
     INIT_EXECUTE_METHOD_ONLY, MULTIPLICATIVE_PARAM, PROJECTIONS
-from psyneulink.core.globals.parameters import Parameter, ParameterAlias
+from psyneulink.core.globals.parameters import Parameter, ParameterAlias, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import is_iterable, convert_to_list
@@ -662,6 +662,7 @@ class LCControlMechanism(ControlMechanism):
 
         modulated_mechanisms = Parameter(None, stateful=False, loggable=False)
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/library/components/mechanisms/modulatory/learning/autoassociativelearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/learning/autoassociativelearningmechanism.py
@@ -104,7 +104,7 @@ from psyneulink.core.components.projections.projection import projection_keyword
 from psyneulink.core.globals.context import ContextFlags
 from psyneulink.core.globals.keywords import \
     ADDITIVE, AUTOASSOCIATIVE_LEARNING_MECHANISM, LEARNING, LEARNING_PROJECTION, LEARNING_SIGNAL, NAME, OWNER_VALUE, VARIABLE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import is_numeric, parameter_spec
@@ -319,6 +319,7 @@ class AutoAssociativeLearningMechanism(LearningMechanism):
 
     classPreferenceLevel = PreferenceLevel.TYPE
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable:tc.any(list, np.ndarray),

--- a/psyneulink/library/components/mechanisms/modulatory/learning/kohonenlearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/learning/kohonenlearningmechanism.py
@@ -108,7 +108,7 @@ from psyneulink.core.globals.context import ContextFlags
 from psyneulink.core.globals.keywords import \
     ADDITIVE, KOHONEN_LEARNING_MECHANISM, \
     LEARNING, LEARNING_PROJECTION, LEARNING_SIGNAL
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import is_numeric, parameter_spec
@@ -320,6 +320,7 @@ class KohonenLearningMechanism(LearningMechanism):
         learning_timing = LearningTiming.EXECUTION_PHASE
         modulation = ADDITIVE
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable:tc.any(list, np.ndarray),

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -380,7 +380,7 @@ from psyneulink.core.globals.context import ContextFlags, handle_external_contex
 from psyneulink.core.globals.keywords import \
     ALLOCATION_SAMPLES, FUNCTION, FUNCTION_PARAMS, INPUT_PORT_VARIABLES, NAME, OWNER_VALUE, \
     THRESHOLD, VARIABLE, PREFERENCE_SET_NAME
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set, REPORT_OUTPUT_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
 from psyneulink.core.globals.utilities import convert_all_elements_to_np_array, is_numeric, is_same_function_spec, object_has_single_value, get_global_seed
@@ -753,6 +753,7 @@ class DDM(ProcessingMechanism):
                             ]
     standard_output_port_names = [i['name'] for i in standard_output_ports]
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -415,7 +415,7 @@ from psyneulink.core.components.functions.stateful.memoryfunctions import \
 from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism_Base
 from psyneulink.core.components.ports.inputport import InputPort
 from psyneulink.core.globals.keywords import EPISODIC_MEMORY_MECHANISM, INITIALIZER, NAME, OWNER_VALUE, VARIABLE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.utilities import deprecation_warning, convert_to_np_array, convert_all_elements_to_np_array
 
@@ -512,6 +512,7 @@ class EpisodicMemoryMechanism(ProcessingMechanism_Base):
         variable = Parameter([[0,0]], pnl_internal=True, constructor_argument='default_variable')
         function = Parameter(ContentAddressableMemory, stateful=False, loggable=False)
 
+    @check_user_specified
     def __init__(self,
                  default_variable:Union[int, list, np.ndarray]=None,
                  size:Optional[Union[int, list, np.ndarray]]=None,

--- a/psyneulink/library/components/mechanisms/processing/leabramechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/leabramechanism.py
@@ -106,7 +106,7 @@ import numpy as np
 from psyneulink.core.components.functions.function import Function_Base
 from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism_Base
 from psyneulink.core.globals.keywords import LEABRA_FUNCTION, LEABRA_FUNCTION_TYPE, LEABRA_MECHANISM, NETWORK, PREFERENCE_SET_NAME
-from psyneulink.core.globals.parameters import FunctionParameter, Parameter
+from psyneulink.core.globals.parameters import FunctionParameter, Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import REPORT_OUTPUT_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
 from psyneulink.core.scheduling.time import TimeScale
@@ -212,6 +212,7 @@ class LeabraFunction(Function_Base):
         variable = Parameter(np.array([[0], [0]]), read_only=True, pnl_internal=True, constructor_argument='default_variable')
         network = None
 
+    @check_user_specified
     def __init__(self,
                  default_variable=None,
                  network=None,
@@ -471,6 +472,7 @@ class LeabraMechanism(ProcessingMechanism_Base):
         network = FunctionParameter(None)
         training_flag = Parameter(False, setter=_training_flag_setter, dependencies='network')
 
+    @check_user_specified
     def __init__(self,
                  network=None,
                  input_size=None,

--- a/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
@@ -153,7 +153,7 @@ from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.components.ports.port import _parse_port_spec
 from psyneulink.core.globals.keywords import \
     COMPARATOR_MECHANISM, FUNCTION, INPUT_PORTS, NAME, OUTCOME, SAMPLE, TARGET, VARIABLE, PREFERENCE_SET_NAME, MSE, SSE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set, REPORT_OUTPUT_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
 from psyneulink.core.globals.utilities import \
@@ -323,6 +323,7 @@ class ComparatorMechanism(ObjectiveMechanism):
     standard_output_port_names = ObjectiveMechanism.standard_output_port_names.copy()
     standard_output_port_names.extend([SSE, MSE])
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/library/components/mechanisms/processing/objective/predictionerrormechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/objective/predictionerrormechanism.py
@@ -172,7 +172,7 @@ from psyneulink.core.components.functions.nonstateful.combinationfunctions impor
 from psyneulink.core.components.mechanisms.mechanism import Mechanism_Base
 from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.globals.keywords import PREDICTION_ERROR_MECHANISM, SAMPLE, TARGET
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set, REPORT_OUTPUT_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel, PREFERENCE_SET_NAME
 from psyneulink.core.globals.utilities import is_numeric
@@ -283,6 +283,7 @@ class PredictionErrorMechanism(ComparatorMechanism):
         sample = None
         target = None
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  sample: tc.optional(tc.any(OutputPort, Mechanism_Base, dict,

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -342,7 +342,7 @@ from psyneulink.core.globals.context import ContextFlags, handle_external_contex
 from psyneulink.core.globals.keywords import \
     CONTRASTIVE_HEBBIAN_MECHANISM, COUNT, FUNCTION, HARD_CLAMP, HOLLOW_MATRIX, MAX_ABS_DIFF, NAME, \
     SIZE, SOFT_CLAMP, TARGET, VARIABLE
-from psyneulink.core.globals.parameters import Parameter, SharedParameter
+from psyneulink.core.globals.parameters import Parameter, SharedParameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.utilities import is_numeric_or_none, parameter_spec
 from psyneulink.library.components.mechanisms.processing.transfer.recurrenttransfermechanism import \
@@ -977,6 +977,7 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
     standard_output_port_names = RecurrentTransferMechanism.standard_output_port_names.copy()
     standard_output_port_names = [i['name'] for i in standard_output_ports]
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  input_size:int,

--- a/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
@@ -90,7 +90,7 @@ from psyneulink.core.globals.context import handle_external_context
 from psyneulink.core.globals.keywords import \
     DEFAULT_MATRIX, FUNCTION, GAUSSIAN, IDENTITY_MATRIX, KOHONEN_MECHANISM, \
     LEARNING_SIGNAL, MATRIX, MAX_INDICATOR, NAME, OWNER_VALUE, OWNER_VARIABLE, RESULT, VARIABLE
-from psyneulink.core.globals.parameters import Parameter, SharedParameter
+from psyneulink.core.globals.parameters import Parameter, SharedParameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.utilities import is_numeric_or_none, parameter_spec
 from psyneulink.library.components.mechanisms.modulatory.learning.kohonenlearningmechanism import KohonenLearningMechanism
@@ -274,6 +274,7 @@ class KohonenMechanism(TransferMechanism):
                                     FUNCTION: OneHot(mode=MAX_INDICATOR)}
                                    ])
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/library/components/mechanisms/processing/transfer/kwtamechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kwtamechanism.py
@@ -187,7 +187,7 @@ import typecheck as tc
 
 from psyneulink.core.components.functions.nonstateful.transferfunctions import Logistic
 from psyneulink.core.globals.keywords import KWTA_MECHANISM, K_VALUE, RATIO, RESULT, THRESHOLD
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.utilities import is_numeric_or_none
 from psyneulink.library.components.mechanisms.processing.transfer.recurrenttransfermechanism import RecurrentTransferMechanism
@@ -343,6 +343,7 @@ class KWTAMechanism(RecurrentTransferMechanism):
         average_based = False
         inhibition_only = True
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
@@ -199,7 +199,7 @@ from psyneulink.core.components.mechanisms.processing.transfermechanism import _
 from psyneulink.core.globals.keywords import \
     CONVERGENCE, FUNCTION, GREATER_THAN_OR_EQUAL, LCA_MECHANISM, LESS_THAN_OR_EQUAL, MATRIX, NAME, \
     RESULT, TERMINATION_THRESHOLD, TERMINATION_MEASURE, TERMINATION_COMPARISION_OP, VALUE, INVERSE_HOLLOW_MATRIX, AUTO
-from psyneulink.core.globals.parameters import FunctionParameter, Parameter
+from psyneulink.core.globals.parameters import FunctionParameter, Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.library.components.mechanisms.processing.transfer.recurrenttransfermechanism import \
     RecurrentTransferMechanism, _recurrent_transfer_mechanism_matrix_getter, _recurrent_transfer_mechanism_matrix_setter
@@ -437,6 +437,7 @@ class LCAMechanism(RecurrentTransferMechanism):
                                    {NAME:MAX_VS_AVG,
                                     FUNCTION:max_vs_avg}])
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -210,7 +210,7 @@ from psyneulink.core.components.projections.pathway.mappingprojection import Map
 from psyneulink.core.globals.context import handle_external_context
 from psyneulink.core.globals.keywords import \
     AUTO, ENERGY, ENTROPY, HETERO, HOLLOW_MATRIX, INPUT_PORT, MATRIX, NAME, RECURRENT_TRANSFER_MECHANISM, RESULT
-from psyneulink.core.globals.parameters import Parameter, SharedParameter
+from psyneulink.core.globals.parameters import Parameter, SharedParameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.registry import register_instance, remove_instance_from_registry
 from psyneulink.core.globals.socket import ConnectionInfo
@@ -644,6 +644,7 @@ class RecurrentTransferMechanism(TransferMechanism):
     standard_output_port_names = TransferMechanism.standard_output_port_names.copy()
     standard_output_port_names.extend([ENERGY_OUTPUT_PORT_NAME, ENTROPY_OUTPUT_PORT_NAME])
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  default_variable=None,

--- a/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
+++ b/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
@@ -112,7 +112,7 @@ from psyneulink.core.components.projections.projection import projection_keyword
 from psyneulink.core.components.shellclasses import Mechanism
 from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.globals.keywords import AUTO_ASSOCIATIVE_PROJECTION, DEFAULT_MATRIX, HOLLOW_MATRIX, FUNCTION, OWNER_MECH
-from psyneulink.core.globals.parameters import SharedParameter, Parameter
+from psyneulink.core.globals.parameters import SharedParameter, Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 
@@ -236,6 +236,7 @@ class AutoAssociativeProjection(MappingProjection):
 
     classPreferenceLevel = PreferenceLevel.TYPE
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  owner=None,

--- a/psyneulink/library/components/projections/pathway/maskedmappingprojection.py
+++ b/psyneulink/library/components/projections/pathway/maskedmappingprojection.py
@@ -73,6 +73,7 @@ from psyneulink.core.components.functions.function import get_matrix
 from psyneulink.core.components.projections.pathway.mappingprojection import MappingProjection
 from psyneulink.core.components.projections.projection import projection_keywords
 from psyneulink.core.globals.keywords import MASKED_MAPPING_PROJECTION, MATRIX
+from psyneulink.core.globals.parameters import check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 
@@ -170,6 +171,7 @@ class MaskedMappingProjection(MappingProjection):
 
     classPreferenceLevel = PreferenceLevel.TYPE
 
+    @check_user_specified
     @tc.typecheck
     def __init__(self,
                  sender=None,

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -150,7 +150,7 @@ from psyneulink.core.compositions.report \
 from psyneulink.core.globals.context import Context, ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import AUTODIFF_COMPOSITION, SOFT_CLAMP
 from psyneulink.core.scheduling.scheduler import Scheduler
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.scheduling.time import TimeScale
 from psyneulink.core import llvm as pnlvm
 
@@ -222,6 +222,7 @@ class AutodiffComposition(Composition):
         pytorch_representation = None
 
     # TODO (CW 9/28/18): add compositions to registry so default arg for name is no longer needed
+    @check_user_specified
     def __init__(self,
                  learning_rate=None,
                  optimizer_type='sgd',

--- a/psyneulink/library/compositions/gymforagercfa.py
+++ b/psyneulink/library/compositions/gymforagercfa.py
@@ -81,7 +81,7 @@ import typecheck as tc
 from psyneulink.library.compositions.regressioncfa import RegressionCFA
 from psyneulink.core.components.functions.nonstateful.learningfunctions import BayesGLM
 from psyneulink.core.globals.keywords import DEFAULT_VARIABLE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 
 __all__ = ['GymForagerCFA']
 
@@ -108,6 +108,7 @@ class GymForagerCFA(RegressionCFA):
     class Parameters(RegressionCFA.Parameters):
         update_weights = Parameter(BayesGLM, stateful=False, loggable=False)
 
+    @check_user_specified
     def __init__(self,
                  name=None,
                  update_weights=BayesGLM,

--- a/psyneulink/library/compositions/regressioncfa.py
+++ b/psyneulink/library/compositions/regressioncfa.py
@@ -85,7 +85,7 @@ from psyneulink.core.components.ports.modulatorysignals.controlsignal import Con
 from psyneulink.core.components.ports.port import _parse_port_spec
 from psyneulink.core.compositions.compositionfunctionapproximator import CompositionFunctionApproximator
 from psyneulink.core.globals.keywords import ALL, CONTROL_SIGNALS, DEFAULT_VARIABLE, VARIABLE
-from psyneulink.core.globals.parameters import Parameter
+from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.utilities import get_deepcopy_with_shared, powerset, tensor_power
 
 __all__ = ['PREDICTION_TERMS', 'PV', 'RegressionCFA']
@@ -246,6 +246,7 @@ class RegressionCFA(CompositionFunctionApproximator):
         previous_state = None
         regression_weights = None
 
+    @check_user_specified
     def __init__(self,
                  name=None,
                  update_weights=None,

--- a/tests/components/test_general.py
+++ b/tests/components/test_general.py
@@ -55,35 +55,6 @@ def test_function_parameters_stateless(class_):
         pass
 
 
-@pytest.mark.parametrize(
-    'class_',
-    component_classes
-)
-def test_parameters_user_specified(class_):
-    violators = set()
-    constructor_parameters = inspect.signature(class_.__init__).parameters
-    for name, param in constructor_parameters.items():
-        if (
-            param.kind in {
-                inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                inspect.Parameter.KEYWORD_ONLY
-            }
-            and name in class_.parameters.names()
-            and param.default is not inspect.Parameter.empty
-            and param.default is not None
-        ):
-            violators.add(name)
-
-    message = (
-        "If a value other than None is used as the default value in a class's"
-        + ' constructor/__init__, for an argument corresponding to a Parameter,'
-        + ' _user_specified will always be True. The default value should be'
-        + " specified in the class's Parameters inner class. Violators for"
-        + f' {class_.__name__}: {violators}'
-    )
-    assert violators == set(), message
-
-
 @pytest.fixture(scope='module')
 def nested_compositions():
     comp = pnl.Composition(name='comp')

--- a/tests/components/test_general.py
+++ b/tests/components/test_general.py
@@ -55,6 +55,14 @@ def test_function_parameters_stateless(class_):
         pass
 
 
+@pytest.mark.parametrize("class_", component_classes)
+def test_constructors_have_check_user_specified(class_):
+    assert "check_user_specified" in inspect.getsource(class_.__init__), (
+        f"The __init__ method of Component {class_.__name__} must be wrapped by"
+        f" check_user_specified in {pnl.core.globals.parameters.check_user_specified.__module__}"
+    )
+
+
 @pytest.fixture(scope='module')
 def nested_compositions():
     comp = pnl.Composition(name='comp')

--- a/tests/misc/test_parameters.py
+++ b/tests/misc/test_parameters.py
@@ -6,6 +6,11 @@ import re
 import warnings
 
 
+NO_PARAMETERS = "NO_PARAMETERS"
+NO_INIT = "NO_INIT"
+NO_VALUE = "NO_VALUE"
+
+
 def shared_parameter_warning_regex(param_name, shared_name=None):
     if shared_name is None:
         shared_name = param_name
@@ -258,11 +263,15 @@ def test_copy():
     [
         (pnl.AdaptiveIntegrator, {'rate': None}, 'rate', False),
         (pnl.AdaptiveIntegrator, {'rate': None}, 'multiplicative_param', False),
+        (pnl.AdaptiveIntegrator, {'rate': 0.5}, 'additive_param', False),
         (pnl.AdaptiveIntegrator, {'rate': 0.5}, 'rate', True),
         (pnl.AdaptiveIntegrator, {'rate': 0.5}, 'multiplicative_param', True),
         (pnl.TransferMechanism, {'integration_rate': None}, 'integration_rate', False),
         (pnl.TransferMechanism, {'integration_rate': 0.5}, 'integration_rate', True),
-    ]
+        (pnl.TransferMechanism, {'initial_value': 0}, 'initial_value', True),
+        (pnl.TransferMechanism, {'initial_value': None}, 'initial_value', False),
+        (pnl.TransferMechanism, {}, 'initial_value', False),
+    ],
 )
 def test_user_specified(cls_, kwargs, parameter, is_user_specified):
     c = cls_(**kwargs)
@@ -442,3 +451,181 @@ class TestSharedParameters:
                     raise
 
         delattr(pnl.AdaptiveIntegrator.Parameters, '_parse_noise')
+
+
+class TestSpecificationType:
+    @staticmethod
+    def _create_params_class_variant(cls_param, init_param, parent_class=pnl.Component):
+        # init_param as Parameter doesn't make sense, only check cls_param
+        if cls_param is pnl.Parameter:
+            cls_param = pnl.Parameter()
+
+        if cls_param is NO_PARAMETERS:
+            if init_param is NO_INIT:
+
+                class TestComponent(parent_class):
+                    pass
+
+            else:
+
+                class TestComponent(parent_class):
+                    def __init__(self, p=init_param):
+                        super().__init__(p=p)
+
+        elif cls_param is NO_VALUE:
+            if init_param is NO_INIT:
+
+                class TestComponent(parent_class):
+                    class Parameters(parent_class.Parameters):
+                        pass
+
+            else:
+
+                class TestComponent(parent_class):
+                    class Parameters(parent_class.Parameters):
+                        pass
+
+                    def __init__(self, p=init_param):
+                        super().__init__(p=p)
+
+        else:
+            if init_param is NO_INIT:
+
+                class TestComponent(parent_class):
+                    class Parameters(parent_class.Parameters):
+                        p = cls_param
+
+            else:
+
+                class TestComponent(parent_class):
+                    class Parameters(parent_class.Parameters):
+                        p = cls_param
+
+                    def __init__(self, p=init_param):
+                        super().__init__(p=p)
+
+        return TestComponent
+
+    @pytest.mark.parametrize(
+        "cls_param, init_param, param_default",
+        [
+            (1, 1, 1),
+            (1, None, 1),
+            (None, 1, 1),
+            (1, NO_INIT, 1),
+            ("foo", "foo", "foo"),
+            (np.array(1), np.array(1), np.array(1)),
+            (np.array([1]), np.array([1]), np.array([1])),
+        ],
+    )
+    def test_valid_assignment(self, cls_param, init_param, param_default):
+        TestComponent = TestSpecificationType._create_params_class_variant(cls_param, init_param)
+        assert TestComponent.defaults.p == param_default
+        assert TestComponent.parameters.p.default_value == param_default
+
+    @pytest.mark.parametrize(
+        "cls_param, init_param",
+        [
+            (1, 2),
+            (2, 1),
+            (1, 1.0),
+            (np.array(1), 1),
+            (np.array([1]), 1),
+            (np.array([1]), np.array(1)),
+            ("foo", "bar"),
+        ],
+    )
+    def test_conflicting_assignments(self, cls_param, init_param):
+        with pytest.raises(AssertionError, match="Conflicting default parameter"):
+            TestSpecificationType._create_params_class_variant(cls_param, init_param)
+
+    @pytest.mark.parametrize(
+        "child_cls_param, child_init_param, parent_value, child_value",
+        [
+            (NO_PARAMETERS, NO_INIT, 1, 1),
+            (NO_VALUE, NO_INIT, 1, 1),
+            (2, NO_INIT, 1, 2),
+            (NO_PARAMETERS, 2, 1, 2),
+            (NO_VALUE, 2, 1, 2),
+            (2, 2, 1, 2),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "parent_cls_param, parent_init_param", [(1, 1), (1, None), (None, 1), (pnl.Parameter, 1)]
+    )
+    def test_inheritance(
+        self,
+        parent_cls_param,
+        parent_init_param,
+        child_cls_param,
+        child_init_param,
+        parent_value,
+        child_value,
+    ):
+        TestParent = TestSpecificationType._create_params_class_variant(
+            parent_cls_param, parent_init_param
+        )
+        TestChild = TestSpecificationType._create_params_class_variant(
+            child_cls_param, child_init_param, parent_class=TestParent
+        )
+
+        assert TestParent.defaults.p == parent_value
+        assert TestParent.parameters.p.default_value == parent_value
+
+        assert TestChild.defaults.p == child_value
+        assert TestChild.parameters.p.default_value == child_value
+
+    @pytest.mark.parametrize("set_from_defaults", [True, False])
+    @pytest.mark.parametrize(
+        "child_cls_param, child_init_param",
+        [(1, 1), (1, None), (None, 1), (NO_PARAMETERS, 1), (1, NO_INIT)],
+    )
+    @pytest.mark.parametrize("parent_cls_param, parent_init_param", [(0, 0), (0, None)])
+    def test_set_and_reset(
+        self,
+        parent_cls_param,
+        parent_init_param,
+        child_cls_param,
+        child_init_param,
+        set_from_defaults,
+    ):
+        def set_p_default(obj, val):
+            if set_from_defaults:
+                obj.defaults.p = val
+            else:
+                obj.parameters.p.default_value = val
+
+        TestParent = TestSpecificationType._create_params_class_variant(
+            parent_cls_param, parent_init_param
+        )
+        TestChild = TestSpecificationType._create_params_class_variant(
+            child_cls_param, child_init_param, parent_class=TestParent
+        )
+        TestGrandchild = TestSpecificationType._create_params_class_variant(
+            NO_PARAMETERS, NO_INIT, parent_class=TestChild
+        )
+
+        set_p_default(TestChild, 10)
+        assert TestParent.defaults.p == 0
+        assert TestChild.defaults.p == 10
+        assert TestGrandchild.defaults.p == 10
+
+        set_p_default(TestGrandchild, 20)
+        assert TestParent.defaults.p == 0
+        assert TestChild.defaults.p == 10
+        assert TestGrandchild.defaults.p == 20
+
+        TestChild.parameters.p.reset()
+        assert TestParent.defaults.p == 0
+        assert TestChild.defaults.p == 1
+        assert TestGrandchild.defaults.p == 20
+
+        TestGrandchild.parameters.p.reset()
+        assert TestParent.defaults.p == 0
+        assert TestChild.defaults.p == 1
+        assert TestGrandchild.defaults.p == 1
+
+        set_p_default(TestGrandchild, 20)
+        assert TestParent.defaults.p == 0
+        assert TestChild.defaults.p == 1
+        assert TestGrandchild.defaults.p == 20

--- a/tests/misc/test_parameters.py
+++ b/tests/misc/test_parameters.py
@@ -469,6 +469,7 @@ class TestSpecificationType:
             else:
 
                 class TestComponent(parent_class):
+                    @pnl.core.globals.parameters.check_user_specified
                     def __init__(self, p=init_param):
                         super().__init__(p=p)
 
@@ -485,6 +486,7 @@ class TestSpecificationType:
                     class Parameters(parent_class.Parameters):
                         pass
 
+                    @pnl.core.globals.parameters.check_user_specified
                     def __init__(self, p=init_param):
                         super().__init__(p=p)
 
@@ -501,6 +503,7 @@ class TestSpecificationType:
                     class Parameters(parent_class.Parameters):
                         p = cls_param
 
+                    @pnl.core.globals.parameters.check_user_specified
                     def __init__(self, p=init_param):
                         super().__init__(p=p)
 
@@ -551,7 +554,8 @@ class TestSpecificationType:
         ],
     )
     @pytest.mark.parametrize(
-        "parent_cls_param, parent_init_param", [(1, 1), (1, None), (None, 1), (pnl.Parameter, 1)]
+        "parent_cls_param, parent_init_param",
+        [(1, 1), (1, None), (None, 1), (pnl.Parameter, 1)],
     )
     def test_inheritance(
         self,


### PR DESCRIPTION
This sets the _user_specified flag more accurately according to the actual arguments passed in to a Component \_\_init\_\_. This allows:
- Parameter default values to be specified as default arguments in \_\_init\_\_ methods
- with the specify_none flag, a Parameter value of None to be user-specified

Any new Component \_\_init\_\_ must now be decorated by `psyneulink.core.globals.parameters.check_user_specified`