### PR TITLE
requirements: Bump minimum numpy version to 1.19.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ llvmlite<0.40
 matplotlib<3.6.4
 modeci_mdf<0.5, >=0.3.4; (platform_machine == 'AMD64' or platform_machine == 'x86_64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
 networkx<3.1
-numpy<1.22.5, >=1.17.0
+numpy<1.22.5, >=1.19.0
 pillow<9.5.0
 pint<0.21.0
 toposort<1.10


### PR DESCRIPTION
Calling gcd on list comprehension fails with numpy<1.19.0

Closes: https://github.com/PrincetonUniversity/PsyNeuLink/issues/2581

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>