### PR TITLE
Composition: fix INPUT roles for ControlMechanism -> inner Composition

### DIFF
--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -1900,7 +1900,7 @@ class ControlMechanism(ModulatoryMechanism_Base):
             self.remove_ports(ctl_sig_attribute[0])
 
     # FIX: 11/15/21 SHOULDN'T THIS BE PUT ON COMPOSITION??
-    def _activate_projections_for_compositions(self, composition=None):
+    def _activate_projections_for_compositions(self, composition=None, context=None):
         """Activate eligible Projections to or from Nodes in Composition.
         If Projection is to or from a node NOT (yet) in the Composition,
         assign it the node's aux_components attribute but do not activate it.
@@ -1948,7 +1948,7 @@ class ControlMechanism(ModulatoryMechanism_Base):
             proj._activate_for_compositions(composition)
 
         for proj in deeply_nested_aux_components.values():
-            composition.add_projection(proj, sender=proj.sender, receiver=proj.receiver)
+            composition.add_projection(proj, sender=proj.sender, receiver=proj.receiver, context=context)
 
         # Add any remaining afferent Projections that have been assigned and are from nodes in composition
         remaining_projections = set(self.projections) - dependent_projections - set(self.composition.projections)

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2295,6 +2295,16 @@ class Port_Base(Port):
         raise PortError(f"{self.__class__.__name__}s are not allowed to have 'efferents' "
                              f"(assignment attempted for {self.full_name}).")
 
+    def get_afferents(self, from_component=None):
+        return self._get_matching_projections(
+            from_component, self.all_afferents, filter_component_is_sender=True
+        )
+
+    def get_efferents(self, to_component=None):
+        return self._get_matching_projections(
+            to_component, self.efferents, filter_component_is_sender=False
+        )
+
     @property
     def full_name(self):
         """Return name relative to owner as:  <owner.name>[<self.name>]"""

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -748,6 +748,8 @@ class Projection_Base(Projection):
             if self not in self.receiver.afferents_info:
                 self.receiver.afferents_info[self] = ConnectionInfo()
 
+        self._creates_scheduling_dependency = True
+
        # Validate variable, function and params
         # Note: pass name of Projection (to override assignment of componentName in super.__init__)
         super(Projection_Base, self).__init__(

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -10812,6 +10812,8 @@ _
             # -DS
 
             context.execution_phase = ContextFlags.PROCESSING
+            build_CIM_input = NotImplemented
+
             if inputs is not None:
                 inputs = self._validate_execution_inputs(inputs)
                 build_CIM_input = self._build_variable_for_input_CIM(inputs)
@@ -10849,6 +10851,7 @@ _
                 self.parameter_CIM.execute(context=context)
 
             else:
+                assert build_CIM_input != NotImplemented, f"{self} not in nested mode and no inputs available"
                 self.input_CIM.execute(build_CIM_input, context=context)
 
                 # Update nested compositions

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -12338,6 +12338,18 @@ _
         if self.controller:
             yield self.controller
 
+    @property
+    def _sender_ports(self):
+        ports = super()._sender_ports
+        ports.extend(self.parameter_CIM.output_ports)
+        return ports
+
+    @property
+    def _receiver_ports(self):
+        ports = super()._receiver_ports
+        ports.extend(self.parameter_CIM.input_ports)
+        return ports
+
     # endregion PROPERTIES
 
     # ******************************************************************************************************************

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -5641,7 +5641,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                    "Composition requires a list of Projections, each of which must have a "
                                    "sender and a receiver.".format(self.name))
 
-    @handle_external_context(source=ContextFlags.METHOD)
+    @handle_external_context(source=ContextFlags.COMMAND_LINE)
     def add_projection(self,
                        projection=None,
                        sender=None,
@@ -6212,7 +6212,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                         # TBI - Shadow projection type? Matrix value?
                         new_projection = MappingProjection(sender=correct_sender,
                                                            receiver=input_port)
-                        self.add_projection(new_projection, sender=correct_sender, receiver=input_port)
+                        self.add_projection(new_projection, sender=correct_sender, receiver=input_port, context=context)
                 else:
                     raise CompositionError(f"Unable to find port specified to be shadowed by '{input_port.owner.name}' "
                                            f"({shadowed_projection.receiver.owner.name}"
@@ -8448,7 +8448,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         self.node_ordering.append(controller)
         self.enable_controller = True
         # FIX: 11/15/21 - SHOULD THIS METHOD BE MOVED HERE (TO COMPOSITION) FROM ControlMechanism
-        controller._activate_projections_for_compositions(self)
+        controller._activate_projections_for_compositions(self, context=context)
         self._analyze_graph(context=context)
         if not invalid_aux_components:
             self._controller_initialization_status = ContextFlags.INITIALIZED
@@ -8634,7 +8634,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         # add sender and receiver to self.parameter_CIM_ports dict
         for p in control_signal.projections:
             # self.add_projection(p)
-            graph_receiver.add_projection(p, receiver=p.receiver, sender=control_signal)
+            graph_receiver.add_projection(p, receiver=p.receiver, sender=control_signal, context=context)
         try:
             sender._remove_projection_to_port(projection)
         except (ValueError, PortError):

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -7291,7 +7291,9 @@ class TestNodeRoles:
         assert {mech, ctl_mech_A, ctl_mech_B} == set(comp.get_nodes_by_role(NodeRole.OUTPUT))
         # Current instantiation always assigns ctl_mech_B as TERMINAL in this case;
         # this is here to flag any violation of this in the future, in case that is not intended
+        assert {mech} == set(comp.get_nodes_by_role(NodeRole.ORIGIN))
         assert {ctl_mech_B} == set(comp.get_nodes_by_role(NodeRole.TERMINAL))
+        assert {mech, ctl_mech_A, ctl_mech_B} == set(comp.get_nodes_by_role(NodeRole.OUTPUT))
 
     def test_LEARNING_hebbian(self):
         A = RecurrentTransferMechanism(name='A', size=2, enable_learning=True)

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -597,11 +597,9 @@ class TestPathway:
         assert p.learning_components is None
 
     def test_pathway_assign_composition_arg_error(self):
-        c = Composition()
-        with pytest.raises(pnl.CompositionError) as error_text:
+        error_text = "'composition' arg of constructor for Pathway must be a Composition"
+        with pytest.raises(pnl.CompositionError, match=error_text):
             p = Pathway(pathway=[], composition='c')
-        assert "\'composition\' can not be specified as an arg in the constructor for a Pathway" in str(
-                error_text.value)
 
     def test_pathway_assign_roles_error(self):
         A = ProcessingMechanism()
@@ -792,7 +790,7 @@ class TestCompositionPathwayArgsAndAdditionMethods:
         p = Pathway(pathway=([A,B], Reinforcement), name='P')
         c = Composition()
 
-        regexp = "LearningFunction found in specification of 'pathway' arg for "\
+        regexp = "LearningFunction found in 'pathway' arg for "\
                  "add_linear_procesing_pathway method .*"\
                 r"Reinforcement'>; it will be ignored"
         with pytest.warns(UserWarning, match=regexp):
@@ -3622,7 +3620,7 @@ class TestRun:
         with pytest.raises(CompositionError) as error_text:
             comp.add_linear_processing_pathway([A, A_to_B, B, C, D, E, C_to_E])
 
-        assert ("The last item in the \'pathway\' arg for add_linear_procesing_pathway method" in str(error_text.value)
+        assert ("The last item in \'pathway\' arg for add_linear_procesing_pathway method" in str(error_text.value)
                 and "cannot be a Projection:" in str(error_text.value))
 
     def test_LPP_two_projections_in_a_row(self):
@@ -6255,7 +6253,7 @@ class TestAuxComponents:
         C = TransferMechanism(name='C',
                               function=Linear(slope=2.0))
 
-        A.aux_components = [(B, NodeRole.TERMINAL), MappingProjection(sender=A, receiver=B)]
+        A.aux_components = [(B, NodeRole.OUTPUT), MappingProjection(sender=A, receiver=B)]
 
         comp = Composition(name='composition')
         comp.add_node(A)
@@ -6275,7 +6273,7 @@ class TestAuxComponents:
 
         assert np.allclose(B.parameters.value.get(comp), [[2.0]])
 
-        assert B in comp.get_nodes_by_role(NodeRole.TERMINAL)
+        assert B in comp.get_nodes_by_role(NodeRole.OUTPUT)
         assert np.allclose(C.parameters.value.get(comp), [[4.0]])
         assert np.allclose(comp.get_output_values(comp), [[2.0], [4.0]])
 

--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -667,7 +667,7 @@ def test_DDM_threshold_modulation_analytical(comp_mode):
     control = pnl.ControlMechanism(control_signals=[(pnl.THRESHOLD, M)])
 
     C = pnl.Composition()
-    C.add_node(M, required_roles=[pnl.NodeRole.ORIGIN, pnl.NodeRole.TERMINAL])
+    C.add_node(M, required_roles=[pnl.NodeRole.INPUT, pnl.NodeRole.OUTPUT])
     C.add_node(control)
     inputs = {M:[1], control:[3]}
     val = C.run(inputs, num_trials=1, execution_mode=comp_mode)
@@ -689,7 +689,7 @@ def test_DDM_threshold_modulation_integrator(comp_mode):
             control_signals=[(pnl.THRESHOLD, M)])
 
     C = pnl.Composition()
-    C.add_node(M, required_roles=[pnl.NodeRole.ORIGIN, pnl.NodeRole.TERMINAL])
+    C.add_node(M, required_roles=[pnl.NodeRole.INPUT, pnl.NodeRole.OUTPUT])
     C.add_node(control)
     inputs = {M:[1], control:[3]}
     val = C.run(inputs, num_trials=1, execution_mode=comp_mode)

--- a/tests/mechanisms/test_modulatory_mechanism.py
+++ b/tests/mechanisms/test_modulatory_mechanism.py
@@ -51,7 +51,7 @@ class TestControlMechanism:
 
         comp = Composition(enable_controller=True)
         comp.add_linear_processing_pathway(pathway=[Tx,Tz])
-        comp.add_node(Ty, required_roles=NodeRole.TERMINAL)
+        comp.add_node(Ty, required_roles=NodeRole.OUTPUT)
         comp.add_controller(C)
 
         assert Tz.parameter_ports[SLOPE].mod_afferents[0].sender.owner == C

--- a/tests/ports/test_input_ports.py
+++ b/tests/ports/test_input_ports.py
@@ -109,7 +109,13 @@ class TestInputPorts:
             assert m.input_port.internal_only is True
         else:
             assert m.input_port.internal_only is False
-        comp = pnl.Composition(nodes=(m, pnl.NodeRole.INTERNAL))
+        comp = pnl.Composition()
+        comp.add_node(
+            m,
+            required_roles=pnl.NodeRole.INTERNAL,
+            context=pnl.Context(source=pnl.ContextFlags.METHOD)
+        )
+        comp._analyze_graph()
         assert pnl.NodeRole.INTERNAL in comp.get_roles_by_node(m)
         assert pnl.NodeRole.INPUT not in comp.get_roles_by_node(m)
 


### PR DESCRIPTION
ControlMechanisms that control something within an inner Composition automatically create MappingProjections to the inner Composition's parameter CIM. This created a scheduling dependency in all cases. These changes cause this dependency to be created only when the pathway/projection from the ControlMechanism to the inner Composition is explicitly created by the user.