### PR TITLE
github-actions: Check CI secret to tag selected OSes to run on self-hosted runners

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -11,6 +11,11 @@ on:
       - 'v**'
   pull_request:
 
+env:
+  SELF_HOSTED_MACOS: ${{ secrets.SELF_HOSTED_MACOS }}
+  SELF_HOSTED_LINUX: ${{ secrets.SELF_HOSTED_LINUX }}
+  SELF_HOSTED_WINDOWS: ${{ secrets.SELF_HOSTED_WINDOWS }}
+
 # run only the latest instance of this workflow job for the current branch/PR
 # cancel older runs
 # fall back to run id if not available (run id is unique -> no cancellations)
@@ -19,28 +24,47 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # A job to select self-hosted runner if requested by an env var
+  select-runner:
+    runs-on: ubuntu-latest
+
+    outputs:
+      self_hosted_macos: ${{ steps.is_self_hosted.outputs.macos && 'macos' || '' }}
+      self_hosted_linux: ${{ steps.is_self_hosted.outputs.linux && 'linux' || '' }}
+      self_hosted_windows: ${{ steps.is_self_hosted.outputs.windows && 'windows' || '' }}
+
+    steps:
+    - name: Add macos
+      id: is_self_hosted
+      run: |
+        echo "macos=$SELF_HOSTED_MACOS" | tee -a $GITHUB_OUTPUT
+        echo "linux=$SELF_HOSTED_LINUX" | tee -a $GITHUB_OUTPUT
+        echo "windows=$SELF_HOSTED_WINDOWS" | tee -a $GITHUB_OUTPUT
+
+  # the main build job
   build:
-    runs-on: ${{ matrix.os }}
+    needs: select-runner
+    runs-on: ${{ (contains(needs.select-runner.outputs.*, matrix.os) && fromJSON(format('[ "self-hosted","{0}", "X64" ]', matrix.os))) || format('{0}-latest', matrix.os) }}
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.7, 3.8, 3.9]
         python-architecture: ['x64']
         extra-args: ['']
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu, macos, windows]
         include:
           # add 32-bit build on windows
           - python-version: 3.8
             python-architecture: 'x86'
-            os: windows-latest
+            os: windows
           # code-coverage build on macos python 3.9
           - python-version: 3.9
-            os: macos-latest
+            os: macos
             extra-args: '--cov=psyneulink'
         exclude:
           # 3.7 is broken on macos-11, https://github.com/actions/virtual-environments/issues/4230
           - python-version: 3.7
-            os: macos-latest
+            os: macos
 
     steps:
     # increased fetch-depth and tag checkout needed to get correct


### PR DESCRIPTION
Checks setting one of the following secrets:
SELF_HOSTED_MACOS, SELF_HOSTED_LINUX, SELF_HOSTED_WINDOWS
If the value stored in any of them evaluates to true (based on GitHub actions expression truth values) the jobs for the respective OS will be tagged to use self-hosted runners.

Without the secret, jobs will use GitHub cloud runners.

"runs-on" doesn't allow direct use of environment variables so we need to pass them via an extra job.

Closes: https://github.com/PrincetonUniversity/PsyNeuLink/issues/2526

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>