### PR TITLE
Fix reference leaks and add compiled cleanup destruction check

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -51,21 +51,9 @@ jobs:
             extra-args: '--forked -m "not llvm"'
 
           # add 32-bit build on windows
-          # split by marks to reduce peak memory
           - python-version: '3.8'
             python-architecture: 'x86'
             os: windows
-            extra-args: '-m llvm'
-
-          - python-version: '3.8'
-            python-architecture: 'x86'
-            os: windows
-            extra-args: '-m "not llvm and composition"'
-
-          - python-version: '3.8'
-            python-architecture: 'x86'
-            os: windows
-            extra-args: '-m "not llvm and not composition"'
 
           # fp32 run on linux python 3.10
           - python-version: '3.10'
@@ -176,16 +164,10 @@ jobs:
       timeout-minutes: 180
       run: pytest --junit-xml=tests_out.xml --verbosity=0 -n logical ${{ matrix.extra-args }}
 
-    # double quotes are disallowed in artifact names
-    - name: Get valid filename string from extra-args
-      id: extra_args_fname
-      run: echo extra_args="$(echo ${{ matrix.extra-args }} | tr -d '\"')" >> $GITHUB_OUTPUT
-      shell: bash
-
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:
-        name: test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}-${{ matrix.version-restrict }}-${{ steps.extra_args_fname.outputs.extra_args }}
+        name: test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}-${{ matrix.version-restrict }}
         path: tests_out.xml
         retention-days: 5
       if: (success() || failure()) && ! contains(matrix.extra-args, 'forked')
@@ -215,4 +197,3 @@ jobs:
         name: dist-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}
         path: dist/
         retention-days: 2
-        overwrite: true

--- a/conftest.py
+++ b/conftest.py
@@ -7,6 +7,7 @@ import pytest
 import re
 import sys
 
+import graph_scheduler as gs
 import psyneulink
 from psyneulink import clear_registry, primary_registries, torch_available
 from psyneulink.core import llvm as pnlvm
@@ -125,6 +126,8 @@ def pytest_runtest_teardown(item):
     for registry in primary_registries:
         # Clear Registry to have a stable reference for indexed suffixes of default names
         clear_registry(registry)
+
+    gs.utilities.cached_hashable_graph_function.cache_clear()
 
     pnlvm.cleanup()
 

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -4097,7 +4097,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             self.add_controller(controller)
         self.controller_mode = controller_mode
         self.controller_time_scale = controller_time_scale
-        self.controller_condition = controller_condition
+        self.controller_condition = copy(controller_condition)
         self.controller_condition.owner = self.controller
         # This is set at runtime and may be used by the controller to assign its
         #     `num_trials_per_estimate <OptimizationControlMechanism.num_trials_per_estimate>` attribute.

--- a/psyneulink/core/llvm/__init__.py
+++ b/psyneulink/core/llvm/__init__.py
@@ -255,7 +255,7 @@ def _get_engines():
 
 
 
-def cleanup():
+def cleanup(check_leaks:bool=False):
     global _cpu_engine
     _cpu_engine = None
     global _ptx_engine
@@ -267,4 +267,16 @@ def cleanup():
     LLVMBinaryFunction.get.cache_clear()
     LLVMBinaryFunction.from_obj.cache_clear()
 
-    LLVMBuilderContext.clear_global()
+    if check_leaks and LLVMBuilderContext.is_active():
+        old_context = LLVMBuilderContext.get_current()
+
+        LLVMBuilderContext.clear_global()
+
+        # check that WeakKeyDictionary is not keeping any references
+        import gc
+        gc.collect()
+        c = list(old_context._cache.keys())
+
+        assert len(c) == 0, c
+    else:
+        LLVMBuilderContext.clear_global()

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -164,6 +164,10 @@ class LLVMBuilderContext:
         return cls.__current_context
 
     @classmethod
+    def is_active(cls):
+        return cls.__current_context is not None
+
+    @classmethod
     def clear_global(cls):
         cls.__current_context = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beartype<0.19.0
 dill<0.3.9
 fastkde>=1.0.24, <1.0.31
-graph-scheduler>=1.1.1, <1.3.0
+graph-scheduler>=1.2.1, <1.3.0
 graphviz<0.21.0
 grpcio<1.64.0
 leabra-psyneulink<0.3.3


### PR DESCRIPTION
Clear graph-scheduler caches after every test.
Create a copy of the scheduler condition in composition to avoid leaking a reference to a global instance.
Restore a single run of x86 CI testing.
Add a check for destruction of compiled structures at the end of each compiled test.

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>