### PR TITLE
simple cleanups

### DIFF
--- a/psyneulink/core/components/functions/userdefinedfunction.py
+++ b/psyneulink/core/components/functions/userdefinedfunction.py
@@ -9,6 +9,7 @@
 #
 # *****************************************  USER-DEFINED FUNCTION  ****************************************************
 
+import builtins
 import numpy as np
 import typecheck as tc
 from inspect import signature, _empty, getsourcelines, getsourcefile, getclosurevars
@@ -34,7 +35,7 @@ class _ExpressionVisitor(ast.NodeVisitor):
         self.functions = set()
 
     def visit_Name(self, node):
-        if node.id not in __builtins__:
+        if node.id not in dir(builtins):
             self.vars.add(node.id)
 
     def visit_Call(self, node):
@@ -44,7 +45,7 @@ class _ExpressionVisitor(ast.NodeVisitor):
         except AttributeError:
             func_id = node.func.id
 
-        if func_id not in __builtins__:
+        if func_id not in dir(builtins):
             self.functions.add(func_id)
 
         for c in ast.iter_child_nodes(node):

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -149,7 +149,7 @@ class CUDAExecution(Execution):
             # 0-sized structures fail to upload
             # provide a small device buffer instead
             return jit_engine.pycuda.driver.mem_alloc(4)
-        return jit_engine.pycuda.driver.to_device(bytearray(data))
+        return jit_engine.pycuda.driver.to_device(bytes(data))
 
     def download_ctype(self, source, ty, name='other'):
         self._downloaded_bytes[name] += ctypes.sizeof(ty)

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -76,15 +76,15 @@ def test_execute(func, variable, params, expected, benchmark, func_mode):
         benchmark(ex, variable)
 
 
-relu_derivative_helper = lambda x : RAND1 if x > 0 else RAND1 * RAND3
 logistic_helper = RAND4 / (1 + np.exp(-(RAND1 * (test_var - RAND2)) + RAND3))
 tanh_derivative_helper = (RAND1 * (test_var + RAND2) + RAND3)
 tanh_derivative_helper = (1 - np.tanh(tanh_derivative_helper)**2) * RAND4 * RAND1
+
 derivative_test_data = [
     (Functions.Linear, test_var, {'slope':RAND1, 'intercept':RAND2}, RAND1),
     (Functions.Exponential, test_var, {'scale':RAND1, 'rate':RAND2}, RAND1 * RAND2 * np.exp(RAND2 * test_var)),
     (Functions.Logistic, test_var, {'gain':RAND1, 'x_0':RAND2, 'offset':RAND3, 'scale':RAND4}, RAND1 * RAND4 * logistic_helper * (1 - logistic_helper)),
-    (Functions.ReLU, test_var, {'gain':RAND1, 'bias':RAND2, 'leak':RAND3}, list(map(relu_derivative_helper, test_var))),
+    (Functions.ReLU, test_var, {'gain':RAND1, 'bias':RAND2, 'leak':RAND3}, np.where(test_var > 0, RAND1, RAND1 * RAND3)),
     (Functions.Tanh, test_var, {'gain':RAND1, 'bias':RAND2, 'offset':RAND3, 'scale':RAND4}, tanh_derivative_helper),
 ]
 


### PR DESCRIPTION
Use 'bytes' instead of 'bytearray' for RO view of ctype structures.
Use np.where instead of custom transformation.
User dir(builtins) instead of __builtins__ .