### PR TITLE
Add PNL specific warning categories

### DIFF
--- a/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
@@ -1632,7 +1632,9 @@ class GridSearch(OptimizationFunction):
             if all(type(x) == np.ndarray for x in variable) and not all(len(x) == len(variable[0]) for x in variable):
                 variable = tuple(variable)
 
-            warnings.warn("Shape mismatch: {} variable expected: {} vs. got: {}".format(self, variable, self.defaults.variable))
+            warnings.warn("Shape mismatch: {} variable expected: {} vs. got: {}".format(
+                          self, variable, self.defaults.variable),
+                          pnlvm.PNLCompilerWarning)
 
         else:
             variable = self.defaults.variable

--- a/psyneulink/core/components/functions/nonstateful/transferfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/transferfunctions.py
@@ -3369,10 +3369,14 @@ class LinearMatrix(TransferFunction):  # ---------------------------------------
     def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tags:frozenset):
         # Restrict to 1d arrays
         if self.defaults.variable.ndim != 1:
-            warnings.warn("Shape mismatch: {} (in {}) got 2D input: {}".format(self, self.owner, self.defaults.variable))
+            warnings.warn("Shape mismatch: {} (in {}) got 2D input: {}".format(
+                          self, self.owner, self.defaults.variable),
+                          pnlvm.PNLCompilerWarning)
             arg_in = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(0)])
         if self.defaults.value.ndim != 1:
-            warnings.warn("Shape mismatch: {} (in {}) has 2D output: {}".format(self, self.owner, self.defaults.value))
+            warnings.warn("Shape mismatch: {} (in {}) has 2D output: {}".format(
+                          self, self.owner, self.defaults.value),
+                          pnlvm.PNLCompilerWarning)
             arg_out = builder.gep(arg_out, [ctx.int32_ty(0), ctx.int32_ty(0)])
 
         matrix = pnlvm.helpers.get_param_ptr(builder, self, params, MATRIX)
@@ -4390,11 +4394,15 @@ class TransferWithCosts(TransferFunction):
         trans_s = pnlvm.helpers.get_state_ptr(builder, self, state, transfer_f.name)
         trans_in = arg_in
         if trans_in.type != trans_f.args[2].type:
-            warnings.warn("Shape mismatch: {} input does not match the transfer function ({}): {} vs. {}".format(self, transfer_f.get(), self.defaults.variable, transfer_f.get().defaults.variable))
+            warnings.warn("Shape mismatch: {} input does not match the transfer function ({}): {} vs. {}".format(
+                          self, transfer_f.get(), self.defaults.variable, transfer_f.get().defaults.variable),
+                          pnlvm.PNLCompilerWarning)
             trans_in = builder.gep(trans_in, [ctx.int32_ty(0), ctx.int32_ty(0)])
         trans_out = arg_out
         if trans_out.type != trans_f.args[3].type:
-            warnings.warn("Shape mismatch: {} output does not match the transfer function ({}): {} vs. {}".format(self, transfer_f.get(), self.defaults.value, transfer_f.get().defaults.value))
+            warnings.warn("Shape mismatch: {} output does not match the transfer function ({}): {} vs. {}".format(
+                          self, transfer_f.get(), self.defaults.value, transfer_f.get().defaults.value),
+                          pnlvm.PNLCompilerWarning)
             trans_out = builder.gep(trans_out, [ctx.int32_ty(0), ctx.int32_ty(0)])
         builder.call(trans_f, [trans_p, trans_s, trans_in, trans_out])
 

--- a/psyneulink/core/components/functions/stateful/statefulfunction.py
+++ b/psyneulink/core/components/functions/stateful/statefulfunction.py
@@ -518,7 +518,8 @@ class StatefulFunction(Function_Base): #  --------------------------------------
             dest_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, a)
             if source_ptr.type != dest_ptr.type:
                 warnings.warn("Shape mismatch: stateful param does not match the initializer: "
-                              "{initializer}({source_ptr.type}) vs. {a}({dest_ptr.type}).")
+                              "{}({}) vs. {}({}).".format(initializer, source_ptr.type, a, dst_ptr.type),
+                              pnlvm.PNLCompilerWarning)
                 # Take a guess that dest just has an extra dimension
                 assert len(dest_ptr.type.pointee) == 1
                 dest_ptr = builder.gep(dest_ptr, [ctx.int32_ty(0),

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3120,7 +3120,9 @@ class Mechanism_Base(Mechanism):
             assert value is mech_val_ptr
         else:
             # FIXME: Does this need some sort of parsing?
-            warnings.warn("Shape mismatch: function result does not match mechanism value param: {} vs. {}".format(value.type.pointee, mech_val_ptr.type.pointee))
+            warnings.warn("Shape mismatch: function result does not match mechanism value param: {} vs. {}".format(
+                          value.type.pointee, mech_val_ptr.type.pointee),
+                          pnlvm.PNLCompilerWarning)
 
         # Update  num_executions parameter
         num_executions_ptr = pnlvm.helpers.get_state_ptr(builder, self, m_state, "num_executions")

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -3247,9 +3247,9 @@ class OptimizationControlMechanism(ControlMechanism):
                 data_out = builder.gep(op_in, [ctx.int32_ty(0), ctx.int32_ty(0)])
 
             if data_in.type != data_out.type:
-                warnings.warn(f"Shape mismatch: Allocation sample '{i}' "
-                              f"({self.parameters.control_allocation_search_space.get()}) "
-                              f"doesn't match input port input ({op.defaults.variable}).")
+                warnings.warn("Shape mismatch: Allocation sample '{}' ({}) doesn't match input port input ({}).".format(
+                               i, self.parameters.control_allocation_search_space.get(), op.defaults.variable),
+                               pnlvm.PNLCompilerWarning)
                 assert len(data_out.type.pointee) == 1
                 data_out = builder.gep(data_out, [ctx.int32_ty(0), ctx.int32_ty(0)])
 

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1571,7 +1571,8 @@ class TransferMechanism(ProcessingMechanism_Base):
             got = np.empty_like(self.termination_measure.defaults.variable)
             if expected.shape != got.shape:
                 warnings.warn("Shape mismatch: Termination measure input: "
-                              "{self.termination_measure.defaults.variable} should be {expected.shape}.")
+                              "{} should be {}.".format(self.termination_measure.defaults.variable, expected.shape),
+                              pnlvm.PNLCompilerWarning)
                 # FIXME: HACK the distance function is not initialized
                 self.termination_measure.defaults.variable = expected
 

--- a/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
@@ -1175,10 +1175,13 @@ class ControlSignal(ModulatorySignal):
             else:
                 ifunc_in = arg_in
             # point output to the proper slot in comb func input
-            assert cost_funcs == 0, "Intensity should eb the first cost function!"
+            assert cost_funcs == 0, "Intensity should be the first cost function!"
             ifunc_out = builder.gep(cfunc_in, [ctx.int32_ty(0), ctx.int32_ty(cost_funcs)])
             if ifunc_out.type != ifunc.args[3].type:
-                warnings.warn("Shape mismatch: {} element of combination func input ({}) doesn't match INTENSITY cost output ({})".format(cost_funcs, self.function.combine_costs_fct.defaults.variable, self.function.intensity_cost_fct.defaults.value))
+                warnings.warn("Shape mismatch: {} element of combination func input ({}) doesn't match INTENSITY cost output ({})".format(
+                              cost_funcs, self.function.combine_costs_fct.defaults.variable,
+                              self.function.intensity_cost_fct.defaults.value),
+                              pnlvm.PNLCompilerWarning)
                 assert self.cost_options == CostFunctions.INTENSITY
                 ifunc_out = cfunc_in
 

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2379,7 +2379,8 @@ class Port_Base(Port):
                 if f_mod_ptr.type != arg_out.type:
                     assert len(f_mod_ptr.type.pointee) == 1
                     warnings.warn("Shape mismatch: Overriding modulation should match parameter port output: {} vs. {}".format(
-                                  afferent.defaults.value, self.defaults.value))
+                                  afferent.defaults.value, self.defaults.value),
+                                  pnlvm.PNLCompilerWarning)
                     f_mod_ptr = builder.gep(f_mod_ptr, [ctx.int32_ty(0), ctx.int32_ty(0)])
                 builder.store(builder.load(f_mod_ptr), arg_out)
                 return builder
@@ -2394,7 +2395,8 @@ class Port_Base(Port):
                 if f_mod_param_ptr.type != f_mod_ptr.type:
                     warnings.warn("Shape mismatch: Modulation vs. modulated parameter: {} vs. {}".format(
                                   afferent.defaults.value,
-                                  getattr(self.function.parameters, name).get(None)))
+                                  getattr(self.function.parameters, name).get(None)),
+                                  pnlvm.PNLCompilerWarning)
                     param_val = pnlvm.helpers.load_extract_scalar_array_one(builder, f_mod_ptr)
                 else:
                     param_val = builder.load(f_mod_ptr)

--- a/psyneulink/core/globals/__init__.py
+++ b/psyneulink/core/globals/__init__.py
@@ -9,6 +9,7 @@ from . import preferences
 from . import registry
 from . import utilities
 from . import sampleiterator
+from . import warnings
 
 from .context import *
 from .defaults import *
@@ -21,6 +22,7 @@ from .preferences import *
 from .registry import *
 from .utilities import *
 from .sampleiterator import *
+from .warnings import *
 
 __all__ = list(context.__all__)
 __all__.extend(defaults.__all__)
@@ -33,3 +35,4 @@ __all__.extend(preferences.__all__)
 __all__.extend(registry.__all__)
 __all__.extend(utilities.__all__)
 __all__.extend(sampleiterator.__all__)
+__all__.extend(warnings.__all__)

--- a/psyneulink/core/globals/warnings.py
+++ b/psyneulink/core/globals/warnings.py
@@ -1,3 +1,4 @@
+import warnings
 
 __all__ = ['PNLWarning', 'PNLInternalWarning', 'PNLUserWarning']
 
@@ -9,3 +10,14 @@ class PNLInternalWarning(PNLWarning):
 
 class PNLUserWarning(PNLWarning):
     pass
+
+
+def _disable_internal_warnings():
+    warnings.simplefilter("ignore", PNLInternalWarning)
+
+def _enable_internal_warnings():
+    warnings.simplefilter("default", PNLInternalWarning)
+
+
+# Disable internal warnings by default
+_disable_internal_warnings()

--- a/psyneulink/core/globals/warnings.py
+++ b/psyneulink/core/globals/warnings.py
@@ -1,0 +1,11 @@
+
+__all__ = ['PNLWarning', 'PNLInternalWarning', 'PNLUserWarning']
+
+class PNLWarning(Warning):
+    pass
+
+class PNLInternalWarning(PNLWarning):
+    pass
+
+class PNLUserWarning(PNLWarning):
+    pass

--- a/psyneulink/core/llvm/__init__.py
+++ b/psyneulink/core/llvm/__init__.py
@@ -25,6 +25,8 @@ from .debug import debug_env
 from .execution import *
 from .execution import _tupleize
 from .jit_engine import *
+from .warnings import *
+
 
 __all__ = ['LLVMBuilderContext', 'ExecutionMode']
 

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -20,6 +20,7 @@ from psyneulink.core.scheduling.condition import Never
 from psyneulink.core.scheduling.time import TimeScale
 from . import helpers
 from .debug import debug_env
+from .warnings import PNLCompilerWarning
 
 class UserDefinedFunctionVisitor(ast.NodeVisitor):
     def __init__(self, ctx, builder, func_globals, func_params, arg_in, arg_out):
@@ -712,7 +713,9 @@ def gen_node_wrapper(ctx, composition, node, *, tags:frozenset):
         proj_function = ctx.import_llvm_function(proj, tags=proj_func_tags)
 
         if proj_out.type != proj_function.args[3].type:
-            warnings.warn("Shape mismatch: Projection ({}) results does not match the receiver state({}) input: {} vs. {}".format(proj, proj.receiver, proj.defaults.value, proj.receiver.defaults.variable))
+            warnings.warn("Shape mismatch: Projection ({}) results don't match the receiver state({}) input: {} vs. {}".format(
+                           proj, proj.receiver, proj.defaults.value, proj.receiver.defaults.variable),
+                           PNLCompilerWarning)
             # Check that this workaround applies only to projections to inner composition
             # that are off by one dimension, but in the 'wrong' direction (we need to add one dim).
             assert len(proj_function.args[3].type.pointee) == 1

--- a/psyneulink/core/llvm/warnings.py
+++ b/psyneulink/core/llvm/warnings.py
@@ -1,0 +1,6 @@
+from ..globals.warnings import PNLInternalWarning
+
+__all__ = ['PNLCompilerWarning']
+
+class PNLCompilerWarning(PNLInternalWarning):
+    pass


### PR DESCRIPTION
Introduce two new warning categories: `PNLInternalWarning` and `PNLUserWarning`.
Internal wanting are set to "ignore" by default.
This default can be overridden by calling private `_enable_internal_warnings` function.
Add a new  `PNLCompilerWarning` category, derived from `PNLInternalWarning`, (and thus ignored by default),
and switch all "shape mismatch" warning cases to use `PNLCompilerWarning`.
pytest overrides warning filters so test issued warnings are not affected.