### PR TITLE
treewide: inherit all component Exceptions from ComponentError

### DIFF
--- a/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
@@ -40,7 +40,7 @@ import typecheck as tc
 
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.functions.function import (
-    DEFAULT_SEED, Function_Base, _random_state_getter,
+    DEFAULT_SEED, Function_Base, FunctionError, _random_state_getter,
     _seed_setter, is_function_type,
 )
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
@@ -66,9 +66,8 @@ SEARCH_TERMINATION_FUNCTION = 'search_termination_function'
 DIRECTION = 'direction'
 SIMULATION_PROGRESS = 'simulation_progress'
 
-class OptimizationFunctionError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class OptimizationFunctionError(FunctionError):
+    pass
 
 
 def _num_estimates_getter(owning_component, context):

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -1087,7 +1087,7 @@ import numpy as np
 import typecheck as tc
 
 from psyneulink.core import llvm as pnlvm
-from psyneulink.core.components.component import Component
+from psyneulink.core.components.component import Component, ComponentError
 from psyneulink.core.components.functions.function import FunctionOutputType
 from psyneulink.core.components.functions.nonstateful.transferfunctions import Linear
 from psyneulink.core.components.ports.inputport import DEFER_VARIABLE_SPEC_TO_MECH_MSG, InputPort
@@ -1125,12 +1125,8 @@ logger = logging.getLogger(__name__)
 MechanismRegistry = {}
 
 
-class MechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class MechanismError(ComponentError):
+    pass
 
 
 class MechParamsDict(UserDict):

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -592,7 +592,7 @@ from psyneulink.core.components.functions.function import Function_Base, is_func
 from psyneulink.core.components.functions.nonstateful.transferfunctions import Identity
 from psyneulink.core.components.functions.nonstateful.combinationfunctions import Concatenate
 from psyneulink.core.components.functions.nonstateful.combinationfunctions import LinearCombination
-from psyneulink.core.components.mechanisms.mechanism import Mechanism, Mechanism_Base
+from psyneulink.core.components.mechanisms.mechanism import Mechanism, Mechanism_Base, MechanismError
 from psyneulink.core.components.mechanisms.modulatory.modulatorymechanism import ModulatoryMechanism_Base
 from psyneulink.core.components.ports.inputport import InputPort
 from psyneulink.core.components.ports.modulatorysignals.controlsignal import ControlSignal
@@ -640,10 +640,10 @@ def _is_control_spec(spec):
         return False
 
 
-class ControlMechanismError(Exception):
-    def __init__(self, error_value, data=None):
-        self.error_value = error_value
+class ControlMechanismError(MechanismError):
+    def __init__(self, message, data=None):
         self.data = data
+        return super().__init__(message)
 
 
 def validate_monitored_port_spec(owner, spec_list):

--- a/psyneulink/core/components/mechanisms/modulatory/control/defaultcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/defaultcontrolmechanism.py
@@ -36,7 +36,7 @@ COMMENT
 import numpy as np
 import typecheck as tc
 
-from psyneulink.core.components.mechanisms.modulatory.control.controlmechanism import ControlMechanism
+from psyneulink.core.components.mechanisms.modulatory.control.controlmechanism import ControlMechanism, ControlMechanismError
 from psyneulink.core.components.mechanisms.processing.objectivemechanism import ObjectiveMechanism
 from psyneulink.core.globals.defaults import defaultControlAllocation
 from psyneulink.core.globals.keywords import CONTROL, INPUT_PORTS, NAME
@@ -50,9 +50,8 @@ __all__ = [
 ]
 
 
-class DefaultControlMechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class DefaultControlMechanismError(ControlMechanismError):
+    pass
 
 
 class DefaultControlMechanism(ControlMechanism):

--- a/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
@@ -183,7 +183,7 @@ Class Reference
 import numpy as np
 import typecheck as tc
 
-from psyneulink.core.components.mechanisms.modulatory.control.controlmechanism import ControlMechanism
+from psyneulink.core.components.mechanisms.modulatory.control.controlmechanism import ControlMechanism, ControlMechanismError
 from psyneulink.core.components.ports.modulatorysignals.gatingsignal import GatingSignal
 from psyneulink.core.components.ports.port import _parse_port_spec
 from psyneulink.core.globals.defaults import defaultGatingAllocation
@@ -222,9 +222,8 @@ def _is_gating_spec(spec):
         return False
 
 
-class GatingMechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class GatingMechanismError(ControlMechanismError):
+    pass
 
 
 class GatingMechanism(ControlMechanism):

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1213,12 +1213,8 @@ def _state_feature_values_getter(owning_component=None, context=None):
     return state_feature_values
 
 
-class OptimizationControlMechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class OptimizationControlMechanismError(ControlMechanismError):
+    pass
 
 
 def _control_allocation_search_space_getter(owning_component=None, context=None):

--- a/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
@@ -534,7 +534,7 @@ import typecheck as tc
 
 from psyneulink.core.components.component import parameter_keywords
 from psyneulink.core.components.functions.nonstateful.learningfunctions import BackPropagation
-from psyneulink.core.components.mechanisms.mechanism import Mechanism_Base
+from psyneulink.core.components.mechanisms.mechanism import Mechanism_Base, MechanismError
 from psyneulink.core.components.mechanisms.modulatory.modulatorymechanism import ModulatoryMechanism_Base
 from psyneulink.core.components.mechanisms.processing.objectivemechanism import ObjectiveMechanism
 from psyneulink.core.components.ports.modulatorysignals.learningsignal import LearningSignal
@@ -641,12 +641,8 @@ ERROR_SOURCES = 'error_sources'
 DefaultTrainingMechanism = ObjectiveMechanism
 
 
-class LearningMechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class LearningMechanismError(MechanismError):
+    pass
 
 
 def _learning_signal_getter(owning_component=None, context=None):

--- a/psyneulink/core/components/mechanisms/modulatory/modulatorymechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/modulatorymechanism.py
@@ -138,7 +138,7 @@ Class Reference
 
 """
 
-from psyneulink.core.components.mechanisms.mechanism import Mechanism_Base
+from psyneulink.core.components.mechanisms.mechanism import Mechanism_Base, MechanismError
 from psyneulink.core.globals.keywords import ADAPTIVE_MECHANISM
 from psyneulink.core.globals.parameters import check_user_specified
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
@@ -148,9 +148,8 @@ __all__ = [
 ]
 
 
-class ModulatoryMechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class ModulatoryMechanismError(MechanismError):
+    pass
 
 
 class ModulatoryMechanism_Base(Mechanism_Base):

--- a/psyneulink/core/components/mechanisms/processing/integratormechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/integratormechanism.py
@@ -88,7 +88,7 @@ import numpy as np
 from psyneulink.core.components.functions.function import Function
 from psyneulink.core.components.functions.stateful.integratorfunctions import AdaptiveIntegrator
 from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism_Base
-from psyneulink.core.components.mechanisms.mechanism import Mechanism
+from psyneulink.core.components.mechanisms.mechanism import Mechanism, MechanismError
 from psyneulink.core.globals.keywords import \
     DEFAULT_VARIABLE, INTEGRATOR_MECHANISM, VARIABLE, PREFERENCE_SET_NAME
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
@@ -102,12 +102,8 @@ __all__ = [
 # IntegratorMechanism parameter keywords:
 DEFAULT_RATE = 0.5
 
-class IntegratorMechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class IntegratorMechanismError(MechanismError):
+    pass
 
 
 class IntegratorMechanism(ProcessingMechanism_Base):

--- a/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
@@ -370,6 +370,7 @@ from collections.abc import Iterable
 import typecheck as tc
 
 from psyneulink.core.components.functions.nonstateful.combinationfunctions import LinearCombination
+from psyneulink.core.components.mechanisms.mechanism import MechanismError
 from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism_Base
 from psyneulink.core.components.ports.inputport import InputPort, INPUT_PORT
 from psyneulink.core.components.ports.outputport import OutputPort
@@ -400,12 +401,8 @@ DEFAULT_MONITORED_PORT_EXPONENT = None
 DEFAULT_MONITORED_PORT_MATRIX = None
 
 
-class ObjectiveMechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class ObjectiveMechanismError(MechanismError):
+    pass
 
 
 class ObjectiveMechanism(ProcessingMechanism_Base):

--- a/psyneulink/core/components/mechanisms/processing/processingmechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/processingmechanism.py
@@ -93,7 +93,7 @@ import numpy as np
 
 from psyneulink.core.components.functions.nonstateful.transferfunctions import SoftMax
 from psyneulink.core.components.functions.nonstateful.selectionfunctions import OneHot
-from psyneulink.core.components.mechanisms.mechanism import Mechanism_Base, Mechanism
+from psyneulink.core.components.mechanisms.mechanism import Mechanism_Base, Mechanism, MechanismError
 from psyneulink.core.components.ports.inputport import InputPort
 from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.globals.keywords import \
@@ -108,9 +108,8 @@ __all__ = [
 ]
 
 
-class ProcessingMechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class ProcessingMechanismError(MechanismError):
+    pass
 
 
 # # These are defined here because STANDARD_DEVIATION AND VARIANCE
@@ -216,13 +215,6 @@ __all__ = [
 
 # ProcessingMechanism parameter keywords:
 DEFAULT_RATE = 0.5
-
-class ProcessingMechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
 
 
 class ProcessingMechanism(ProcessingMechanism_Base):

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -883,12 +883,8 @@ Transfer_DEFAULT_OFFSET = 0
 logger = logging.getLogger(__name__)
 
 
-class TransferError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class TransferError(MechanismError):
+    pass
 
 
 def _integrator_mode_setter(value, owning_component=None, context=None):

--- a/psyneulink/core/components/ports/inputport.py
+++ b/psyneulink/core/components/ports/inputport.py
@@ -613,12 +613,8 @@ EXPONENT_INDEX = 2
 
 DEFER_VARIABLE_SPEC_TO_MECH_MSG = "InputPort variable not yet defined, defer to Mechanism"
 
-class InputPortError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class InputPortError(PortError):
+    pass
 
 
 class InputPort(Port_Base):

--- a/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
@@ -411,7 +411,7 @@ from psyneulink.core.components.functions.nonstateful.combinationfunctions impor
 from psyneulink.core.components.functions.nonstateful.transferfunctions import Exponential, Linear, CostFunctions, \
     TransferWithCosts
 from psyneulink.core.components.functions.stateful.integratorfunctions import SimpleIntegrator
-from psyneulink.core.components.ports.modulatorysignals.modulatorysignal import ModulatorySignal
+from psyneulink.core.components.ports.modulatorysignals.modulatorysignal import ModulatorySignal, ModulatorySignalError
 from psyneulink.core.components.ports.outputport import _output_port_variable_getter
 from psyneulink.core.globals.context import ContextFlags
 from psyneulink.core.globals.defaults import defaultControlAllocation
@@ -440,13 +440,8 @@ from psyneulink.core.components.functions.nonstateful.transferfunctions import \
 COST_OPTIONS = 'cost_options'
 
 
-class ControlSignalError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-
-    def __str__(self):
-        return repr(self.error_value)
+class ControlSignalError(ModulatorySignalError):
+    pass
 
 
 class ControlSignal(ModulatorySignal):

--- a/psyneulink/core/components/ports/modulatorysignals/gatingsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/gatingsignal.py
@@ -247,6 +247,7 @@ import numpy as np
 import typecheck as tc
 
 from psyneulink.core.components.ports.modulatorysignals.controlsignal import ControlSignal
+from psyneulink.core.components.ports.modulatorysignals.modulatorysignal import ModulatorySignalError
 from psyneulink.core.components.ports.outputport import _output_port_variable_getter
 from psyneulink.core.globals.defaults import defaultGatingAllocation
 from psyneulink.core.globals.keywords import \
@@ -261,12 +262,8 @@ __all__ = [
 ]
 
 
-class GatingSignalError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class GatingSignalError(ModulatorySignalError):
+    pass
 
 
 gating_signal_keywords = {GATE}

--- a/psyneulink/core/components/ports/modulatorysignals/learningsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/learningsignal.py
@@ -190,7 +190,7 @@ Class Reference
 import numpy as np
 import typecheck as tc
 
-from psyneulink.core.components.ports.modulatorysignals.modulatorysignal import ModulatorySignal
+from psyneulink.core.components.ports.modulatorysignals.modulatorysignal import ModulatorySignal, ModulatorySignalError
 from psyneulink.core.components.ports.outputport import PRIMARY
 from psyneulink.core.globals.keywords import \
     LEARNING_PROJECTION, LEARNING_SIGNAL, OUTPUT_PORT_PARAMS, PARAMETER_PORT, PARAMETER_PORTS, RECEIVER
@@ -204,13 +204,8 @@ __all__ = [
 ]
 
 
-class LearningSignalError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-
-    def __str__(self):
-        return repr(self.error_value)
+class LearningSignalError(ModulatorySignalError):
+    pass
 
 
 class LearningSignal(ModulatorySignal):

--- a/psyneulink/core/components/ports/modulatorysignals/modulatorysignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/modulatorysignal.py
@@ -407,6 +407,7 @@ Class Reference
 
 from psyneulink.core.components.component import component_keywords
 from psyneulink.core.components.ports.outputport import OutputPort
+from psyneulink.core.components.ports.port import PortError
 from psyneulink.core.globals.context import ContextFlags
 from psyneulink.core.globals.defaults import defaultModulatoryAllocation
 from psyneulink.core.globals.keywords import \
@@ -439,12 +440,8 @@ modulatory_signal_keywords.update(component_keywords)
 modulation_type_keywords = [MULTIPLICATIVE_PARAM, ADDITIVE_PARAM, OVERRIDE, DISABLE]
 
 
-class ModulatorySignalError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class ModulatorySignalError(PortError):
+    pass
 
 
 class ModulatorySignal(OutputPort):

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -623,7 +623,7 @@ import typecheck as tc
 
 from psyneulink.core.components.component import Component, ComponentError
 from psyneulink.core.components.functions.function import Function
-from psyneulink.core.components.ports.port import Port_Base, _instantiate_port_list, port_type_keywords
+from psyneulink.core.components.ports.port import Port_Base, PortError, _instantiate_port_list, port_type_keywords
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import \
     ALL, ASSIGN, CALCULATE, CONTEXT, CONTROL_SIGNAL, FUNCTION, GATING_SIGNAL, INDEX, INPUT_PORT, INPUT_PORTS, \
@@ -751,12 +751,8 @@ def _output_port_variable_getter(owning_component=None, context=None, output_por
     return _parse_output_port_variable(owning_component._variable_spec, owning_component.owner, context, output_port_name)
 
 
-class OutputPortError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class OutputPortError(PortError):
+    pass
 
 
 class OutputPort(Port_Base):

--- a/psyneulink/core/components/ports/parameterport.py
+++ b/psyneulink/core/components/ports/parameterport.py
@@ -597,12 +597,8 @@ class ParameterPortList(ContentAddressableList):
             return ''
 
 
-class ParameterPortError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class ParameterPortError(PortError):
+    pass
 
 
 class ParameterPort(Port_Base):

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -847,13 +847,8 @@ def _is_port_class(spec):
 #        Individual portRegistries (used for naming) are created for each Mechanism
 PortRegistry = {}
 
-class PortError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-
-    def __str__(self):
-        return repr(self.error_value)
+class PortError(ComponentError):
+    pass
 
 
 # DOCUMENT:  INSTANTIATION CREATES AN ATTIRBUTE ON THE OWNER MECHANISM WITH THE PORT'S NAME + VALUE_SUFFIX

--- a/psyneulink/core/components/projections/modulatory/controlprojection.py
+++ b/psyneulink/core/components/projections/modulatory/controlprojection.py
@@ -133,12 +133,8 @@ projection_keywords.update({CONTROL_PROJECTION, CONTROL})
 
 CONTROL_SIGNAL_PARAMS = 'control_signal_params'
 
-class ControlProjectionError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class ControlProjectionError(ProjectionError):
+    pass
 
 
 class ControlProjection(ModulatoryProjection_Base):

--- a/psyneulink/core/components/projections/modulatory/gatingprojection.py
+++ b/psyneulink/core/components/projections/modulatory/gatingprojection.py
@@ -124,12 +124,8 @@ parameter_keywords.update({GATING_PROJECTION, GATE})
 projection_keywords.update({GATING_PROJECTION, GATE})
 GATING_SIGNAL_PARAMS = 'gating_signal_params'
 
-class GatingProjectionError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class GatingProjectionError(ProjectionError):
+    pass
 
 
 def _gating_signal_getter(owning_component=None, context=None):

--- a/psyneulink/core/components/projections/modulatory/learningprojection.py
+++ b/psyneulink/core/components/projections/modulatory/learningprojection.py
@@ -196,7 +196,7 @@ from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.components.ports.parameterport import ParameterPort
 from psyneulink.core.components.projections.modulatory.modulatoryprojection import ModulatoryProjection_Base
 from psyneulink.core.components.projections.pathway.mappingprojection import MappingProjection
-from psyneulink.core.components.projections.projection import projection_keywords
+from psyneulink.core.components.projections.projection import ProjectionError, projection_keywords
 from psyneulink.core.components.shellclasses import ShellClass
 from psyneulink.core.globals.context import ContextFlags
 from psyneulink.core.globals.keywords import \
@@ -222,12 +222,8 @@ WT_MATRIX_RECEIVERS_DIM = 1
 DefaultTrainingMechanism = ObjectiveMechanism
 
 
-class LearningProjectionError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class LearningProjectionError(ProjectionError):
+    pass
 
 
 def _learning_signal_getter(owning_component=None, context=None):

--- a/psyneulink/core/components/projections/modulatory/modulatoryprojection.py
+++ b/psyneulink/core/components/projections/modulatory/modulatoryprojection.py
@@ -94,7 +94,7 @@ Class Reference
 
 """
 
-from psyneulink.core.components.projections.projection import Projection_Base
+from psyneulink.core.components.projections.projection import Projection_Base, ProjectionError
 from psyneulink.core.globals.keywords import MODULATORY_PROJECTION, NAME
 from psyneulink.core.globals.log import ContextFlags
 
@@ -106,9 +106,8 @@ __all__ = [
 MODULATORY_SIGNAL_PARAMS = 'modulatory_signal_params'
 
 
-class ModulatoryProjectionError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class ModulatoryProjectionError(ProjectionError):
+    pass
 
 
 class ModulatoryProjection_Base(Projection_Base):

--- a/psyneulink/core/components/projections/pathway/mappingprojection.py
+++ b/psyneulink/core/components/projections/pathway/mappingprojection.py
@@ -310,9 +310,8 @@ parameter_keywords.update({MAPPING_PROJECTION})
 projection_keywords.update({MAPPING_PROJECTION})
 
 
-class MappingError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class MappingError(ProjectionError):
+    pass
 
 
 def _mapping_projection_matrix_getter(owning_component=None, context=None):

--- a/psyneulink/core/components/projections/pathway/pathwayprojection.py
+++ b/psyneulink/core/components/projections/pathway/pathwayprojection.py
@@ -60,15 +60,14 @@ See `Projection <Projection_Class_Reference>`.
 
 """
 
-from psyneulink.core.components.projections.projection import Projection_Base
+from psyneulink.core.components.projections.projection import Projection_Base, ProjectionError
 from psyneulink.core.globals.context import ContextFlags
 from psyneulink.core.globals.keywords import NAME, PATHWAY_PROJECTION, RECEIVER, SENDER
 
 __all__ = []
 
-class PathwayProjectionError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class PathwayProjectionError(ProjectionError):
+    pass
 
 
 class PathwayProjection_Base(Projection_Base):

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -404,6 +404,7 @@ import numpy as np
 import typecheck as tc
 
 from psyneulink.core import llvm as pnlvm
+from psyneulink.core.components.component import ComponentError
 from psyneulink.core.components.functions.function import get_matrix
 from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism
 from psyneulink.core.components.functions.nonstateful.transferfunctions import LinearMatrix
@@ -467,9 +468,8 @@ def projection_param_keywords():
 ProjectionTuple = namedtuple("ProjectionTuple", "port, weight, exponent, projection")
 
 
-class ProjectionError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class ProjectionError(ComponentError):
+    pass
 
 class DuplicateProjectionError(Exception):
     def __init__(self, error_value):

--- a/psyneulink/core/components/shellclasses.py
+++ b/psyneulink/core/components/shellclasses.py
@@ -27,7 +27,7 @@ TBI:
 
 """
 
-from psyneulink.core.components.component import Component
+from psyneulink.core.components.component import Component, ComponentError
 from psyneulink.core.globals.parameters import check_user_specified
 
 __all__ = [
@@ -35,12 +35,8 @@ __all__ = [
 ]
 
 
-class ShellClassError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class ShellClassError(ComponentError):
+    pass
 
 
 def _attempt_to_call_base_class(cls, alternative):

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -2770,7 +2770,7 @@ import typecheck as tc
 from PIL import Image
 
 from psyneulink.core import llvm as pnlvm
-from psyneulink.core.components.component import Component, ComponentsMeta
+from psyneulink.core.components.component import Component, ComponentError, ComponentsMeta
 from psyneulink.core.components.functions.fitfunctions import make_likelihood_function
 from psyneulink.core.components.functions.function import is_function_type, RandomMatrix
 from psyneulink.core.components.functions.nonstateful.combinationfunctions import \
@@ -2848,14 +2848,8 @@ logger = logging.getLogger(__name__)
 CompositionRegistry = {}
 
 
-class CompositionError(Exception):
-
-    def __init__(self, error_value, **kwargs):
-        self.error_value = error_value
-        self.return_items = kwargs
-
-    def __str__(self):
-        return repr(self.error_value)
+class CompositionError(ComponentError):
+    pass
 
 
 class RunError(Exception):
@@ -6957,7 +6951,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
                 def handle_misc_errors(proj, error):
                     raise CompositionError(f"Bad Projection specification in {pathway_arg_str} ({proj}): "
-                                           f"{str(error.error_value)}")
+                                           f"{error}")
 
                 def handle_duplicates(sender, receiver):
                     duplicate = [p for p in receiver.afferents if p in sender.efferents]
@@ -7076,7 +7070,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                     #   (since all Projections to or from it have been implemented)
                                     node_pairs = [pair for pair in node_pairs if (proj.owner not in pair)]
                                 except (InputPortError, ProjectionError) as error:
-                                    raise ProjectionError(str(error.error_value))
+                                    raise ProjectionError(error) from error
 
                         except (InputPortError, ProjectionError, MappingError) as error:
                             handle_misc_errors(proj, error)
@@ -7311,7 +7305,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             input_source, output_source, learned_projection = \
                 self._unpack_processing_components_of_learning_pathway(pathway, default_projection_matrix)
         except CompositionError as e:
-            raise CompositionError(e.error_value.replace('this method',
+            raise CompositionError(e.args[0].replace('this method',
                                                          f'{learning_function.__name__} {LearningFunction.__name__}'))
 
         # Add required role before calling add_linear_process_pathway so NodeRole.OUTPUTS are properly assigned

--- a/psyneulink/core/compositions/compositionfunctionapproximator.py
+++ b/psyneulink/core/compositions/compositionfunctionapproximator.py
@@ -53,7 +53,7 @@ Class Reference
 
 """
 
-from psyneulink.core.compositions.composition import Composition
+from psyneulink.core.compositions.composition import Composition, CompositionError
 from psyneulink.core.globals.context import Context
 from psyneulink.core.globals.keywords import COMPOSITION_FUNCTION_APPROXIMATOR
 
@@ -62,9 +62,8 @@ __all__ = ['CompositionFunctionApproximator']
 from psyneulink.core.globals.parameters import check_user_specified
 
 
-class CompositionFunctionApproximatorError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class CompositionFunctionApproximatorError(CompositionError):
+    pass
 
 
 class CompositionFunctionApproximator(Composition):

--- a/psyneulink/core/compositions/parameterestimationcomposition.py
+++ b/psyneulink/core/compositions/parameterestimationcomposition.py
@@ -147,7 +147,7 @@ from psyneulink.core.components.mechanisms.modulatory.control.optimizationcontro
     OptimizationControlMechanism
 from psyneulink.core.components.mechanisms.processing.objectivemechanism import ObjectiveMechanism
 from psyneulink.core.components.ports.modulatorysignals.controlsignal import ControlSignal
-from psyneulink.core.compositions.composition import Composition
+from psyneulink.core.compositions.composition import Composition, CompositionError
 from psyneulink.core.globals.context import Context, ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import BEFORE
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
@@ -163,9 +163,8 @@ CONTROLLER_SPECIFICATION_ARGS = {'controller',
                                  'retain_old_simulation_data'}
 
 
-class ParameterEstimationCompositionError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class ParameterEstimationCompositionError(CompositionError):
+    pass
 
 
 def _initial_seed_getter(owning_component, context=None):

--- a/psyneulink/library/components/mechanisms/modulatory/control/agt/agtcontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/control/agt/agtcontrolmechanism.py
@@ -163,7 +163,7 @@ Class Reference
 import typecheck as tc
 
 from psyneulink.core.components.functions.stateful.integratorfunctions import DualAdaptiveIntegrator
-from psyneulink.core.components.mechanisms.modulatory.control.controlmechanism import ControlMechanism
+from psyneulink.core.components.mechanisms.modulatory.control.controlmechanism import ControlMechanism, ControlMechanismError
 from psyneulink.core.components.mechanisms.processing.objectivemechanism import MONITORED_OUTPUT_PORTS, ObjectiveMechanism
 from psyneulink.core.components.shellclasses import Mechanism
 from psyneulink.core.components.ports.outputport import OutputPort
@@ -179,9 +179,8 @@ __all__ = [
 
 MONITORED_OUTPUT_PORT_NAME_SUFFIX = '_Monitor'
 
-class AGTControlMechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class AGTControlMechanismError(ControlMechanismError):
+    pass
 
 
 class AGTControlMechanism(ControlMechanism):

--- a/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
@@ -300,7 +300,7 @@ import typecheck as tc
 
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.functions.stateful.integratorfunctions import FitzHughNagumoIntegrator
-from psyneulink.core.components.mechanisms.modulatory.control.controlmechanism import ControlMechanism
+from psyneulink.core.components.mechanisms.modulatory.control.controlmechanism import ControlMechanism, ControlMechanismError
 from psyneulink.core.components.mechanisms.processing.objectivemechanism import ObjectiveMechanism
 from psyneulink.core.components.projections.modulatory.controlprojection import ControlProjection
 from psyneulink.core.components.shellclasses import Mechanism
@@ -320,9 +320,8 @@ __all__ = [
 MODULATED_MECHANISMS = 'modulated_mechanisms'
 CONTROL_SIGNAL_NAME = 'LCControlMechanism_ControlSignal'
 
-class LCControlMechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class LCControlMechanismError(ControlMechanismError):
+    pass
 
 
 class LCControlMechanism(ControlMechanism):

--- a/psyneulink/library/components/mechanisms/modulatory/learning/autoassociativelearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/learning/autoassociativelearningmechanism.py
@@ -98,7 +98,7 @@ from psyneulink.core.components.component import parameter_keywords
 from psyneulink.core.components.functions.function import is_function_type
 from psyneulink.core.components.functions.nonstateful.learningfunctions import Hebbian
 from psyneulink.core.components.mechanisms.modulatory.learning.learningmechanism import \
-    ACTIVATION_INPUT, LearningMechanism, LearningTiming, LearningType
+    ACTIVATION_INPUT, LearningMechanism, LearningMechanismError, LearningTiming, LearningType
 from psyneulink.core.components.mechanisms.processing.objectivemechanism import ObjectiveMechanism
 from psyneulink.core.components.projections.projection import projection_keywords
 from psyneulink.core.globals.context import ContextFlags
@@ -124,12 +124,8 @@ output_port_names = [LEARNING_SIGNAL]
 
 DefaultTrainingMechanism = ObjectiveMechanism
 
-class AutoAssociativeLearningMechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class AutoAssociativeLearningMechanismError(LearningMechanismError):
+    pass
 
 
 class AutoAssociativeLearningMechanism(LearningMechanism):

--- a/psyneulink/library/components/mechanisms/modulatory/learning/kohonenlearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/learning/kohonenlearningmechanism.py
@@ -101,7 +101,7 @@ from psyneulink.core.components.component import parameter_keywords
 from psyneulink.core.components.functions.function import is_function_type
 from psyneulink.core.components.functions.nonstateful.learningfunctions import Hebbian
 from psyneulink.core.components.mechanisms.modulatory.learning.learningmechanism import \
-    ACTIVATION_INPUT, ACTIVATION_OUTPUT, LearningMechanism, LearningTiming, LearningType
+    ACTIVATION_INPUT, ACTIVATION_OUTPUT, LearningMechanism, LearningMechanismError, LearningTiming, LearningType
 from psyneulink.core.components.projections.projection import projection_keywords
 from psyneulink.core.components.ports.parameterport import ParameterPort
 from psyneulink.core.globals.context import ContextFlags
@@ -128,12 +128,8 @@ output_port_names = [LEARNING_SIGNAL]
 # DefaultTrainingMechanism = ObjectiveMechanism
 
 
-class KohonenLearningMechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class KohonenLearningMechanismError(LearningMechanismError):
+    pass
 
 
 class KohonenLearningMechanism(LearningMechanism):

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -373,6 +373,7 @@ from psyneulink.core.components.functions.nonstateful.distributionfunctions impo
     DriftDiffusionAnalytical
 from psyneulink.core.components.functions.nonstateful.combinationfunctions import Reduce
 from psyneulink.core.components.mechanisms.modulatory.control.controlmechanism import _is_control_spec
+from psyneulink.core.components.mechanisms.mechanism import MechanismError
 from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism
 from psyneulink.core.components.ports.modulatorysignals.controlsignal import ControlSignal
 from psyneulink.core.components.ports.outputport import SEQUENTIAL, StandardOutputPorts
@@ -431,12 +432,8 @@ def decision_variable_to_array(x):
         return [0,x]
 
 
-class DDMError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class DDMError(MechanismError):
+    pass
 
 
 class DDM(ProcessingMechanism):

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -412,6 +412,7 @@ import numpy as np
 from psyneulink.core.components.functions.function import Function
 from psyneulink.core.components.functions.stateful.memoryfunctions import \
     DictionaryMemory, ContentAddressableMemory
+from psyneulink.core.components.mechanisms.mechanism import MechanismError
 from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism_Base
 from psyneulink.core.components.ports.inputport import InputPort
 from psyneulink.core.globals.keywords import EPISODIC_MEMORY_MECHANISM, INITIALIZER, NAME, OWNER_VALUE, VARIABLE
@@ -430,12 +431,8 @@ DEFAULT_INPUT_PORT_NAME_SUFFIX = '_INPUT'
 DEFAULT_OUTPUT_PORT_PREFIX = 'RETRIEVED_'
 
 
-class EpisodicMemoryMechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class EpisodicMemoryMechanismError(MechanismError):
+    pass
 
 
 class EpisodicMemoryMechanism(ProcessingMechanism_Base):

--- a/psyneulink/library/components/mechanisms/processing/leabramechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/leabramechanism.py
@@ -103,6 +103,7 @@ import numbers
 
 import numpy as np
 
+from psyneulink.core.components.component import ComponentError
 from psyneulink.core.components.functions.function import Function_Base
 from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism_Base
 from psyneulink.core.globals.keywords import LEABRA_FUNCTION, LEABRA_FUNCTION_TYPE, LEABRA_MECHANISM, NETWORK, PREFERENCE_SET_NAME
@@ -124,13 +125,8 @@ input_port_names = [MAIN_INPUT, LEARNING_TARGET]
 output_port_name = [MAIN_OUTPUT]
 
 
-class LeabraError(Exception):
-
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class LeabraError(ComponentError):
+    pass
 
 
 class LeabraFunction(Function_Base):

--- a/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/objective/comparatormechanism.py
@@ -145,7 +145,7 @@ import numpy as np
 import typecheck as tc
 
 from psyneulink.core.components.functions.nonstateful.combinationfunctions import LinearCombination
-from psyneulink.core.components.mechanisms.mechanism import Mechanism_Base
+from psyneulink.core.components.mechanisms.mechanism import Mechanism_Base, MechanismError
 from psyneulink.core.components.mechanisms.processing.objectivemechanism import ObjectiveMechanism
 from psyneulink.core.components.shellclasses import Mechanism
 from psyneulink.core.components.ports.inputport import InputPort
@@ -169,12 +169,8 @@ L0 = Loss.L0.name
 L1 = Loss.L1.name
 CROSS_ENTROPY = Loss.CROSS_ENTROPY.name
 
-class ComparatorMechanismError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class ComparatorMechanismError(MechanismError):
+    pass
 
 
 class ComparatorMechanism(ObjectiveMechanism):

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -334,10 +334,11 @@ from collections.abc import Iterable
 import copy
 import numpy as np
 import typecheck as tc
+
 from psyneulink.core.components.functions.function import get_matrix, is_function_type
 from psyneulink.core.components.functions.nonstateful.learningfunctions import ContrastiveHebbian, Hebbian
 from psyneulink.core.components.functions.nonstateful.objectivefunctions import Distance
-from psyneulink.core.components.mechanisms.mechanism import Mechanism
+from psyneulink.core.components.mechanisms.mechanism import Mechanism, MechanismError
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import \
     CONTRASTIVE_HEBBIAN_MECHANISM, COUNT, FUNCTION, HARD_CLAMP, HOLLOW_MATRIX, MAX_ABS_DIFF, NAME, \
@@ -383,12 +384,8 @@ MINUS_PHASE = False
 PLUS_PHASE  = True
 
 
-class ContrastiveHebbianError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class ContrastiveHebbianError(MechanismError):
+    pass
 
 
 def _CHM_output_activity_getter(owning_component=None, context=None):

--- a/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
@@ -82,7 +82,7 @@ from psyneulink.core.components.functions.nonstateful.learningfunctions import K
 from psyneulink.core.components.functions.nonstateful.selectionfunctions import OneHot
 from psyneulink.core.components.mechanisms.modulatory.learning.learningmechanism import \
     ACTIVATION_INPUT, ACTIVATION_OUTPUT, LearningMechanism
-from psyneulink.core.components.mechanisms.mechanism import Mechanism
+from psyneulink.core.components.mechanisms.mechanism import Mechanism, MechanismError
 from psyneulink.core.components.mechanisms.processing.transfermechanism import TransferMechanism
 from psyneulink.core.components.projections.modulatory.learningprojection import LearningProjection
 from psyneulink.core.components.projections.pathway.mappingprojection import MappingProjection
@@ -102,12 +102,8 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-class KohonenError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class KohonenError(MechanismError):
+    pass
 
 
 MAXIMUM_ACTIVITY = 'MAXIMUM_ACTIVITY'

--- a/psyneulink/library/components/mechanisms/processing/transfer/kwtamechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kwtamechanism.py
@@ -190,6 +190,7 @@ from psyneulink.core.globals.keywords import KWTA_MECHANISM, K_VALUE, RATIO, RES
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import is_pref_set
 from psyneulink.core.globals.utilities import is_numeric_or_none
+from psyneulink.core.components.mechanisms.mechanism import MechanismError
 from psyneulink.library.components.mechanisms.processing.transfer.recurrenttransfermechanism import RecurrentTransferMechanism
 from psyneulink.library.components.projections.pathway.autoassociativeprojection import get_auto_matrix, get_hetero_matrix
 
@@ -199,12 +200,8 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-class KWTAError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class KWTAError(MechanismError):
+    pass
 
 class KWTAMechanism(RecurrentTransferMechanism):
     """

--- a/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
@@ -195,6 +195,7 @@ from psyneulink.core.components.functions.nonstateful.objectivefunctions import 
 from psyneulink.core.components.functions.nonstateful.selectionfunctions import max_vs_avg, max_vs_next, MAX_VS_NEXT, MAX_VS_AVG
 from psyneulink.core.components.functions.stateful.integratorfunctions import LeakyCompetingIntegrator
 from psyneulink.core.components.functions.nonstateful.transferfunctions import Logistic
+from psyneulink.core.components.mechanisms.mechanism import MechanismError
 from psyneulink.core.components.mechanisms.processing.transfermechanism import _integrator_mode_setter
 from psyneulink.core.globals.keywords import \
     CONVERGENCE, FUNCTION, GREATER_THAN_OR_EQUAL, LCA_MECHANISM, LESS_THAN_OR_EQUAL, MATRIX, NAME, \
@@ -210,12 +211,8 @@ __all__ = ['LCAMechanism', 'LCAError', 'CONVERGENCE']
 logger = logging.getLogger(__name__)
 
 
-class LCAError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class LCAError(MechanismError):
+    pass
 
 
 

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -198,7 +198,7 @@ from psyneulink.core.components.functions.nonstateful.learningfunctions import H
 from psyneulink.core.components.functions.nonstateful.objectivefunctions import Stability
 from psyneulink.core.components.functions.stateful.integratorfunctions import AdaptiveIntegrator
 from psyneulink.core.components.functions.userdefinedfunction import UserDefinedFunction
-from psyneulink.core.components.mechanisms.mechanism import Mechanism_Base
+from psyneulink.core.components.mechanisms.mechanism import Mechanism_Base, MechanismError
 from psyneulink.core.components.mechanisms.modulatory.learning.learningmechanism import \
     ACTIVATION_INPUT, LEARNING_SIGNAL, LearningMechanism
 from psyneulink.core.components.mechanisms.processing.transfermechanism import TransferMechanism
@@ -243,12 +243,8 @@ ENTROPY_OUTPUT_PORT_NAME='ENTROPY'
 
 
 
-class RecurrentTransferError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
-
-    def __str__(self):
-        return repr(self.error_value)
+class RecurrentTransferError(MechanismError):
+    pass
 
 
 def _recurrent_transfer_mechanism_matrix_getter(owning_component=None, context=None):

--- a/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
+++ b/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
@@ -107,7 +107,7 @@ import typecheck as tc
 from psyneulink.core.components.component import parameter_keywords
 from psyneulink.core.components.functions.nonstateful.transferfunctions import LinearMatrix
 from psyneulink.core.components.functions.function import get_matrix
-from psyneulink.core.components.projections.pathway.mappingprojection import MappingProjection
+from psyneulink.core.components.projections.pathway.mappingprojection import MappingError, MappingProjection
 from psyneulink.core.components.projections.projection import projection_keywords
 from psyneulink.core.components.shellclasses import Mechanism
 from psyneulink.core.components.ports.outputport import OutputPort
@@ -124,9 +124,8 @@ parameter_keywords.update({AUTO_ASSOCIATIVE_PROJECTION})
 projection_keywords.update({AUTO_ASSOCIATIVE_PROJECTION})
 
 
-class AutoAssociativeError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class AutoAssociativeError(MappingError):
+    pass
 
 
 class AutoAssociativeProjection(MappingProjection):

--- a/psyneulink/library/components/projections/pathway/maskedmappingprojection.py
+++ b/psyneulink/library/components/projections/pathway/maskedmappingprojection.py
@@ -70,7 +70,7 @@ import typecheck as tc
 
 from psyneulink.core.components.component import parameter_keywords
 from psyneulink.core.components.functions.function import get_matrix
-from psyneulink.core.components.projections.pathway.mappingprojection import MappingProjection
+from psyneulink.core.components.projections.pathway.mappingprojection import MappingError, MappingProjection
 from psyneulink.core.components.projections.projection import projection_keywords
 from psyneulink.core.globals.keywords import MASKED_MAPPING_PROJECTION, MATRIX
 from psyneulink.core.globals.parameters import check_user_specified
@@ -91,9 +91,8 @@ EXPONENTIATE = 'exponentiate'
 parameter_keywords.update({MASKED_MAPPING_PROJECTION})
 projection_keywords.update({MASKED_MAPPING_PROJECTION})
 
-class MaskedMappingProjectionError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class MaskedMappingProjectionError(MappingError):
+    pass
 
 class MaskedMappingProjection(MappingProjection):
     """

--- a/psyneulink/library/compositions/gymforagercfa.py
+++ b/psyneulink/library/compositions/gymforagercfa.py
@@ -78,7 +78,7 @@ Class Reference
 import numpy as np
 import typecheck as tc
 
-from psyneulink.library.compositions.regressioncfa import RegressionCFA
+from psyneulink.library.compositions.regressioncfa import RegressionCFA, RegressionCFAError
 from psyneulink.core.components.functions.nonstateful.learningfunctions import BayesGLM
 from psyneulink.core.globals.keywords import DEFAULT_VARIABLE
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
@@ -86,9 +86,8 @@ from psyneulink.core.globals.parameters import Parameter, check_user_specified
 __all__ = ['GymForagerCFA']
 
 
-class GymForagerCFAError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class GymForagerCFAError(RegressionCFAError):
+    pass
 
 
 class GymForagerCFA(RegressionCFA):

--- a/psyneulink/library/compositions/regressioncfa.py
+++ b/psyneulink/library/compositions/regressioncfa.py
@@ -83,7 +83,7 @@ from itertools import product
 from psyneulink.core.components.functions.nonstateful.learningfunctions import BayesGLM
 from psyneulink.core.components.ports.modulatorysignals.controlsignal import ControlSignal
 from psyneulink.core.components.ports.port import _parse_port_spec
-from psyneulink.core.compositions.compositionfunctionapproximator import CompositionFunctionApproximator
+from psyneulink.core.compositions.compositionfunctionapproximator import CompositionFunctionApproximator, CompositionFunctionApproximatorError
 from psyneulink.core.globals.keywords import ALL, CONTROL_SIGNALS, DEFAULT_VARIABLE, VARIABLE
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.utilities import get_deepcopy_with_shared, powerset, tensor_power
@@ -148,9 +148,8 @@ class PV(Enum):
     COST = 8
 
 
-class RegressionCFAError(Exception):
-    def __init__(self, error_value):
-        self.error_value = error_value
+class RegressionCFAError(CompositionFunctionApproximatorError):
+    pass
 
 
 class RegressionCFA(CompositionFunctionApproximator):

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -512,9 +512,9 @@ class TestAddProjection:
         proj = MappingProjection(sender=A, receiver=B)
         with pytest.raises(CompositionError) as error:
             comp.add_projection(projection=proj, receiver=C)
-            assert '"Receiver (\'composition-pytests-C\') assigned to ' \
+            assert 'Receiver (\'composition-pytests-C\') assigned to ' \
                    '\'MappingProjection from composition-pytests-A[RESULT] to composition-pytests-B[InputPort-0] ' \
-                   'is incompatible with the positions of these Components in \'Composition-0\'."' == str(error.value)
+                   'is incompatible with the positions of these Components in \'Composition-0\'.' == str(error.value)
 
     @pytest.mark.stress
     @pytest.mark.parametrize(
@@ -3401,9 +3401,9 @@ class TestRun:
         comp.add_projection(MappingProjection(sender=A, receiver=C), A, C)
         with pytest.raises(CompositionError) as error_text:
             comp.add_projection(MappingProjection(sender=B, receiver=D), B, C)
-        assert '"Receiver (\'composition-pytests-C\') assigned to ' \
+        assert 'Receiver (\'composition-pytests-C\') assigned to ' \
                '\'MappingProjection from composition-pytests-B[RESULT] to composition-pytests-D[InputPort-0] ' \
-               'is incompatible with the positions of these Components in \'Composition-0\'."' == str(error_text.value)
+               'is incompatible with the positions of these Components in \'Composition-0\'.' == str(error_text.value)
 
     def test_projection_assignment_mistake_swap2(self):
         # A ----> C --
@@ -3423,9 +3423,9 @@ class TestRun:
         comp.add_projection(MappingProjection(sender=A, receiver=C), A, C)
         with pytest.raises(CompositionError) as error_text:
             comp.add_projection(MappingProjection(sender=B, receiver=C), B, D)
-        assert '"Receiver (\'composition-pytests-D\') assigned to ' \
+        assert 'Receiver (\'composition-pytests-D\') assigned to ' \
                '\'MappingProjection from composition-pytests-B[RESULT] to composition-pytests-C[InputPort-0] ' \
-               'is incompatible with the positions of these Components in \'Composition-0\'."' == str(error_text.value)
+               'is incompatible with the positions of these Components in \'Composition-0\'.' == str(error_text.value)
 
     @pytest.mark.composition
     def test_run_5_mechanisms_2_origins_1_terminal(self, comp_mode):
@@ -6461,7 +6461,7 @@ class TestShadowInputs:
                 ocomp = Composition(nodes=[mcomp,O], name='OUTER COMP')
             assert 'Attempt to shadow the input to a node (B) in a nested Composition of OUTER COMP ' \
                    'that is not an INPUT Node of that Composition is not currently supported.' \
-                   in err.value.error_value
+                   in str(err)
 
     def test_failure_to_find_node_to_shadow(self):
         A = ProcessingMechanism(name='A')
@@ -6907,20 +6907,20 @@ class TestNodeRoles:
         results_by_node = ocomp.get_results_by_nodes(nodes=Z, use_labels=True)
         assert repr(results_by_node) == '{(ProcessingMechanism Z): [\'red\']}'
 
-        label_not_in_dict_error_msg = '"Inappropriate use of \'purple\' as a stimulus for A in MIDDLE COMP: ' \
-                                      'it is not a label in its input_labels_dict."'
+        label_not_in_dict_error_msg = 'Inappropriate use of \'purple\' as a stimulus for A in MIDDLE COMP: ' \
+                                      'it is not a label in its input_labels_dict.'
         with pytest.raises(CompositionError) as error_text:
             ocomp.run(inputs={mcomp:[[0],['purple']],Q:['red']})
         assert label_not_in_dict_error_msg in str(error_text.value)
 
-        no_label_dict_error_msg = '"Inappropriate use of str (\'red\') as a stimulus for X in MIDDLE COMP: ' \
-                                  'it does not have an input_labels_dict."'
+        no_label_dict_error_msg = 'Inappropriate use of str (\'red\') as a stimulus for X in MIDDLE COMP: ' \
+                                  'it does not have an input_labels_dict.'
         with pytest.raises(CompositionError) as error_text:
             ocomp.run(inputs={mcomp:[['red'],['red']],Q:['red']})
         assert no_label_dict_error_msg in str(error_text.value)
 
-        no_such_node_error_msg = '"Nodes specified in get_results_by_nodes() method not found in OUTER COMP ' \
-                                 'nor any Compositions nested within it: [\'N\']"'
+        no_such_node_error_msg = 'Nodes specified in get_results_by_nodes() method not found in OUTER COMP ' \
+                                 'nor any Compositions nested within it: [\'N\']'
         with pytest.raises(CompositionError) as error_text:
             ocomp.get_results_by_nodes(nodes=['N'])
         assert no_such_node_error_msg in str(error_text.value)
@@ -6994,7 +6994,7 @@ class TestNodeRoles:
                                 allow_probes=allow_probes,
                                 include_probes_in_output=include_probes_in_output)
                 ocomp._analyze_graph()
-            assert err.value.error_value == err_msg
+            assert str(err.value) == err_msg
 
     def test_two_node_cycle(self):
         A = TransferMechanism()

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -132,8 +132,7 @@ class TestControlSpecification:
                          'and/or OutputPorts to be monitored for control.'
         with pytest.raises(pnl.ControlMechanismError) as error:
             pnl.Composition(controller=pnl.ControlMechanism(objective_mechanism=mech))
-        error_msg = error.value.error_value
-        assert expected_error in error_msg
+        assert expected_error in str(error.value)
 
     def test_objective_mechanism_spec_as_monitor_for_control_error(self):
         expected_error = 'The \'monitor_for_control\' arg of \'ControlMechanism-0\' contains a specification ' \
@@ -141,8 +140,7 @@ class TestControlSpecification:
                          'This should be specified in its \'objective_mechanism\' argument.'
         with pytest.raises(pnl.ControlMechanismError) as error:
             pnl.Composition(controller=pnl.ControlMechanism(monitor_for_control=pnl.ObjectiveMechanism()))
-        error_msg = error.value.error_value
-        assert expected_error in error_msg
+        assert expected_error in str(error.value)
 
     @pytest.mark.state_features
     @pytest.mark.parametrize("control_spec", [CONTROL, PROJECTIONS])
@@ -621,7 +619,7 @@ class TestControlSpecification:
 
         with pytest.raises(pnl.OptimizationControlMechanismError) as error_text:
             ocomp.run({initial_node_a: [1]})
-        assert expected_text in error_text.value.error_value
+        assert expected_text in str(error_text.value)
 
         ocomp.add_linear_processing_pathway([deferred_node, initial_node_b])
         assert ocomp.controller.state_features == {'ia[InputPort-0]': 'ia[InputPort-0]',
@@ -670,8 +668,8 @@ class TestControlSpecification:
                 ])
         )
 
-        text = '"Controller has \'outcome_ouput_ports\' that receive Projections from the following Components ' \
-               'that do not belong to its agent_rep (ocomp): [\'deferred\']."'
+        text = 'Controller has \'outcome_ouput_ports\' that receive Projections from the following Components ' \
+               + 'that do not belong to its agent_rep (ocomp): [\'deferred\'].'
         with pytest.raises(pnl.OptimizationControlMechanismError) as error:
             ocomp.run({initial_node: [1]})
         assert text == str(error.value)
@@ -1073,7 +1071,7 @@ class TestControlMechanisms:
                 ocomp.add_controller(ocm)
                 ocomp._analyze_graph()
                 ocomp.run()
-            assert err.value.error_value == err_msg
+            assert str(err.value) == err_msg
 
     messages = [
         # 0
@@ -1083,16 +1081,16 @@ class TestControlMechanisms:
         f"behavior, use its get_inputs_format() method to see the format for its inputs.",
 
         # 1
-        f'\'Attempt to shadow the input to a node (IB) in a nested Composition of OUTER COMP '
-        f'that is not an INPUT Node of that Composition is not currently supported.\'',
+        'Attempt to shadow the input to a node (IB) in a nested Composition of OUTER COMP '
+        + 'that is not an INPUT Node of that Composition is not currently supported.',
 
         # 2
-        f'"\'OptimizationControlMechanism-0\' has \'state_features\' specified ([\'SHADOWED INPUT OF EXT[InputPort-0] '
-        f'FOR IA[InputPort-0]\']) that are missing from \'OUTER COMP\' and any Compositions nested within it."',
+        '\'OptimizationControlMechanism-0\' has \'state_features\' specified ([\'SHADOWED INPUT OF EXT[InputPort-0] '
+        + 'FOR IA[InputPort-0]\']) that are missing from \'OUTER COMP\' and any Compositions nested within it.',
 
         # 3
-        '"\'OptimizationControlMechanism-0\' has \'state_features\' specified ([\'INPUT FROM EXT[OutputPort-0] '
-        'FOR IA[InputPort-0]\']) that are missing from \'OUTER COMP\' and any Compositions nested within it."',
+        '\'OptimizationControlMechanism-0\' has \'state_features\' specified ([\'INPUT FROM EXT[OutputPort-0] '
+        + 'FOR IA[InputPort-0]\']) that are missing from \'OUTER COMP\' and any Compositions nested within it.',
 
         # 4
         f"The '{pnl.STATE_FEATURES}' argument has been specified for 'OptimizationControlMechanism-0' that is using "
@@ -1116,8 +1114,8 @@ class TestControlMechanisms:
         f"will generate an error.",
 
         # 7
-        f'"The number of \'state_features\' specified for OptimizationControlMechanism-0 (4) is more than the number '
-        f'of INPUT Nodes (3) of the Composition assigned as its agent_rep (\'OUTER COMP\')."',
+        'The number of \'state_features\' specified for OptimizationControlMechanism-0 (4) is more than the number '
+        + 'of INPUT Nodes (3) of the Composition assigned as its agent_rep (\'OUTER COMP\').',
 
         # 8
         f'The \'state_features\' specified for \'OptimizationControlMechanism-0\' contains an item (OC) '

--- a/tests/composition/test_learning.py
+++ b/tests/composition/test_learning.py
@@ -421,8 +421,8 @@ class TestLearningPathwayMethods:
                               pway.target: 0.0},
                       execution_mode=execution_mode,
                       num_trials=2)
-        assert error.value.error_value == f"ExecutionMode.{execution_mode.name} cannot be used in the learn() " \
-                                                f"method of \'Composition-0\' because it is not an AutodiffComposition"
+        assert str(error.value) == f"ExecutionMode.{execution_mode.name} cannot be used in the learn() " \
+                                   f"method of \'Composition-0\' because it is not an AutodiffComposition"
 
 
 class TestNoLearning:
@@ -1718,7 +1718,7 @@ class TestNestedLearning:
         try:
             outer_comp.learn({oa: 1, ot: 1})
         except CompositionError as e:
-            assert e.error_value == (
+            assert str(e) == (
                    f'Target mechanism {inner_comp_target.name} of nested Composition {inner_comp.name} is not being projected to '
                     f'from its enclosing Composition {outer_comp.name}. For a call to {outer_comp.name}.learn, {inner_comp_target.name} '
                     f'must have an afferent projection with a target value so that an error term may be computed. '

--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -404,9 +404,9 @@ def test_DDM_input_fn():
             execute_until_finished=False,
         )
         float(T.execute(stim))
-    assert '"Input to \'DDM\' ([(NormalDist Normal Distribution Function' in str(error_text.value)
+    assert 'Input to \'DDM\' ([(NormalDist Normal Distribution Function' in str(error_text.value)
     assert 'is incompatible with its corresponding InputPort (DDM[InputPort-0]): ' \
-           '\'unsupported operand type(s) for *: \'NormalDist\' and \'float\'.\'"' in str(error_text.value)
+           '\'unsupported operand type(s) for *: \'NormalDist\' and \'float\'.\'' in str(error_text.value)
 
 # ======================================= RATE TESTS ============================================
 

--- a/tests/mechanisms/test_kwta.py
+++ b/tests/mechanisms/test_kwta.py
@@ -57,7 +57,7 @@ class TestKWTAInputs:
                 size = 4,
             )
             K.execute(["one", "two", "three", "four"])
-        assert ('"Input to \'K\' ([\'one\' \'two\' \'three\' \'four\']) is incompatible with its corresponding '
+        assert ('Input to \'K\' ([\'one\' \'two\' \'three\' \'four\']) is incompatible with its corresponding '
                 'InputPort (K[InputPort-0]):' in str(error_text.value))
 
     def test_kwta_var_list_of_strings(self):

--- a/tests/mechanisms/test_recurrent_transfer_mechanism.py
+++ b/tests/mechanisms/test_recurrent_transfer_mechanism.py
@@ -189,7 +189,7 @@ class TestRecurrentTransferMechanismInputs:
                 integrator_mode=True
             )
             R.execute(["one", "two", "three", "four"])
-        assert '"Input to \'R\' ([\'one\' \'two\' \'three\' \'four\']) is incompatible ' \
+        assert 'Input to \'R\' ([\'one\' \'two\' \'three\' \'four\']) is incompatible ' \
                'with its corresponding InputPort (R[InputPort-0]): ' in str(error_text.value)
 
     def test_recurrent_mech_var_list_of_strings(self):

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -107,7 +107,7 @@ class TestTransferMechanismInputs:
                 integrator_mode=True
             )
             T.execute(["one", "two", "three", "four"])
-        assert '"Input to \'T\' ([\'one\' \'two\' \'three\' \'four\']) is incompatible ' \
+        assert 'Input to \'T\' ([\'one\' \'two\' \'three\' \'four\']) is incompatible ' \
                'with its corresponding InputPort (T[InputPort-0]): ' in str(error_text.value)
 
     @pytest.mark.mechanism

--- a/tests/ports/test_input_ports.py
+++ b/tests/ports/test_input_ports.py
@@ -132,9 +132,9 @@ class TestInputPorts:
         A = pnl.InputPort()
         with pytest.raises(pnl.PortError) as error:
             A.efferents
-        assert '"InputPorts do not have \'efferents\'; (access attempted for Deferred Init InputPort)."' \
+        assert 'InputPorts do not have \'efferents\'; (access attempted for Deferred Init InputPort).' \
                in str(error.value)
         with pytest.raises(pnl.PortError) as error:
             A.efferents = ['test']
-        assert '"InputPorts are not allowed to have \'efferents\' ' \
-               '(assignment attempted for Deferred Init InputPort)."' in str(error.value)
+        assert 'InputPorts are not allowed to have \'efferents\' ' \
+               '(assignment attempted for Deferred Init InputPort).' in str(error.value)

--- a/tests/ports/test_output_ports.py
+++ b/tests/ports/test_output_ports.py
@@ -71,9 +71,9 @@ class TestOutputPorts:
         A = pnl.OutputPort()
         with pytest.raises(pnl.PortError) as error:
             A.path_afferents
-        assert '"OutputPorts do not have \'path_afferents\'; (access attempted for Deferred Init OutputPort)."' \
+        assert 'OutputPorts do not have \'path_afferents\'; (access attempted for Deferred Init OutputPort).' \
                in str(error.value)
         with pytest.raises(pnl.PortError) as error:
             A.path_afferents = ['test']
-        assert '"OutputPorts are not allowed to have \'path_afferents\' ' \
-               '(assignment attempted for Deferred Init OutputPort)."' in str(error.value)
+        assert 'OutputPorts are not allowed to have \'path_afferents\' ' \
+               '(assignment attempted for Deferred Init OutputPort).' in str(error.value)

--- a/tests/ports/test_parameter_ports.py
+++ b/tests/ports/test_parameter_ports.py
@@ -74,23 +74,23 @@ class TestParameterPorts:
         A = TransferMechanism()
         with pytest.raises(pnl.PortError) as error:
             A.parameter_ports['slope'].path_afferents
-        assert '"ParameterPorts do not have \'path_afferents\'; (access attempted for TransferMechanism-0[slope])."' \
+        assert 'ParameterPorts do not have \'path_afferents\'; (access attempted for TransferMechanism-0[slope]).' \
                in str(error.value)
         with pytest.raises(pnl.PortError) as error:
             A.parameter_ports['slope'].path_afferents = ['test']
-        assert '"ParameterPorts are not allowed to have \'path_afferents\' ' \
-               '(assignment attempted for TransferMechanism-0[slope])."' in str(error.value)
+        assert 'ParameterPorts are not allowed to have \'path_afferents\' ' \
+               '(assignment attempted for TransferMechanism-0[slope]).' in str(error.value)
 
     def test_no_efferents(self):
         A = TransferMechanism()
         with pytest.raises(pnl.PortError) as error:
             A.parameter_ports['slope'].efferents
-        assert '"ParameterPorts do not have \'efferents\'; (access attempted for TransferMechanism-0[slope])."' \
+        assert 'ParameterPorts do not have \'efferents\'; (access attempted for TransferMechanism-0[slope]).' \
                in str(error.value)
         with pytest.raises(pnl.PortError) as error:
             A.parameter_ports['slope'].efferents = ['test']
-        assert '"ParameterPorts are not allowed to have \'efferents\' ' \
-               '(assignment attempted for TransferMechanism-0[slope])."' in str(error.value)
+        assert 'ParameterPorts are not allowed to have \'efferents\' ' \
+               '(assignment attempted for TransferMechanism-0[slope]).' in str(error.value)
 
 class TestConfigurableParameters:
     def test_configurable_params(self):

--- a/tests/projections/test_projection_specifications.py
+++ b/tests/projections/test_projection_specifications.py
@@ -58,12 +58,12 @@ class TestProjectionSpecificationFormats:
         (pnl.CONTROL, None),
         (pnl.MODULATES, None),
         (pnl.PROJECTIONS, None),
-        ('mod and ctl', '"Both \'control\' and \'modulates\' arguments are specified in '
-                        'the constructor for \'ControlSignal; Should use just \'control\'."'),
+        ('mod and ctl', 'Both \'control\' and \'modulates\' arguments are specified in '
+                        'the constructor for \'ControlSignal; Should use just \'control\'.'),
         ('proj and ctl', 'Both \'control\' and \'projections\' arguments are specified in the constructor for '
                          '\'ControlSignal; Must use just one or the other.'),
-        ('proj and mod','"Both \'modulates\' and \'projections\' arguments are specified in the constructor for '
-                        '\'ControlSignal; Should use just \'projections\' (or \'control\') "')
+        ('proj and mod','Both \'modulates\' and \'projections\' arguments are specified in the constructor for '
+                        '\'ControlSignal; Should use just \'projections\' (or \'control\') ')
     ])
     @pytest.mark.control
     def test_control_signal_projections_arg(self, args):
@@ -92,12 +92,12 @@ class TestProjectionSpecificationFormats:
         (pnl.GATE, None),
         (pnl.MODULATES, None),
         (pnl.PROJECTIONS, None),
-        ('mod and gate', '"Both \'gate\' and \'modulates\' arguments are specified in the constructor for '
-                         '\'GatingSignal; Should use just \'gate\'."'),
+        ('mod and gate', 'Both \'gate\' and \'modulates\' arguments are specified in the constructor for '
+                         '\'GatingSignal; Should use just \'gate\'.'),
         ('proj and gate', 'Both \'gate\' and \'projections\' arguments are specified in the constructor for '
                           '\'GatingSignal; Must use just one or the other.'),
-        ('proj and mod','"Both \'modulates\' and \'projections\' arguments are specified in the constructor for '
-                        '\'GatingSignal; Should use just \'projections\' (or \'gate\') "')
+        ('proj and mod','Both \'modulates\' and \'projections\' arguments are specified in the constructor for '
+                        '\'GatingSignal; Should use just \'projections\' (or \'gate\') ')
     ])
     @pytest.mark.control
     def test_gating_signal_projections_arg(self, args):
@@ -140,13 +140,13 @@ class TestProjectionSpecificationFormats:
         if extra_spec:
             ctl_sig_spec.update({extra_spec:[M.parameter_ports[pnl.STARTING_VALUE]]})
             gating_sig_spec.update({extra_spec:[M.output_ports[pnl.RESPONSE_TIME]]})
-            ctl_err_msg = '"Both \'PROJECTIONS\' and \'CONTROL\' entries found in specification dict for ' \
-                          '\'ControlSignal\' of \'ControlMechanism-0\'. Must use only one or the other."'
+            ctl_err_msg = 'Both \'PROJECTIONS\' and \'CONTROL\' entries found in specification dict for ' \
+                          '\'ControlSignal\' of \'ControlMechanism-0\'. Must use only one or the other.'
             with pytest.raises(pnl.ControlSignalError) as err:
                 pnl.ControlMechanism(control_signals=[ctl_sig_spec])
             assert ctl_err_msg == str(err.value)
-            gating_err_msg = '"Both \'PROJECTIONS\' and \'GATE\' entries found in specification dict for ' \
-                             '\'GatingSignal\' of \'GatingMechanism-0\'. Must use only one or the other."'
+            gating_err_msg = 'Both \'PROJECTIONS\' and \'GATE\' entries found in specification dict for ' \
+                             '\'GatingSignal\' of \'GatingMechanism-0\'. Must use only one or the other.'
             with pytest.raises(pnl.GatingSignalError) as err:
                 pnl.GatingMechanism(gating_signals=[gating_sig_spec])
             assert gating_err_msg == str(err.value)


### PR DESCRIPTION
useful for checking for categories of pnl component errors all at once