### PR TITLE
llvm: Implement compiled Angle and SoftMax derivative Functions

### DIFF
--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -56,6 +56,7 @@ def module_count():
 
 _BUILTIN_PREFIX = "__pnl_builtin_"
 _builtin_intrinsics = frozenset(('pow', 'log', 'exp', 'tanh', 'coth', 'csch',
+                                 'sin', 'cos',
                                  'is_close_float', 'is_close_double',
                                  'mt_rand_init', 'philox_rand_init'))
 

--- a/psyneulink/core/llvm/builtins.py
+++ b/psyneulink/core/llvm/builtins.py
@@ -448,7 +448,7 @@ def setup_coth(ctx):
     exp_f = ctx.get_builtin("exp", [x.type])
     # (e**2x + 1)/(e**2x - 1) is faster but doesn't handle large inputs (exp -> Inf) well (Inf/Inf = NaN)
     # (1 + (2/(exp(2*x) - 1))) is a bit slower but handles large inputs better
-    # (e**2x + 1)/(e**2x - 1)
+
     _2x = builder.fmul(x.type(2), x)
     e2x = builder.call(exp_f, [_2x])
     den = builder.fsub(e2x, e2x.type(1))
@@ -463,6 +463,8 @@ def setup_pnl_intrinsics(ctx):
     double_intr_ty = ir.FunctionType(ctx.float_ty, (ctx.float_ty, ctx.float_ty))
 
     # Create function declarations
+    ir.Function(ctx.module, single_intr_ty, name=_BUILTIN_PREFIX + "cos")
+    ir.Function(ctx.module, single_intr_ty, name=_BUILTIN_PREFIX + "sin")
     ir.Function(ctx.module, single_intr_ty, name=_BUILTIN_PREFIX + "exp")
     ir.Function(ctx.module, single_intr_ty, name=_BUILTIN_PREFIX + "log")
     ir.Function(ctx.module, double_intr_ty, name=_BUILTIN_PREFIX + "pow")
@@ -483,7 +485,7 @@ def _generate_intrinsic_wrapper(module, name, ret, args):
 def _generate_cpu_builtins_module(_float_ty):
     """Generate function wrappers for log, exp, and pow intrinsics."""
     module = ir.Module(name="cpu_builtins")
-    for intrinsic in ('exp', 'log'):
+    for intrinsic in ('sin', 'cos', 'exp', 'log'):
         _generate_intrinsic_wrapper(module, intrinsic, _float_ty, [_float_ty])
 
     _generate_intrinsic_wrapper(module, "pow", _float_ty, [_float_ty, _float_ty])

--- a/psyneulink/core/llvm/jit_engine.py
+++ b/psyneulink/core/llvm/jit_engine.py
@@ -279,6 +279,8 @@ class cpu_jit_engine(jit_engine):
 
 
 _ptx_builtin_source = """
+__device__ {type} __pnl_builtin_sin({type} a) {{ return sin(a); }}
+__device__ {type} __pnl_builtin_cos({type} a) {{ return cos(a); }}
 __device__ {type} __pnl_builtin_log({type} a) {{ return log(a); }}
 __device__ {type} __pnl_builtin_exp({type} a) {{ return exp(a); }}
 __device__ {type} __pnl_builtin_pow({type} a, {type} b) {{ return pow(a, b); }}

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -80,7 +80,7 @@ derivative_test_data = [
     (Functions.Linear, test_var, {'slope':RAND1, 'intercept':RAND2}, RAND1),
     (Functions.Exponential, test_var, {'scale':RAND1, 'rate':RAND2}, RAND1 * RAND2 * np.exp(RAND2 * test_var)),
     (Functions.Logistic, test_var, {'gain':RAND1, 'x_0':RAND2, 'offset':RAND3, 'scale':RAND4}, RAND1 * RAND4 * logistic_helper * (1 - logistic_helper)),
-    (Functions.ReLU, test_var, {'gain':RAND1, 'bias':RAND2, 'leak':RAND3}, np.where(test_var > 0, RAND1, RAND1 * RAND3)),
+    (Functions.ReLU, test_var, {'gain':RAND1, 'bias':RAND2, 'leak':RAND3}, np.where((test_var - RAND2) > 0, RAND1, RAND1 * RAND3)),
     (Functions.Tanh, test_var, {'gain':RAND1, 'bias':RAND2, 'offset':RAND3, 'scale':RAND4}, tanh_derivative_helper),
 ]
 

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -62,8 +62,6 @@ test_data = [
 @pytest.mark.benchmark
 @pytest.mark.parametrize("func, variable, params, expected", test_data)
 def test_execute(func, variable, params, expected, benchmark, func_mode):
-    if 'Angle' in func.componentName and func_mode != 'Python':
-        pytest.skip('Angle not yet supported by LLVM or PTX')
     benchmark.group = "TransferFunction " + func.componentName
     f = func(default_variable=variable, **params)
     ex = pytest.helpers.get_func_execution(f, func_mode)

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -86,19 +86,11 @@ derivative_test_data = [
     (Functions.Tanh, test_var, {'gain':RAND1, 'bias':RAND2, 'offset':RAND3, 'scale':RAND4}, tanh_derivative_helper),
 ]
 
-derivative_names = [
-    "LINEAR_DERIVATIVE",
-    "EXPONENTIAL_DERIVATIVE",
-    "LOGISTIC_DERIVATIVE",
-    "RELU_DERIVATIVE",
-    "TANH_DERIVATIVE",
-]
-
 @pytest.mark.function
 @pytest.mark.transfer_function
 @pytest.mark.benchmark
-@pytest.mark.parametrize("func, variable, params, expected", derivative_test_data, ids=derivative_names)
-def test_execute_derivative(func, variable, params, expected, benchmark, func_mode):
+@pytest.mark.parametrize("func, variable, params, expected", derivative_test_data, ids=lambda x: getattr(x, 'name', None))
+def test_transfer_derivative(func, variable, params, expected, benchmark, func_mode):
     f = func(default_variable=variable, **params)
     benchmark.group = "TransferFunction " + func.componentName + " Derivative"
     if func_mode == 'Python':

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -4,8 +4,6 @@ import psyneulink.core.components.functions.nonstateful.transferfunctions as Fun
 import psyneulink.core.globals.keywords as kw
 import pytest
 
-from math import e, pi, sqrt
-
 SIZE=10
 np.random.seed(0)
 test_var = np.random.rand(SIZE)
@@ -25,7 +23,7 @@ softmax_helper = np.exp(softmax_helper) / np.sum(np.exp(softmax_helper))
 tanh_helper = (RAND1 * (test_var + RAND2 - RAND3) + RAND4)
 tanh_helper = np.tanh(tanh_helper)
 
-gaussian_helper = e**(-(test_var - RAND2)**2 / (2 * RAND1**2)) / sqrt(2 * pi * RAND1)
+gaussian_helper = np.e**(-(test_var - RAND2)**2 / (2 * RAND1**2)) / np.sqrt(2 * np.pi * RAND1)
 gaussian_helper = RAND3 * gaussian_helper + RAND4
 
 def gaussian_distort_helper(seed):

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -82,6 +82,12 @@ derivative_test_data = [
     (Functions.Logistic, test_var, {'gain':RAND1, 'x_0':RAND2, 'offset':RAND3, 'scale':RAND4}, RAND1 * RAND4 * logistic_helper * (1 - logistic_helper)),
     (Functions.ReLU, test_var, {'gain':RAND1, 'bias':RAND2, 'leak':RAND3}, np.where((test_var - RAND2) > 0, RAND1, RAND1 * RAND3)),
     (Functions.Tanh, test_var, {'gain':RAND1, 'bias':RAND2, 'offset':RAND3, 'scale':RAND4}, tanh_derivative_helper),
+    (Functions.SoftMax, test_var, {'gain':RAND1, 'params':{kw.OUTPUT_TYPE:kw.MAX_VAL}, 'per_item': False},
+     [-0.010680386821751537, -0.011118109698906909, -0.01082040340318878, -0.010670257514724047, -0.010362498859374309,
+      -0.010933660158663306, -0.010397412260182806, -0.011602329078808718, 0.09684744183944892, -0.010262384043848513]),
+    (Functions.SoftMax, test_var, {'gain':RAND1, 'params':{kw.OUTPUT_TYPE:kw.MAX_INDICATOR}, 'per_item': False},
+     [-0.010680386821751537, -0.011118109698906909, -0.01082040340318878, -0.010670257514724047, -0.010362498859374309,
+      -0.010933660158663306, -0.010397412260182806, -0.011602329078808718, 0.09684744183944892, -0.010262384043848513]),
 ]
 
 @pytest.mark.function

--- a/tests/llvm/test_builtins_intrinsics.py
+++ b/tests/llvm/test_builtins_intrinsics.py
@@ -25,8 +25,10 @@ y = np.random.rand()
                          (lambda x: 1.0 / np.sinh(x), (450,), "__pnl_builtin_csch", 1 / np.sinh(450)),
                          #~900 is the limit after which exp(x) used in csch formula returns inf
                          (lambda x: 1.0 / np.sinh(x), (900,), "__pnl_builtin_csch", 1 / np.sinh(900)),
+                         (np.sin, (x,), "__pnl_builtin_sin", np.sin(x)),
+                         (np.cos, (x,), "__pnl_builtin_cos", np.cos(x)),
                          ], ids=["EXP", "Large EXP", "LOG", "POW", "TANH", "Large TANH", "COTH", "Large COTH",
-                                "CSCH", "Large CSCH", "xLarge CSCH"])
+                                "CSCH", "Large CSCH", "xLarge CSCH", "SIN", "COS"])
 def test_builtin_op(benchmark, op, args, builtin, result, func_mode):
     if func_mode == 'Python':
         f = op


### PR DESCRIPTION
Switch to fixed implementation of ReLU derivative in both Python and compiled variant.
Use input consistently in SoftMax derivative (Python).
Add sin and cos builtin functions, PTX can't select instructions for llvm.sin/llvm.cos opcodes.