### PR TITLE
llvm: Use weak references and proxy objects in _node_wrapper objects

### DIFF
--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -63,7 +63,7 @@ _builtin_intrinsics = frozenset(('pow', 'log', 'exp', 'tanh', 'coth', 'csch',
 
 class _node_wrapper():
     def __init__(self, composition, node):
-        self._comp = composition
+        self._comp = weakref.proxy(composition)
         self._node = node
 
     def _gen_llvm_function(self, *, ctx, tags:frozenset):

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -403,7 +403,7 @@ class LLVMBuilderContext:
     def get_node_wrapper(self, composition, node):
         cache = getattr(composition, '_node_wrappers', None)
         if cache is None:
-            cache = dict()
+            cache = weakref.WeakKeyDictionary()
             setattr(composition, '_node_wrappers', cache)
         return cache.setdefault(node, _node_wrapper(composition, node))
 

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -66,6 +66,9 @@ class _node_wrapper():
         self._comp = weakref.proxy(composition)
         self._node = node
 
+    def __repr__(self):
+        return "Node wrapper for node '{}' in composition '{}'".format(self._node, self._comp)
+
     def _gen_llvm_function(self, *, ctx, tags:frozenset):
         return codegen.gen_node_wrapper(ctx, self._comp, self._node, tags=tags)
 


### PR DESCRIPTION
Add human-readable name