### PR TITLE
llvm, Mechanism: Apply modulation to initializers during node reset

### DIFF
--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3146,13 +3146,18 @@ class Mechanism_Base(Mechanism):
                                                         arg_out])
         return builder, is_finished_cond
 
-    def _gen_llvm_function_reset(self, ctx, builder, params, state, arg_in, arg_out, *, tags:frozenset):
+    def _gen_llvm_function_reset(self, ctx, builder, m_base_params, m_state, m_arg_in, m_arg_out, *, tags:frozenset):
         assert "reset" in tags
+
         reinit_func = ctx.import_llvm_function(self.function, tags=tags)
-        reinit_params = pnlvm.helpers.get_param_ptr(builder, self, params, "function")
-        reinit_state = pnlvm.helpers.get_state_ptr(builder, self, state, "function")
         reinit_in = builder.alloca(reinit_func.args[2].type.pointee, name="reinit_in")
         reinit_out = builder.alloca(reinit_func.args[3].type.pointee, name="reinit_out")
+
+        reinit_base_params = pnlvm.helpers.get_param_ptr(builder, self, m_base_params, "function")
+        reinit_params, builder = self._gen_llvm_param_ports_for_obj(
+                self.function, reinit_base_params, ctx, builder, m_base_params, m_state, m_arg_in)
+        reinit_state = pnlvm.helpers.get_state_ptr(builder, self, m_state, "function")
+
         builder.call(reinit_func, [reinit_params, reinit_state, reinit_in,
                                    reinit_out])
 

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -1033,6 +1033,12 @@ class Projection_Base(Projection):
 
     # Provide invocation wrapper
     def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:frozenset):
+
+        if "passthrough" in tags:
+            assert arg_in.type == arg_out.type, "Requestd passthrough projection but types are not compatible IN: {} OUT: {}".format(arg_in.type, arg_out.type)
+            builder.store(builder.load(arg_in), arg_out)
+            return builder
+
         mf_state = pnlvm.helpers.get_state_ptr(builder, self, state, self.parameters.function.name)
         mf_params = pnlvm.helpers.get_param_ptr(builder, self, params, self.parameters.function.name)
         main_function = ctx.import_llvm_function(self.function)

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -650,18 +650,18 @@ def gen_node_wrapper(ctx, composition, node, *, tags:frozenset):
             continue
 
         # Get location of projection input data
-        par_mech = proj.sender.owner
-        if par_mech in composition._all_nodes:
-            parent_idx = composition._get_node_index(par_mech)
+        send_mech = proj.sender.owner
+        if send_mech in composition._all_nodes:
+            send_node_idx = composition._get_node_index(send_mech)
         else:
-            assert par_mech is par_mech.composition.output_CIM
-            parent_idx = composition.nodes.index(par_mech.composition)
+            assert send_mech is send_mech.composition.output_CIM
+            send_node_idx = composition.nodes.index(send_mech.composition)
 
-        assert proj.sender in par_mech.output_ports
-        output_port_idx = par_mech.output_ports.index(proj.sender)
+        assert proj.sender in send_mech.output_ports
+        output_port_idx = send_mech.output_ports.index(proj.sender)
         proj_in = builder.gep(data_in, [ctx.int32_ty(0),
                                         ctx.int32_ty(0),
-                                        ctx.int32_ty(parent_idx),
+                                        ctx.int32_ty(send_node_idx),
                                         ctx.int32_ty(output_port_idx)])
 
         # Get location of projection output (in mechanism's input structure)


### PR DESCRIPTION
Add "passthrough" variant to Projection execution.
Passthrough mode does not invoke the projection function.
This is used to pass modulatory values before the execution starts.
    
Execute modulatory projections in "passthrogh mode" when calling node wrapper for node reset.
Rename projection origin from 'parent'->'sender'
    
Apply modulation before calling function "reset" in mechanism.
    
Add tests.
