### PR TITLE
treewide: Add missing whitespace after keyword

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2739,7 +2739,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
             raise ComponentError("PROGRAM ERROR: got {} instead of string, Component, or Class".format(param_value))
 
         if param_spec not in MODULATORY_SPEC_KEYWORDS:
-            return(param_value)
+            return (param_value)
 
         try:
             param_default_value = getattr(self.defaults, param_name)

--- a/psyneulink/core/components/functions/stateful/integratorfunctions.py
+++ b/psyneulink/core/components/functions/stateful/integratorfunctions.py
@@ -2461,7 +2461,7 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
         )
 
     def _validate_noise(self, noise):
-        if noise is not None and not isinstance(noise, float) and not(isinstance(noise, np.ndarray) and np.issubdtype(noise.dtype, np.floating)):
+        if noise is not None and not isinstance(noise, float) and not (isinstance(noise, np.ndarray) and np.issubdtype(noise.dtype, np.floating)):
             raise FunctionError(
                 "Invalid noise parameter for {}: {}. DriftDiffusionIntegrator requires noise parameter to be a float or float array."
                 " Noise parameter is used to construct the standard DDM noise distribution".format(self.name, type(noise)))
@@ -2989,7 +2989,7 @@ class DriftOnASphereIntegrator(IntegratorFunction):  # -------------------------
             noise = np.array(noise)
         if noise is not None:
             if (not isinstance(noise, float)
-                    and not(isinstance(noise, np.ndarray) and np.issubdtype(noise.dtype, np.floating))):
+                    and not (isinstance(noise, np.ndarray) and np.issubdtype(noise.dtype, np.floating))):
                 raise FunctionError(
                     f"Invalid noise parameter for {self.name}: {type(noise)}. "
                     f"DriftOnASphereIntegrator requires noise parameter to be a float or float array.")

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -1800,12 +1800,12 @@ class Port_Base(Port):
         try:
             if projection in self.mod_afferents or projection in self.path_afferents:
                 self._remove_projection_to_port(projection, context=context)
-        except(PortError):
+        except PortError:
             pass
         try:
             if projection in self.efferents:
                 self._remove_projection_from_port(projection, context=context)
-        except(PortError):
+        except PortError:
             pass
 
     def _remove_projection_from_port(self, projection, context=None):

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6354,7 +6354,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             # Get info for nested node
             node, comp = next((item for item in self._get_nested_nodes() if item[0] is port.owner), (None, None))
             if node:
-                return(port, node, comp)
+                return (port, node, comp)
             else:
                 raise CompositionError(f"No source found for {projection.name} in {self.name}.")
 

--- a/psyneulink/core/globals/log.py
+++ b/psyneulink/core/globals/log.py
@@ -1632,7 +1632,7 @@ class Log:
 
             csv += next_eid_entry_data
 
-        return(csv)
+        return (csv)
 
     def _validate_entries_arg(self, entries, loggable=True, logged=False):
         from psyneulink.core.components.component import Component

--- a/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
@@ -930,15 +930,15 @@ class LCControlMechanism(ControlMechanism):
 
             # Delete ControlProjection ControlSignal's list of efferents
             index = self.control_signals[0].efferents[control_projection]
-            del(self.control_signals[0].efferents[index])
+            del self.control_signals[0].efferents[index]
 
             # Delete ControlProjection from recipient ParameterPort
             index = parameter_port.mod_afferents[control_projection]
-            del(parameter_port.mod_afferents[index])
+            del parameter_port.mod_afferents[index]
 
             # Delete Mechanism from self.modulated_mechanisms
             index = self.modulated_mechanisms.index(mech)
-            del(self.modulated_mechanisms[index])
+            del self.modulated_mechanisms[index]
 
     def show(self):
         """Display the `OutputPorts <OutputPort>` monitored by the LCControlMechanism's `objective_mechanism`

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1085,7 +1085,7 @@ class RecurrentTransferMechanism(TransferMechanism):
             new_input_port = InputPort(owner=self, name=RECURRENT, variable=self.defaults.variable[0],
                                         internal_only=True)
             assert (len(new_input_port.all_afferents) == 0)  # just a sanity check
-            assert(self.input_port.name != "Recurrent Input Port")
+            assert self.input_port.name != "Recurrent Input Port"
             # Rename existing InputPort as EXTERNAL
             remove_instance_from_registry(registry=self._portRegistry,
                                           category=INPUT_PORT,

--- a/tests/components/test_general.py
+++ b/tests/components/test_general.py
@@ -126,7 +126,7 @@ def test_all_dependent_parameters(
     params_inner_comp_keys = set(params_inner_comp.keys())
 
     assert params_inner_comp_keys.issubset(params_comp_keys)
-    assert(
+    assert (
         len(params_comp_keys) == 0
         or not params_comp_keys.issubset(params_inner_comp_keys)
     )

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -7629,14 +7629,12 @@ class TestMisc:
         comp.run(inputs={A: [0], B: [0]})
 
         assert type(comp.scheduler.conditions[A]) is pnl.Always
-        assert(
-            type(comp.scheduler.conditions[B]) is pnl.EveryNCalls
-            and comp.scheduler.conditions[B].args == (A, 2)
-        )
-        assert(
-            type(comp.scheduler.conditions[C]) is pnl.EveryNCalls
-            and comp.scheduler.conditions[C].args == (A, 2)
-        )
+        assert type(comp.scheduler.conditions[B]) is pnl.EveryNCalls
+        assert comp.scheduler.conditions[B].args == (A, 2)
+
+        assert type(comp.scheduler.conditions[C]) is pnl.EveryNCalls
+        assert comp.scheduler.conditions[C].args == (A, 2)
+
         assert comp.scheduler.execution_list[comp.default_execution_id] == [{A}, {A, B}, {C}]
         assert set(comp.scheduler._user_specified_conds.keys()) == {B, C}
 
@@ -7654,10 +7652,9 @@ class TestMisc:
 
         assert type(comp.scheduler.conditions[A]) is pnl.Always
         assert B not in comp.scheduler.conditions
-        assert(
-            type(comp.scheduler.conditions[C]) is pnl.EveryNCalls
-            and comp.scheduler.conditions[C].args == (A, 2)
-        )
+        assert type(comp.scheduler.conditions[C]) is pnl.EveryNCalls
+        assert comp.scheduler.conditions[C].args == (A, 2)
+
         assert comp.scheduler.execution_list[comp.default_execution_id] == [{A}, {A}, {C}]
         assert set(comp.scheduler._user_specified_conds.keys()) == {C}
 

--- a/tests/composition/test_show_graph.py
+++ b/tests/composition/test_show_graph.py
@@ -766,7 +766,7 @@ class TestControl:
                 #    OCM's outcome_input_port.
                 # If the test fails in this condition, it could mean that the bug has been corrected.
                 # The bug may be the same one as in eb61303808ad2a5ba46fdd18d0e583283397915c
-                raise(AssertionError,"FAILURE TO REPLICATE BUGGY SHOW_GRAPH OUTPUT -- SEE COMMENT IN TEST")
+                raise (AssertionError,"FAILURE TO REPLICATE BUGGY SHOW_GRAPH OUTPUT -- SEE COMMENT IN TEST")
             # elif ('show_node_structure' in show_graph_kwargs
             #         and ('show_cim' in show_graph_kwargs
             #              and show_graph_kwargs['show_cim'] is True)
@@ -775,7 +775,7 @@ class TestControl:
             # ):
             #     pass
             else:
-                raise(AssertionError)
+                raise (AssertionError)
 
     # def test_show_graph_for_nested_composition_as_agent_rep(self):
     #     """Note: this is the same as test_control/test_nested_composition_as_agent_rep but with show_graph()"""

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -625,7 +625,7 @@ def test_udf_composition_terminal(comp_mode, benchmark):
     T2 = TransferMechanism(size=3, function=Linear)
     c2 = Composition(pathways=[[T2, myMech]])
     benchmark(c2.run, inputs={T2: [[1, 2, 3]]}, execution_mode=comp_mode)
-    assert(np.allclose(c2.results[0][0], [3, 1]))
+    assert np.allclose(c2.results[0][0], [3, 1])
 
 
 def test_udf_with_pnl_func():

--- a/tests/mechanisms/test_input_state_spec.py
+++ b/tests/mechanisms/test_input_state_spec.py
@@ -698,9 +698,9 @@ class TestInputPortSpec:
             # Don't bother to specify anything as the value for each entry in the dict, since doesn't get there
             TransferMechanism(input_ports=[{'MY PORT A':{},
                                              'MY PORT B':{}}])
-        assert ('There is more than one entry of the InputPort specification dictionary' in str(error_text.value)
-                and'that is not a keyword; there should be only one (used to name the Port, with a list of '
-                   'Projection specifications' in str(error_text.value))
+        assert 'There is more than one entry of the InputPort specification dictionary' in str(error_text.value)
+        assert ('that is not a keyword; there should be only one (used to name the Port, with a list of '
+                    'Projection specifications' in str(error_text.value))
 
     # ------------------------------------------------------------------------------------------------
     # TEST 32

--- a/tests/mechanisms/test_kwta.py
+++ b/tests/mechanisms/test_kwta.py
@@ -16,9 +16,9 @@ class TestKWTAInputs:
     def test_kwta_empty_spec(self):
         K = KWTAMechanism()
         np.testing.assert_allclose(K.value, K.defaults.value)
-        assert(K.defaults.variable == [[0]])
-        assert(K.size == [1])
-        assert(K.matrix.base == [[5]])
+        assert K.defaults.variable == [[0]]
+        assert K.size == [1]
+        assert K.matrix.base == [[5]]
 
     def test_kwta_check_attrs(self):
         K = KWTAMechanism(
@@ -26,11 +26,11 @@ class TestKWTAInputs:
             size=3
         )
         np.testing.assert_allclose(K.value, K.defaults.value)
-        assert(np.allclose(K.defaults.variable, [[0., 0., 0.]]))
-        assert(K.size == [3])
-        assert(np.allclose(K.matrix.base, [[5, 0, 0], [0, 5, 0], [0, 0, 5]]))
-        assert(K.recurrent_projection.sender is K.output_port)
-        assert(K.recurrent_projection.receiver is K.input_port)
+        assert np.allclose(K.defaults.variable, [[0., 0., 0.]])
+        assert K.size == [3]
+        assert np.allclose(K.matrix.base, [[5, 0, 0], [0, 5, 0], [0, 0, 5]])
+        assert K.recurrent_projection.sender is K.output_port
+        assert K.recurrent_projection.receiver is K.input_port
 
     def test_kwta_inputs_list_of_ints(self):
         K = KWTAMechanism(
@@ -38,17 +38,17 @@ class TestKWTAInputs:
             default_variable=[0, 0, 0, 0]
         )
         val = K.execute([10, 12, 0, -1])
-        assert(np.allclose(val, [[0.9933071490757153, 0.9990889488055994, 0.0066928509242848554, 0.0024726231566347743]]))
+        assert np.allclose(val, [[0.9933071490757153, 0.9990889488055994, 0.0066928509242848554, 0.0024726231566347743]])
         val = K.execute([1, 2, 3, 0])
-        assert(np.allclose(val, [[0.3775406687981454, 0.6224593312018546, 0.8175744761936437, 0.18242552380635635]]))
+        assert np.allclose(val, [[0.3775406687981454, 0.6224593312018546, 0.8175744761936437, 0.18242552380635635]])
 
     def test_kwta_no_inputs(self):
         K = KWTAMechanism(
             name='K'
         )
-        assert(K.defaults.variable == [[0]])
+        assert K.defaults.variable == [[0]]
         val = K.execute([10])
-        assert(np.allclose(val, [[0.5]]))
+        assert np.allclose(val, [[0.5]])
 
     def test_kwta_inputs_list_of_strings(self):
         with pytest.raises(MechanismError) as error_text:
@@ -57,8 +57,8 @@ class TestKWTAInputs:
                 size = 4,
             )
             K.execute(["one", "two", "three", "four"])
-        assert('"Input to \'K\' ([\'one\' \'two\' \'three\' \'four\']) is incompatible with its corresponding '
-               'InputPort (K[InputPort-0]): \'cannot perform reduce with flexible type.\'"' in str(error_text.value))
+        assert ('"Input to \'K\' ([\'one\' \'two\' \'three\' \'four\']) is incompatible with its corresponding '
+                'InputPort (K[InputPort-0]): \'cannot perform reduce with flexible type.\'"' in str(error_text.value))
 
     def test_kwta_var_list_of_strings(self):
         with pytest.raises(ParameterError) as error_text:
@@ -67,7 +67,7 @@ class TestKWTAInputs:
                 default_variable=['a', 'b', 'c', 'd'],
                 integrator_mode=True
             )
-        assert("non-numeric entries" in str(error_text.value))
+        assert ("non-numeric entries" in str(error_text.value))
 
     def test_recurrent_mech_inputs_mismatched_with_default_longer(self):
         with pytest.raises(MechanismError) as error_text:
@@ -76,7 +76,7 @@ class TestKWTAInputs:
                 size=4
             )
             K.execute([1, 2, 3, 4, 5])
-        assert("does not match required length" in str(error_text.value))
+        assert ("does not match required length" in str(error_text.value))
 
     def test_recurrent_mech_inputs_mismatched_with_default_shorter(self):
         with pytest.raises(MechanismError) as error_text:
@@ -85,7 +85,7 @@ class TestKWTAInputs:
                 size=6
             )
             K.execute([1, 2, 3, 4, 5])
-        assert("does not match required length" in str(error_text.value))
+        assert ("does not match required length" in str(error_text.value))
 
 
 class TestKWTAFunction:
@@ -174,7 +174,7 @@ class TestKWTAMatrix:
                     matrix=m
                 )
                 val = K.execute([10, 10, 10, 10])
-                assert(np.allclose(val, [[.5, .5, .5, .5]]))
+                assert np.allclose(val, [[.5, .5, .5, .5]])
 
     def test_kwta_matrix_auto_hetero_spec(self):
         K = KWTAMechanism(
@@ -183,7 +183,7 @@ class TestKWTAMatrix:
             auto=3,
             hetero=2
         )
-        assert(np.allclose(K.recurrent_projection.matrix.base, [[3, 2, 2, 2], [2, 3, 2, 2], [2, 2, 3, 2], [2, 2, 2, 3]]))
+        assert np.allclose(K.recurrent_projection.matrix.base, [[3, 2, 2, 2], [2, 3, 2, 2], [2, 2, 3, 2], [2, 2, 2, 3]])
 
     def test_kwta_matrix_hetero_spec(self):
         K = KWTAMechanism(
@@ -191,7 +191,7 @@ class TestKWTAMatrix:
             size=3,
             hetero=-.5,
         )
-        assert(np.allclose(K.recurrent_projection.matrix.base, [[5, -.5, -.5], [-.5, 5, -.5], [-.5, -.5, 5]]))
+        assert np.allclose(K.recurrent_projection.matrix.base, [[5, -.5, -.5], [-.5, 5, -.5], [-.5, -.5, 5]])
 
     def test_kwta_matrix_auto_spec(self):
         K = KWTAMechanism(
@@ -199,7 +199,7 @@ class TestKWTAMatrix:
             size=3,
             auto=-.5,
         )
-        assert(np.allclose(K.recurrent_projection.matrix.base, [[-.5, 0, 0], [0, -.5, 0], [0, 0, -.5]]))
+        assert np.allclose(K.recurrent_projection.matrix.base, [[-.5, 0, 0], [0, -.5, 0], [0, 0, -.5]])
 
 
 class TestKWTARatio:


### PR DESCRIPTION
E275 reported by the new pycodestyle package (v2.9.0)

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>