### PR TITLE
github-actions/codeql: Skip CI job on pushes that only update documentation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,8 @@ name: "CodeQL"
 on:
   push:
     branches: [ "master", "devel" ]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches: [ "master", "devel" ]
   schedule:


### PR DESCRIPTION
Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>