### PR TITLE
github-actions/install-pnl: Restrict jupyter-server to <2

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -51,7 +51,7 @@ runs:
           # terminado >= 0.10.0 pulls in pywinpty >= 1.1.0
           # scipy >=1.9.2 doesn't provide win32 wheel and GA doesn't have working fortran on windows
           # scikit-learn >= 1.1.3 doesn't provide win32 wheel
-          [[ ${{ runner.os }} = Windows* ]] && pip install "pywinpty<1" "terminado<0.10" "scipy<1.9.2" "scikit-learn<1.1.3" "statsmodels<0.13.3" -c requirements.txt
+          [[ ${{ runner.os }} = Windows* ]] && pip install "pywinpty<1" "terminado<0.10" "scipy<1.9.2" "scikit-learn<1.1.3" "statsmodels<0.13.3" "jupyter-server<2" -c requirements.txt
         fi
 
     - name: Install updated package


### PR DESCRIPTION
jupyter pulls in jupyter-server-terminals which requires pywinpty>=2.0.3 on windows [0]

[0] https://github.com/jupyter-server/jupyter_server_terminals/blob/main/pyproject.toml

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>