### PR TITLE
github-actions/install-pnl/dependabot_pr: Skip package version check for not installed packages

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -89,6 +89,8 @@ runs:
       if: ${{ startsWith(github.head_ref, 'dependabot/pip') && matrix.pnl-version != 'base' }}
       shell: bash
       run: |
-        pip show ${{ steps.new_package.outputs.new_package }} | grep 'Version' | tee installed_version.deps
-        cmp -s new_version.deps installed_version.deps || echo "::error::Package version restricted by dependencies: ${{ steps.new_package.outputs.new_package }}"
-        diff new_version.deps installed_version.deps
+        if [ $(pip list | grep -o ${{ steps.new_package.outputs.new_package }} | wc -l) != "0" ] ; then
+          pip show ${{ steps.new_package.outputs.new_package }} | grep 'Version' | tee installed_version.deps
+          cmp -s new_version.deps installed_version.deps || echo "::error::Package version restricted by dependencies: ${{ steps.new_package.outputs.new_package }}"
+          diff new_version.deps installed_version.deps
+        fi


### PR DESCRIPTION
This happens if the package is a dependency with 'extras', e.g. a 'doc' or 'cuda' dependency not installed in 'dev' CI jobs.
Fixes package bumps of docs dependencies.

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>