### PR TITLE
github-actions: Fix detection of wheel cache directory location

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -60,7 +60,7 @@ runs:
       id: new_package
       run: |
         export NEW_PACKAGE=$(echo '${{ github.head_ref }}' | cut -f 4 -d/ | sed 's/-gt.*//' | sed 's/-lt.*//')
-        echo "{new_package}={$NEW_PACKAGE}" >> $GITHUB_OUTPUT
+        echo "new_package=$NEW_PACKAGE" >> $GITHUB_OUTPUT
         # save a list of all installed packages (including pip, wheel; it's never empty)
         pip freeze --all > orig
         pip install "$(echo $NEW_PACKAGE | sed 's/[-_]/./g' | xargs grep *requirements.txt -h -e | head -n1)"

--- a/.github/actions/on-branch/action.yml
+++ b/.github/actions/on-branch/action.yml
@@ -25,4 +25,4 @@ runs:
         git describe --always --tags
         export ON_BRANCH=$(git branch -a --contains ${{ github.ref }} | grep -q '^  remotes/origin/${{ inputs.branch }}$' && echo "${{ inputs.branch }}" || echo "")
         echo "Found out: ${ON_BRANCH}"
-        echo "{on_branch}={$ON_BRANCH}" >> $GITHUB_OUTPUT
+        echo "on_branch=$ON_BRANCH" >> $GITHUB_OUTPUT

--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -82,8 +82,8 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ steps.pip_cache.outputs.pip_cache_dir }}/wheels
-        key: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-${{ hashFiles('requirements.txt') }}-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-${{ hashFiles('requirements.txt', 'doc_requirements.txt') }}-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-${{ hashFiles('requirements.txt', 'doc_requirements.txt') }}
 
     # We need to install all PNL deps since docs config imports psyneulink module
     - name: Install local, editable PNL package

--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -76,7 +76,7 @@ jobs:
       run: |
         python -m pip install -U pip
         python -m pip --version
-        echo "{pip_cache_dir}={$(python -m pip cache dir)}" >> $GITHUB_OUTPUT
+        echo "pip_cache_dir=$(python -m pip cache dir)" | tee -a $GITHUB_OUTPUT
 
     - name: Wheels cache
       uses: actions/cache@v3

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -67,8 +67,8 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ steps.pip_cache.outputs.pip_cache_dir }}/wheels
-        key: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-${{ hashFiles('requirements.txt') }}-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-${{ hashFiles('requirements.txt', 'dev_requirements.txt') }}-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-${{ hashFiles('requirements.txt', 'dev_requirements.txt') }}
 
     - name: Install local, editable PNL package
       uses: ./.github/actions/install-pnl

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -61,7 +61,7 @@ jobs:
       run: |
         python -m pip install -U pip
         python -m pip --version
-        echo "{pip_cache_dir}={$(python -m pip cache dir)}" >> $GITHUB_OUTPUT
+        echo "pip_cache_dir=$(python -m pip cache dir)" | tee -a $GITHUB_OUTPUT
 
     - name: Wheels cache
       uses: actions/cache@v3

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -34,8 +34,8 @@ jobs:
         python setup.py sdist
         python setup.py bdist_wheel
         cd dist
-        echo "{sdist}={$(ls *.tar.gz)}" >> $GITHUB_OUTPUT
-        echo "{wheel}={$(ls *.whl)}" >> $GITHUB_OUTPUT
+        echo "sdist=$(ls *.tar.gz)" >> $GITHUB_OUTPUT
+        echo "wheel=$(ls *.whl)" >> $GITHUB_OUTPUT
 
     - name: Upload Python dist files
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Use correct format of outputs written to GITHUB_OUTPUT.
Consider additional dependency files (dev_, doc_) when creating cache keys.