### PR TITLE
docs: Remove invalid escape sequences

### DIFF
--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -1216,7 +1216,7 @@ class RandomMatrix():
     .. technical_note::
        A call to the class calls `random_matrix <Utilities.random_matrix>`, passing **sender_size** and
        **receiver_size** to `random_matrix <Utilities.random_matrix>` as its **num_rows** and **num_cols**
-       arguments, respectively, and passing the `center <RandomMatrix.offset>`\-0.5 and `range <RandomMatrix.scale>`
+       arguments, respectively, and passing the `center <RandomMatrix.offset>`-0.5 and `range <RandomMatrix.scale>`
        attributes specified at construction to `random_matrix <Utilities.random_matrix>` as its **offset**
        and **scale** arguments, respectively.
 

--- a/psyneulink/core/components/functions/stateful/integratorfunctions.py
+++ b/psyneulink/core/components/functions/stateful/integratorfunctions.py
@@ -429,7 +429,7 @@ class AccumulatorIntegrator(IntegratorFunction):  # ----------------------------
     so that, with each call to `function <AccumulatorIntegrator._function>`, the accumulated value increases by:
 
     .. math::
-        increment \\cdot rate^{time\\ step}.
+        increment \\cdot rate^{time\\_step}.
 
     Thus, accumulation increases lineary in steps of `increment <AccumulatorIntegrator.increment>`
     if `rate <AccumulatorIntegrator.rate>`\\=1.0, and exponentially otherwise.
@@ -2216,7 +2216,7 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
 
     offset : float, list or 1d array : default 0.0
         specifies constant value added to integral in each call to `function <DriftDiffusionIntegrator._function>`
-        if it's absolute value is below `threshold <DriftDiffusionIntegrator.threshold>`\;
+        if it's absolute value is below `threshold <DriftDiffusionIntegrator.threshold>`;
         if it is a list or array, it must be the same length as `variable <DriftDiffusionIntegrator.variable>`
         (see `offset <DriftDiffusionIntegrator.offset>` for details).
 

--- a/psyneulink/core/components/functions/stateful/memoryfunctions.py
+++ b/psyneulink/core/components/functions/stateful/memoryfunctions.py
@@ -501,7 +501,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
       the entry closest to `variable <ContentAddressableMemory.variable>` is retrieved from is retrieved from `memory
       <ContentAddressableMemory.memory>`.  The entry is chosen by calling, in order:
 
-        * `distance_function <ContentAddressableMemory.distance_function>`\: generates a list of and compares
+        * `distance_function <ContentAddressableMemory.distance_function>`: generates a list of and compares
           `distances <ContentAddressableMemory.distances>` between `variable <ContentAddressableMemory.variable>`
           and each entry in `memory <ContentAddressableMemory.memory>`, possibly weighted by `distance_field_weights
           <ContentAddressableMemory.distance_field_weights>`, as follows:
@@ -528,7 +528,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
                between `variable <ContentAddressableMemory.variable>` and entries for those fields are not included
                in the averaging of distances by field.
 
-        * `selection_function <ContentAddressableMemory.selection_function>`\: called with the list of distances
+        * `selection_function <ContentAddressableMemory.selection_function>`: called with the list of distances
           to determine which entries to select for consideration. If more than on entry from `memory
           <ContentAddressableMemory.memory>` is identified, `equidistant_entries_select
           <ContentAddressableMemory.equidistant_entries_select>` is used to determine which to retrieve.  If no
@@ -765,7 +765,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
 
     noise : float, list, 2d array, or Function : default 0.0
         specifies random value(s) added to `variable <ContentAddressableMemory.variable>` before storing in
-        `memory <ContentAddressableMemory.memory>`\;  if a list or 2d array, it must be the same shape as `variable
+        `memory <ContentAddressableMemory.memory>`;  if a list or 2d array, it must be the same shape as `variable
          ContentAddressableMemory.variable>` (see `noise <ContentAddressableMemory.noise>` for details).
 
     initializer : 3d array or list : default None

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -9828,7 +9828,7 @@ _
         2d list of values of OUTPUT Nodes at end of last trial : list[list]
           each item in the list is the `output_values <Mechanism_Base.output_values>` for an `OUTPUT` `Node
           <Composition_Nodes>` of the Composition, listed in the order listed in `get_nodes_by_role
-          <Composition.get_nodes_by_role>`\(`NodeRole.OUTPUT <OUTPUT>`).
+          <Composition.get_nodes_by_role>`\\ (`NodeRole.OUTPUT <OUTPUT>`).
 
           .. note::
             The `results <Composition.results>` attribute of the Composition contains a list of the outputs for all

--- a/psyneulink/core/compositions/pathway.py
+++ b/psyneulink/core/compositions/pathway.py
@@ -252,7 +252,7 @@ can be specified (e.g., the **pathways** argument of the constructor for a `Comp
 <Composition.add_pathways>` method), they can be specified in a list, in which each item of the list can be any of
 the forms above, or one of the following:
 
-    * **Pathway** object or constructor: Pathway(pathway=\ `Pathway specification <Pathway_Specification>`,...).
+    * **Pathway** object or constructor: Pathway(pathway=\\ `Pathway specification <Pathway_Specification>`,...).
     ..
     .. _Pathway_Specification_Dictionary:
     * **dict**: {name : Pathway) -- in which **name** is a str and **Pathway** is a Pathway object or constuctor,

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ xfail_strict = True
 
 filterwarnings =
 	error:Creating an ndarray from ragged nested sequences \(which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes\) is deprecated.*:numpy.VisibleDeprecationWarning
+	error:Invalid escape sequence
 	ignore:Multiple ParameterPorts:UserWarning
 
 [pycodestyle]

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -3566,7 +3566,7 @@ class TestModelBasedOptimizationControlMechanisms_Execution:
         warning_msg = f'"\'OptimizationControlMechanism-0\' has \'num_estimates = {num_estimates}\' specified, ' \
                       f'but its \'agent_rep\' (\'comp\') has no random variables: ' \
                       f'\'RANDOMIZATION_CONTROL_SIGNAL\' will not be created, and num_estimates set to None."'
-        with pytest.warns(warning_type) as warning:
+        with pytest.warns(warning_type) as warnings:
             ocm = pnl.OptimizationControlMechanism(agent_rep=comp,
                                                    state_features=[A.input_port],
                                                    objective_mechanism=objective_mech,
@@ -3574,7 +3574,7 @@ class TestModelBasedOptimizationControlMechanisms_Execution:
                                                    num_estimates=num_estimates,
                                                    control_signals=[control_signal])
             if warning_type:
-                assert repr(warning[5].message.args[0]) == warning_msg
+                assert any(warning_msg == repr(w.message.args[0]) for w in warnings)
 
         comp.add_controller(ocm)
         inputs = {A: [[[1.0]]]}

--- a/versioneer.py
+++ b/versioneer.py
@@ -418,7 +418,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
     return stdout, p.returncode
 
 
-LONG_VERSION_PY['git'] = '''
+LONG_VERSION_PY['git'] = r'''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build


### PR DESCRIPTION
The escape sequences were ignored so we can just remove the escaping '\'.
Check that the required warning is present at any position in "test_model_based_num_estimates".
Use raw string when listing code in versioneer.py.
Change warning for invalid escape sequences to error.

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>