### PR TITLE
JSON/MDF: determine fixed onnx noise values at test time

### DIFF
--- a/tests/json/test_json.py
+++ b/tests/json/test_json.py
@@ -2,13 +2,14 @@ import numpy as np
 import os
 import psyneulink as pnl
 import pytest
-import sys
 
 
 pytest.importorskip(
     'modeci_mdf',
     reason='JSON methods require modeci_mdf package'
 )
+from modeci_mdf.execution_engine import evaluate_onnx_expr  # noqa: E402
+
 
 # stroop stimuli
 red = [1, 0]
@@ -168,37 +169,36 @@ def test_write_json_file_multiple_comps(
 # Values are generated from running onnx function RandomUniform and
 # RandomNormal with parameters used in model_integrators.py (seed 0).
 # RandomNormal values are different on mac versus linux and windows
-if sys.platform == 'linux':
-    onnx_integrators_fixed_seeded_noise = {
-        'A': [[-0.9999843239784241]],
-        'B': [[-1.1295466423034668]],
-        'C': [[-0.0647732987999916]],
-        'D': [[-0.499992161989212]],
-        'E': [[-0.2499941289424896]],
+onnx_noise_data = {
+    'onnx_ops.randomuniform': {
+        'A': {'low': -1.0, 'high': 1.0, 'seed': 0, 'shape': (1, 1)},
+        'D': {'low': -0.5, 'high': 0.5, 'seed': 0, 'shape': (1, 1)},
+        'E': {'low': -0.25, 'high': 0.5, 'seed': 0, 'shape': (1, 1)}
+    },
+    'onnx_ops.randomnormal': {
+        'B': {'mean': -1.0, 'scale': 0.5, 'seed': 0, 'shape': (1, 1)},
+        'C': {'mean': 0.0, 'scale': 0.25, 'seed': 0, 'shape': (1, 1)},
     }
-elif sys.platform == 'win32':
-    onnx_integrators_fixed_seeded_noise = {
-        'A': [[0.0976270437240601]],
-        'B': [[-0.4184607267379761]],
-        'C': [[0.290769636631012]],
-        'D': [[0.04881352186203]],
-        'E': [[0.1616101264953613]],
-    }
-else:
-    assert sys.platform == 'darwin'
-    onnx_integrators_fixed_seeded_noise = {
-        'A': [[-0.9999550580978394]],
-        'B': [[-0.8846577405929565]],
-        'C': [[0.0576711297035217]],
-        'D': [[-0.4999775290489197]],
-        'E': [[-0.2499831467866898]],
-    }
+}
+onnx_integrators_fixed_seeded_noise = {}
+integrators_runtime_params = None
 
-integrators_runtime_params = (
-    'runtime_params={'
-    + ','.join([f'{k}: {{ "noise": {v} }}' for k, v in onnx_integrators_fixed_seeded_noise.items()])
-    + '}'
-)
+for func_type in onnx_noise_data:
+    for node, args in onnx_noise_data[func_type].items():
+        # generates output from onnx noise functions with seed 0 to be
+        # passed in in runtime_params during psyneulink execution
+        onnx_integrators_fixed_seeded_noise[node] = evaluate_onnx_expr(
+            func_type, base_parameters=args, evaluated_parameters=args
+        )
+
+# high precision printing needed because script will be executed from string
+# 16 is insufficient on windows
+with np.printoptions(precision=32):
+    integrators_runtime_params = (
+        'runtime_params={'
+        + ','.join([f'{k}: {{ "noise": {v} }}' for k, v in onnx_integrators_fixed_seeded_noise.items()])
+        + '}'
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
prevents need to manually determine values based on OS or onnxruntime
version