### PR TITLE
requirements: Restrict modeci_mdf to 64bit cpython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ grpcio<1.43.0
 grpcio-tools<1.43.0
 llvmlite<0.40
 matplotlib<3.5.4
-modeci_mdf<0.5, >=0.3.4
+modeci_mdf<0.5, >=0.3.4; (platform_machine == 'AMD64' or platform_machine == 'x86_64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
 networkx<2.9
 numpy<1.21.7, >=1.17.0
 pillow<9.3.0


### PR DESCRIPTION
modeci_mdf pulls in pytorch[0] so it needs the same constraints.

[0] https://github.com/ModECI/MDF/blob/main/setup.cfg

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>