### PR TITLE
github-actions: Restrict statsmodels to <0.13.3 on x86

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -51,7 +51,7 @@ runs:
           # terminado >= 0.10.0 pulls in pywinpty >= 1.1.0
           # scipy >=1.9.2 doesn't provide win32 wheel and GA doesn't have working fortran on windows
           # scikit-learn >= 1.1.3 doesn't provide win32 wheel
-          [[ ${{ runner.os }} = Windows* ]] && pip install "pywinpty<1" "terminado<0.10" "scipy<1.9.2" "scikit-learn<1.1.3" -c requirements.txt
+          [[ ${{ runner.os }} = Windows* ]] && pip install "pywinpty<1" "terminado<0.10" "scipy<1.9.2" "scikit-learn<1.1.3" "statsmodels<0.13.3" -c requirements.txt
         fi
 
     - name: Install updated package


### PR DESCRIPTION
statsmodels doesn't provide 32-bit wheels for >=0.13.3, and the build process tries to pull in scipy-1.9.3 triggering the issue that was addressed in e607c0973f74eceb514c2de9eb6e3ae7dfa29716 [0]

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>

[0] https://github.com/PrincetonUniversity/PsyNeuLink/actions/runs/3371876413/jobs/5594642498