### PR TITLE
tests/TransferMechanism: Use the correct execution mode in test_transfer_mech_integration_rate_0_8

### DIFF
--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -903,14 +903,14 @@ class TestTransferMechanismTimeConstant:
         )
         EX = pytest.helpers.get_mech_execution(T, mech_mode)
 
-        val1 = T.execute([1 for i in range(VECTOR_SIZE)])
-        val2 = T.execute([1 for i in range(VECTOR_SIZE)])
+        val1 = EX([1 for i in range(VECTOR_SIZE)])
+        val2 = EX([1 for i in range(VECTOR_SIZE)])
 
         assert np.allclose(val1, [[0.8 for i in range(VECTOR_SIZE)]])
         assert np.allclose(val2, [[0.96 for i in range(VECTOR_SIZE)]])
 
         if benchmark.enabled:
-            benchmark(T.execute, [0 for i in range(VECTOR_SIZE)])
+            benchmark(EX, [0 for i in range(VECTOR_SIZE)])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism


### PR DESCRIPTION
"EX" represents the right invocation variant;  compiled or GPU or Python execution,
use that instead of always executing Python version.

Fixes: cf57224670a0830dd555f34e04c0d4a083d3b996
("test/mechanisms/TransferMechanism: Only run benchmarks if enabled")

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>