### PR TITLE
Revert "requirements: update pytorch requirement from <1.9.0 to <2.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ numpy<1.21.4, >=1.17.0
 pillow<9.2.0
 pint<0.18
 toposort<1.8
-torch>=1.8.0, <2.0.0; (platform_machine == 'AMD64' or platform_machine == 'x86_64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
+torch>=1.8.0, <1.9.0; (platform_machine == 'AMD64' or platform_machine == 'x86_64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
 typecheck-decorator<=1.2
 leabra-psyneulink<=0.3.2
 rich>=10.1, <10.13


### PR DESCRIPTION
The versioning scheme uses 1.10.y, 1.11.v, ... instead of bumping to
2.0.x.

This reverts commit 70aa4923ea6f89fe0107206d7f159665a0544675.