### PR TITLE
llvm: Cleanup codegen of mechanisms that modify function return value

### DIFF
--- a/psyneulink/core/components/functions/stateful/integratorfunctions.py
+++ b/psyneulink/core/components/functions/stateful/integratorfunctions.py
@@ -2538,10 +2538,6 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
         builder.call(rand_f, [random_state, rand_val_ptr])
         rand_val = builder.load(rand_val_ptr)
 
-        if isinstance(rate.type, pnlvm.ir.ArrayType):
-            assert len(rate.type) == 1
-            rate = builder.extract_value(rate, 0)
-
         # Get state pointers
         prev_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, "previous_value")
         prev_time_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, "previous_time")
@@ -2550,10 +2546,8 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
         #       + np.sqrt(time_step_size * noise) * random_state.normal()
         prev_val_ptr = builder.gep(prev_ptr, [ctx.int32_ty(0), index])
         prev_val = builder.load(prev_val_ptr)
+
         val = builder.load(builder.gep(vi, [ctx.int32_ty(0), index]))
-        if isinstance(val.type, pnlvm.ir.ArrayType):
-            assert len(val.type) == 1
-            val = builder.extract_value(val, 0)
         val = builder.fmul(val, rate)
         val = builder.fmul(val, time_step_size)
         val = builder.fadd(val, prev_val)

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -588,7 +588,6 @@ import warnings
 import numpy as np
 import typecheck as tc
 
-from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.functions.function import Function_Base, is_function_type
 from psyneulink.core.components.functions.nonstateful.transferfunctions import Identity
 from psyneulink.core.components.functions.nonstateful.combinationfunctions import Concatenate

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1544,13 +1544,11 @@ class TransferMechanism(ProcessingMechanism_Base):
             return builder.fcmp_ordered("!=", is_finished_flag,
                                               is_finished_flag.type(0))
 
-        # If modulated, termination threshold is single element array
-        if isinstance(threshold_ptr.type.pointee, pnlvm.ir.ArrayType):
-            assert len(threshold_ptr.type.pointee) == 1
-            threshold_ptr = builder.gep(threshold_ptr, [ctx.int32_ty(0),
-                                                        ctx.int32_ty(0)])
+        # If modulated, termination threshold is single element array.
+        # Otherwise, it is scalar
+        threshold = pnlvm.helpers.load_extract_scalar_array_one(builder,
+                                                                threshold_ptr)
 
-        threshold = builder.load(threshold_ptr)
         cmp_val_ptr = builder.alloca(threshold.type, name="is_finished_value")
         if self.termination_measure is max:
             assert self._termination_measure_num_items_expected == 1

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -262,12 +262,9 @@ class LLVMBuilderContext:
         used_seed = builder.load(used_seed_ptr)
 
         seed_ptr = helpers.get_param_ptr(builder, component, params, "seed")
-        if isinstance(seed_ptr.type.pointee, ir.ArrayType):
-            # Modulated params are usually single element arrays
-            seed_ptr = builder.gep(seed_ptr, [self.int32_ty(0), self.int32_ty(0)])
-        new_seed = builder.load(seed_ptr)
+        new_seed = pnlvm.helpers.load_extract_scalar_array_one(builder, seed_ptr)
         # FIXME: The seed should ideally be integer already.
-        #        However, it can be modulated and we don't support,
+        #        However, it can be modulated and we don't support
         #        passing integer values as computed results.
         new_seed = builder.fptoui(new_seed, used_seed.type)
 

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -215,9 +215,8 @@ class LLVMBuilderContext:
                 a.attributes.add('nonnull')
 
         metadata = self.get_debug_location(llvm_func, component)
-        if metadata is not None:
-            scope = dict(metadata.operands)["scope"]
-            llvm_func.set_metadata("dbg", scope)
+        scope = dict(metadata.operands)["scope"]
+        llvm_func.set_metadata("dbg", scope)
 
         # Create entry block
         block = llvm_func.append_basic_block(name="entry")
@@ -327,9 +326,7 @@ class LLVMBuilderContext:
 
     @staticmethod
     def update_debug_loc_position(di_loc: ir.DIValue, line:int, column:int):
-        subprogram_operand = di_loc.operands[2]
-        assert subprogram_operand[0] == 'scope'
-        di_func = subprogram_operand[1]
+        di_func = dict(di_loc.operands)["scope"]
 
         return di_loc.parent.add_debug_info("DILocation", {
             "line": line, "column": column, "scope": di_func,

--- a/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
@@ -834,12 +834,11 @@ class LCControlMechanism(ControlMechanism):
 
         return gain_t, output_values[0], output_values[1], output_values[2]
 
-    def _gen_llvm_invoke_function(self, ctx, builder, function, params, state,
-                                  variable, out, *, tags:frozenset):
-        assert function is self.function
-        mf_out, builder = super()._gen_llvm_invoke_function(ctx, builder, function,
-                                                            params, state, variable,
-                                                            None, tags=tags)
+    def _gen_llvm_mechanism_functions(self, ctx, builder, m_base_params, m_params, m_state, m_in,
+                                      m_val, ip_output, *, tags:frozenset):
+        mf_out, builder = super()._gen_llvm_mechanism_functions(ctx, builder, m_base_params,
+                                                                m_params, m_state, m_in,
+                                                                None, ip_output, tags=tags)
 
         # prepend gain type (matches output[1] type)
         gain_ty = mf_out.type.pointee.elements[1]
@@ -849,11 +848,10 @@ class LCControlMechanism(ControlMechanism):
 
         # allocate a new output location if the type doesn't match the one
         # provided by the caller.
-        if mech_out_ty != out.type.pointee:
-            out = builder.alloca(mech_out_ty, name="mechanism_out")
+        if mech_out_ty != m_val.type.pointee:
+            m_val = builder.alloca(mech_out_ty, name="mechanism_out")
 
         # Load mechanism parameters
-        m_params = builder.function.args[0]
         scaling_factor_ptr = pnlvm.helpers.get_param_ptr(builder, self, m_params,
                                                          "scaling_factor_gain")
         base_factor_ptr = pnlvm.helpers.get_param_ptr(builder, self, m_params,
@@ -864,7 +862,7 @@ class LCControlMechanism(ControlMechanism):
 
         # Apply to the entire first subvector
         vi = builder.gep(mf_out, [ctx.int32_ty(0), ctx.int32_ty(1)])
-        vo = builder.gep(out, [ctx.int32_ty(0), ctx.int32_ty(0)])
+        vo = builder.gep(m_val, [ctx.int32_ty(0), ctx.int32_ty(0)])
 
         with pnlvm.helpers.array_ptr_loop(builder, vi, "LC_gain") as (b1, index):
             in_ptr = b1.gep(vi, [ctx.int32_ty(0), index])
@@ -879,11 +877,11 @@ class LCControlMechanism(ControlMechanism):
         # copy the main function return value
         for i, _ in enumerate(mf_out.type.pointee.elements):
             ptr = builder.gep(mf_out, [ctx.int32_ty(0), ctx.int32_ty(i)])
-            out_ptr = builder.gep(out, [ctx.int32_ty(0), ctx.int32_ty(i + 1)])
+            out_ptr = builder.gep(m_val, [ctx.int32_ty(0), ctx.int32_ty(i + 1)])
             val = builder.load(ptr)
             builder.store(val, out_ptr)
 
-        return out, builder
+        return m_val, builder
 
     # 5/8/20: ELIMINATE SYSTEM
     # SEEMS TO STILL BE USED BY SOME MODELS;  DELETE WHEN THOSE ARE UPDATED

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1132,15 +1132,15 @@ class DDM(ProcessingMechanism):
                 dst = builder.gep(mech_out, [ctx.int32_ty(0), ctx.int32_ty(idx)])
                 builder.store(builder.load(src), dst)
 
-            # Handle upper threshold probability
-            src = builder.gep(mf_out, [ctx.int32_ty(0), ctx.int32_ty(1),
-                                       ctx.int32_ty(0)])
+            # Handle upper threshold probability (1 - Lower Threshold)
+            src = builder.gep(mech_out, [ctx.int32_ty(0),
+                                         ctx.int32_ty(self.PROBABILITY_LOWER_THRESHOLD_INDEX),
+                                         ctx.int32_ty(0)])
             dst = builder.gep(mech_out, [ctx.int32_ty(0),
-                ctx.int32_ty(self.PROBABILITY_UPPER_THRESHOLD_INDEX),
-                ctx.int32_ty(0)])
+                                         ctx.int32_ty(self.PROBABILITY_UPPER_THRESHOLD_INDEX),
+                                         ctx.int32_ty(0)])
             prob_lower_thr = builder.load(src)
-            prob_upper_thr = builder.fsub(prob_lower_thr.type(1),
-                                          prob_lower_thr)
+            prob_upper_thr = builder.fsub(prob_lower_thr.type(1), prob_lower_thr)
             builder.store(prob_upper_thr, dst)
 
             # Load function threshold


### PR DESCRIPTION
LCControlMechanism and DDM both modify function return values before using them as mechanism values.
Overloading _gen_llvm_mechanism_functions instead of _gen_llvm_invoke_function gives direct
access to modulated mechanism parameters without accessing the LLVM function arguments.

Use helper functions instead of explicitly checking types when possible.
Drop no longer needed shape workarounds.