### PR TITLE
Better requirements on MDF

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,7 @@ grpcio<1.43.0
 grpcio-tools<1.43.0
 llvmlite<0.40
 matplotlib<3.5.3
-modeci_mdf>=0.3.4, <0.4.2
-modelspec<0.2.6
+modeci_mdf~=0.4.1
 networkx<2.9
 numpy<1.21.7, >=1.17.0
 pillow<9.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ grpcio<1.43.0
 grpcio-tools<1.43.0
 llvmlite<0.40
 matplotlib<3.5.4
-modeci_mdf>=0.3.4
+modeci_mdf<0.5, >=0.3.4
 networkx<2.9
 numpy<1.21.7, >=1.17.0
 pillow<9.3.0


### PR DESCRIPTION
@davidt0x @kmantel I think this is a better way to specify dependencies for mdf/modelspec. PNL doesn't explicilty use modelspec, so should leave which version to use to mdf's dependencies. 

This form for the dependency will mean it will use the latest mdf 0.4.x version. If we introduce a breaking change we bump mdf to 0.5.x and updated the dependency in pnl only then. 