### PR TITLE
github-actions: Restrict scipy to <1.9.2 on x86

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -49,7 +49,7 @@ runs:
           sed -i /modeci_mdf/d requirements.txt
           # pywinpty is a transitive dependency and v1.0+ removed support for x86 wheels
           # terminado >= 0.10.0 pulls in pywinpty >= 1.1.0
-          [[ ${{ runner.os }} = Windows* ]] && pip install "pywinpty<1" "terminado<0.10"
+          [[ ${{ runner.os }} = Windows* ]] && pip install "pywinpty<1" "terminado<0.10" "scipy<1.9.2" -c requirements.txt
         fi
 
     - name: Install updated package


### PR DESCRIPTION
scipy doesn't provide 32-bit wheels for 1.9.2

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>