### PR TITLE
llvm: Add support for more SoftMax output types

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1333,6 +1333,10 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
         if hasattr(self, 'nodes'):
             whitelist.add("num_executions")
 
+        # Drop combination function params from RTM if not needed
+        if getattr(self.parameters, 'has_recurrent_input_port', False):
+            blacklist.update(['combination_function'])
+
         def _is_compilation_state(p):
             #FIXME: This should use defaults instead of 'p.get'
             return p.name not in blacklist and \
@@ -1424,6 +1428,10 @@ class Component(JSONDumpable, metaclass=ComponentsMeta):
             blacklist.update(["execute_until_finished", "max_executions_before_finished"])
             # "has_initializers" is only used by RTM
             blacklist.update(["has_initializers"])
+
+        # Drop combination function params from RTM if not needed
+        if getattr(self.parameters, 'has_recurrent_input_port', False):
+            blacklist.update(['combination_function'])
 
         def _is_compilation_param(p):
             if p.name not in blacklist and not isinstance(p, (ParameterAlias, SharedParameter)):

--- a/psyneulink/core/components/mechanisms/processing/processingmechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/processingmechanism.py
@@ -98,7 +98,7 @@ from psyneulink.core.components.ports.inputport import InputPort
 from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.globals.keywords import \
     FUNCTION, MAX_ABS_INDICATOR, MAX_ABS_ONE_HOT, MAX_ABS_VAL, MAX_INDICATOR, MAX_ONE_HOT, MAX_VAL, MEAN, MEDIAN, \
-    NAME, PROB, PROCESSING_MECHANISM, PREFERENCE_SET_NAME, STANDARD_DEVIATION, VARIANCE
+    NAME, PROB, PROCESSING_MECHANISM, PREFERENCE_SET_NAME, STANDARD_DEVIATION, VARIANCE, VARIABLE, OWNER_VALUE
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set, REPORT_OUTPUT_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
 
@@ -165,6 +165,7 @@ class ProcessingMechanism_Base(Mechanism_Base):
                                   {NAME: MAX_ABS_INDICATOR,
                                    FUNCTION: OneHot(mode=MAX_ABS_INDICATOR)},
                                   {NAME: PROB,
+                                   VARIABLE: OWNER_VALUE,
                                    FUNCTION: SoftMax(output=PROB)}])
     standard_output_port_names = [i['name'] for i in standard_output_ports]
 

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -199,7 +199,7 @@ class LLVMBuilderContext:
         if name in _builtin_intrinsics:
             return self.import_llvm_function(_BUILTIN_PREFIX + name)
         if name in ('maxnum'):
-            function_type = pnlvm.ir.FunctionType(args[0], [args[0], args[0]])
+            function_type = ir.FunctionType(args[0], [args[0], args[0]])
         return self.module.declare_intrinsic("llvm." + name, args, function_type)
 
     def create_llvm_function(self, args, component, name=None, *, return_type=ir.VoidType(), tags:frozenset=frozenset()):
@@ -207,8 +207,8 @@ class LLVMBuilderContext:
 
         # Builtins are already unique and need to keep their special name
         func_name = name if name.startswith(_BUILTIN_PREFIX) else self.get_unique_name(name)
-        func_ty = pnlvm.ir.FunctionType(return_type, args)
-        llvm_func = pnlvm.ir.Function(self.module, func_ty, name=func_name)
+        func_ty = ir.FunctionType(return_type, args)
+        llvm_func = ir.Function(self.module, func_ty, name=func_name)
         llvm_func.attributes.add('argmemonly')
         for a in llvm_func.args:
             if isinstance(a.type, ir.PointerType):
@@ -221,7 +221,7 @@ class LLVMBuilderContext:
 
         # Create entry block
         block = llvm_func.append_basic_block(name="entry")
-        builder = pnlvm.ir.IRBuilder(block)
+        builder = ir.IRBuilder(block)
         builder.debug_metadata = metadata
 
         return builder

--- a/psyneulink/core/llvm/builtins.py
+++ b/psyneulink/core/llvm/builtins.py
@@ -11,12 +11,8 @@
 from llvmlite import ir
 
 
-from . import debug
 from . import helpers
 from .builder_context import LLVMBuilderContext, _BUILTIN_PREFIX
-
-
-debug_env = debug.debug_env
 
 
 def _setup_builtin_func_builder(ctx, name, args, *, return_type=ir.VoidType()):

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1341,6 +1341,8 @@ class RecurrentTransferMechanism(TransferMechanism):
             # input
             builder.call(recurrent_f, [recurrent_params, recurrent_state, recurrent_in, recurrent_out])
 
+        assert not self.has_recurrent_input_port, "Configuration using combination function is not supported!"
+
         return super()._gen_llvm_input_ports(ctx, builder, params, state, arg_in)
 
     def _gen_llvm_output_ports(self, ctx, builder, value,

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -35,25 +35,43 @@ def gaussian_distort_helper(seed):
 
 
 test_data = [
-    (Functions.Linear, test_var, {'slope':RAND1, 'intercept':RAND2}, None, test_var * RAND1 + RAND2),
-    (Functions.Exponential, test_var, {'scale':RAND1, 'rate':RAND2}, None, RAND1 * np.exp(RAND2 * test_var)),
-    (Functions.Logistic, test_var, {'gain':RAND1, 'x_0':RAND2, 'offset':RAND3, 'scale':RAND4}, None, RAND4 / (1 + np.exp(-(RAND1 * (test_var - RAND2)) + RAND3))),
-    (Functions.Tanh, test_var, {'gain':RAND1, 'bias':RAND2, 'x_0':RAND3, 'offset':RAND4}, None, tanh_helper),
-    (Functions.ReLU, test_var, {'gain':RAND1, 'bias':RAND2, 'leak':RAND3}, None, np.maximum(RAND1 * (test_var - RAND2), RAND3 * RAND1 *(test_var - RAND2))),
-    (Functions.Angle, [0.5488135,  0.71518937, 0.60276338, 0.54488318, 0.4236548,
-                       0.64589411, 0.43758721, 0.891773, 0.96366276, 0.38344152], {}, None,
-     [0.85314409, 0.00556188, 0.01070476, 0.0214405,  0.05559454,
-      0.08091079, 0.21657281, 0.19296643, 0.21343805, 0.92738261, 0.00483101]),
-    (Functions.Gaussian, test_var, {'standard_deviation':RAND1, 'bias':RAND2, 'scale':RAND3, 'offset':RAND4}, None, gaussian_helper),
-    (Functions.GaussianDistort, test_var.tolist(), {'bias': RAND1, 'variance':RAND2, 'offset':RAND3, 'scale':RAND4 }, None, gaussian_distort_helper(0)),
-    (Functions.GaussianDistort, test_var.tolist(), {'bias': RAND1, 'variance':RAND2, 'offset':RAND3, 'scale':RAND4, 'seed':0 }, None, gaussian_distort_helper(0)),
-    (Functions.SoftMax, test_var, {'gain':RAND1, 'per_item': False}, None, softmax_helper),
-    (Functions.SoftMax, test_var, {'gain':RAND1, 'params':{kw.OUTPUT_TYPE:kw.MAX_VAL}, 'per_item': False}, None, np.where(softmax_helper == np.max(softmax_helper), np.max(softmax_helper), 0)),
-    (Functions.SoftMax, test_var, {'gain':RAND1, 'params':{kw.OUTPUT_TYPE:kw.MAX_INDICATOR}, 'per_item': False}, None, np.where(softmax_helper == np.max(softmax_helper), 1, 0)),
-    (Functions.LinearMatrix, test_var.tolist(), {'matrix':test_matrix.tolist()}, None, np.dot(test_var, test_matrix)),
-    (Functions.LinearMatrix, test_var.tolist(), {'matrix':test_matrix_l.tolist()}, None, np.dot(test_var, test_matrix_l)),
-    (Functions.LinearMatrix, test_var.tolist(), {'matrix':test_matrix_s.tolist()}, None, np.dot(test_var, test_matrix_s)),
+    pytest.param(Functions.Linear, test_var, {'slope':RAND1, 'intercept':RAND2}, test_var * RAND1 + RAND2, id="LINEAR"),
+    pytest.param(Functions.Exponential, test_var, {'scale':RAND1, 'rate':RAND2}, RAND1 * np.exp(RAND2 * test_var), id="EXPONENTIAL"),
+    pytest.param(Functions.Logistic, test_var, {'gain':RAND1, 'x_0':RAND2, 'offset':RAND3, 'scale':RAND4}, RAND4 / (1 + np.exp(-(RAND1 * (test_var - RAND2)) + RAND3)), id="LOGISTIC"),
+    pytest.param(Functions.Tanh, test_var, {'gain':RAND1, 'bias':RAND2, 'x_0':RAND3, 'offset':RAND4}, tanh_helper, id="TANH"),
+    pytest.param(Functions.ReLU, test_var, {'gain':RAND1, 'bias':RAND2, 'leak':RAND3}, np.maximum(RAND1 * (test_var - RAND2), RAND3 * RAND1 *(test_var - RAND2)), id="RELU"),
+    pytest.param(Functions.Angle, [0.5488135,  0.71518937, 0.60276338, 0.54488318, 0.4236548,
+                                   0.64589411, 0.43758721, 0.891773, 0.96366276, 0.38344152], {},
+                 [0.85314409, 0.00556188, 0.01070476, 0.0214405,  0.05559454,
+                  0.08091079, 0.21657281, 0.19296643, 0.21343805, 0.92738261, 0.00483101],
+                 id="ANGLE"),
+    pytest.param(Functions.Gaussian, test_var, {'standard_deviation':RAND1, 'bias':RAND2, 'scale':RAND3, 'offset':RAND4}, gaussian_helper, id="GAUSSIAN"),
+    pytest.param(Functions.GaussianDistort, test_var.tolist(), {'bias': RAND1, 'variance':RAND2, 'offset':RAND3, 'scale':RAND4 }, gaussian_distort_helper(0), id="GAUSSIAN DISTORT GLOBAL SEED"),
+    pytest.param(Functions.GaussianDistort, test_var.tolist(), {'bias': RAND1, 'variance':RAND2, 'offset':RAND3, 'scale':RAND4, 'seed':0 }, gaussian_distort_helper(0), id="GAUSSIAN DISTORT"),
+    pytest.param(Functions.SoftMax, test_var, {'gain':RAND1, 'per_item': False}, softmax_helper, id="SOFT_MAX ALL"),
+    pytest.param(Functions.SoftMax, test_var, {'gain':RAND1, 'params':{kw.OUTPUT_TYPE:kw.MAX_VAL}, 'per_item': False}, np.where(softmax_helper == np.max(softmax_helper), np.max(softmax_helper), 0), id="SOFT_MAX MAX_VAL"),
+    pytest.param(Functions.SoftMax, test_var, {'gain':RAND1, 'params':{kw.OUTPUT_TYPE:kw.MAX_INDICATOR}, 'per_item': False}, np.where(softmax_helper == np.max(softmax_helper), 1, 0), id="SOFT_MAX MAX_INDICATOR"),
+    pytest.param(Functions.LinearMatrix, test_var.tolist(), {'matrix':test_matrix.tolist()}, np.dot(test_var, test_matrix), id="LINEAR_MATRIX SQUARE"),
+    pytest.param(Functions.LinearMatrix, test_var.tolist(), {'matrix':test_matrix_l.tolist()}, np.dot(test_var, test_matrix_l), id="LINEAR_MATRIX WIDE"),
+    pytest.param(Functions.LinearMatrix, test_var.tolist(), {'matrix':test_matrix_s.tolist()}, np.dot(test_var, test_matrix_s), id="LINEAR_MATRIX TALL"),
 ]
+
+@pytest.mark.function
+@pytest.mark.transfer_function
+@pytest.mark.benchmark
+@pytest.mark.parametrize("func, variable, params, expected", test_data)
+def test_execute(func, variable, params, expected, benchmark, func_mode):
+    if 'Angle' in func.componentName and func_mode != 'Python':
+        pytest.skip('Angle not yet supported by LLVM or PTX')
+    benchmark.group = "TransferFunction " + func.componentName
+    f = func(default_variable=variable, **params)
+    ex = pytest.helpers.get_func_execution(f, func_mode)
+
+    res = ex(variable)
+    assert np.allclose(res, expected)
+    if benchmark.enabled:
+        benchmark(ex, variable)
+
 
 relu_derivative_helper = lambda x : RAND1 if x > 0 else RAND1 * RAND3
 logistic_helper = RAND4 / (1 + np.exp(-(RAND1 * (test_var - RAND2)) + RAND3))
@@ -67,25 +85,6 @@ derivative_test_data = [
     (Functions.Tanh, test_var, {'gain':RAND1, 'bias':RAND2, 'offset':RAND3, 'scale':RAND4}, tanh_derivative_helper),
 ]
 
-# use list, naming function produces ugly names
-names = [
-    "LINEAR",
-    "EXPONENTIAL",
-    "LOGISTIC",
-    "TANH",
-    "RELU",
-    "ANGLE",
-    "GAUSIAN",
-    "GAUSSIAN DISTORT GLOBAL SEED",
-    "GAUSSIAN DISTORT",
-    "SOFT_MAX ALL",
-    "SOFT_MAX MAX_VAL",
-    "SOFT_MAX MAX_INDICATOR",
-    "LINEAR_MATRIX SQUARE",
-    "LINEAR_MATRIX WIDE",
-    "LINEAR_MATRIX TALL",
-]
-
 derivative_names = [
     "LINEAR_DERIVATIVE",
     "EXPONENTIAL_DERIVATIVE",
@@ -93,23 +92,6 @@ derivative_names = [
     "RELU_DERIVATIVE",
     "TANH_DERIVATIVE",
 ]
-
-@pytest.mark.function
-@pytest.mark.transfer_function
-@pytest.mark.benchmark
-@pytest.mark.parametrize("func, variable, params, fail, expected", test_data, ids=names)
-def test_execute(func, variable, params, fail, expected, benchmark, func_mode):
-    if 'Angle' in func.componentName and func_mode != 'Python':
-        pytest.skip('Angle not yet supported by LLVM or PTX')
-    benchmark.group = "TransferFunction " + func.componentName
-    f = func(default_variable=variable, **params)
-    ex = pytest.helpers.get_func_execution(f, func_mode)
-
-    res = ex(variable)
-    assert np.allclose(res, expected)
-    if benchmark.enabled:
-        benchmark(ex, variable)
-
 
 @pytest.mark.function
 @pytest.mark.transfer_function

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -7,6 +7,7 @@ import pytest
 from math import e, pi, sqrt
 
 SIZE=10
+np.random.seed(0)
 test_var = np.random.rand(SIZE)
 test_matrix = np.random.rand(SIZE, SIZE)
 test_matrix_s = np.random.rand(SIZE, SIZE // 4)
@@ -51,6 +52,8 @@ test_data = [
     pytest.param(Functions.SoftMax, test_var, {'gain':RAND1, 'per_item': False}, softmax_helper, id="SOFT_MAX ALL"),
     pytest.param(Functions.SoftMax, test_var, {'gain':RAND1, 'params':{kw.OUTPUT_TYPE:kw.MAX_VAL}, 'per_item': False}, np.where(softmax_helper == np.max(softmax_helper), np.max(softmax_helper), 0), id="SOFT_MAX MAX_VAL"),
     pytest.param(Functions.SoftMax, test_var, {'gain':RAND1, 'params':{kw.OUTPUT_TYPE:kw.MAX_INDICATOR}, 'per_item': False}, np.where(softmax_helper == np.max(softmax_helper), 1, 0), id="SOFT_MAX MAX_INDICATOR"),
+    pytest.param(Functions.SoftMax, test_var, {'gain':RAND1, 'params':{kw.OUTPUT_TYPE:kw.PROB}, 'per_item': False},
+                 [0.0, 0.0, 0.0, 0.0, test_var[4], 0.0, 0.0, 0.0, 0.0, 0.0], id="SOFT_MAX PROB"),
     pytest.param(Functions.LinearMatrix, test_var.tolist(), {'matrix':test_matrix.tolist()}, np.dot(test_var, test_matrix), id="LINEAR_MATRIX SQUARE"),
     pytest.param(Functions.LinearMatrix, test_var.tolist(), {'matrix':test_matrix_l.tolist()}, np.dot(test_var, test_matrix_l), id="LINEAR_MATRIX WIDE"),
     pytest.param(Functions.LinearMatrix, test_var.tolist(), {'matrix':test_matrix_s.tolist()}, np.dot(test_var, test_matrix_s), id="LINEAR_MATRIX TALL"),

--- a/tests/mechanisms/test_processing_mechanism.py
+++ b/tests/mechanisms/test_processing_mechanism.py
@@ -248,6 +248,7 @@ class TestProcessingMechanismStandardOutputPorts:
                                               (MAX_ABS_INDICATOR, [0, 0, 1]),
                                               (MAX_ABS_ONE_HOT, [0, 0, 4]),
                                               (MAX_VAL, [2]),
+                                              (PROB, [0, 2, 0]),
                                              ],
                              ids=lambda x: x if isinstance(x, str) else "")
     def test_output_ports(self, mech_mode, op, expected, benchmark):
@@ -265,7 +266,6 @@ class TestProcessingMechanismStandardOutputPorts:
                                               (STANDARD_DEVIATION, [1.24721913]),
                                               (VARIANCE, [1.55555556]),
                                               (MAX_ABS_VAL, [4]),
-                                              (PROB, [0, 2, 0]),
                                              ],
                              ids=lambda x: x if isinstance(x, str) else "")
     def test_output_ports2(self, op, expected):


### PR DESCRIPTION
Convert MAX_VAL, and MAX_INDICATOR SoftMax output types to use OneHot nested function.
Add support for PROB SoftMax output type.
Add support for compiling PROB standard output.
Check that we're not using combination_function in compiled RTM.
Drop nested parameters and state of combination function if not used in RTM.