### PR TITLE
github-actions: Drop python3.7 macos job

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -22,10 +22,6 @@ jobs:
         extra-args: ['']
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
-          # 3.7 is broken on macos-11, https://github.com/actions/virtual-environments/issues/4230
-          - python-version: 3.7
-            python-architecture: 'x64'
-            os: macos-10.15
           # add 32-bit build on windows
           - python-version: 3.8
             python-architecture: 'x86'


### PR DESCRIPTION
Python 3.7 is broken on macos-11 [0],
at the same time macos-10.15 will be removed by github-actions[1].

[0] https://github.com/actions/virtual-environments/issues/4230
[1] https://github.com/actions/virtual-environments/issues/5583

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>