### PR TITLE
github-actions: Use environment files to set outputs

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -58,7 +58,7 @@ runs:
       id: new_package
       run: |
         export NEW_PACKAGE=$(echo '${{ github.head_ref }}' | cut -f 4 -d/ | sed 's/-gt.*//' | sed 's/-lt.*//')
-        echo "::set-output name=new_package::$NEW_PACKAGE"
+        echo "{new_package}={$NEW_PACKAGE}" >> $GITHUB_OUTPUT
         # save a list of all installed packages (including pip, wheel; it's never empty)
         pip freeze --all > orig
         pip install "$(echo $NEW_PACKAGE | sed 's/[-_]/./g' | xargs grep *requirements.txt -h -e | head -n1)"

--- a/.github/actions/on-branch/action.yml
+++ b/.github/actions/on-branch/action.yml
@@ -25,4 +25,4 @@ runs:
         git describe --always --tags
         export ON_BRANCH=$(git branch -a --contains ${{ github.ref }} | grep -q '^  remotes/origin/${{ inputs.branch }}$' && echo "${{ inputs.branch }}" || echo "")
         echo "Found out: ${ON_BRANCH}"
-        echo "::set-output name=on_branch::$ON_BRANCH"
+        echo "{on_branch}={$ON_BRANCH}" >> $GITHUB_OUTPUT

--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -76,7 +76,7 @@ jobs:
       run: |
         python -m pip install -U pip
         python -m pip --version
-        echo ::set-output name=pip_cache_dir::$(python -m pip cache dir)
+        echo "{pip_cache_dir}={$(python -m pip cache dir)}" >> $GITHUB_OUTPUT
 
     - name: Wheels cache
       uses: actions/cache@v3

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -61,7 +61,7 @@ jobs:
       run: |
         python -m pip install -U pip
         python -m pip --version
-        echo ::set-output name=pip_cache_dir::$(python -m pip cache dir)
+        echo "{pip_cache_dir}={$(python -m pip cache dir)}" >> $GITHUB_OUTPUT
 
     - name: Wheels cache
       uses: actions/cache@v3

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -34,8 +34,8 @@ jobs:
         python setup.py sdist
         python setup.py bdist_wheel
         cd dist
-        echo ::set-output name=sdist::$(ls *.tar.gz)
-        echo ::set-output name=wheel::$(ls *.whl)
+        echo "{sdist}={$(ls *.tar.gz)}" >> $GITHUB_OUTPUT
+        echo "{wheel}={$(ls *.whl)}" >> $GITHUB_OUTPUT
 
     - name: Upload Python dist files
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
The old way of using workflow commands is going away[0]

[0] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>