### PR TITLE
tests: Use custom name prefix for Components instantiated during test enumeration.

### DIFF
--- a/psyneulink/__init__.py
+++ b/psyneulink/__init__.py
@@ -84,7 +84,6 @@ for handler in _logging.root.handlers:
 
 primary_registries = [
     CompositionRegistry,
-    ControlMechanismRegistry,
     DeferredInitRegistry,
     FunctionRegistry,
     GatingMechanismRegistry,

--- a/psyneulink/__init__.py
+++ b/psyneulink/__init__.py
@@ -86,7 +86,6 @@ primary_registries = [
     CompositionRegistry,
     DeferredInitRegistry,
     FunctionRegistry,
-    GatingMechanismRegistry,
     MechanismRegistry,
     PathwayRegistry,
     PortRegistry,

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -612,15 +612,13 @@ from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import ContentAddressableList, convert_to_list, convert_to_np_array, is_iterable
 
 __all__ = [
-    'CONTROL_ALLOCATION', 'GATING_ALLOCATION', 'ControlMechanism', 'ControlMechanismError', 'ControlMechanismRegistry',
+    'CONTROL_ALLOCATION', 'GATING_ALLOCATION', 'ControlMechanism', 'ControlMechanismError',
 ]
 
 CONTROL_ALLOCATION = 'control_allocation'
 GATING_ALLOCATION = 'gating_allocation'
 
 MonitoredOutputPortTuple = collections.namedtuple("MonitoredOutputPortTuple", "output_port weight exponent matrix")
-
-ControlMechanismRegistry = {}
 
 def _is_control_spec(spec):
     from psyneulink.core.components.projections.modulatory.controlprojection import ControlProjection

--- a/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
@@ -196,10 +196,8 @@ from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import ContentAddressableList, convert_to_list
 
 __all__ = [
-    'GatingMechanism', 'GatingMechanismError', 'GatingMechanismRegistry'
+    'GatingMechanism', 'GatingMechanismError',
 ]
-
-GatingMechanismRegistry = {}
 
 
 def _is_gating_spec(spec):

--- a/psyneulink/core/globals/registry.py
+++ b/psyneulink/core/globals/registry.py
@@ -217,6 +217,8 @@ def register_category(entry,
         raise RegistryError("Requested entry {0} not of type {1}".format(entry, base_class))
 
 
+_register_auto_name_prefix = ""
+
 def register_instance(entry, name, base_class, registry, sub_dict):
 
     renamed_instance_counts = registry[sub_dict].renamed_instance_counts
@@ -224,10 +226,13 @@ def register_instance(entry, name, base_class, registry, sub_dict):
     # If entry (instance) name is None, set entry's name to sub_dict-n where n is the next available numeric suffix
     # (starting at 0) based on the number of unnamed/renamed sub_dict objects that have already been assigned names
     if name is None:
-        entry.name = '{0}-{1}'.format(sub_dict, renamed_instance_counts[sub_dict])
+        entry.name = '{0}{1}-{2}'.format(_register_auto_name_prefix, sub_dict, renamed_instance_counts[sub_dict])
         renamed = True
     else:
         entry.name = name
+
+    assert not entry.name.startswith("__pnl_") or entry.name.startswith(_register_auto_name_prefix), \
+        "Using reserved name: {}".format(entry.name)
 
     while entry.name in registry[sub_dict].instanceDict:
         # if the decided name (provided or determined) is already assigned to an object, get the non-suffixed name,

--- a/psyneulink/library/components/mechanisms/modulatory/control/agt/agtcontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/control/agt/agtcontrolmechanism.py
@@ -174,12 +174,10 @@ from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 
 __all__ = [
-    'AGTControlMechanism', 'AGTControlMechanismError', 'ControlMechanismRegistry', 'MONITORED_OUTPUT_PORT_NAME_SUFFIX'
+    'AGTControlMechanism', 'AGTControlMechanismError', 'MONITORED_OUTPUT_PORT_NAME_SUFFIX'
 ]
 
 MONITORED_OUTPUT_PORT_NAME_SUFFIX = '_Monitor'
-
-ControlMechanismRegistry = {}
 
 class AGTControlMechanismError(Exception):
     def __init__(self, error_value):

--- a/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
@@ -313,14 +313,12 @@ from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import is_iterable, convert_to_list
 
 __all__ = [
-    'CONTROL_SIGNAL_NAME', 'ControlMechanismRegistry', 'LCControlMechanism', 'LCControlMechanismError',
+    'CONTROL_SIGNAL_NAME', 'LCControlMechanism', 'LCControlMechanismError',
     'MODULATED_MECHANISMS',
 ]
 
 MODULATED_MECHANISMS = 'modulated_mechanisms'
 CONTROL_SIGNAL_NAME = 'LCControlMechanism_ControlSignal'
-
-ControlMechanismRegistry = {}
 
 class LCControlMechanismError(Exception):
     def __init__(self, error_value):


### PR DESCRIPTION
The names of components instantiated during test enumeration depend on the order in which the tests are enumerated and shouldn't be used.
Introduce a concept of reserved names (names beginning with "__pnl_" and add a mechanism to add a custom reserved prefix to all generated Component names.
Use the new mechanism to add a common prefix to all Components instantiated during test enumeration.
This makes sure that the names of such components don't conflict with names autogenerated during test execution.
It also makes it easier to detect if any test depends on the name of a Component passed via a parameter.