### PR TITLE
tests, treewide: Add missing "composition" marks

### DIFF
--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -2600,6 +2600,7 @@ class TestControlMechanisms:
         assert np.allclose(best_second, comp.results[1])
 
 
+@pytest.mark.composition
 @pytest.mark.control
 class TestModelBasedOptimizationControlMechanisms_Execution:
     def test_ocm_default_function(self):
@@ -2950,8 +2951,6 @@ class TestModelBasedOptimizationControlMechanisms_Execution:
                                # Note: Skip decision variable OutputPort
                                evc_gratton.simulation_results[simulation][1:])
 
-    @pytest.mark.control
-    @pytest.mark.composition
     def test_laming_validation_specify_control_signals(self):
         # Mechanisms
         Input = pnl.TransferMechanism(name='Input')
@@ -3072,8 +3071,6 @@ class TestModelBasedOptimizationControlMechanisms_Execution:
                 err_msg='Failed on expected_output[{0}]'.format(trial)
             )
 
-    @pytest.mark.control
-    @pytest.mark.composition
     def test_stateful_mechanism_in_simulation(self):
         # Mechanisms
         Input = pnl.TransferMechanism(name='Input', integrator_mode=True)
@@ -3211,8 +3208,6 @@ class TestModelBasedOptimizationControlMechanisms_Execution:
                 err_msg='Failed on expected_output[{0}]'.format(trial)
             )
 
-    @pytest.mark.control
-    @pytest.mark.composition
     @pytest.mark.benchmark(group="Model Based OCM")
     @pytest.mark.parametrize("mode", pytest.helpers.get_comp_execution_modes() +
                                      [pytest.helpers.cuda_param('Python-PTX'),
@@ -3262,8 +3257,6 @@ class TestModelBasedOptimizationControlMechanisms_Execution:
         if benchmark.enabled:
             benchmark(comp.run, inputs, execution_mode=mode)
 
-    @pytest.mark.control
-    @pytest.mark.composition
     @pytest.mark.benchmark(group="Model Based OCM")
     @pytest.mark.parametrize("mode", pytest.helpers.get_comp_execution_modes() +
                                      [pytest.helpers.cuda_param('Python-PTX'),
@@ -3652,8 +3645,6 @@ class TestModelBasedOptimizationControlMechanisms_Execution:
         # initial 1 + each allocation sample (1, 2, 3) integrated
         assert B.parameters.value.get(comp) == 7
 
-    @pytest.mark.control
-    @pytest.mark.composition
     @pytest.mark.benchmark(group="Multilevel")
     def test_grid_search_random_selection(self, comp_mode, benchmark):
         A = pnl.ProcessingMechanism(name='A')
@@ -3700,8 +3691,7 @@ class TestModelBasedOptimizationControlMechanisms_Execution:
             benchmark(comp.run, inputs=inputs, num_trials=10, context='bench_outer_comp', execution_mode=comp_mode)
             assert len(A.log.get_logged_entries()) == 0
 
-    @pytest.mark.control
-    @pytest.mark.composition
+
     def test_input_CIM_assignment(self, comp_mode):
         input_a = pnl.ProcessingMechanism(name='oa', function=pnl.Linear(slope=1))
         input_b = pnl.ProcessingMechanism(name='ob', function=pnl.Linear(slope=1))
@@ -3863,6 +3853,7 @@ class TestSampleIterator:
         assert sample_iterator.num == len(sample_list)
 
 
+@pytest.mark.composition
 @pytest.mark.control
 class TestControlTimeScales:
 

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -604,6 +604,7 @@ def test_user_def_func_builtin_direct(func, args, expected, benchmark):
     val = benchmark(func, *args)
     assert np.allclose(val, expected)
 
+@pytest.mark.composition
 @pytest.mark.benchmark(group="UDF as Composition Origin")
 def test_udf_composition_origin(comp_mode, benchmark):
     def myFunction(variable, context):
@@ -616,6 +617,7 @@ def test_udf_composition_origin(comp_mode, benchmark):
     assert np.allclose(c.results[0][0], [3, 1])
 
 
+@pytest.mark.composition
 @pytest.mark.benchmark(group="UDF as Composition Terminal")
 def test_udf_composition_terminal(comp_mode, benchmark):
     def myFunction(variable, context):

--- a/tests/mechanisms/test_control_mechanism.py
+++ b/tests/mechanisms/test_control_mechanism.py
@@ -10,6 +10,7 @@ class TestLCControlMechanism:
 
     @pytest.mark.mechanism
     @pytest.mark.control_mechanism
+    @pytest.mark.composition
     @pytest.mark.benchmark(group="LCControlMechanism Default")
     def test_lc_control_mechanism_as_controller(self, benchmark):
         G = 1.0
@@ -93,6 +94,7 @@ class TestLCControlMechanism:
         if benchmark.enabled:
             benchmark(EX, [10.0])
 
+    @pytest.mark.composition
     def test_lc_control_modulated_mechanisms_all(self):
 
         T_1 = pnl.TransferMechanism(name='T_1')
@@ -110,7 +112,9 @@ class TestLCControlMechanism:
         assert T_2.parameter_ports[pnl.SLOPE].mod_afferents[0] in LC.control_signals[0].efferents
 
 
+@pytest.mark.composition
 class TestControlMechanism:
+
     def test_control_modulation(self):
         Tx = pnl.TransferMechanism(name='Tx')
         Ty = pnl.TransferMechanism(name='Ty')

--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -159,6 +159,7 @@ class TestThreshold:
     #     assert np.allclose(decision_variables_a, [2.0, 4.0, 5.0, 5.0, 5.0])
 
 
+    @pytest.mark.composition
     def test_is_finished_stops_composition(self):
         D = DDM(name='DDM',
                 function=DriftDiffusionIntegrator(threshold=10.0, time_step_size=1.0),
@@ -183,6 +184,7 @@ class TestThreshold:
     #
     #     sched = Scheduler(system=S)
 
+@pytest.mark.composition
 class TestInputPorts:
 
     def test_regular_input_mode(self):
@@ -631,6 +633,7 @@ def test_WhenFinished_DDM_Analytical():
     c.is_satisfied()
 
 
+@pytest.mark.composition
 @pytest.mark.ddm_mechanism
 @pytest.mark.mechanism
 @pytest.mark.benchmark(group="DDM-comp")
@@ -659,8 +662,8 @@ def test_DDM_in_composition(benchmark, comp_mode):
         benchmark(C.run, inputs, num_trials=2, execution_mode=comp_mode)
 
 
+@pytest.mark.composition
 @pytest.mark.ddm_mechanism
-@pytest.mark.mechanism
 def test_DDM_threshold_modulation(comp_mode):
     M = pnl.DDM(
         name='DDM',
@@ -689,6 +692,8 @@ def test_DDM_threshold_modulation(comp_mode):
     assert np.allclose(val[0], [60.0])
     assert np.allclose(val[1], [60.2])
 
+
+@pytest.mark.composition
 @pytest.mark.parametrize(["noise", "threshold", "expected_results"],[
                             (1.0, 0.0, (0.0, 1.0)),
                             (1.5, 2, (-2.0, 1.0)),
@@ -772,7 +777,7 @@ def test_sequence_of_DDM_mechs_in_Composition_Pathway():
         np.testing.assert_allclose(val, expected, atol=1e-08, err_msg='Failed on expected_output[{0}]'.format(i))
 
 
-@pytest.mark.mechanism
+@pytest.mark.composition
 @pytest.mark.ddm_mechanism
 def test_DDMMechanism_LCA_equivalent(comp_mode):
 

--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -1174,7 +1174,7 @@ class TestStatefulness:
         assert I.has_initializers
         assert hasattr(I, "reset_stateful_function_when")
 
-    @pytest.mark.mechanism
+    @pytest.mark.composition
     @pytest.mark.integrator_mechanism
     @pytest.mark.parametrize('cond0, cond1, expected', [
         (pnl.Never(), pnl.AtTrial(2),
@@ -1218,6 +1218,7 @@ class TestStatefulness:
 
         assert np.allclose(expected, C.results)
 
+    @pytest.mark.composition
     def test_reset_stateful_function_when(self):
         I1 = IntegratorMechanism()
         I2 = IntegratorMechanism()

--- a/tests/mechanisms/test_lca.py
+++ b/tests/mechanisms/test_lca.py
@@ -12,7 +12,8 @@ from psyneulink.library.components.mechanisms.processing.transfer.lcamechanism i
     LCAMechanism, MAX_VS_AVG, MAX_VS_NEXT, CONVERGENCE
 
 class TestLCA:
-    @pytest.mark.mechanism
+
+    @pytest.mark.composition
     @pytest.mark.lca_mechanism
     @pytest.mark.benchmark(group="LCAMechanism")
     def test_LCAMechanism_length_1(self, benchmark, comp_mode):
@@ -59,7 +60,7 @@ class TestLCA:
         if benchmark.enabled:
             benchmark(C.run, inputs={T: [1.0]}, num_trials=3, execution_mode=comp_mode)
 
-    @pytest.mark.mechanism
+    @pytest.mark.composition
     @pytest.mark.lca_mechanism
     @pytest.mark.benchmark(group="LCAMechanism")
     def test_LCAMechanism_length_2(self, benchmark, comp_mode):
@@ -120,6 +121,7 @@ class TestLCA:
         if benchmark.enabled:
             benchmark(C.run, inputs={T: [1.0, 2.0]}, num_trials=3, execution_mode=comp_mode)
 
+    @pytest.mark.composition
     def test_equivalance_of_threshold_and_when_finished_condition(self):
         # Note: This tests the equivalence of results when:
         #       execute_until_finished is True for the LCAMechanism (by default)
@@ -152,7 +154,7 @@ class TestLCA:
 
     # Note: In the following tests, since the LCAMechanism's threshold is specified
     #       it executes until the it reaches threshold.
-    @pytest.mark.mechanism
+    @pytest.mark.composition
     @pytest.mark.lca_mechanism
     @pytest.mark.benchmark(group="LCAMechanism")
     def test_LCAMechanism_threshold(self, benchmark, comp_mode):
@@ -164,6 +166,7 @@ class TestLCA:
         if benchmark.enabled:
             benchmark(comp.run, inputs={lca:[1,0]}, execution_mode=comp_mode)
 
+    @pytest.mark.composition
     def test_LCAMechanism_threshold_with_max_vs_next(self):
         lca = LCAMechanism(size=3, leak=0.5, threshold=0.1, threshold_criterion=MAX_VS_NEXT)
         comp = Composition()
@@ -171,6 +174,7 @@ class TestLCA:
         result = comp.run(inputs={lca:[1,0.5,0]})
         assert np.allclose(result, [[0.52490032, 0.42367594, 0.32874867]])
 
+    @pytest.mark.composition
     def test_LCAMechanism_threshold_with_max_vs_avg(self):
         lca = LCAMechanism(size=3, leak=0.5, threshold=0.1, threshold_criterion=MAX_VS_AVG)
         comp = Composition()
@@ -178,7 +182,7 @@ class TestLCA:
         result = comp.run(inputs={lca:[1,0.5,0]})
         assert np.allclose(result, [[0.51180475, 0.44161738, 0.37374946]])
 
-    @pytest.mark.mechanism
+    @pytest.mark.composition
     @pytest.mark.lca_mechanism
     @pytest.mark.benchmark(group="LCAMechanism")
     def test_LCAMechanism_threshold_with_convergence(self, benchmark, comp_mode):
@@ -192,7 +196,7 @@ class TestLCA:
         if benchmark.enabled:
             benchmark(comp.run, inputs={lca:[0,1,2]}, execution_mode=comp_mode)
 
-    @pytest.mark.mechanism
+    @pytest.mark.composition
     @pytest.mark.lca_mechanism
     def test_equivalance_of_threshold_and_termination_specifications_just_threshold(self, comp_mode):
         # Note: This tests the equivalence of using LCAMechanism-specific threshold arguments and
@@ -215,6 +219,7 @@ class TestLCA:
         result2 = comp2.run(inputs={lca_termination:[1,0]}, execution_mode=comp_mode)
         assert np.allclose(result1, result2)
 
+    @pytest.mark.composition
     def test_equivalance_of_threshold_and_termination_specifications_max_vs_next(self):
         # Note: This tests the equivalence of using LCAMechanism-specific threshold arguments and
         #       generic TransferMechanism termination_<*> arguments
@@ -255,7 +260,7 @@ class TestLCA:
     #     result = comp.run(inputs={lca:[1,0]})
     #     assert np.allclose(result, [[0.71463572, 0.28536428]])
 
-    @pytest.mark.mechanism
+    @pytest.mark.composition
     @pytest.mark.lca_mechanism
     def test_LCAMechanism_DDM_equivalent(self, comp_mode):
         lca = LCAMechanism(size=2, leak=0., threshold=1, auto=0, hetero=0,
@@ -268,6 +273,7 @@ class TestLCA:
 
 class TestLCAReset:
 
+    @pytest.mark.composition
     def test_reset_run(self):
 
         L = LCAMechanism(name="L",

--- a/tests/mechanisms/test_recurrent_transfer_mechanism.py
+++ b/tests/mechanisms/test_recurrent_transfer_mechanism.py
@@ -21,6 +21,7 @@ from psyneulink.library.components.mechanisms.processing.transfer.recurrenttrans
     RecurrentTransferError, RecurrentTransferMechanism
 from psyneulink.library.components.projections.pathway.autoassociativeprojection import AutoAssociativeProjection
 
+@pytest.mark.composition
 class TestMatrixSpec:
     def test_recurrent_mech_matrix(self):
 
@@ -628,6 +629,7 @@ class TestRecurrentTransferMechanismTimeConstant:
 # won't get executed if we only use the execute() method of Mechanism: thus, to test it we must use a Composition
 
 
+@pytest.mark.composition
 def run_twice_in_composition(mech, input1, input2=None):
     if input2 is None:
         input2 = input1
@@ -637,6 +639,7 @@ def run_twice_in_composition(mech, input1, input2=None):
     return result[0]
 
 
+@pytest.mark.composition
 class TestRecurrentTransferMechanismInProcess:
     simple_prefs = {REPORT_OUTPUT_PREF: False, VERBOSE_PREF: False}
 
@@ -722,6 +725,7 @@ class TestRecurrentTransferMechanismInProcess:
         np.testing.assert_allclose(R.parameters.value.get(c), [[21, 3, 12, 35]])
 
 
+@pytest.mark.composition
 class TestRecurrentTransferMechanismInComposition:
     simple_prefs = {REPORT_OUTPUT_PREF: False, VERBOSE_PREF: False}
 
@@ -957,6 +961,7 @@ class TestRecurrentTransferMechanismInComposition:
         np.testing.assert_allclose(R.output_port.parameters.value.get(C),[0.0, 1.18518086, 0.0, 1.18518086])
 
 
+@pytest.mark.composition
 class TestRecurrentTransferMechanismReset:
 
     def test_reset_run(self):
@@ -1024,6 +1029,7 @@ class TestClip:
         assert np.allclose(R.execute([[-5.0, -1.0, 5.0], [5.0, -5.0, 1.0], [1.0, 5.0, 5.0]]),
                            [[-2.0, -1.0, 2.0], [2.0, -2.0, 1.0], [1.0, 2.0, 2.0]])
 
+@pytest.mark.composition
 class TestRecurrentInputPort:
 
     def test_ris_simple(self):
@@ -1061,6 +1067,7 @@ class TestCustomCombinationFunction:
         result = R2.execute([1,2])
         np.testing.assert_allclose(result, [[0,0]])
 
+    @pytest.mark.composition
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism
     @pytest.mark.parametrize('cond0, cond1, expected', [
@@ -1107,6 +1114,7 @@ class TestCustomCombinationFunction:
 
         assert np.allclose(expected, C.results)
 
+    @pytest.mark.composition
     @pytest.mark.mechanism
     @pytest.mark.integrator_mechanism
     @pytest.mark.parametrize('cond0, cond1, expected', [
@@ -1152,7 +1160,7 @@ class TestCustomCombinationFunction:
 
         assert np.allclose(exp, C.results)
 
-    @pytest.mark.mechanism
+    @pytest.mark.composition
     @pytest.mark.integrator_mechanism
     @pytest.mark.parametrize('until_finished, expected', [
         (True, [[[[0.96875]]], [[[0.9990234375]]]]), # The 5th and the 10th iteration
@@ -1177,6 +1185,7 @@ class TestCustomCombinationFunction:
         assert np.allclose(expected[0], results)
         assert np.allclose(expected[1], results2)
 
+@pytest.mark.composition
 class TestDebugProperties:
 
     def test_defaults(self):

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -1430,6 +1430,7 @@ class TestIntegratorMode:
         # linear fn: 0.595*1.0 = 0.595
         assert np.allclose(T.integrator_function.previous_value, 0.595)
 
+    @pytest.mark.composition
     def test_previous_value_persistence_run(self):
         T = TransferMechanism(name="T",
                               initial_value=0.5,
@@ -1497,6 +1498,7 @@ class TestIntegratorMode:
         assert np.allclose(T.integrator_function.previous_value, 0.46)  # property that looks at integrator, which updated with mech exec
         assert np.allclose(T.value, 0.46)  # on mechanism, but updates with exec
 
+    @pytest.mark.composition
     def test_reset_run(self):
         T = TransferMechanism(name="T",
                               initial_value=0.5,
@@ -1537,6 +1539,7 @@ class TestIntegratorMode:
         # linear fn: 0.595*1.0 = 0.595
         assert np.allclose(T.integrator_function.parameters.previous_value.get(C), 0.595)
 
+    @pytest.mark.composition
     def test_reset_run_array(self):
         T = TransferMechanism(name="T",
                               default_variable=[0.0, 0.0, 0.0],
@@ -1577,6 +1580,7 @@ class TestIntegratorMode:
         # linear fn: 0.595*1.0 = 0.595
         assert np.allclose(T.integrator_function.parameters.previous_value.get(C), [0.595, 0.595, 0.595])
 
+    @pytest.mark.composition
     def test_reset_run_2darray(self):
 
         initial_val = [[0.5, 0.5, 0.5]]
@@ -1629,6 +1633,7 @@ class TestIntegratorMode:
         assert "not allowed because its `integrator_mode` parameter" in str(err_txt.value)
         assert "is currently set to \'False\'; try setting it to \'True\'" in str(err_txt.value)
 
+    @pytest.mark.composition
     def test_switch_mode(self):
         T = TransferMechanism(integrator_mode=True,
                               on_resume_integrator_mode=LAST_INTEGRATED_VALUE)
@@ -1659,6 +1664,7 @@ class TestIntegratorMode:
         C.run({T: [[1.0], [1.0], [1.0]]})
         assert np.allclose(T.parameters.value.get(C), [[0.984375]])
 
+    @pytest.mark.composition
     def test_initial_values_softmax(self):
         T = TransferMechanism(default_variable=[[0.0, 0.0], [0.0, 0.0]],
                               function=SoftMax(),
@@ -1695,6 +1701,7 @@ class TestIntegratorMode:
         T.execute(1)
 
 
+@pytest.mark.composition
 class TestOnResumeIntegratorMode:
 
     def test_last_integrated_value_spec(self):
@@ -1777,7 +1784,6 @@ class TestOnResumeIntegratorMode:
         # Trial 1: 0.5*0.5 + 0.5*2.0 = 1.25 * 1.0 = 1.25
         assert np.allclose(T.parameters.value.get(C), [[1.25]])
 
-    @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
     @pytest.mark.benchmark(group="TransferMechanism")
     # 'LLVM' mode is not supported, because synchronization of compiler and

--- a/tests/ports/test_output_ports.py
+++ b/tests/ports/test_output_ports.py
@@ -31,6 +31,7 @@ class TestOutputPorts:
         for i, e in zip(res, expected):
             assert np.array_equal(i, e)
 
+    @pytest.mark.composition
     @pytest.mark.mechanism
     @pytest.mark.parametrize('spec, expected1, expected2',
                              [((pnl.OWNER_VALUE, 0), [1], [1]),

--- a/tests/scheduling/test_condition.py
+++ b/tests/scheduling/test_condition.py
@@ -82,6 +82,7 @@ class TestCondition:
         assert not cond.is_satisfied(False, c=False)
         assert not cond.is_satisfied(False, c=False, extra_arg=True)
 
+    @pytest.mark.composition
     class TestGeneric:
         def test_WhileNot_AtPass(self):
             comp = Composition()
@@ -115,6 +116,7 @@ class TestCondition:
             expected_output = [A, A, set(), A, A]
             assert output == pytest.helpers.setify_expected_output(expected_output)
 
+    @pytest.mark.composition
     class TestRelative:
 
         def test_Any_end_before_one_finished(self):
@@ -211,6 +213,7 @@ class TestCondition:
 
             assert output == pytest.helpers.setify_expected_output(expected_output)
 
+    @pytest.mark.composition
     class TestTime:
 
         def test_BeforeTimeStep(self):
@@ -480,6 +483,7 @@ class TestCondition:
             expected_output = [set(), A, A, A, A]
             assert output == pytest.helpers.setify_expected_output(expected_output)
 
+    @pytest.mark.composition
     class TestComponentBased:
 
         def test_BeforeNCalls(self):
@@ -562,6 +566,7 @@ class TestCondition:
 
     class TestConvenience:
 
+        @pytest.mark.composition
         def test_AtTrialStart(self):
             comp = Composition()
             A = TransferMechanism(name='A')
@@ -579,6 +584,7 @@ class TestCondition:
             expected_output = [A, B, A, A]
             assert output == pytest.helpers.setify_expected_output(expected_output)
 
+    @pytest.mark.composition
     def test_composite_condition_multi(self):
         comp = Composition()
         A = TransferMechanism(function=Linear(slope=5.0, intercept=2.0), name='A')
@@ -613,6 +619,7 @@ class TestCondition:
         ]
         assert output == pytest.helpers.setify_expected_output(expected_output)
 
+    @pytest.mark.composition
     def test_AfterNCallsCombined(self):
         comp = Composition()
         A = TransferMechanism(function=Linear(slope=5.0, intercept=2.0), name='A')
@@ -640,6 +647,7 @@ class TestCondition:
         ]
         assert output == pytest.helpers.setify_expected_output(expected_output)
 
+    @pytest.mark.composition
     def test_AllHaveRun(self):
         comp = Composition()
         A = TransferMechanism(function=Linear(slope=5.0, intercept=2.0), name='A')
@@ -667,6 +675,7 @@ class TestCondition:
         ]
         assert output == pytest.helpers.setify_expected_output(expected_output)
 
+    @pytest.mark.composition
     def test_AllHaveRun_2(self):
         comp = Composition()
         A = TransferMechanism(function=Linear(slope=5.0, intercept=2.0), name='A')
@@ -692,6 +701,7 @@ class TestCondition:
         ]
         assert output == pytest.helpers.setify_expected_output(expected_output)
 
+    @pytest.mark.composition
     @pytest.mark.parametrize(
         'parameter, indices, default_variable, integration_rate, expected_results',
         [
@@ -723,6 +733,7 @@ class TestCondition:
 
         np.testing.assert_array_equal(comp.results, expected_results)
 
+    @pytest.mark.composition
     @pytest.mark.parametrize(
         'comparator, increment, threshold, expected_results',
         [
@@ -755,6 +766,7 @@ class TestCondition:
 
         np.testing.assert_array_equal(comp.results, expected_results)
 
+    @pytest.mark.composition
     @pytest.mark.parametrize(
         'comparator, increment, threshold, atol, rtol, expected_results',
         [
@@ -790,6 +802,7 @@ class TestCondition:
         np.testing.assert_array_equal(comp.results, expected_results)
 
 
+@pytest.mark.composition
 class TestWhenFinished:
 
     @classmethod
@@ -984,6 +997,7 @@ class TestAbsolute:
     B = TransferMechanism(name='scheduler-pytests-B')
     C = TransferMechanism(name='scheduler-pytests-C')
 
+    @pytest.mark.composition
     @pytest.mark.parametrize(
         'conditions, termination_conds',
         [
@@ -1036,6 +1050,7 @@ class TestAbsolute:
             for i in range(1, len(executions)):
                 assert (executions[i] - executions[i - 1]) == cond.repeat
 
+    @pytest.mark.composition
     @pytest.mark.parametrize(
         'conditions, termination_conds',
         [

--- a/tests/scheduling/test_scheduler.py
+++ b/tests/scheduling/test_scheduler.py
@@ -1498,7 +1498,7 @@ class TestFeedback:
         }
         assert comp.scheduler.dependency_dict == expected_dependencies
 
-    @pytest.mark.mechanism
+    @pytest.mark.composition
     @pytest.mark.transfer_mechanism
     @pytest.mark.parametrize('timescale, expected',
                              [(TimeScale.TIME_STEP, [[0.5], [0.4375]]),


### PR DESCRIPTION
Add missing pytest.mark.composition to test that construct and run Composition.

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>