### PR TITLE
llvm: Use modulated parameter values in 'is_finished' variant

### DIFF
--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3088,7 +3088,7 @@ class Mechanism_Base(Mechanism):
 
         return f_out, builder
 
-    def _gen_llvm_is_finished_cond(self, ctx, builder, m_params, m_state):
+    def _gen_llvm_is_finished_cond(self, ctx, builder, m_base_params, m_state, m_inputs):
         return ctx.bool_ty(1)
 
     def _gen_llvm_mechanism_functions(self, ctx, builder, m_base_params, m_params, m_state, m_in,
@@ -3141,7 +3141,7 @@ class Mechanism_Base(Mechanism):
 
         # is_finished should be checked after output ports ran
         is_finished_f = ctx.import_llvm_function(self, tags=tags.union({"is_finished"}))
-        is_finished_cond = builder.call(is_finished_f, [m_params, m_state, arg_in,
+        is_finished_cond = builder.call(is_finished_f, [m_base_params, m_state, arg_in,
                                                         arg_out])
         return builder, is_finished_cond
 
@@ -3176,8 +3176,8 @@ class Mechanism_Base(Mechanism):
 
         builder = ctx.create_llvm_function(args, self, return_type=ctx.bool_ty,
                                            tags=tags)
-        params, state = builder.function.args[:2]
-        finished = self._gen_llvm_is_finished_cond(ctx, builder, params, state)
+        params, state, inputs = builder.function.args[:3]
+        finished = self._gen_llvm_is_finished_cond(ctx, builder, params, state, inputs)
         builder.ret(finished)
         return builder.function
 

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1230,7 +1230,6 @@ class DDM(ProcessingMechanism):
     def _gen_llvm_is_finished_cond(self, ctx, builder, m_base_params, m_state, m_in):
         # Setup pointers to internal function
         f_state = pnlvm.helpers.get_state_ptr(builder, self, m_state, "function")
-        f_base_params = pnlvm.helpers.get_param_ptr(builder, self, m_base_params, "function")
 
         # Find the single numeric entry in previous_value.
         # This exists only if the 'function' is 'integrator'
@@ -1247,11 +1246,15 @@ class DDM(ProcessingMechanism):
         llvm_fabs = ctx.get_builtin("fabs", [ctx.float_ty])
         prev_val = builder.call(llvm_fabs, [prev_val])
 
+        # Get functions params and apply modulation
+        f_base_params = pnlvm.helpers.get_param_ptr(builder, self, m_base_params, "function")
+        f_params, builder = self._gen_llvm_param_ports_for_obj(
+                self.function, f_base_params, ctx, builder, m_base_params, m_state, m_in)
 
         # Get threshold value
         threshold_ptr = pnlvm.helpers.get_param_ptr(builder,
                                                     self.function,
-                                                    f_base_params,
+                                                    f_params,
                                                     "threshold")
 
         threshold_ptr = builder.gep(threshold_ptr, [ctx.int32_ty(0), ctx.int32_ty(0)])

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1227,14 +1227,15 @@ class DDM(ProcessingMechanism):
             return True
         return False
 
-    def _gen_llvm_is_finished_cond(self, ctx, builder, params, state):
+    def _gen_llvm_is_finished_cond(self, ctx, builder, m_base_params, m_state, m_in):
         # Setup pointers to internal function
-        func_state_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, "function")
-        func_param_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, "function")
+        f_state = pnlvm.helpers.get_state_ptr(builder, self, m_state, "function")
+        f_base_params = pnlvm.helpers.get_param_ptr(builder, self, m_base_params, "function")
 
-        # Find the single numeric entry in previous_value
+        # Find the single numeric entry in previous_value.
+        # This exists only if the 'function' is 'integrator'
         try:
-            prev_val_ptr = pnlvm.helpers.get_state_ptr(builder, self.function, func_state_ptr, "previous_value")
+            prev_val_ptr = pnlvm.helpers.get_state_ptr(builder, self.function, f_state, "previous_value")
         except ValueError:
             return ctx.bool_ty(1)
 
@@ -1247,10 +1248,10 @@ class DDM(ProcessingMechanism):
         prev_val = builder.call(llvm_fabs, [prev_val])
 
 
-        # obtain threshold value
+        # Get threshold value
         threshold_ptr = pnlvm.helpers.get_param_ptr(builder,
                                                     self.function,
-                                                    func_param_ptr,
+                                                    f_base_params,
                                                     "threshold")
 
         threshold_ptr = builder.gep(threshold_ptr, [ctx.int32_ty(0), ctx.int32_ty(0)])

--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -665,30 +665,21 @@ def test_DDM_in_composition(benchmark, comp_mode):
 @pytest.mark.composition
 @pytest.mark.ddm_mechanism
 def test_DDM_threshold_modulation(comp_mode):
-    M = pnl.DDM(
-        name='DDM',
-        function=pnl.DriftDiffusionAnalytical(
-            threshold=20.0,
-        ),
-    )
-    monitor = pnl.TransferMechanism(default_variable=[[0.0]],
-                                    size=1,
-                                    function=pnl.Linear(slope=1, intercept=0),
-                                    output_ports=[pnl.RESULT],
-                                    name='monitor')
+    M = pnl.DDM(name='DDM',
+                function=pnl.DriftDiffusionAnalytical(
+                    threshold=20.0,
+                ),
+               )
 
-    control = pnl.ControlMechanism(
-            monitor_for_control=monitor,
-            control_signals=[(pnl.THRESHOLD, M)])
+    control = pnl.ControlMechanism(control_signals=[(pnl.THRESHOLD, M)])
 
     C = pnl.Composition()
     C.add_node(M, required_roles=[pnl.NodeRole.ORIGIN, pnl.NodeRole.TERMINAL])
-    C.add_node(monitor)
     C.add_node(control)
-    inputs = {M:[1], monitor:[3]}
+    inputs = {M:[1], control:[3]}
     val = C.run(inputs, num_trials=1, execution_mode=comp_mode)
-    # FIXME: Python version returns dtype=object
-    val = np.asfarray(val)
+
+    # Default modulation is 'multiplicative so the threshold is 20 * 3
     assert np.allclose(val[0], [60.0])
     assert np.allclose(val[1], [60.2])
 

--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -664,7 +664,7 @@ def test_DDM_in_composition(benchmark, comp_mode):
 
 @pytest.mark.composition
 @pytest.mark.ddm_mechanism
-def test_DDM_threshold_modulation(comp_mode):
+def test_DDM_threshold_modulation_analytical(comp_mode):
     M = pnl.DDM(name='DDM',
                 function=pnl.DriftDiffusionAnalytical(
                     threshold=20.0,
@@ -682,6 +682,27 @@ def test_DDM_threshold_modulation(comp_mode):
     # Default modulation is 'multiplicative so the threshold is 20 * 3
     assert np.allclose(val[0], [60.0])
     assert np.allclose(val[1], [60.2])
+
+
+@pytest.mark.composition
+@pytest.mark.ddm_mechanism
+def test_DDM_threshold_modulation_integrator(comp_mode):
+    M = pnl.DDM(name='DDM',
+                execute_until_finished=True,
+                function=pnl.DriftDiffusionIntegrator(threshold=20),
+               )
+
+    control = pnl.ControlMechanism(
+            control_signals=[(pnl.THRESHOLD, M)])
+
+    C = pnl.Composition()
+    C.add_node(M, required_roles=[pnl.NodeRole.ORIGIN, pnl.NodeRole.TERMINAL])
+    C.add_node(control)
+    inputs = {M:[1], control:[3]}
+    val = C.run(inputs, num_trials=1, execution_mode=comp_mode)
+
+    assert np.allclose(val[0], [60.0])
+    assert np.allclose(val[1], [60.0])
 
 
 @pytest.mark.composition


### PR DESCRIPTION
Consistently use modulated mechanism parameters (e.g. threshold) of TransferMechanism in `is_finished` function whether it's called from inside the mechanism loop, or by the scheduler.
Use modulated function parameters in DDM's 'is_finished' function in both internal and scheduler invocation.