### PR TITLE
EpisodicMemoryMechanism: make memory (_memory_init) a FunctionParameter

### DIFF
--- a/psyneulink/core/components/functions/stateful/memoryfunctions.py
+++ b/psyneulink/core/components/functions/stateful/memoryfunctions.py
@@ -23,6 +23,7 @@ Functions that store and can return a record of their input.
 
 """
 
+import copy
 import numbers
 import warnings
 from collections import deque
@@ -2541,8 +2542,8 @@ class DictionaryMemory(MemoryFunction):  # -------------------------------------
             previous_value = self._get_current_parameter_value("initializer", context)
 
         if previous_value == []:
-            self.parameters.previous_value._get(context).clear()
             value = np.ndarray(shape=(2, 0, len(self.defaults.variable[0])))
+            self.parameters.previous_value._set(copy.deepcopy(value), context)
 
         else:
             value = self._initialize_previous_value(previous_value, context=context)

--- a/tests/mechanisms/test_episodic_memory.py
+++ b/tests/mechanisms/test_episodic_memory.py
@@ -221,8 +221,11 @@ def test_with_contentaddressablememory(name, func, func_params, mech_params, tes
 def test_contentaddressable_memory_warnings_and_errors():
 
     # both memory arg of Mechanism and initializer for its function are specified
-    text = "The 'memory' argument specified for EpisodicMemoryMechanism-0 will override the specification " \
-            "for the 'initializer' argument of its function"
+    text = (
+        r"Specification of the \"memory\" parameter[.\S\s]*The value"
+        + r" specified on \(ContentAddressableMemory ContentAddressableMemory"
+        + r" Function-\d\) will be used\."
+    )
     with pytest.warns(UserWarning, match=text):
         em = EpisodicMemoryMechanism(
             memory = [[[1,2,3],[4,5,6]]],


### PR DESCRIPTION
Shared with its function initializer. Changes conflict behavior to be consistent with other SharedParameters (function value favored over owner value). For discussion on this, see https://github.com/PrincetonUniversity/PsyNeuLink/issues/2600