### PR TITLE
MDF: support DriftDiffusionIntegrator

### DIFF
--- a/psyneulink/core/components/functions/stateful/integratorfunctions.py
+++ b/psyneulink/core/components/functions/stateful/integratorfunctions.py
@@ -2407,7 +2407,7 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
         non_decision_time = Parameter(0.0, modulable=True)
         threshold = Parameter(100.0, modulable=True)
         time_step_size = Parameter(1.0, modulable=True)
-        previous_time = Parameter(None, initializer='non_decision_time', pnl_internal=True)
+        previous_time = Parameter(0.0, initializer='non_decision_time', pnl_internal=True)
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
         seed = Parameter(DEFAULT_SEED, modulable=True, fallback_default=True, setter=_seed_setter)
         enable_output_type_conversion = Parameter(
@@ -2894,7 +2894,7 @@ class DriftOnASphereIntegrator(IntegratorFunction):  # -------------------------
         starting_point = 0.0
         # threshold = Parameter(100.0, modulable=True)
         time_step_size = Parameter(1.0, modulable=True)
-        previous_time = Parameter(None, initializer='starting_point', pnl_internal=True)
+        previous_time = Parameter(0.0, initializer='starting_point', pnl_internal=True)
         dimension = Parameter(3, stateful=False, read_only=True)
         initializer = Parameter([0], initalizer='variable', stateful=True)
         angle_function = Parameter(None, stateful=False, loggable=False)

--- a/psyneulink/core/components/functions/stateful/integratorfunctions.py
+++ b/psyneulink/core/components/functions/stateful/integratorfunctions.py
@@ -33,7 +33,7 @@ import typecheck as tc
 
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.component import DefaultsFlexibility
-from psyneulink.core.components.functions.nonstateful.distributionfunctions import DistributionFunction
+from psyneulink.core.components.functions.nonstateful.distributionfunctions import DistributionFunction, NormalDist
 from psyneulink.core.components.functions.function import (
     DEFAULT_SEED, FunctionError, _random_state_getter,
     _seed_setter, _noise_setter
@@ -51,7 +51,7 @@ from psyneulink.core.globals.keywords import \
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.utilities import parameter_spec, all_within_range, \
-    convert_all_elements_to_np_array
+    convert_all_elements_to_np_array, parse_valid_identifier
 
 __all__ = ['SimpleIntegrator', 'AdaptiveIntegrator', 'DriftDiffusionIntegrator', 'DriftOnASphereIntegrator',
            'OrnsteinUhlenbeckIntegrator', 'FitzHughNagumoIntegrator', 'AccumulatorIntegrator',
@@ -2339,6 +2339,10 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
     """
 
     componentName = DRIFT_DIFFUSION_INTEGRATOR_FUNCTION
+    _mdf_stateful_parameter_indices = {
+        'previous_value': 0,
+        'previous_time': 1,
+    }
 
     class Parameters(IntegratorFunction.Parameters):
         """
@@ -2407,7 +2411,7 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
         non_decision_time = Parameter(0.0, modulable=True)
         threshold = Parameter(100.0, modulable=True)
         time_step_size = Parameter(1.0, modulable=True)
-        previous_time = Parameter(0.0, initializer='non_decision_time', pnl_internal=True)
+        previous_time = Parameter(0.0, initializer='non_decision_time')
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
         seed = Parameter(DEFAULT_SEED, modulable=True, fallback_default=True, setter=_seed_setter)
         enable_output_type_conversion = Parameter(
@@ -2417,6 +2421,8 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
             pnl_internal=True,
             read_only=True
         )
+        # used only to allow putting random_draw in runtime_params for MDF tests
+        random_draw = Parameter()
 
         def _parse_initializer(self, initializer):
             if initializer.ndim > 1:
@@ -2504,7 +2510,11 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
         variable = self.parameters._parse_initializer(variable)
         previous_value = self.parameters.previous_value._get(context)
 
-        random_draw = np.array([random_state.normal() for _ in list(variable)])
+        try:
+            random_draw = params['random_draw']
+        except (KeyError, TypeError):
+            random_draw = np.array([random_state.normal() for _ in list(variable)])
+
         value = previous_value + rate * variable * time_step_size \
                 + noise * np.sqrt(time_step_size) * random_draw
 
@@ -2584,6 +2594,50 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
             previous_time=previous_time,
             context=context
         )
+
+    def _assign_to_mdf_model(self, model, input_id):
+        import modeci_mdf.mdf as mdf
+
+        self_id = parse_valid_identifier(self.name)
+        parameters = self._mdf_model_parameters
+        parameters[self._model_spec_id_parameters][MODEL_SPEC_ID_MDF_VARIABLE] = input_id
+        threshold = parameters[self._model_spec_id_parameters]['threshold']
+
+        random_draw_func = mdf.Function(
+            id=f'{self_id}_random_draw',
+            function=NormalDist._model_spec_generic_type_name,
+            args={'shape': (len(self.defaults.variable),), 'seed': self.defaults.seed}
+        )
+        unclipped_func = mdf.Function(
+            id=f'{self_id}_unclipped',
+            value=f'(previous_value + rate * {MODEL_SPEC_ID_MDF_VARIABLE} * time_step_size + noise * math.sqrt(time_step_size) * {random_draw_func.id}) + offset',
+            args={
+                k: v for k, v in parameters[self._model_spec_id_parameters].items()
+                if (k not in self.parameters or getattr(self.parameters, k).initializer is None)
+            }
+        )
+        lower_clipped = mdf.Function(
+            id=f'{self_id}_lower_clipped',
+            value=f'max({unclipped_func.id}, -1 * threshold)',
+            args={'threshold': np.full_like(self.defaults.previous_value, threshold)}
+        )
+        result = mdf.Function(
+            id=f'{self_id}_value_result',
+            value=f'min({lower_clipped.id}, threshold)',
+            args={'threshold': np.full_like(self.defaults.previous_value, threshold)}
+        )
+
+        model.functions.extend([
+            random_draw_func,
+            unclipped_func,
+            lower_clipped,
+            result,
+        ])
+
+        return super()._assign_to_mdf_model(model, input_id)
+
+    def as_expression(self):
+        return f'{parse_valid_identifier(self.name)}_value_result, previous_time'
 
 
 class DriftOnASphereIntegrator(IntegratorFunction):  # -----------------------------------------------------------------

--- a/psyneulink/core/components/functions/stateful/statefulfunction.py
+++ b/psyneulink/core/components/functions/stateful/statefulfunction.py
@@ -168,6 +168,11 @@ class StatefulFunction(Function_Base): #  --------------------------------------
     componentType = STATEFUL_FUNCTION_TYPE
     componentName = STATEFUL_FUNCTION
 
+    # TODO: consider moving this to a Parameter attribute
+    _mdf_stateful_parameter_indices = {
+        'previous_value': None
+    }
+
     class Parameters(Function_Base.Parameters):
         """
             Attributes

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -1098,7 +1098,6 @@ from psyneulink.core.components.ports.port import \
     REMOVE_PORTS, PORT_SPEC, _parse_port_spec, PORT_SPECIFIC_PARAMS, PROJECTION_SPECIFIC_PARAMS
 from psyneulink.core.components.shellclasses import Mechanism, Projection, Port
 from psyneulink.core.globals.context import Context, ContextFlags, handle_external_context
-from psyneulink.core.globals.mdf import _get_variable_parameter_name
 # TODO: remove unused keywords
 from psyneulink.core.globals.keywords import \
     ADDITIVE_PARAM, EXECUTION_PHASE, EXPONENT, FUNCTION_PARAMS, \
@@ -4194,20 +4193,12 @@ class Mechanism_Base(Mechanism):
 
             model.output_ports.append(op_model)
 
-        function_model = self.function.as_mdf_model()
-
-        for _, func_param in function_model.metadata['function_stateful_params'].items():
-            model.parameters.append(mdf.Parameter(**func_param))
-
         if len(ip.path_afferents) > 1:
             primary_function_input_name = combination_function_dimreduce_id
         else:
             primary_function_input_name = model.input_ports[0].id
 
-        self.function._set_mdf_arg(
-            function_model, _get_variable_parameter_name(self.function), primary_function_input_name
-        )
-        model.functions.append(function_model)
+        self.function._assign_to_mdf_model(model, primary_function_input_name)
 
         return model
 

--- a/psyneulink/core/components/mechanisms/processing/integratormechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/integratormechanism.py
@@ -94,7 +94,6 @@ from psyneulink.core.globals.keywords import \
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set, REPORT_OUTPUT_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
-from psyneulink.core.globals.utilities import parse_valid_identifier
 
 __all__ = [
     'DEFAULT_RATE', 'IntegratorMechanism', 'IntegratorMechanismError'
@@ -230,29 +229,3 @@ class IntegratorMechanism(ProcessingMechanism_Base):
                                                 input_ports=input_ports,
                                                 function=function,
                                                 params=params)
-
-    def as_mdf_model(self):
-        import modeci_mdf.mdf as mdf
-
-        model = super().as_mdf_model()
-        function_model = [
-            f for f in model.functions
-            if f.id == parse_valid_identifier(self.function.name)
-        ][0]
-        assert function_model.id == parse_valid_identifier(self.function.name), (function_model.id, parse_valid_identifier(self.function.name))
-
-        for _, func_param in function_model.metadata['function_stateful_params'].items():
-            model.parameters.append(mdf.Parameter(**func_param))
-
-        res = self.function._get_mdf_noise_function()
-        try:
-            main_noise_function, extra_noise_functions = res
-        except TypeError:
-            pass
-        else:
-            main_noise_function.id = f'{model.id}_{main_noise_function.id}'
-            model.functions.append(main_noise_function)
-            model.functions.extend(extra_noise_functions)
-            function_model.args['noise'] = main_noise_function.id
-
-        return model

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -1302,6 +1302,8 @@ class OutputPort(Port_Base):
         return mdf.OutputPort(
             id=parse_valid_identifier(self.name),
             value=value,
+            shape=str(self.defaults.value.shape),
+            type=str(self.defaults.value.dtype),
             **self._mdf_metadata
         )
 

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -1288,7 +1288,7 @@ class OutputPort(Port_Base):
     def as_mdf_model(self):
         import modeci_mdf.mdf as mdf
 
-        owner_func_name = parse_valid_identifier(self.owner.function.name)
+        owner_func_name = parse_valid_identifier(f'{self.owner.name}_{self.owner.function.name}')
         if self._variable_spec == OWNER_VALUE:
             value = owner_func_name
         elif isinstance(self._variable_spec, tuple) and self._variable_spec[0] == OWNER_VALUE:

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -1110,7 +1110,7 @@ class Projection_Base(Projection):
             edge_function = edge_node.function
             edge_node = edge_node.as_mdf_model()
 
-            func_model = [f for f in edge_node.functions if f.id == parse_valid_identifier(edge_function.name)][0]
+            func_model = [f for f in edge_node.functions if f.id == parse_valid_identifier(f'{edge_node.id}_{edge_function.name}')][0]
             var_name = _get_variable_parameter_name(edge_function)
 
             # 2d variable on LinearMatrix will be incorrect on import back to psyneulink


### PR DESCRIPTION
- DriftDiffusionIntegrator exportable into MDF with equivalent results
- organizational changes to general psyneulink MDF export code to make it easier to add MDF support for more complex psyneulink Functions