### PR TITLE
tests/mechanism: Do not check for string value of numpy error embedded in MechanismError

### DIFF
--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2634,14 +2634,15 @@ class Mechanism_Base(Mechanism):
                 # Call input_port._execute with newly assigned variable and assign result to input_port.value
                 base_error_msg = f"Input to '{self.name}' ({input_item}) is incompatible " \
                                  f"with its corresponding {InputPort.__name__} ({input_port.full_name})"
+                variable = input_port.parameters.variable.get(context)
                 try:
-                    input_port.parameters.value._set(
-                        input_port._execute(input_port.parameters.variable.get(context), context),
-                        context)
-                except (RunError,TypeError) as error:
+                    value = input_port._execute(variable, context)
+                except (RunError, TypeError) as error:
                     raise MechanismError(f"{base_error_msg}: '{error.args[0]}.'")
                 except:
                     raise MechanismError(f"{base_error_msg}.")
+                else:
+                    input_port.parameters.value._set(value, context)
             else:
                 raise MechanismError(f"Length ({len(input_item)}) of input ({input_item}) does not match "
                                      f"required length ({input_port.default_input_shape.size}) for input "

--- a/tests/mechanisms/test_kwta.py
+++ b/tests/mechanisms/test_kwta.py
@@ -58,7 +58,7 @@ class TestKWTAInputs:
             )
             K.execute(["one", "two", "three", "four"])
         assert ('"Input to \'K\' ([\'one\' \'two\' \'three\' \'four\']) is incompatible with its corresponding '
-                'InputPort (K[InputPort-0]): \'cannot perform reduce with flexible type.\'"' in str(error_text.value))
+                'InputPort (K[InputPort-0]):' in str(error_text.value))
 
     def test_kwta_var_list_of_strings(self):
         with pytest.raises(ParameterError) as error_text:

--- a/tests/mechanisms/test_recurrent_transfer_mechanism.py
+++ b/tests/mechanisms/test_recurrent_transfer_mechanism.py
@@ -190,8 +190,7 @@ class TestRecurrentTransferMechanismInputs:
             )
             R.execute(["one", "two", "three", "four"])
         assert '"Input to \'R\' ([\'one\' \'two\' \'three\' \'four\']) is incompatible ' \
-               'with its corresponding InputPort (R[InputPort-0]): ' \
-               '\'cannot perform reduce with flexible type.\'"' in str(error_text.value)
+               'with its corresponding InputPort (R[InputPort-0]): ' in str(error_text.value)
 
     def test_recurrent_mech_var_list_of_strings(self):
         with pytest.raises(ParameterError) as error_text:

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -108,8 +108,7 @@ class TestTransferMechanismInputs:
             )
             T.execute(["one", "two", "three", "four"])
         assert '"Input to \'T\' ([\'one\' \'two\' \'three\' \'four\']) is incompatible ' \
-               'with its corresponding InputPort (T[InputPort-0]): ' \
-               '\'cannot perform reduce with flexible type.\'"' in str(error_text.value)
+               'with its corresponding InputPort (T[InputPort-0]): ' in str(error_text.value)
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism


### PR DESCRIPTION
String values of errors are not stable and can change between versions.
Fixes 'input_list_of_strings' tests when using numpy>=1.22.x.
Refactor handling of input port execution exceptions to only check calls to 'execute', parameter set/get do not throw exceptions.

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>