### PR TITLE
github-actions: Constraint broken transitive dependencies

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -70,7 +70,7 @@ runs:
           echo "new_package=$NEW_PACKAGE" >> $GITHUB_OUTPUT
           # save a list of all installed packages (including pip, wheel; it's never empty)
           pip freeze --all > orig
-          pip install "$(echo $NEW_PACKAGE | sed 's/[-_]/./g' | xargs grep *requirements.txt -h -e | head -n1)" -c env_constraints.txt
+          pip install "$(echo $NEW_PACKAGE | sed 's/[-_]/./g' | xargs grep *requirements.txt -h -e | head -n1)" -c env_constraints.txt -c broken_trans_deps.txt
           pip show "$NEW_PACKAGE" | grep 'Version' | tee new_version.deps
           # uninstall new packages but skip those from previous steps (pywinpty, terminado on windows x86)
           # the 'orig' list is not empty (includes at least pip, wheel)
@@ -82,7 +82,7 @@ runs:
     - name: Python dependencies
       shell: bash
       run: |
-        pip install -e .[${{ inputs.features }}] -c env_constraints.txt
+        pip install -e .[${{ inputs.features }}] -c env_constraints.txt -c broken_trans_deps.txt
 
     - name: "Cleanup old wheels"
       shell: bash

--- a/broken_trans_deps.txt
+++ b/broken_trans_deps.txt
@@ -1,0 +1,5 @@
+# This file constraints broken (transitive) dependencies
+
+# onnxruntime-1.14.0 is broken on macos/x64
+# https://github.com/microsoft/onnxruntime/issues/14663
+onnxruntime != 1.14.0; platform_system=="Darwin"


### PR DESCRIPTION
Add onnxruntime-1.14.0 on macos to the constraint. https://github.com/microsoft/onnxruntime/issues/14663