### PR TITLE
Fix/contentaddressablememory empty entry

### DIFF
--- a/psyneulink/core/components/functions/stateful/memoryfunctions.py
+++ b/psyneulink/core/components/functions/stateful/memoryfunctions.py
@@ -1685,7 +1685,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         if field_weights is None:
             # Could be from get_memory called from COMMAND LINE without field_weights
             field_weights = self._get_current_parameter_value('distance_field_weights', context)
-        # Set item in field_weights to None if it is None or an empty list:
+        # Set any items in field_weights to None if they are None or an empty list:
         field_weights = np.atleast_1d([None if
                                        fw is None or fw == [] or isinstance(fw, np.ndarray) and fw.tolist()==[]
                                        else fw

--- a/psyneulink/core/components/functions/stateful/memoryfunctions.py
+++ b/psyneulink/core/components/functions/stateful/memoryfunctions.py
@@ -1696,21 +1696,14 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
             #                               ) * np.array([f if f is not None else 0 for f in field_weights])
             # Report None if any element of cue, candidate or field_weights is None or empty list:
             distances_by_field = np.array([None]*num_fields)
-            for i in range(num_fields):
-                if all([(item is not None and item is not []) for item in [cue[i], candidate[i], field_weights]]):
-                    distances_by_field[i] = distance_fct([cue[i], candidate[i]])
-            # Replace None's in field_weights with 0 to allow multiplication
-            distances_by_field = distances_by_field * np.array([f if f is not None else 0 for f in field_weights])
-            # distances_by_field = np.array([distance_fct([cue[i], candidate[i]])
-            #                                if all([(item is not None and item != []) for item in [cue[i], candidate[i], field_weights]]) else None]
-            #                                for i in range(num_fields))
             # If field_weights is scalar, splay out as array of length num_fields so can iterate through all of them
             if len(field_weights)==1:
                 field_weights = np.full(num_fields, field_weights[0])
-            # Replace 0's with None's for fields with None in field_weights
-            distances_by_field = np.array([distances_by_field[i]
-                                           if f is not None else None for i,f in enumerate(field_weights)])
-            return distances_by_field
+            for i in range(num_fields):
+                if not any([item is None or item == [] or isinstance(item, np.ndarray) and item.tolist() == []
+                            for item in [cue[i], candidate[i], field_weights[i]]]):
+                    distances_by_field[i] = distance_fct([cue[i], candidate[i]]) * field_weights[i]
+            return list(distances_by_field)
 
         elif granularity == 'full_entry':
             # Use first element as scalar if it is a homogenous array (i.e., all elements are the same)

--- a/psyneulink/core/components/functions/stateful/memoryfunctions.py
+++ b/psyneulink/core/components/functions/stateful/memoryfunctions.py
@@ -1690,10 +1690,20 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         if granularity == 'per_field':
             # Note: this is just used for reporting, and not determining storage or retrieval
 
-            # Replace None's with 0 to allow multiplication
-            distances_by_field = np.array([distance_fct([cue[i], candidate[i]])
-                                           for i in range(num_fields)]
-                                          ) * np.array([f if f is not None else 0 for f in field_weights])
+            # # Replace None's with 0 to allow multiplication
+            # old_distances_by_field = np.array([distance_fct([cue[i], candidate[i]])
+            #                                for i in range(num_fields)]
+            #                               ) * np.array([f if f is not None else 0 for f in field_weights])
+            # Report None if any element of cue, candidate or field_weights is None or empty list:
+            distances_by_field = np.array([None]*num_fields)
+            for i in range(num_fields):
+                if all([(item is not None and item is not []) for item in [cue[i], candidate[i], field_weights]]):
+                    distances_by_field[i] = distance_fct([cue[i], candidate[i]])
+            # Replace None's in field_weights with 0 to allow multiplication
+            distances_by_field = distances_by_field * np.array([f if f is not None else 0 for f in field_weights])
+            # distances_by_field = np.array([distance_fct([cue[i], candidate[i]])
+            #                                if all([(item is not None and item != []) for item in [cue[i], candidate[i], field_weights]]) else None]
+            #                                for i in range(num_fields))
             # If field_weights is scalar, splay out as array of length num_fields so can iterate through all of them
             if len(field_weights)==1:
                 field_weights = np.full(num_fields, field_weights[0])

--- a/psyneulink/core/components/functions/stateful/memoryfunctions.py
+++ b/psyneulink/core/components/functions/stateful/memoryfunctions.py
@@ -1693,7 +1693,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         if granularity == 'per_field':
             # Note: this is just used for reporting, and not determining storage or retrieval
             # Report None if any element of cue, candidate or field_weights is None or empty list:
-            distances_by_field = np.array([None]*num_fields)
+            distances_by_field = np.array([None] * num_fields)
             # If field_weights is scalar, splay out as array of length num_fields so can iterate through all of them
             if len(field_weights)==1:
                 field_weights = np.full(num_fields, field_weights[0])

--- a/psyneulink/core/components/functions/stateful/memoryfunctions.py
+++ b/psyneulink/core/components/functions/stateful/memoryfunctions.py
@@ -1685,15 +1685,13 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         if field_weights is None:
             # Could be from get_memory called from COMMAND LINE without field_weights
             field_weights = self._get_current_parameter_value('distance_field_weights', context)
-        field_weights = np.atleast_1d(field_weights)
-
+        # Set item in field_weights to None if it is None or an empty list:
+        field_weights = np.atleast_1d([None if
+                                       fw is None or fw == [] or isinstance(fw, np.ndarray) and fw.tolist()==[]
+                                       else fw
+                                       for fw in field_weights])
         if granularity == 'per_field':
             # Note: this is just used for reporting, and not determining storage or retrieval
-
-            # # Replace None's with 0 to allow multiplication
-            # old_distances_by_field = np.array([distance_fct([cue[i], candidate[i]])
-            #                                for i in range(num_fields)]
-            #                               ) * np.array([f if f is not None else 0 for f in field_weights])
             # Report None if any element of cue, candidate or field_weights is None or empty list:
             distances_by_field = np.array([None]*num_fields)
             # If field_weights is scalar, splay out as array of length num_fields so can iterate through all of them

--- a/tests/functions/test_memory.py
+++ b/tests/functions/test_memory.py
@@ -678,23 +678,23 @@ class TestContentAddressableMemory:
         c.distance_field_weights=[1,0]
         retrieved = c([[1,2,3],[4,5,10]])
         assert np.all(retrieved==np.array([[1,2,3],[4,5,6]]))
-        assert all(c.distances_by_field == [0.0, 0.0])
+        assert c.distances_by_field == [0.0, 0.0]
 
         c.distance_field_weights=[0,1]
         retrieved = c([[1,2,3],[4,5,10]])
         assert np.all(retrieved==np.array([[1,2,10],[4,5,10]]))
-        assert all(c.distances_by_field == [0.0, 0.0])
+        assert c.distances_by_field == [0.0, 0.0]
 
         # Test with None as field weight
         c.distance_field_weights=[None,1]
         retrieved = c([[1,2,3],[4,5,10]])
         assert np.all(retrieved==np.array([[1,2,10],[4,5,10]]))
-        assert all(c.distances_by_field == [None, 0.0])
+        assert c.distances_by_field == [None, 0.0]
 
         c.distance_field_weights=[1, None]
         retrieved = c([[1,2,3],[4,5,10]])
         assert np.all(retrieved==np.array([[1,2,3],[4,5,6]]))
-        assert all(c.distances_by_field == [0.0, None])
+        assert c.distances_by_field == [0.0, None]
 
     # FIX: COULD CONDENSE THESE TESTS BY PARAMETERIZING FIELD-WEIGHTS AND ALSO INCLUDE DISTANCE METRIC AS A PARAM
     def test_ContentAddressableMemory_parametric_distances(self):

--- a/tests/functions/test_memory.py
+++ b/tests/functions/test_memory.py
@@ -696,6 +696,17 @@ class TestContentAddressableMemory:
         assert np.all(retrieved==np.array([[1,2,3],[4,5,6]]))
         assert c.distances_by_field == [0.0, None]
 
+        # Test with [] as field weight
+        c.distance_field_weights=[[],1]
+        retrieved = c([[1,2,3],[4,5,10]])
+        assert np.all(retrieved==np.array([[1,2,10],[4,5,10]]))
+        assert c.distances_by_field == [None, 0.0]
+
+        c.distance_field_weights=[1, []]
+        retrieved = c([[1,2,3],[4,5,10]])
+        assert np.all(retrieved==np.array([[1,2,3],[4,5,6]]))
+        assert c.distances_by_field == [0.0, None]
+
     # FIX: COULD CONDENSE THESE TESTS BY PARAMETERIZING FIELD-WEIGHTS AND ALSO INCLUDE DISTANCE METRIC AS A PARAM
     def test_ContentAddressableMemory_parametric_distances(self):
 

--- a/tests/json/model_backprop.json
+++ b/tests/json/model_backprop.json
@@ -1,0 +1,1547 @@
+{
+    "Composition-0": {
+        "format": "ModECI MDF v0.3.3",
+        "generating_application": "PsyNeuLink v0.11.0.0+343.gfba4374945",
+        "graphs": {
+            "Composition_0": {
+                "conditions": {
+                    "node_specific": {
+                        "Target": {
+                            "type": "Always",
+                            "args": {}
+                        },
+                        "TransferMechanism_0": {
+                            "type": "Always",
+                            "args": {}
+                        },
+                        "TransferMechanism_1": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "TransferMechanism_0",
+                                "n": 1
+                            }
+                        },
+                        "TransferMechanism_2": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "TransferMechanism_1",
+                                "n": 1
+                            }
+                        },
+                        "Comparator": {
+                            "type": "All",
+                            "args": {
+                                "args": [
+                                    {
+                                        "type": "EveryNCalls",
+                                        "args": {
+                                            "dependency": "Target",
+                                            "n": 1
+                                        }
+                                    },
+                                    {
+                                        "type": "EveryNCalls",
+                                        "args": {
+                                            "dependency": "TransferMechanism_2",
+                                            "n": 1
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_1_RESULT__to_TransferMechanism_2_InputPort_0_": {
+                            "type": "All",
+                            "args": {
+                                "args": [
+                                    {
+                                        "type": "EveryNCalls",
+                                        "args": {
+                                            "dependency": "Comparator",
+                                            "n": 1
+                                        }
+                                    },
+                                    {
+                                        "type": "EveryNCalls",
+                                        "args": {
+                                            "dependency": "TransferMechanism_1",
+                                            "n": 1
+                                        }
+                                    },
+                                    {
+                                        "type": "EveryNCalls",
+                                        "args": {
+                                            "dependency": "TransferMechanism_2",
+                                            "n": 1
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_0_RESULT__to_TransferMechanism_1_InputPort_0_": {
+                            "type": "All",
+                            "args": {
+                                "args": [
+                                    {
+                                        "type": "EveryNCalls",
+                                        "args": {
+                                            "dependency": "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_1_RESULT__to_TransferMechanism_2_InputPort_0_",
+                                            "n": 1
+                                        }
+                                    },
+                                    {
+                                        "type": "EveryNCalls",
+                                        "args": {
+                                            "dependency": "TransferMechanism_1",
+                                            "n": 1
+                                        }
+                                    },
+                                    {
+                                        "type": "EveryNCalls",
+                                        "args": {
+                                            "dependency": "TransferMechanism_0",
+                                            "n": 1
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "termination": {
+                        "environment_sequence": {
+                            "type": "Never",
+                            "args": {}
+                        },
+                        "environment_state_update": {
+                            "type": "AllHaveRun",
+                            "args": {
+                                "dependencies": []
+                            }
+                        }
+                    }
+                },
+                "metadata": {
+                    "type": "Composition",
+                    "input_specification": null,
+                    "has_initializers": false,
+                    "retain_old_simulation_data": false,
+                    "execute_until_finished": true,
+                    "max_executions_before_finished": 1000,
+                    "results": [],
+                    "variable": [
+                        0
+                    ],
+                    "simulation_results": [],
+                    "node_ordering": [
+                        "TransferMechanism_0",
+                        "TransferMechanism_1",
+                        "TransferMechanism_2",
+                        "Target",
+                        "Comparator",
+                        "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_1_RESULT__to_TransferMechanism_2_InputPort_0_",
+                        "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_0_RESULT__to_TransferMechanism_1_InputPort_0_"
+                    ],
+                    "required_node_roles": [
+                        [
+                            "Target",
+                            "NodeRole.TARGET"
+                        ],
+                        [
+                            "Target",
+                            "NodeRole.LEARNING"
+                        ],
+                        [
+                            "Comparator",
+                            "NodeRole.LEARNING_OBJECTIVE"
+                        ],
+                        [
+                            "Comparator",
+                            "NodeRole.LEARNING"
+                        ],
+                        [
+                            "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_1_RESULT__to_TransferMechanism_2_InputPort_0_",
+                            "NodeRole.LEARNING"
+                        ],
+                        [
+                            "TransferMechanism_2",
+                            "NodeRole.OUTPUT"
+                        ],
+                        [
+                            "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_0_RESULT__to_TransferMechanism_1_InputPort_0_",
+                            "NodeRole.LEARNING"
+                        ]
+                    ],
+                    "controller": null
+                },
+                "nodes": {
+                    "TransferMechanism_0": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_0": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_0"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_1": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "TransferMechanism_0_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_5": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "TransferMechanism_0_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "TransferMechanism_0_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "TransferMechanism_0_RESULT": {
+                                "value": "Linear_Function_5",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "TransferMechanism_1": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_1": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_1"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_3": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "TransferMechanism_1_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_14": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "TransferMechanism_1_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "TransferMechanism_1_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "TransferMechanism_1_RESULT": {
+                                "value": "Linear_Function_14",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "TransferMechanism_2": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_2": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_2"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_5": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "TransferMechanism_2_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_23": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "TransferMechanism_2_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "TransferMechanism_2_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "TransferMechanism_2_RESULT": {
+                                "value": "Linear_Function_23",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "Target": {
+                        "metadata": {
+                            "type": "ProcessingMechanism",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0.0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null
+                        },
+                        "input_ports": {
+                            "Target_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_39": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "Target_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "Target_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0.0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "Target_OutputPort_0": {
+                                "value": "Linear_Function_39",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "Comparator": {
+                        "metadata": {
+                            "type": "ComparatorMechanism",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0.0
+                                ],
+                                [
+                                    0.0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": [
+                                "OUTCOME",
+                                "MSE"
+                            ],
+                            "sample": null,
+                            "input_ports": [
+                                {}
+                            ],
+                            "target": null
+                        },
+                        "input_ports": {
+                            "Comparator_SAMPLE": {
+                                "shape": "(1,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null
+                                }
+                            },
+                            "Comparator_TARGET": {
+                                "shape": "(1,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "LinearCombination_Function_1": {
+                                "function": {
+                                    "linearcombination": {
+                                        "offset": 0.0,
+                                        "scale": 1.0,
+                                        "variable0": "Comparator_SAMPLE"
+                                    }
+                                },
+                                "args": {
+                                    "offset": 0.0,
+                                    "scale": 1.0,
+                                    "variable0": "Comparator_SAMPLE"
+                                },
+                                "metadata": {
+                                    "type": "LinearCombination",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0.0
+                                        ],
+                                        [
+                                            0.0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "operation": "sum",
+                                    "weights": null,
+                                    "exponents": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "Comparator_OUTCOME": {
+                                "value": "LinearCombination_Function_1",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": false,
+                                    "projections": null
+                                }
+                            },
+                            "Comparator_MSE": {
+                                "value": "LinearCombination_Function_1",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": false,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_1_RESULT__to_TransferMechanism_2_InputPort_0_": {
+                        "metadata": {
+                            "type": "LearningMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0.0
+                                ],
+                                [
+                                    0.0
+                                ],
+                                [
+                                    0.0
+                                ]
+                            ],
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "learning_signal": null,
+                            "learning_enabled": "after",
+                            "modulation": "additive_param",
+                            "error_matrix": null,
+                            "learning_signals": [
+                                {
+                                    "name": "LearningSignal",
+                                    "variable": [
+                                        "OWNER_VALUE",
+                                        0
+                                    ]
+                                }
+                            ],
+                            "input_ports": [
+                                "activation_input",
+                                "activation_output",
+                                "error_signal"
+                            ],
+                            "output_ports": [
+                                {
+                                    "name": "error_signal",
+                                    "port_type": "OutputPort",
+                                    "variable": [
+                                        "OWNER_VALUE",
+                                        1
+                                    ]
+                                }
+                            ],
+                            "error_signal": null
+                        },
+                        "input_ports": {
+                            "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_1_RESULT__to_TransferMechanism_2_InputPort_0__activation_input": {
+                                "shape": "(1,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            },
+                            "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_1_RESULT__to_TransferMechanism_2_InputPort_0__activation_output": {
+                                "shape": "(1,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            },
+                            "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_1_RESULT__to_TransferMechanism_2_InputPort_0__error_signal": {
+                                "shape": "(1,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Backpropagation_Learning_Function_0": {
+                                "function": {
+                                    "backpropagation": {
+                                        "learning_rate": 0.05,
+                                        "error_matrix": [
+                                            [
+                                                0.0
+                                            ]
+                                        ],
+                                        "variable0": "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_1_RESULT__to_TransferMechanism_2_InputPort_0__activation_input"
+                                    }
+                                },
+                                "args": {
+                                    "learning_rate": 0.05,
+                                    "error_matrix": [
+                                        [
+                                            0.0
+                                        ]
+                                    ],
+                                    "variable0": "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_1_RESULT__to_TransferMechanism_2_InputPort_0__activation_input"
+                                },
+                                "metadata": {
+                                    "type": "BackPropagation",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0.0
+                                        ],
+                                        [
+                                            0.0
+                                        ],
+                                        [
+                                            0.0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.DEFAULT",
+                                    "activation_derivative_fct": null,
+                                    "loss_function": "MSE",
+                                    "activation_output": [
+                                        0
+                                    ],
+                                    "error_signal": [
+                                        0
+                                    ],
+                                    "activation_input": [
+                                        0
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_1_RESULT__to_TransferMechanism_2_InputPort_0__error_signal": {
+                                "value": "Backpropagation_Learning_Function_0[1]",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            },
+                            "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_1_RESULT__to_TransferMechanism_2_InputPort_0__LearningSignal": {
+                                "value": "Backpropagation_Learning_Function_0[0]",
+                                "metadata": {
+                                    "type": "LearningSignal",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            0.0
+                                        ]
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "learning_rate": null,
+                                    "modulation": "additive_param",
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_0_RESULT__to_TransferMechanism_1_InputPort_0_": {
+                        "metadata": {
+                            "type": "LearningMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0.0
+                                ],
+                                [
+                                    0.0
+                                ],
+                                [
+                                    0.0
+                                ]
+                            ],
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "learning_signal": null,
+                            "learning_enabled": "after",
+                            "modulation": "additive_param",
+                            "error_matrix": null,
+                            "learning_signals": [
+                                {
+                                    "name": "LearningSignal",
+                                    "variable": [
+                                        "OWNER_VALUE",
+                                        0
+                                    ]
+                                }
+                            ],
+                            "input_ports": [
+                                "activation_input",
+                                "activation_output",
+                                "error_signal"
+                            ],
+                            "output_ports": [
+                                {
+                                    "name": "error_signal",
+                                    "port_type": "OutputPort",
+                                    "variable": [
+                                        "OWNER_VALUE",
+                                        1
+                                    ]
+                                }
+                            ],
+                            "error_signal": null
+                        },
+                        "input_ports": {
+                            "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_0_RESULT__to_TransferMechanism_1_InputPort_0__activation_input": {
+                                "shape": "(1,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            },
+                            "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_0_RESULT__to_TransferMechanism_1_InputPort_0__activation_output": {
+                                "shape": "(1,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            },
+                            "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_0_RESULT__to_TransferMechanism_1_InputPort_0__error_signal": {
+                                "shape": "(1,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Backpropagation_Learning_Function_3": {
+                                "function": {
+                                    "backpropagation": {
+                                        "learning_rate": 0.05,
+                                        "error_matrix": [
+                                            [
+                                                0.0
+                                            ]
+                                        ],
+                                        "variable0": "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_0_RESULT__to_TransferMechanism_1_InputPort_0__activation_input"
+                                    }
+                                },
+                                "args": {
+                                    "learning_rate": 0.05,
+                                    "error_matrix": [
+                                        [
+                                            0.0
+                                        ]
+                                    ],
+                                    "variable0": "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_0_RESULT__to_TransferMechanism_1_InputPort_0__activation_input"
+                                },
+                                "metadata": {
+                                    "type": "BackPropagation",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0.0
+                                        ],
+                                        [
+                                            0.0
+                                        ],
+                                        [
+                                            0.0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.DEFAULT",
+                                    "activation_derivative_fct": null,
+                                    "loss_function": null,
+                                    "activation_output": [
+                                        0
+                                    ],
+                                    "error_signal": [
+                                        0
+                                    ],
+                                    "activation_input": [
+                                        0
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_0_RESULT__to_TransferMechanism_1_InputPort_0__error_signal": {
+                                "value": "Backpropagation_Learning_Function_3[1]",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": false,
+                                    "projections": null
+                                }
+                            },
+                            "Learning_Mechanism_for_MappingProjection_from_TransferMechanism_0_RESULT__to_TransferMechanism_1_InputPort_0__LearningSignal": {
+                                "value": "Backpropagation_Learning_Function_3[0]",
+                                "metadata": {
+                                    "type": "LearningSignal",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            0.0
+                                        ]
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "learning_rate": null,
+                                    "modulation": "additive_param",
+                                    "projections": null
+                                }
+                            }
+                        }
+                    }
+                },
+                "edges": {
+                    "MappingProjection_from_TransferMechanism_0_RESULT__to_TransferMechanism_1_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "TransferMechanism_0",
+                        "receiver": "TransferMechanism_1",
+                        "sender_port": "TransferMechanism_0_RESULT",
+                        "receiver_port": "TransferMechanism_1_InputPort_0",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_0": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_TransferMechanism_1_RESULT__to_TransferMechanism_2_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "TransferMechanism_1",
+                        "receiver": "TransferMechanism_2",
+                        "sender_port": "TransferMechanism_1_RESULT",
+                        "receiver_port": "TransferMechanism_2_InputPort_0",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_1": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_Target_OutputPort_0__to_Comparator_TARGET_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "Target",
+                        "receiver": "Comparator",
+                        "sender_port": "Target_OutputPort_0",
+                        "receiver_port": "Comparator_TARGET",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_5": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_TransferMechanism_2_RESULT__to_Comparator_SAMPLE_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "TransferMechanism_2",
+                        "receiver": "Comparator",
+                        "sender_port": "TransferMechanism_2_RESULT",
+                        "receiver_port": "Comparator_SAMPLE",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_4": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/json/model_basic.json
+++ b/tests/json/model_basic.json
@@ -1,0 +1,488 @@
+{
+    "comp": {
+        "format": "ModECI MDF v0.3.3",
+        "generating_application": "PsyNeuLink v0.11.0.0+343.gfba4374945",
+        "graphs": {
+            "comp": {
+                "conditions": {
+                    "node_specific": {
+                        "A": {
+                            "type": "EveryNPasses",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                            }
+                        },
+                        "B": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "A",
+                                "n": 2
+                            }
+                        }
+                    },
+                    "termination": {
+                        "environment_sequence": {
+                            "type": "AfterNEnvironmentStateUpdates",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_SEQUENCE"
+                            }
+                        },
+                        "environment_state_update": {
+                            "type": "All",
+                            "args": {
+                                "args": [
+                                    {
+                                        "type": "Not",
+                                        "args": {
+                                            "condition": {
+                                                "type": "BeforeNCalls",
+                                                "args": {
+                                                    "dependency": "B",
+                                                    "n": 5,
+                                                    "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "metadata": {
+                    "type": "Composition",
+                    "input_specification": null,
+                    "has_initializers": false,
+                    "retain_old_simulation_data": false,
+                    "execute_until_finished": true,
+                    "max_executions_before_finished": 1000,
+                    "results": [],
+                    "variable": [
+                        0
+                    ],
+                    "simulation_results": [],
+                    "node_ordering": [
+                        "A",
+                        "B"
+                    ],
+                    "required_node_roles": [],
+                    "controller": null
+                },
+                "nodes": {
+                    "A": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_0": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_0"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_1": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "A_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_6": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 2.0,
+                                        "slope": 5.0,
+                                        "variable0": "A_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 2.0,
+                                    "slope": 5.0,
+                                    "variable0": "A_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "A_RESULT": {
+                                "value": "Linear_Function_6",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        2.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "B": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_1": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_1"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_3": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "B_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Logistic_Function_0": {
+                                "function": {
+                                    "logistic": {
+                                        "offset": 0.0,
+                                        "gain": 1.0,
+                                        "scale": 1.0,
+                                        "bias": 0.0,
+                                        "x_0": 0,
+                                        "variable0": "B_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "offset": 0.0,
+                                    "gain": 1.0,
+                                    "scale": 1.0,
+                                    "bias": 0.0,
+                                    "x_0": 0,
+                                    "variable0": "B_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Logistic",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": [
+                                        0,
+                                        1
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "B_RESULT": {
+                                "value": "Logistic_Function_0",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.5
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    }
+                },
+                "edges": {
+                    "MappingProjection_from_A_RESULT__to_B_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "A",
+                        "receiver": "B",
+                        "sender_port": "A_RESULT",
+                        "receiver_port": "B_InputPort_0",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_0": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            2.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/json/model_basic_non_identity.json
+++ b/tests/json/model_basic_non_identity.json
@@ -1,0 +1,541 @@
+{
+    "comp": {
+        "format": "ModECI MDF v0.3.3",
+        "generating_application": "PsyNeuLink v0.11.0.0+343.gfba4374945",
+        "graphs": {
+            "comp": {
+                "conditions": {
+                    "node_specific": {
+                        "A": {
+                            "type": "EveryNPasses",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                            }
+                        },
+                        "B": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "A",
+                                "n": 2
+                            }
+                        }
+                    },
+                    "termination": {
+                        "environment_sequence": {
+                            "type": "AfterNEnvironmentStateUpdates",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_SEQUENCE"
+                            }
+                        },
+                        "environment_state_update": {
+                            "type": "AfterNCalls",
+                            "args": {
+                                "dependency": "B",
+                                "n": 4,
+                                "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                            }
+                        }
+                    }
+                },
+                "metadata": {
+                    "type": "Composition",
+                    "input_specification": null,
+                    "has_initializers": false,
+                    "retain_old_simulation_data": false,
+                    "execute_until_finished": true,
+                    "max_executions_before_finished": 1000,
+                    "results": [],
+                    "variable": [
+                        0
+                    ],
+                    "simulation_results": [],
+                    "node_ordering": [
+                        "A",
+                        "B"
+                    ],
+                    "required_node_roles": [],
+                    "excluded_node_roles": [
+                        [
+                            "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node",
+                            "NodeRole.OUTPUT"
+                        ]
+                    ],
+                    "controller": null
+                },
+                "nodes": {
+                    "A": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_0": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_0"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_1": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "A_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_6": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 2.0,
+                                        "slope": 5.0,
+                                        "variable0": "A_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 2.0,
+                                    "slope": 5.0,
+                                    "variable0": "A_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "A_RESULT": {
+                                "value": "Linear_Function_6",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        2.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "B": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_1": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_1"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_3": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "B_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Logistic_Function_0": {
+                                "function": {
+                                    "logistic": {
+                                        "offset": 0.0,
+                                        "gain": 1.0,
+                                        "scale": 1.0,
+                                        "bias": 0.0,
+                                        "x_0": 0,
+                                        "variable0": "B_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "offset": 0.0,
+                                    "gain": 1.0,
+                                    "scale": 1.0,
+                                    "bias": 0.0,
+                                    "x_0": 0,
+                                    "variable0": "B_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Logistic",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": [
+                                        0,
+                                        1
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "B_RESULT": {
+                                "value": "Logistic_Function_0",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.5
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node": {
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    2.0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null,
+                            "exponent": null,
+                            "weight": null
+                        },
+                        "input_ports": {
+                            "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        2.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "LinearMatrix_Function_6": {
+                                "function": {
+                                    "onnx::MatMul": {
+                                        "B": [
+                                            [
+                                                2.0
+                                            ]
+                                        ],
+                                        "A": "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "B": [
+                                        [
+                                            2.0
+                                        ]
+                                    ],
+                                    "A": "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "LinearMatrix",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "A": [
+                                        2.0
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node_OutputPort_0": {
+                                "value": "LinearMatrix_Function_6",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        4.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    }
+                },
+                "edges": {
+                    "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_pre_edge": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "A",
+                        "receiver": "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node",
+                        "sender_port": "A_RESULT",
+                        "receiver_port": "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node_InputPort_0"
+                    },
+                    "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_post_edge": {
+                        "sender": "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node",
+                        "receiver": "B",
+                        "sender_port": "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node_OutputPort_0",
+                        "receiver_port": "B_InputPort_0"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/json/model_integrators.json
+++ b/tests/json/model_integrators.json
@@ -1,0 +1,1895 @@
+{
+    "comp": {
+        "format": "ModECI MDF v0.3.3",
+        "generating_application": "PsyNeuLink v0.11.0.0+343.gfba4374945",
+        "graphs": {
+            "comp": {
+                "conditions": {
+                    "node_specific": {
+                        "A": {
+                            "type": "EveryNPasses",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                            }
+                        },
+                        "B": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "A",
+                                "n": 2
+                            }
+                        },
+                        "C": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "B",
+                                "n": 2
+                            }
+                        },
+                        "D": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "C",
+                                "n": 2
+                            }
+                        },
+                        "E": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "D",
+                                "n": 2
+                            }
+                        }
+                    },
+                    "termination": {
+                        "environment_sequence": {
+                            "type": "AfterNEnvironmentStateUpdates",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_SEQUENCE"
+                            }
+                        },
+                        "environment_state_update": {
+                            "type": "All",
+                            "args": {
+                                "args": [
+                                    {
+                                        "type": "Not",
+                                        "args": {
+                                            "condition": {
+                                                "type": "BeforeNCalls",
+                                                "args": {
+                                                    "dependency": "E",
+                                                    "n": 5,
+                                                    "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "metadata": {
+                    "type": "Composition",
+                    "input_specification": null,
+                    "has_initializers": false,
+                    "retain_old_simulation_data": false,
+                    "execute_until_finished": true,
+                    "max_executions_before_finished": 1000,
+                    "results": [],
+                    "variable": [
+                        0
+                    ],
+                    "simulation_results": [],
+                    "node_ordering": [
+                        "A",
+                        "B",
+                        "C",
+                        "D",
+                        "E"
+                    ],
+                    "required_node_roles": [],
+                    "controller": null
+                },
+                "nodes": {
+                    "A": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "SimpleIntegrator_Function_0": {
+                                    "value": "previous_value + (variable0 * rate) + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5
+                                    },
+                                    "metadata": {
+                                        "type": "SimpleIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "noise": {
+                                            "Uniform_Distribution_Function_0": {
+                                                "function": {
+                                                    "onnx::RandomUniform": {
+                                                        "seed": 0,
+                                                        "high": 1.0,
+                                                        "low": -1.0,
+                                                        "shape": [
+                                                            1,
+                                                            1
+                                                        ]
+                                                    }
+                                                },
+                                                "args": {
+                                                    "seed": 0,
+                                                    "high": 1.0,
+                                                    "low": -1.0,
+                                                    "shape": [
+                                                        1,
+                                                        1
+                                                    ]
+                                                },
+                                                "metadata": {
+                                                    "type": "UniformDist",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "enable_output_type_conversion": false,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        [
+                                                            0
+                                                        ]
+                                                    ],
+                                                    "changes_shape": false,
+                                                    "output_type": "FunctionOutputType.DEFAULT",
+                                                    "random_state": null,
+                                                    "function_stateful_params": {}
+                                                }
+                                            }
+                                        },
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "SimpleIntegrator_Function_0"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_1": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": true,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "A_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_6": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 1.0,
+                                        "slope": 0.5,
+                                        "variable0": "SimpleIntegrator_Function_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 1.0,
+                                    "slope": 0.5,
+                                    "variable0": "SimpleIntegrator_Function_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            },
+                            "SimpleIntegrator_Function_0": {
+                                "value": "previous_value + (A_InputPort_0 * 0.5) + A_SimpleIntegrator_Function_0_noise + 0.0",
+                                "args": {
+                                    "offset": 0.0,
+                                    "rate": 0.5,
+                                    "variable0": "A_InputPort_0",
+                                    "noise": "A_SimpleIntegrator_Function_0_noise"
+                                },
+                                "metadata": {
+                                    "type": "SimpleIntegrator",
+                                    "has_initializers": true,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": false,
+                                    "output_type": "FunctionOutputType.DEFAULT",
+                                    "initializer": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "noise": {
+                                        "Uniform_Distribution_Function_0": {
+                                            "function": {
+                                                "onnx::RandomUniform": {
+                                                    "seed": 0,
+                                                    "high": 1.0,
+                                                    "low": -1.0,
+                                                    "shape": [
+                                                        1,
+                                                        1
+                                                    ]
+                                                }
+                                            },
+                                            "args": {
+                                                "seed": 0,
+                                                "high": 1.0,
+                                                "low": -1.0,
+                                                "shape": [
+                                                    1,
+                                                    1
+                                                ]
+                                            },
+                                            "metadata": {
+                                                "type": "UniformDist",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "enable_output_type_conversion": false,
+                                                "max_executions_before_finished": 1000,
+                                                "variable": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "changes_shape": false,
+                                                "output_type": "FunctionOutputType.DEFAULT",
+                                                "random_state": null,
+                                                "function_stateful_params": {}
+                                            }
+                                        }
+                                    },
+                                    "function_stateful_params": {
+                                        "previous_value": {
+                                            "id": "previous_value",
+                                            "default_initial_value": [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            "value": "SimpleIntegrator_Function_0"
+                                        }
+                                    }
+                                }
+                            },
+                            "A_SimpleIntegrator_Function_0_noise": {
+                                "value": "Uniform_Distribution_Function_2",
+                                "args": {
+                                    "variable0": "Uniform_Distribution_Function_2"
+                                }
+                            },
+                            "Uniform_Distribution_Function_2": {
+                                "function": {
+                                    "onnx::RandomUniform": {
+                                        "seed": 0,
+                                        "high": 1.0,
+                                        "low": -1.0,
+                                        "shape": [
+                                            1,
+                                            1
+                                        ]
+                                    }
+                                },
+                                "args": {
+                                    "seed": 0,
+                                    "high": 1.0,
+                                    "low": -1.0,
+                                    "shape": [
+                                        1,
+                                        1
+                                    ]
+                                },
+                                "metadata": {
+                                    "type": "UniformDist",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.DEFAULT",
+                                    "random_state": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "previous_value": {
+                                "default_initial_value": [
+                                    [
+                                        0
+                                    ]
+                                ],
+                                "value": "SimpleIntegrator_Function_0"
+                            }
+                        },
+                        "output_ports": {
+                            "A_RESULT": {
+                                "value": "Linear_Function_6",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        1.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "B": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_0": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": -1,
+                                        "rate": 0.9
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "noise": {
+                                            "Normal_Distribution_Function_0": {
+                                                "function": {
+                                                    "onnx::RandomNormal": {
+                                                        "mean": -1.0,
+                                                        "seed": 0,
+                                                        "scale": 0.5,
+                                                        "shape": [
+                                                            1,
+                                                            1
+                                                        ]
+                                                    }
+                                                },
+                                                "args": {
+                                                    "mean": -1.0,
+                                                    "seed": 0,
+                                                    "scale": 0.5,
+                                                    "shape": [
+                                                        1,
+                                                        1
+                                                    ]
+                                                },
+                                                "metadata": {
+                                                    "type": "NormalDist",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "enable_output_type_conversion": false,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        [
+                                                            0
+                                                        ]
+                                                    ],
+                                                    "changes_shape": false,
+                                                    "output_type": "FunctionOutputType.DEFAULT",
+                                                    "random_state": null,
+                                                    "function_stateful_params": {}
+                                                }
+                                            }
+                                        },
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_0"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_3": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": true,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "B_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Logistic_Function_0": {
+                                "function": {
+                                    "logistic": {
+                                        "offset": 0.0,
+                                        "gain": 0.1,
+                                        "scale": 1.0,
+                                        "bias": 0.0,
+                                        "x_0": 0,
+                                        "variable0": "AdaptiveIntegrator_Function_0"
+                                    }
+                                },
+                                "args": {
+                                    "offset": 0.0,
+                                    "gain": 0.1,
+                                    "scale": 1.0,
+                                    "bias": 0.0,
+                                    "x_0": 0,
+                                    "variable0": "AdaptiveIntegrator_Function_0"
+                                },
+                                "metadata": {
+                                    "type": "Logistic",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": [
+                                        0,
+                                        1
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            },
+                            "AdaptiveIntegrator_Function_0": {
+                                "value": "(1 - 0.9) * previous_value + 0.9 * B_InputPort_0 + B_AdaptiveIntegrator_Function_0_noise + -1",
+                                "args": {
+                                    "offset": -1,
+                                    "rate": 0.9,
+                                    "variable0": "B_InputPort_0",
+                                    "noise": "B_AdaptiveIntegrator_Function_0_noise"
+                                },
+                                "metadata": {
+                                    "type": "AdaptiveIntegrator",
+                                    "has_initializers": true,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": false,
+                                    "output_type": "FunctionOutputType.DEFAULT",
+                                    "initializer": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "noise": {
+                                        "Normal_Distribution_Function_0": {
+                                            "function": {
+                                                "onnx::RandomNormal": {
+                                                    "mean": -1.0,
+                                                    "seed": 0,
+                                                    "scale": 0.5,
+                                                    "shape": [
+                                                        1,
+                                                        1
+                                                    ]
+                                                }
+                                            },
+                                            "args": {
+                                                "mean": -1.0,
+                                                "seed": 0,
+                                                "scale": 0.5,
+                                                "shape": [
+                                                    1,
+                                                    1
+                                                ]
+                                            },
+                                            "metadata": {
+                                                "type": "NormalDist",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "enable_output_type_conversion": false,
+                                                "max_executions_before_finished": 1000,
+                                                "variable": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "changes_shape": false,
+                                                "output_type": "FunctionOutputType.DEFAULT",
+                                                "random_state": null,
+                                                "function_stateful_params": {}
+                                            }
+                                        }
+                                    },
+                                    "function_stateful_params": {
+                                        "previous_value": {
+                                            "id": "previous_value",
+                                            "default_initial_value": [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            "value": "AdaptiveIntegrator_Function_0"
+                                        }
+                                    }
+                                }
+                            },
+                            "B_AdaptiveIntegrator_Function_0_noise": {
+                                "value": "Normal_Distribution_Function_2",
+                                "args": {
+                                    "variable0": "Normal_Distribution_Function_2"
+                                }
+                            },
+                            "Normal_Distribution_Function_2": {
+                                "function": {
+                                    "onnx::RandomNormal": {
+                                        "mean": -1.0,
+                                        "seed": 0,
+                                        "scale": 0.5,
+                                        "shape": [
+                                            1,
+                                            1
+                                        ]
+                                    }
+                                },
+                                "args": {
+                                    "mean": -1.0,
+                                    "seed": 0,
+                                    "scale": 0.5,
+                                    "shape": [
+                                        1,
+                                        1
+                                    ]
+                                },
+                                "metadata": {
+                                    "type": "NormalDist",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.DEFAULT",
+                                    "random_state": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "previous_value": {
+                                "default_initial_value": [
+                                    [
+                                        0
+                                    ]
+                                ],
+                                "value": "AdaptiveIntegrator_Function_0"
+                            }
+                        },
+                        "output_ports": {
+                            "B_RESULT": {
+                                "value": "Logistic_Function_0",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.5
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "C": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AccumulatorIntegrator_Function_0": {
+                                    "value": "previous_value * rate + noise + increment",
+                                    "args": {
+                                        "increment": 0.0,
+                                        "rate": 0.5
+                                    },
+                                    "metadata": {
+                                        "type": "AccumulatorIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "noise": {
+                                            "Normal_Distribution_Function_3": {
+                                                "function": {
+                                                    "onnx::RandomNormal": {
+                                                        "mean": 0.0,
+                                                        "seed": 0,
+                                                        "scale": 0.25,
+                                                        "shape": [
+                                                            1,
+                                                            1
+                                                        ]
+                                                    }
+                                                },
+                                                "args": {
+                                                    "mean": 0.0,
+                                                    "seed": 0,
+                                                    "scale": 0.25,
+                                                    "shape": [
+                                                        1,
+                                                        1
+                                                    ]
+                                                },
+                                                "metadata": {
+                                                    "type": "NormalDist",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "enable_output_type_conversion": false,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        [
+                                                            0
+                                                        ]
+                                                    ],
+                                                    "changes_shape": false,
+                                                    "output_type": "FunctionOutputType.DEFAULT",
+                                                    "random_state": null,
+                                                    "function_stateful_params": {}
+                                                }
+                                            }
+                                        },
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AccumulatorIntegrator_Function_0"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_5": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": true,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "C_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_39": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "AccumulatorIntegrator_Function_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "AccumulatorIntegrator_Function_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            },
+                            "AccumulatorIntegrator_Function_0": {
+                                "value": "previous_value * 0.5 + C_AccumulatorIntegrator_Function_0_noise + 0.0",
+                                "args": {
+                                    "increment": 0.0,
+                                    "rate": 0.5,
+                                    "variable0": "C_InputPort_0",
+                                    "noise": "C_AccumulatorIntegrator_Function_0_noise"
+                                },
+                                "metadata": {
+                                    "type": "AccumulatorIntegrator",
+                                    "has_initializers": true,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": false,
+                                    "output_type": "FunctionOutputType.DEFAULT",
+                                    "initializer": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "noise": {
+                                        "Normal_Distribution_Function_3": {
+                                            "function": {
+                                                "onnx::RandomNormal": {
+                                                    "mean": 0.0,
+                                                    "seed": 0,
+                                                    "scale": 0.25,
+                                                    "shape": [
+                                                        1,
+                                                        1
+                                                    ]
+                                                }
+                                            },
+                                            "args": {
+                                                "mean": 0.0,
+                                                "seed": 0,
+                                                "scale": 0.25,
+                                                "shape": [
+                                                    1,
+                                                    1
+                                                ]
+                                            },
+                                            "metadata": {
+                                                "type": "NormalDist",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "enable_output_type_conversion": false,
+                                                "max_executions_before_finished": 1000,
+                                                "variable": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "changes_shape": false,
+                                                "output_type": "FunctionOutputType.DEFAULT",
+                                                "random_state": null,
+                                                "function_stateful_params": {}
+                                            }
+                                        }
+                                    },
+                                    "function_stateful_params": {
+                                        "previous_value": {
+                                            "id": "previous_value",
+                                            "default_initial_value": [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            "value": "AccumulatorIntegrator_Function_0"
+                                        }
+                                    }
+                                }
+                            },
+                            "C_AccumulatorIntegrator_Function_0_noise": {
+                                "value": "Normal_Distribution_Function_5",
+                                "args": {
+                                    "variable0": "Normal_Distribution_Function_5"
+                                }
+                            },
+                            "Normal_Distribution_Function_5": {
+                                "function": {
+                                    "onnx::RandomNormal": {
+                                        "mean": 0.0,
+                                        "seed": 0,
+                                        "scale": 0.25,
+                                        "shape": [
+                                            1,
+                                            1
+                                        ]
+                                    }
+                                },
+                                "args": {
+                                    "mean": 0.0,
+                                    "seed": 0,
+                                    "scale": 0.25,
+                                    "shape": [
+                                        1,
+                                        1
+                                    ]
+                                },
+                                "metadata": {
+                                    "type": "NormalDist",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.DEFAULT",
+                                    "random_state": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "previous_value": {
+                                "default_initial_value": [
+                                    [
+                                        0
+                                    ]
+                                ],
+                                "value": "AccumulatorIntegrator_Function_0"
+                            }
+                        },
+                        "output_ports": {
+                            "C_RESULT": {
+                                "value": "Linear_Function_39",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "D": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "LeakyCompetingIntegrator_Function_0": {
+                                    "value": "previous_value + (-rate * previous_value + variable0) * time_step_size + noise * (time_step_size ** 0.5)",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "time_step_size": 0.2,
+                                        "rate": 0.5
+                                    },
+                                    "metadata": {
+                                        "type": "LeakyCompetingIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "noise": {
+                                            "Uniform_Distribution_Function_3": {
+                                                "function": {
+                                                    "onnx::RandomUniform": {
+                                                        "seed": 0,
+                                                        "high": 0.5,
+                                                        "low": -0.5,
+                                                        "shape": [
+                                                            1,
+                                                            1
+                                                        ]
+                                                    }
+                                                },
+                                                "args": {
+                                                    "seed": 0,
+                                                    "high": 0.5,
+                                                    "low": -0.5,
+                                                    "shape": [
+                                                        1,
+                                                        1
+                                                    ]
+                                                },
+                                                "metadata": {
+                                                    "type": "UniformDist",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "enable_output_type_conversion": false,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        [
+                                                            0
+                                                        ]
+                                                    ],
+                                                    "changes_shape": false,
+                                                    "output_type": "FunctionOutputType.DEFAULT",
+                                                    "random_state": null,
+                                                    "function_stateful_params": {}
+                                                }
+                                            }
+                                        },
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "LeakyCompetingIntegrator_Function_0"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_7": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": true,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "D_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_51": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "LeakyCompetingIntegrator_Function_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "LeakyCompetingIntegrator_Function_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            },
+                            "LeakyCompetingIntegrator_Function_0": {
+                                "value": "previous_value + (-0.5 * previous_value + D_InputPort_0) * 0.2 + D_LeakyCompetingIntegrator_Function_0_noise * (0.2 ** 0.5)",
+                                "args": {
+                                    "offset": 0.0,
+                                    "time_step_size": 0.2,
+                                    "rate": 0.5,
+                                    "variable0": "D_InputPort_0",
+                                    "noise": "D_LeakyCompetingIntegrator_Function_0_noise"
+                                },
+                                "metadata": {
+                                    "type": "LeakyCompetingIntegrator",
+                                    "has_initializers": true,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": false,
+                                    "output_type": "FunctionOutputType.DEFAULT",
+                                    "initializer": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "noise": {
+                                        "Uniform_Distribution_Function_3": {
+                                            "function": {
+                                                "onnx::RandomUniform": {
+                                                    "seed": 0,
+                                                    "high": 0.5,
+                                                    "low": -0.5,
+                                                    "shape": [
+                                                        1,
+                                                        1
+                                                    ]
+                                                }
+                                            },
+                                            "args": {
+                                                "seed": 0,
+                                                "high": 0.5,
+                                                "low": -0.5,
+                                                "shape": [
+                                                    1,
+                                                    1
+                                                ]
+                                            },
+                                            "metadata": {
+                                                "type": "UniformDist",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "enable_output_type_conversion": false,
+                                                "max_executions_before_finished": 1000,
+                                                "variable": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "changes_shape": false,
+                                                "output_type": "FunctionOutputType.DEFAULT",
+                                                "random_state": null,
+                                                "function_stateful_params": {}
+                                            }
+                                        }
+                                    },
+                                    "function_stateful_params": {
+                                        "previous_value": {
+                                            "id": "previous_value",
+                                            "default_initial_value": [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            "value": "LeakyCompetingIntegrator_Function_0"
+                                        }
+                                    }
+                                }
+                            },
+                            "D_LeakyCompetingIntegrator_Function_0_noise": {
+                                "value": "Uniform_Distribution_Function_5",
+                                "args": {
+                                    "variable0": "Uniform_Distribution_Function_5"
+                                }
+                            },
+                            "Uniform_Distribution_Function_5": {
+                                "function": {
+                                    "onnx::RandomUniform": {
+                                        "seed": 0,
+                                        "high": 0.5,
+                                        "low": -0.5,
+                                        "shape": [
+                                            1,
+                                            1
+                                        ]
+                                    }
+                                },
+                                "args": {
+                                    "seed": 0,
+                                    "high": 0.5,
+                                    "low": -0.5,
+                                    "shape": [
+                                        1,
+                                        1
+                                    ]
+                                },
+                                "metadata": {
+                                    "type": "UniformDist",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.DEFAULT",
+                                    "random_state": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "previous_value": {
+                                "default_initial_value": [
+                                    [
+                                        0
+                                    ]
+                                ],
+                                "value": "LeakyCompetingIntegrator_Function_0"
+                            }
+                        },
+                        "output_ports": {
+                            "D_RESULT": {
+                                "value": "Linear_Function_51",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "E": {
+                        "metadata": {
+                            "type": "IntegratorMechanism",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null
+                        },
+                        "input_ports": {
+                            "E_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "SimpleIntegrator_Function_3": {
+                                "value": "previous_value + (E_InputPort_0 * 0.5) + E_SimpleIntegrator_Function_3_noise + -1",
+                                "args": {
+                                    "offset": -1,
+                                    "rate": 0.5,
+                                    "variable0": "E_InputPort_0",
+                                    "noise": "E_SimpleIntegrator_Function_3_noise"
+                                },
+                                "metadata": {
+                                    "type": "SimpleIntegrator",
+                                    "has_initializers": true,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "initializer": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "noise": {
+                                        "Uniform_Distribution_Function_6": {
+                                            "function": {
+                                                "onnx::RandomUniform": {
+                                                    "seed": 0,
+                                                    "high": 0.5,
+                                                    "low": -0.25,
+                                                    "shape": [
+                                                        1,
+                                                        1
+                                                    ]
+                                                }
+                                            },
+                                            "args": {
+                                                "seed": 0,
+                                                "high": 0.5,
+                                                "low": -0.25,
+                                                "shape": [
+                                                    1,
+                                                    1
+                                                ]
+                                            },
+                                            "metadata": {
+                                                "type": "UniformDist",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "enable_output_type_conversion": false,
+                                                "max_executions_before_finished": 1000,
+                                                "variable": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "changes_shape": false,
+                                                "output_type": "FunctionOutputType.DEFAULT",
+                                                "random_state": null,
+                                                "function_stateful_params": {}
+                                            }
+                                        }
+                                    },
+                                    "function_stateful_params": {
+                                        "previous_value": {
+                                            "id": "previous_value",
+                                            "default_initial_value": [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            "value": "SimpleIntegrator_Function_3"
+                                        }
+                                    }
+                                }
+                            },
+                            "E_SimpleIntegrator_Function_3_noise": {
+                                "value": "Uniform_Distribution_Function_8",
+                                "args": {
+                                    "variable0": "Uniform_Distribution_Function_8"
+                                }
+                            },
+                            "Uniform_Distribution_Function_8": {
+                                "function": {
+                                    "onnx::RandomUniform": {
+                                        "seed": 0,
+                                        "high": 0.5,
+                                        "low": -0.25,
+                                        "shape": [
+                                            1,
+                                            1
+                                        ]
+                                    }
+                                },
+                                "args": {
+                                    "seed": 0,
+                                    "high": 0.5,
+                                    "low": -0.25,
+                                    "shape": [
+                                        1,
+                                        1
+                                    ]
+                                },
+                                "metadata": {
+                                    "type": "UniformDist",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.DEFAULT",
+                                    "random_state": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "previous_value": {
+                                "default_initial_value": [
+                                    [
+                                        0
+                                    ]
+                                ],
+                                "value": "SimpleIntegrator_Function_3"
+                            }
+                        },
+                        "output_ports": {
+                            "E_OutputPort_0": {
+                                "value": "SimpleIntegrator_Function_3",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        -0.6621510582239205
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    }
+                },
+                "edges": {
+                    "MappingProjection_from_A_RESULT__to_B_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "A",
+                        "receiver": "B",
+                        "sender_port": "A_RESULT",
+                        "receiver_port": "B_InputPort_0",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_0": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            1.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_B_RESULT__to_C_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "B",
+                        "receiver": "C",
+                        "sender_port": "B_RESULT",
+                        "receiver_port": "C_InputPort_0",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_1": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.5
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_C_RESULT__to_D_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "C",
+                        "receiver": "D",
+                        "sender_port": "C_RESULT",
+                        "receiver_port": "D_InputPort_0",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_2": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_D_RESULT__to_E_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "D",
+                        "receiver": "E",
+                        "sender_port": "D_RESULT",
+                        "receiver_port": "E_InputPort_0",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_3": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/json/model_nested_comp_with_scheduler.json
+++ b/tests/json/model_nested_comp_with_scheduler.json
@@ -1,0 +1,1454 @@
+{
+    "comp": {
+        "format": "ModECI MDF v0.3.3",
+        "generating_application": "PsyNeuLink v0.11.0.0+343.gfba4374945",
+        "graphs": {
+            "comp": {
+                "conditions": {
+                    "node_specific": {
+                        "A": {
+                            "type": "EveryNPasses",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                            }
+                        },
+                        "B": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "A",
+                                "n": 2
+                            }
+                        },
+                        "C": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "B",
+                                "n": 2
+                            }
+                        },
+                        "D": {
+                            "type": "TimeInterval",
+                            "args": {
+                                "repeat": null,
+                                "start": "1 millisecond",
+                                "end": null,
+                                "unit": "millisecond",
+                                "start_inclusive": true,
+                                "end_inclusive": true
+                            }
+                        },
+                        "Inner_Composition": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "C",
+                                "n": 1
+                            }
+                        }
+                    },
+                    "termination": {
+                        "environment_sequence": {
+                            "type": "AfterNEnvironmentStateUpdates",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_SEQUENCE"
+                            }
+                        },
+                        "environment_state_update": {
+                            "type": "AfterNCalls",
+                            "args": {
+                                "dependency": "D",
+                                "n": 4,
+                                "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                            }
+                        }
+                    }
+                },
+                "metadata": {
+                    "type": "Composition",
+                    "input_specification": null,
+                    "has_initializers": false,
+                    "retain_old_simulation_data": false,
+                    "execute_until_finished": true,
+                    "max_executions_before_finished": 1000,
+                    "results": [],
+                    "variable": [
+                        0
+                    ],
+                    "simulation_results": [],
+                    "node_ordering": [
+                        "A",
+                        "B",
+                        "C",
+                        "D",
+                        "Inner Composition"
+                    ],
+                    "required_node_roles": [],
+                    "controller": null
+                },
+                "nodes": {
+                    "A": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_0": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_0"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_1": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "A_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_12": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 2.0,
+                                        "slope": 5.0,
+                                        "variable0": "A_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 2.0,
+                                    "slope": 5.0,
+                                    "variable0": "A_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "A_RESULT": {
+                                "value": "Linear_Function_12",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        2.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "B": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_1": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_1"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_3": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "B_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Logistic_Function_0": {
+                                "function": {
+                                    "logistic": {
+                                        "offset": 0.0,
+                                        "gain": 1.0,
+                                        "scale": 1.0,
+                                        "bias": 0.0,
+                                        "x_0": 0,
+                                        "variable0": "B_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "offset": 0.0,
+                                    "gain": 1.0,
+                                    "scale": 1.0,
+                                    "bias": 0.0,
+                                    "x_0": 0,
+                                    "variable0": "B_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Logistic",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": [
+                                        0,
+                                        1
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "B_RESULT": {
+                                "value": "Logistic_Function_0",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.5
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "C": {
+                        "metadata": {
+                            "type": "RecurrentTransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_2": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_2"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "has_recurrent_input_port": false,
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "combination_function": {
+                                "LinearCombination_Function_1": {
+                                    "function": {
+                                        "linearcombination": {
+                                            "offset": 0.0,
+                                            "scale": 1.0
+                                        }
+                                    },
+                                    "args": {
+                                        "offset": 0.0,
+                                        "scale": 1.0
+                                    },
+                                    "metadata": {
+                                        "type": "LinearCombination",
+                                        "has_initializers": false,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "operation": "sum",
+                                        "weights": null,
+                                        "exponents": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "enable_learning": false,
+                            "termination_measure": {
+                                "Distance_Function_2_5": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ],
+                            "matrix": "HollowMatrix"
+                        },
+                        "input_ports": {
+                            "C_input_port_C_recurrent_projection": {
+                                "shape": "(1,)",
+                                "type": "float64"
+                            },
+                            "C_input_port_MappingProjection_from_A_RESULT__to_C_InputPort_0_": {
+                                "shape": "(1,)",
+                                "type": "float64"
+                            }
+                        },
+                        "functions": {
+                            "C_input_combination_function": {
+                                "function": {
+                                    "onnx::ReduceSum": {
+                                        "data": "combination_function_input_data",
+                                        "axes": 0
+                                    }
+                                },
+                                "args": {
+                                    "data": "combination_function_input_data",
+                                    "axes": 0
+                                }
+                            },
+                            "C_input_combination_function_dimreduce": {
+                                "value": "C_input_combination_function[0][0]",
+                                "args": {
+                                    "variable0": "C_input_combination_function"
+                                }
+                            },
+                            "Linear_Function_44": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "C_input_combination_function_dimreduce"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "C_input_combination_function_dimreduce"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "hetero": {
+                                "value": 0
+                            },
+                            "smoothing_factor": {
+                                "value": 0.5
+                            },
+                            "auto": {
+                                "value": 1
+                            },
+                            "combination_function_input_data": {
+                                "value": "[C_input_port_C_recurrent_projection, C_input_port_MappingProjection_from_A_RESULT__to_C_InputPort_0_]"
+                            }
+                        },
+                        "output_ports": {
+                            "C_RESULT": {
+                                "value": "Linear_Function_44",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "D": {
+                        "metadata": {
+                            "type": "IntegratorMechanism",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null
+                        },
+                        "input_ports": {
+                            "D_input_port_MappingProjection_from_B_RESULT__to_D_InputPort_0_": {
+                                "shape": "(1,)",
+                                "type": "float64"
+                            },
+                            "D_input_port_MappingProjection_from_C_RESULT__to_D_InputPort_0_": {
+                                "shape": "(1,)",
+                                "type": "float64"
+                            }
+                        },
+                        "functions": {
+                            "D_input_combination_function": {
+                                "function": {
+                                    "onnx::ReduceSum": {
+                                        "data": "combination_function_input_data",
+                                        "axes": 0
+                                    }
+                                },
+                                "args": {
+                                    "data": "combination_function_input_data",
+                                    "axes": 0
+                                }
+                            },
+                            "D_input_combination_function_dimreduce": {
+                                "value": "D_input_combination_function[0][0]",
+                                "args": {
+                                    "variable0": "D_input_combination_function"
+                                }
+                            },
+                            "SimpleIntegrator_Function_0": {
+                                "value": "previous_value + (D_input_combination_function_dimreduce * 1.0) + 0.0 + 0.0",
+                                "args": {
+                                    "offset": 0.0,
+                                    "rate": 1.0,
+                                    "noise": 0.0,
+                                    "variable0": "D_input_combination_function_dimreduce"
+                                },
+                                "metadata": {
+                                    "type": "SimpleIntegrator",
+                                    "has_initializers": true,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "initializer": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "function_stateful_params": {
+                                        "previous_value": {
+                                            "id": "previous_value",
+                                            "default_initial_value": [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            "value": "SimpleIntegrator_Function_0"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "combination_function_input_data": {
+                                "value": "[D_input_port_MappingProjection_from_B_RESULT__to_D_InputPort_0_, D_input_port_MappingProjection_from_C_RESULT__to_D_InputPort_0_]"
+                            },
+                            "previous_value": {
+                                "default_initial_value": [
+                                    [
+                                        0
+                                    ]
+                                ],
+                                "value": "SimpleIntegrator_Function_0"
+                            }
+                        },
+                        "output_ports": {
+                            "D_OutputPort_0": {
+                                "value": "SimpleIntegrator_Function_0",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "Inner_Composition": {
+                        "conditions": {
+                            "node_specific": {
+                                "E": {
+                                    "type": "Always",
+                                    "args": {}
+                                },
+                                "F": {
+                                    "type": "EveryNCalls",
+                                    "args": {
+                                        "dependency": "E",
+                                        "n": 1
+                                    }
+                                }
+                            },
+                            "termination": {
+                                "environment_sequence": {
+                                    "type": "Never",
+                                    "args": {}
+                                },
+                                "environment_state_update": {
+                                    "type": "AllHaveRun",
+                                    "args": {
+                                        "dependencies": []
+                                    }
+                                }
+                            }
+                        },
+                        "metadata": {
+                            "type": "Composition",
+                            "input_specification": null,
+                            "has_initializers": false,
+                            "retain_old_simulation_data": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "results": [],
+                            "variable": [
+                                0
+                            ],
+                            "simulation_results": [],
+                            "node_ordering": [
+                                "E",
+                                "F"
+                            ],
+                            "required_node_roles": [],
+                            "controller": null
+                        },
+                        "nodes": {
+                            "E": {
+                                "metadata": {
+                                    "type": "TransferMechanism",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "termination_measure_value": 0.0,
+                                    "output_labels_dict": {},
+                                    "input_port_variables": null,
+                                    "input_labels_dict": {},
+                                    "integrator_function_value": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "integrator_function": {
+                                        "AdaptiveIntegrator_Function_3": {
+                                            "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                            "args": {
+                                                "offset": 0.0,
+                                                "rate": 0.5,
+                                                "noise": 0.0
+                                            },
+                                            "metadata": {
+                                                "type": "AdaptiveIntegrator",
+                                                "has_initializers": true,
+                                                "max_executions_before_finished": 1000,
+                                                "execute_until_finished": true,
+                                                "variable": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "changes_shape": false,
+                                                "enable_output_type_conversion": false,
+                                                "output_type": "FunctionOutputType.DEFAULT",
+                                                "initializer": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "function_stateful_params": {
+                                                    "previous_value": {
+                                                        "id": "previous_value",
+                                                        "default_initial_value": [
+                                                            [
+                                                                0
+                                                            ]
+                                                        ],
+                                                        "value": "AdaptiveIntegrator_Function_3"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "termination_comparison_op": "<=",
+                                    "termination_threshold": null,
+                                    "clip": null,
+                                    "termination_measure": {
+                                        "Distance_Function_2_7": {
+                                            "function": {
+                                                "distance": {}
+                                            },
+                                            "args": {},
+                                            "metadata": {
+                                                "type": "Distance",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "enable_output_type_conversion": false,
+                                                "max_executions_before_finished": 1000,
+                                                "variable": [
+                                                    [
+                                                        [
+                                                            0
+                                                        ]
+                                                    ],
+                                                    [
+                                                        [
+                                                            0
+                                                        ]
+                                                    ]
+                                                ],
+                                                "changes_shape": false,
+                                                "output_type": "FunctionOutputType.DEFAULT",
+                                                "normalize": false,
+                                                "metric": "max_abs_diff",
+                                                "function_stateful_params": {}
+                                            }
+                                        }
+                                    },
+                                    "input_ports": null,
+                                    "integrator_mode": false,
+                                    "on_resume_integrator_mode": "current_value",
+                                    "output_ports": [
+                                        "RESULTS"
+                                    ]
+                                },
+                                "input_ports": {
+                                    "E_InputPort_0": {
+                                        "shape": "(1,)",
+                                        "type": "int64",
+                                        "metadata": {
+                                            "type": "InputPort",
+                                            "has_initializers": false,
+                                            "execute_until_finished": true,
+                                            "internal_only": false,
+                                            "max_executions_before_finished": 1000,
+                                            "variable": [
+                                                0
+                                            ],
+                                            "shadow_inputs": null,
+                                            "require_projection_in_composition": true,
+                                            "default_input": null,
+                                            "exponent": null,
+                                            "projections": null,
+                                            "combine": null,
+                                            "weight": null
+                                        }
+                                    }
+                                },
+                                "functions": {
+                                    "Linear_Function_59": {
+                                        "function": {
+                                            "linear": {
+                                                "intercept": 0.0,
+                                                "slope": 1.0,
+                                                "variable0": "E_InputPort_0"
+                                            }
+                                        },
+                                        "args": {
+                                            "intercept": 0.0,
+                                            "slope": 1.0,
+                                            "variable0": "E_InputPort_0"
+                                        },
+                                        "metadata": {
+                                            "type": "Linear",
+                                            "has_initializers": false,
+                                            "execute_until_finished": true,
+                                            "enable_output_type_conversion": true,
+                                            "max_executions_before_finished": 1000,
+                                            "changes_shape": false,
+                                            "variable": [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                            "bounds": null,
+                                            "function_stateful_params": {}
+                                        }
+                                    }
+                                },
+                                "output_ports": {
+                                    "E_RESULT": {
+                                        "value": "Linear_Function_59",
+                                        "metadata": {
+                                            "type": "OutputPort",
+                                            "has_initializers": false,
+                                            "execute_until_finished": true,
+                                            "max_executions_before_finished": 1000,
+                                            "variable": [
+                                                0.0
+                                            ],
+                                            "require_projection_in_composition": true,
+                                            "projections": null
+                                        }
+                                    }
+                                }
+                            },
+                            "F": {
+                                "metadata": {
+                                    "type": "TransferMechanism",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "termination_measure_value": 0.0,
+                                    "output_labels_dict": {},
+                                    "input_port_variables": null,
+                                    "input_labels_dict": {},
+                                    "integrator_function_value": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "integrator_function": {
+                                        "AdaptiveIntegrator_Function_4": {
+                                            "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                            "args": {
+                                                "offset": 0.0,
+                                                "rate": 0.5,
+                                                "noise": 0.0
+                                            },
+                                            "metadata": {
+                                                "type": "AdaptiveIntegrator",
+                                                "has_initializers": true,
+                                                "max_executions_before_finished": 1000,
+                                                "execute_until_finished": true,
+                                                "variable": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "changes_shape": false,
+                                                "enable_output_type_conversion": false,
+                                                "output_type": "FunctionOutputType.DEFAULT",
+                                                "initializer": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "function_stateful_params": {
+                                                    "previous_value": {
+                                                        "id": "previous_value",
+                                                        "default_initial_value": [
+                                                            [
+                                                                0
+                                                            ]
+                                                        ],
+                                                        "value": "AdaptiveIntegrator_Function_4"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "termination_comparison_op": "<=",
+                                    "termination_threshold": null,
+                                    "clip": null,
+                                    "termination_measure": {
+                                        "Distance_Function_2_9": {
+                                            "function": {
+                                                "distance": {}
+                                            },
+                                            "args": {},
+                                            "metadata": {
+                                                "type": "Distance",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "enable_output_type_conversion": false,
+                                                "max_executions_before_finished": 1000,
+                                                "variable": [
+                                                    [
+                                                        [
+                                                            0
+                                                        ]
+                                                    ],
+                                                    [
+                                                        [
+                                                            0
+                                                        ]
+                                                    ]
+                                                ],
+                                                "changes_shape": false,
+                                                "output_type": "FunctionOutputType.DEFAULT",
+                                                "normalize": false,
+                                                "metric": "max_abs_diff",
+                                                "function_stateful_params": {}
+                                            }
+                                        }
+                                    },
+                                    "input_ports": null,
+                                    "integrator_mode": false,
+                                    "on_resume_integrator_mode": "current_value",
+                                    "output_ports": [
+                                        "RESULTS"
+                                    ]
+                                },
+                                "input_ports": {
+                                    "F_InputPort_0": {
+                                        "shape": "(1, 1)",
+                                        "type": "float64",
+                                        "metadata": {
+                                            "type": "InputPort",
+                                            "has_initializers": false,
+                                            "execute_until_finished": true,
+                                            "internal_only": false,
+                                            "max_executions_before_finished": 1000,
+                                            "variable": [
+                                                [
+                                                    0.0
+                                                ]
+                                            ],
+                                            "shadow_inputs": null,
+                                            "require_projection_in_composition": true,
+                                            "default_input": null,
+                                            "exponent": null,
+                                            "projections": null,
+                                            "combine": null,
+                                            "weight": null
+                                        }
+                                    }
+                                },
+                                "functions": {
+                                    "Linear_Function_68": {
+                                        "function": {
+                                            "linear": {
+                                                "intercept": 0.0,
+                                                "slope": 1.0,
+                                                "variable0": "F_InputPort_0"
+                                            }
+                                        },
+                                        "args": {
+                                            "intercept": 0.0,
+                                            "slope": 1.0,
+                                            "variable0": "F_InputPort_0"
+                                        },
+                                        "metadata": {
+                                            "type": "Linear",
+                                            "has_initializers": false,
+                                            "execute_until_finished": true,
+                                            "enable_output_type_conversion": true,
+                                            "max_executions_before_finished": 1000,
+                                            "changes_shape": false,
+                                            "variable": [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                            "bounds": null,
+                                            "function_stateful_params": {}
+                                        }
+                                    }
+                                },
+                                "output_ports": {
+                                    "F_RESULT": {
+                                        "value": "Linear_Function_68",
+                                        "metadata": {
+                                            "type": "OutputPort",
+                                            "has_initializers": false,
+                                            "execute_until_finished": true,
+                                            "max_executions_before_finished": 1000,
+                                            "variable": [
+                                                0.0
+                                            ],
+                                            "require_projection_in_composition": true,
+                                            "projections": null
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "edges": {
+                            "MappingProjection_from_E_RESULT__to_F_InputPort_0_": {
+                                "parameters": {
+                                    "weight": 1
+                                },
+                                "sender": "E",
+                                "receiver": "F",
+                                "sender_port": "E_RESULT",
+                                "receiver_port": "F_InputPort_0",
+                                "metadata": {
+                                    "type": "MappingProjection",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "exponent": null,
+                                    "weight": null,
+                                    "functions": {
+                                        "LinearMatrix_Function_10": {
+                                            "function": {
+                                                "onnx::MatMul": {
+                                                    "B": [
+                                                        [
+                                                            1.0
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "args": {
+                                                "B": [
+                                                    [
+                                                        1.0
+                                                    ]
+                                                ]
+                                            },
+                                            "metadata": {
+                                                "type": "LinearMatrix",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "enable_output_type_conversion": false,
+                                                "max_executions_before_finished": 1000,
+                                                "A": [
+                                                    0.0
+                                                ],
+                                                "changes_shape": false,
+                                                "output_type": "FunctionOutputType.DEFAULT",
+                                                "bounds": null,
+                                                "function_stateful_params": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "edges": {
+                    "MappingProjection_from_A_RESULT__to_B_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "A",
+                        "receiver": "B",
+                        "sender_port": "A_RESULT",
+                        "receiver_port": "B_InputPort_0",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_5": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            2.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_A_RESULT__to_C_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "A",
+                        "receiver": "C",
+                        "sender_port": "A_RESULT",
+                        "receiver_port": "C_input_port_MappingProjection_from_A_RESULT__to_C_InputPort_0_",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_6": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            2.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_B_RESULT__to_D_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "B",
+                        "receiver": "D",
+                        "sender_port": "B_RESULT",
+                        "receiver_port": "D_input_port_MappingProjection_from_B_RESULT__to_D_InputPort_0_",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_7": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.5
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_C_RESULT__to_D_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "C",
+                        "receiver": "D",
+                        "sender_port": "C_RESULT",
+                        "receiver_port": "D_input_port_MappingProjection_from_C_RESULT__to_D_InputPort_0_",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_8": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/json/model_udfs.json
+++ b/tests/json/model_udfs.json
@@ -1,0 +1,516 @@
+{
+    "comp": {
+        "format": "ModECI MDF v0.3.3",
+        "generating_application": "PsyNeuLink v0.11.0.0+343.gfba4374945",
+        "graphs": {
+            "comp": {
+                "conditions": {
+                    "node_specific": {
+                        "A": {
+                            "type": "Always",
+                            "args": {}
+                        },
+                        "B": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "A",
+                                "n": 2
+                            }
+                        },
+                        "C": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "B",
+                                "n": 2
+                            }
+                        }
+                    },
+                    "termination": {
+                        "environment_sequence": {
+                            "type": "Never",
+                            "args": {}
+                        },
+                        "environment_state_update": {
+                            "type": "AllHaveRun",
+                            "args": {
+                                "dependencies": []
+                            }
+                        }
+                    }
+                },
+                "metadata": {
+                    "type": "Composition",
+                    "input_specification": null,
+                    "has_initializers": false,
+                    "retain_old_simulation_data": false,
+                    "execute_until_finished": true,
+                    "max_executions_before_finished": 1000,
+                    "results": [],
+                    "variable": [
+                        0
+                    ],
+                    "simulation_results": [],
+                    "node_ordering": [
+                        "A",
+                        "B",
+                        "C"
+                    ],
+                    "required_node_roles": [],
+                    "controller": null
+                },
+                "nodes": {
+                    "A": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_0": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_0"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_1": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "A_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_5": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "A_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "A_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "A_RESULT": {
+                                "value": "Linear_Function_5",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "B": {
+                        "metadata": {
+                            "type": "ProcessingMechanism",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null
+                        },
+                        "input_ports": {
+                            "B_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "USER_DEFINED_FUNCTION_0": {
+                                "function": {
+                                    "sin": {
+                                        "scale": 1,
+                                        "variable0": "B_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "scale": 1,
+                                    "variable0": "B_InputPort_0"
+                                },
+                                "metadata": {
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "custom_function": "sin",
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "B_OutputPort_0": {
+                                "value": "USER_DEFINED_FUNCTION_0",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "C": {
+                        "metadata": {
+                            "type": "ProcessingMechanism",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null
+                        },
+                        "input_ports": {
+                            "C_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "USER_DEFINED_FUNCTION_3": {
+                                "function": {
+                                    "cos": {
+                                        "scale": 1,
+                                        "variable0": "C_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "scale": 1,
+                                    "variable0": "C_InputPort_0"
+                                },
+                                "metadata": {
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "custom_function": "cos",
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "C_OutputPort_0": {
+                                "value": "USER_DEFINED_FUNCTION_3",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        1.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    }
+                },
+                "edges": {
+                    "MappingProjection_from_A_RESULT__to_B_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "A",
+                        "receiver": "B",
+                        "sender_port": "A_RESULT",
+                        "receiver_port": "B_InputPort_0",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_0": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_B_OutputPort_0__to_C_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "B",
+                        "receiver": "C",
+                        "sender_port": "B_OutputPort_0",
+                        "receiver_port": "C_InputPort_0",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_1": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/json/model_varied_matrix_sizes.json
+++ b/tests/json/model_varied_matrix_sizes.json
@@ -1,0 +1,1492 @@
+{
+    "comp": {
+        "format": "ModECI MDF v0.3.3",
+        "generating_application": "PsyNeuLink v0.11.0.0+343.gfba4374945",
+        "graphs": {
+            "comp": {
+                "conditions": {
+                    "node_specific": {
+                        "A": {
+                            "type": "Always",
+                            "args": {}
+                        },
+                        "B": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "A",
+                                "n": 1
+                            }
+                        },
+                        "C": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "A",
+                                "n": 1
+                            }
+                        },
+                        "D": {
+                            "type": "All",
+                            "args": {
+                                "args": [
+                                    {
+                                        "type": "EveryNCalls",
+                                        "args": {
+                                            "dependency": "B",
+                                            "n": 1
+                                        }
+                                    },
+                                    {
+                                        "type": "EveryNCalls",
+                                        "args": {
+                                            "dependency": "C",
+                                            "n": 1
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "termination": {
+                        "environment_sequence": {
+                            "type": "Never",
+                            "args": {}
+                        },
+                        "environment_state_update": {
+                            "type": "AllHaveRun",
+                            "args": {
+                                "dependencies": []
+                            }
+                        }
+                    }
+                },
+                "metadata": {
+                    "type": "Composition",
+                    "input_specification": null,
+                    "has_initializers": false,
+                    "retain_old_simulation_data": false,
+                    "execute_until_finished": true,
+                    "max_executions_before_finished": 1000,
+                    "results": [],
+                    "variable": [
+                        0
+                    ],
+                    "simulation_results": [],
+                    "node_ordering": [
+                        "A",
+                        "B",
+                        "C",
+                        "D"
+                    ],
+                    "required_node_roles": [],
+                    "excluded_node_roles": [
+                        [
+                            "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node",
+                            "NodeRole.OUTPUT"
+                        ],
+                        [
+                            "MappingProjection_from_A_RESULT__to_C_InputPort_0__dummy_node",
+                            "NodeRole.OUTPUT"
+                        ],
+                        [
+                            "MappingProjection_from_B_RESULT__to_D_InputPort_0__dummy_node",
+                            "NodeRole.OUTPUT"
+                        ],
+                        [
+                            "MappingProjection_from_C_RESULT__to_D_InputPort_0__dummy_node",
+                            "NodeRole.OUTPUT"
+                        ]
+                    ],
+                    "controller": null
+                },
+                "nodes": {
+                    "A": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_0": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0.0,
+                                                0.0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0.0,
+                                                0.0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0.0,
+                                                        0.0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_0"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_1": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0.0,
+                                                    0.0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0.0,
+                                                    0.0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "A_InputPort_0": {
+                                "shape": "(2,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_11": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "A_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "A_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "A_RESULT": {
+                                "value": "Linear_Function_11",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "B": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_1": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0.0,
+                                                0.0,
+                                                0.0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0.0,
+                                                0.0,
+                                                0.0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0.0,
+                                                        0.0,
+                                                        0.0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_1"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_3": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0.0,
+                                                    0.0,
+                                                    0.0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0.0,
+                                                    0.0,
+                                                    0.0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "B_InputPort_0": {
+                                "shape": "(3,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_20": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "B_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "B_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "B_RESULT": {
+                                "value": "Linear_Function_20",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "C": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_2": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0.0,
+                                                0.0,
+                                                0.0,
+                                                0.0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0.0,
+                                                0.0,
+                                                0.0,
+                                                0.0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0.0,
+                                                        0.0,
+                                                        0.0,
+                                                        0.0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_2"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_5": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0.0,
+                                                    0.0,
+                                                    0.0,
+                                                    0.0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0.0,
+                                                    0.0,
+                                                    0.0,
+                                                    0.0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "C_InputPort_0": {
+                                "shape": "(4,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_29": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "C_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "C_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0,
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "C_RESULT": {
+                                "value": "Linear_Function_29",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "D": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_3": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0.0,
+                                                0.0,
+                                                0.0,
+                                                0.0,
+                                                0.0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0.0,
+                                                0.0,
+                                                0.0,
+                                                0.0,
+                                                0.0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0.0,
+                                                        0.0,
+                                                        0.0,
+                                                        0.0,
+                                                        0.0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_3"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_7": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0.0,
+                                                    0.0,
+                                                    0.0,
+                                                    0.0,
+                                                    0.0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0.0,
+                                                    0.0,
+                                                    0.0,
+                                                    0.0,
+                                                    0.0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "D_input_port_MappingProjection_from_B_RESULT__to_D_InputPort_0_": {
+                                "shape": "(5,)",
+                                "type": "float64"
+                            },
+                            "D_input_port_MappingProjection_from_C_RESULT__to_D_InputPort_0_": {
+                                "shape": "(5,)",
+                                "type": "float64"
+                            }
+                        },
+                        "functions": {
+                            "D_input_combination_function": {
+                                "function": {
+                                    "onnx::ReduceSum": {
+                                        "data": "combination_function_input_data",
+                                        "axes": 0
+                                    }
+                                },
+                                "args": {
+                                    "data": "combination_function_input_data",
+                                    "axes": 0
+                                }
+                            },
+                            "D_input_combination_function_dimreduce": {
+                                "value": "D_input_combination_function[0][0]",
+                                "args": {
+                                    "variable0": "D_input_combination_function"
+                                }
+                            },
+                            "Linear_Function_38": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "D_input_combination_function_dimreduce"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "D_input_combination_function_dimreduce"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0,
+                                            0.0,
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "combination_function_input_data": {
+                                "value": "[D_input_port_MappingProjection_from_B_RESULT__to_D_InputPort_0_, D_input_port_MappingProjection_from_C_RESULT__to_D_InputPort_0_]"
+                            }
+                        },
+                        "output_ports": {
+                            "D_RESULT": {
+                                "value": "Linear_Function_38",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node": {
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null,
+                            "exponent": null,
+                            "weight": null
+                        },
+                        "input_ports": {
+                            "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node_InputPort_0": {
+                                "shape": "(2,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "LinearMatrix_Function_9": {
+                                "function": {
+                                    "onnx::MatMul": {
+                                        "B": [
+                                            [
+                                                1.0,
+                                                2.0,
+                                                3.0
+                                            ],
+                                            [
+                                                4.0,
+                                                5.0,
+                                                6.0
+                                            ]
+                                        ],
+                                        "A": "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "B": [
+                                        [
+                                            1.0,
+                                            2.0,
+                                            3.0
+                                        ],
+                                        [
+                                            4.0,
+                                            5.0,
+                                            6.0
+                                        ]
+                                    ],
+                                    "A": "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "LinearMatrix",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "A": [
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node_OutputPort_0": {
+                                "value": "LinearMatrix_Function_9",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_A_RESULT__to_C_InputPort_0__dummy_node": {
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null,
+                            "exponent": null,
+                            "weight": null
+                        },
+                        "input_ports": {
+                            "MappingProjection_from_A_RESULT__to_C_InputPort_0__dummy_node_InputPort_0": {
+                                "shape": "(2,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "LinearMatrix_Function_12": {
+                                "function": {
+                                    "onnx::MatMul": {
+                                        "B": [
+                                            [
+                                                1.0,
+                                                2.0,
+                                                3.0,
+                                                4.0
+                                            ],
+                                            [
+                                                5.0,
+                                                6.0,
+                                                7.0,
+                                                8.0
+                                            ]
+                                        ],
+                                        "A": "MappingProjection_from_A_RESULT__to_C_InputPort_0__dummy_node_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "B": [
+                                        [
+                                            1.0,
+                                            2.0,
+                                            3.0,
+                                            4.0
+                                        ],
+                                        [
+                                            5.0,
+                                            6.0,
+                                            7.0,
+                                            8.0
+                                        ]
+                                    ],
+                                    "A": "MappingProjection_from_A_RESULT__to_C_InputPort_0__dummy_node_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "LinearMatrix",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "A": [
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "MappingProjection_from_A_RESULT__to_C_InputPort_0__dummy_node_OutputPort_0": {
+                                "value": "LinearMatrix_Function_12",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_B_RESULT__to_D_InputPort_0__dummy_node": {
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null,
+                            "exponent": null,
+                            "weight": null
+                        },
+                        "input_ports": {
+                            "MappingProjection_from_B_RESULT__to_D_InputPort_0__dummy_node_InputPort_0": {
+                                "shape": "(3,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "LinearMatrix_Function_15": {
+                                "function": {
+                                    "onnx::MatMul": {
+                                        "B": [
+                                            [
+                                                1.0,
+                                                2.0,
+                                                3.0,
+                                                4.0,
+                                                5.0
+                                            ],
+                                            [
+                                                6.0,
+                                                7.0,
+                                                8.0,
+                                                9.0,
+                                                10.0
+                                            ],
+                                            [
+                                                11.0,
+                                                12.0,
+                                                13.0,
+                                                14.0,
+                                                15.0
+                                            ]
+                                        ],
+                                        "A": "MappingProjection_from_B_RESULT__to_D_InputPort_0__dummy_node_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "B": [
+                                        [
+                                            1.0,
+                                            2.0,
+                                            3.0,
+                                            4.0,
+                                            5.0
+                                        ],
+                                        [
+                                            6.0,
+                                            7.0,
+                                            8.0,
+                                            9.0,
+                                            10.0
+                                        ],
+                                        [
+                                            11.0,
+                                            12.0,
+                                            13.0,
+                                            14.0,
+                                            15.0
+                                        ]
+                                    ],
+                                    "A": "MappingProjection_from_B_RESULT__to_D_InputPort_0__dummy_node_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "LinearMatrix",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "A": [
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "MappingProjection_from_B_RESULT__to_D_InputPort_0__dummy_node_OutputPort_0": {
+                                "value": "LinearMatrix_Function_15",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_C_RESULT__to_D_InputPort_0__dummy_node": {
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null,
+                            "exponent": null,
+                            "weight": null
+                        },
+                        "input_ports": {
+                            "MappingProjection_from_C_RESULT__to_D_InputPort_0__dummy_node_InputPort_0": {
+                                "shape": "(4,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "LinearMatrix_Function_18": {
+                                "function": {
+                                    "onnx::MatMul": {
+                                        "B": [
+                                            [
+                                                1.0,
+                                                2.0,
+                                                3.0,
+                                                4.0,
+                                                5.0
+                                            ],
+                                            [
+                                                6.0,
+                                                7.0,
+                                                8.0,
+                                                9.0,
+                                                10.0
+                                            ],
+                                            [
+                                                11.0,
+                                                12.0,
+                                                13.0,
+                                                14.0,
+                                                15.0
+                                            ],
+                                            [
+                                                16.0,
+                                                17.0,
+                                                18.0,
+                                                19.0,
+                                                20.0
+                                            ]
+                                        ],
+                                        "A": "MappingProjection_from_C_RESULT__to_D_InputPort_0__dummy_node_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "B": [
+                                        [
+                                            1.0,
+                                            2.0,
+                                            3.0,
+                                            4.0,
+                                            5.0
+                                        ],
+                                        [
+                                            6.0,
+                                            7.0,
+                                            8.0,
+                                            9.0,
+                                            10.0
+                                        ],
+                                        [
+                                            11.0,
+                                            12.0,
+                                            13.0,
+                                            14.0,
+                                            15.0
+                                        ],
+                                        [
+                                            16.0,
+                                            17.0,
+                                            18.0,
+                                            19.0,
+                                            20.0
+                                        ]
+                                    ],
+                                    "A": "MappingProjection_from_C_RESULT__to_D_InputPort_0__dummy_node_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "LinearMatrix",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "A": [
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "MappingProjection_from_C_RESULT__to_D_InputPort_0__dummy_node_OutputPort_0": {
+                                "value": "LinearMatrix_Function_18",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    }
+                },
+                "edges": {
+                    "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_pre_edge": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "A",
+                        "receiver": "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node",
+                        "sender_port": "A_RESULT",
+                        "receiver_port": "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node_InputPort_0"
+                    },
+                    "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_post_edge": {
+                        "sender": "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node",
+                        "receiver": "B",
+                        "sender_port": "MappingProjection_from_A_RESULT__to_B_InputPort_0__dummy_node_OutputPort_0",
+                        "receiver_port": "B_InputPort_0"
+                    },
+                    "MappingProjection_from_A_RESULT__to_C_InputPort_0__dummy_pre_edge": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "A",
+                        "receiver": "MappingProjection_from_A_RESULT__to_C_InputPort_0__dummy_node",
+                        "sender_port": "A_RESULT",
+                        "receiver_port": "MappingProjection_from_A_RESULT__to_C_InputPort_0__dummy_node_InputPort_0"
+                    },
+                    "MappingProjection_from_A_RESULT__to_C_InputPort_0__dummy_post_edge": {
+                        "sender": "MappingProjection_from_A_RESULT__to_C_InputPort_0__dummy_node",
+                        "receiver": "C",
+                        "sender_port": "MappingProjection_from_A_RESULT__to_C_InputPort_0__dummy_node_OutputPort_0",
+                        "receiver_port": "C_InputPort_0"
+                    },
+                    "MappingProjection_from_B_RESULT__to_D_InputPort_0__dummy_pre_edge": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "B",
+                        "receiver": "MappingProjection_from_B_RESULT__to_D_InputPort_0__dummy_node",
+                        "sender_port": "B_RESULT",
+                        "receiver_port": "MappingProjection_from_B_RESULT__to_D_InputPort_0__dummy_node_InputPort_0"
+                    },
+                    "MappingProjection_from_B_RESULT__to_D_InputPort_0__dummy_post_edge": {
+                        "sender": "MappingProjection_from_B_RESULT__to_D_InputPort_0__dummy_node",
+                        "receiver": "D",
+                        "sender_port": "MappingProjection_from_B_RESULT__to_D_InputPort_0__dummy_node_OutputPort_0",
+                        "receiver_port": "D_input_port_MappingProjection_from_B_RESULT__to_D_InputPort_0_"
+                    },
+                    "MappingProjection_from_C_RESULT__to_D_InputPort_0__dummy_pre_edge": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "C",
+                        "receiver": "MappingProjection_from_C_RESULT__to_D_InputPort_0__dummy_node",
+                        "sender_port": "C_RESULT",
+                        "receiver_port": "MappingProjection_from_C_RESULT__to_D_InputPort_0__dummy_node_InputPort_0"
+                    },
+                    "MappingProjection_from_C_RESULT__to_D_InputPort_0__dummy_post_edge": {
+                        "sender": "MappingProjection_from_C_RESULT__to_D_InputPort_0__dummy_node",
+                        "receiver": "D",
+                        "sender_port": "MappingProjection_from_C_RESULT__to_D_InputPort_0__dummy_node_OutputPort_0",
+                        "receiver_port": "D_input_port_MappingProjection_from_C_RESULT__to_D_InputPort_0_"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/json/model_with_control.json
+++ b/tests/json/model_with_control.json
@@ -1,0 +1,3445 @@
+{
+    "comp": {
+        "format": "ModECI MDF v0.3.3",
+        "generating_application": "PsyNeuLink v0.11.0.0+343.gfba4374945",
+        "graphs": {
+            "comp": {
+                "conditions": {
+                    "node_specific": {
+                        "reward": {
+                            "type": "Always",
+                            "args": {}
+                        },
+                        "Input": {
+                            "type": "Always",
+                            "args": {}
+                        },
+                        "Decision": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "Input",
+                                "n": 1
+                            }
+                        },
+                        "ObjectiveMechanism_0": {
+                            "type": "All",
+                            "args": {
+                                "args": [
+                                    {
+                                        "type": "EveryNCalls",
+                                        "args": {
+                                            "dependency": "reward",
+                                            "n": 1
+                                        }
+                                    },
+                                    {
+                                        "type": "EveryNCalls",
+                                        "args": {
+                                            "dependency": "Decision",
+                                            "n": 1
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "termination": {
+                        "environment_sequence": {
+                            "type": "Never",
+                            "args": {}
+                        },
+                        "environment_state_update": {
+                            "type": "AllHaveRun",
+                            "args": {
+                                "dependencies": []
+                            }
+                        }
+                    }
+                },
+                "metadata": {
+                    "type": "Composition",
+                    "input_specification": null,
+                    "has_initializers": false,
+                    "retain_old_simulation_data": false,
+                    "execute_until_finished": true,
+                    "max_executions_before_finished": 1000,
+                    "results": [],
+                    "variable": [
+                        0
+                    ],
+                    "simulation_results": [],
+                    "node_ordering": [
+                        "reward",
+                        "Decision",
+                        "Input",
+                        "ObjectiveMechanism_0",
+                        "OptimizationControlMechanism_0"
+                    ],
+                    "required_node_roles": [
+                        [
+                            "reward",
+                            "NodeRole.OUTPUT"
+                        ],
+                        [
+                            "Decision",
+                            "NodeRole.OUTPUT"
+                        ],
+                        [
+                            "ObjectiveMechanism_0",
+                            "NodeRole.CONTROLLER_OBJECTIVE"
+                        ]
+                    ],
+                    "controller": {
+                        "OptimizationControlMechanism_0": {
+                            "metadata": {
+                                "type": "OptimizationControlMechanism",
+                                "has_initializers": false,
+                                "max_executions_before_finished": 1000,
+                                "simulation_ids": [],
+                                "execute_until_finished": true,
+                                "modulation": "multiplicative_param",
+                                "output_labels_dict": {},
+                                "input_port_variables": null,
+                                "outcome": null,
+                                "net_outcome": null,
+                                "agent_rep": "comp",
+                                "state_feature_values": null,
+                                "control_signal_costs": null,
+                                "input_labels_dict": {},
+                                "comp_execution_mode": "Python",
+                                "compute_net_outcome": "gASVUQEAAAAAAACMCmRpbGwuX2RpbGyUjBBfY3JlYXRlX2Z1bmN0aW9ulJOUKGgAjAxfY3JlYXRl\nX2NvZGWUk5QoSwJLAEsASwJLAktDQwh8AHwBGABTAJROhZQpjAdvdXRjb21llIwEY29zdJSGlIxy\nL1VzZXJzL2pkYy9QeUNoYXJtUHJvamVjdHMvUHN5TmV1TGluay9wc3luZXVsaW5rL2NvcmUvY29t\ncG9uZW50cy9tZWNoYW5pc21zL21vZHVsYXRvcnkvY29udHJvbC9jb250cm9sbWVjaGFuaXNtLnB5\nlIwIPGxhbWJkYT6UTWkEQwCUKSl0lFKUY3BzeW5ldWxpbmsuY29yZS5jb21wb25lbnRzLm1lY2hh\nbmlzbXMubW9kdWxhdG9yeS5jb250cm9sLmNvbnRyb2xtZWNoYW5pc20KX19kaWN0X18KaAtOTn2U\nTnSUUpQu\n",
+                                "initial_seed": null,
+                                "saved_values": null,
+                                "outcome_input_ports": "[(InputPort OUTCOME)]",
+                                "costs": null,
+                                "state_feature_function": {
+                                    "AdaptiveIntegrator_Function_2": {
+                                        "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                        "args": {
+                                            "offset": 0.0,
+                                            "rate": 0.5,
+                                            "noise": 0.0
+                                        },
+                                        "metadata": {
+                                            "type": "AdaptiveIntegrator",
+                                            "has_initializers": true,
+                                            "max_executions_before_finished": 1000,
+                                            "execute_until_finished": true,
+                                            "variable": [
+                                                0
+                                            ],
+                                            "changes_shape": false,
+                                            "enable_output_type_conversion": false,
+                                            "output_type": "FunctionOutputType.DEFAULT",
+                                            "initializer": [
+                                                0
+                                            ],
+                                            "function_stateful_params": {
+                                                "previous_value": {
+                                                    "id": "previous_value",
+                                                    "default_initial_value": [
+                                                        0
+                                                    ],
+                                                    "value": "AdaptiveIntegrator_Function_2"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "objective_mechanism": {
+                                    "ObjectiveMechanism_0": {
+                                        "metadata": {
+                                            "type": "ObjectiveMechanism",
+                                            "has_initializers": false,
+                                            "input_port_variables": null,
+                                            "execute_until_finished": true,
+                                            "max_executions_before_finished": 1000,
+                                            "variable": [
+                                                [
+                                                    0.0
+                                                ],
+                                                [
+                                                    0.0
+                                                ],
+                                                [
+                                                    0.0
+                                                ]
+                                            ],
+                                            "input_labels_dict": {},
+                                            "output_labels_dict": {},
+                                            "output_ports": [
+                                                "OUTCOME"
+                                            ],
+                                            "input_ports": [
+                                                {
+                                                    "reward": {
+                                                        "metadata": {
+                                                            "type": "TransferMechanism",
+                                                            "has_initializers": false,
+                                                            "max_executions_before_finished": 1000,
+                                                            "execute_until_finished": true,
+                                                            "variable": [
+                                                                [
+                                                                    0
+                                                                ]
+                                                            ],
+                                                            "termination_measure_value": 0.0,
+                                                            "output_labels_dict": {},
+                                                            "input_port_variables": null,
+                                                            "input_labels_dict": {},
+                                                            "integrator_function_value": [
+                                                                [
+                                                                    0
+                                                                ]
+                                                            ],
+                                                            "integrator_function": {
+                                                                "AdaptiveIntegrator_Function_1": {
+                                                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                                                    "args": {
+                                                                        "offset": 0.0,
+                                                                        "rate": 0.5,
+                                                                        "noise": 0.0
+                                                                    },
+                                                                    "metadata": {
+                                                                        "type": "AdaptiveIntegrator",
+                                                                        "has_initializers": true,
+                                                                        "max_executions_before_finished": 1000,
+                                                                        "execute_until_finished": true,
+                                                                        "variable": [
+                                                                            [
+                                                                                0
+                                                                            ]
+                                                                        ],
+                                                                        "changes_shape": false,
+                                                                        "enable_output_type_conversion": false,
+                                                                        "output_type": "FunctionOutputType.DEFAULT",
+                                                                        "initializer": [
+                                                                            [
+                                                                                0
+                                                                            ]
+                                                                        ],
+                                                                        "function_stateful_params": {
+                                                                            "previous_value": {
+                                                                                "id": "previous_value",
+                                                                                "default_initial_value": [
+                                                                                    [
+                                                                                        0
+                                                                                    ]
+                                                                                ],
+                                                                                "value": "AdaptiveIntegrator_Function_1"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            },
+                                                            "termination_comparison_op": "<=",
+                                                            "termination_threshold": null,
+                                                            "clip": null,
+                                                            "termination_measure": {
+                                                                "Distance_Function_2_3": {
+                                                                    "function": {
+                                                                        "distance": {}
+                                                                    },
+                                                                    "args": {},
+                                                                    "metadata": {
+                                                                        "type": "Distance",
+                                                                        "has_initializers": false,
+                                                                        "execute_until_finished": true,
+                                                                        "enable_output_type_conversion": false,
+                                                                        "max_executions_before_finished": 1000,
+                                                                        "variable": [
+                                                                            [
+                                                                                [
+                                                                                    0
+                                                                                ]
+                                                                            ],
+                                                                            [
+                                                                                [
+                                                                                    0
+                                                                                ]
+                                                                            ]
+                                                                        ],
+                                                                        "changes_shape": false,
+                                                                        "output_type": "FunctionOutputType.DEFAULT",
+                                                                        "normalize": false,
+                                                                        "metric": "max_abs_diff",
+                                                                        "function_stateful_params": {}
+                                                                    }
+                                                                }
+                                                            },
+                                                            "input_ports": null,
+                                                            "integrator_mode": false,
+                                                            "on_resume_integrator_mode": "current_value",
+                                                            "output_ports": [
+                                                                "RESULT",
+                                                                "MEAN",
+                                                                "variance"
+                                                            ]
+                                                        },
+                                                        "input_ports": {
+                                                            "reward_InputPort_0": {
+                                                                "shape": "(1,)",
+                                                                "type": "int64",
+                                                                "metadata": {
+                                                                    "type": "InputPort",
+                                                                    "has_initializers": false,
+                                                                    "execute_until_finished": true,
+                                                                    "internal_only": false,
+                                                                    "max_executions_before_finished": 1000,
+                                                                    "variable": [
+                                                                        0
+                                                                    ],
+                                                                    "shadow_inputs": null,
+                                                                    "require_projection_in_composition": true,
+                                                                    "default_input": null,
+                                                                    "exponent": null,
+                                                                    "projections": null,
+                                                                    "combine": null,
+                                                                    "weight": null
+                                                                }
+                                                            }
+                                                        },
+                                                        "functions": {
+                                                            "Linear_Function_14": {
+                                                                "function": {
+                                                                    "linear": {
+                                                                        "intercept": 0.0,
+                                                                        "slope": 1.0,
+                                                                        "variable0": "reward_InputPort_0"
+                                                                    }
+                                                                },
+                                                                "args": {
+                                                                    "intercept": 0.0,
+                                                                    "slope": 1.0,
+                                                                    "variable0": "reward_InputPort_0"
+                                                                },
+                                                                "metadata": {
+                                                                    "type": "Linear",
+                                                                    "has_initializers": false,
+                                                                    "execute_until_finished": true,
+                                                                    "enable_output_type_conversion": true,
+                                                                    "max_executions_before_finished": 1000,
+                                                                    "changes_shape": false,
+                                                                    "variable": [
+                                                                        [
+                                                                            0
+                                                                        ]
+                                                                    ],
+                                                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                                    "bounds": null,
+                                                                    "function_stateful_params": {}
+                                                                }
+                                                            }
+                                                        },
+                                                        "output_ports": {
+                                                            "reward_RESULT": {
+                                                                "value": "Linear_Function_14",
+                                                                "metadata": {
+                                                                    "type": "OutputPort",
+                                                                    "has_initializers": false,
+                                                                    "execute_until_finished": true,
+                                                                    "max_executions_before_finished": 1000,
+                                                                    "variable": [
+                                                                        0.0
+                                                                    ],
+                                                                    "require_projection_in_composition": true,
+                                                                    "projections": null
+                                                                }
+                                                            },
+                                                            "reward_MEAN": {
+                                                                "value": "Linear_Function_14",
+                                                                "metadata": {
+                                                                    "type": "OutputPort",
+                                                                    "has_initializers": false,
+                                                                    "execute_until_finished": true,
+                                                                    "max_executions_before_finished": 1000,
+                                                                    "variable": [
+                                                                        0.0
+                                                                    ],
+                                                                    "require_projection_in_composition": true,
+                                                                    "projections": null
+                                                                }
+                                                            },
+                                                            "reward_variance": {
+                                                                "value": "Linear_Function_14",
+                                                                "metadata": {
+                                                                    "type": "OutputPort",
+                                                                    "has_initializers": false,
+                                                                    "execute_until_finished": true,
+                                                                    "max_executions_before_finished": 1000,
+                                                                    "variable": [
+                                                                        0.0
+                                                                    ],
+                                                                    "require_projection_in_composition": true,
+                                                                    "projections": null
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Decision.output_ports.PROBABILITY_UPPER_THRESHOLD",
+                                                {
+                                                    "port_spec": "Decision.output_ports.RESPONSE_TIME",
+                                                    "weight": -1,
+                                                    "exponent": 1
+                                                }
+                                            ]
+                                        },
+                                        "input_ports": {
+                                            "ObjectiveMechanism_0_Value_of_reward__RESULT_": {
+                                                "shape": "(1, 1)",
+                                                "type": "float64",
+                                                "metadata": {
+                                                    "type": "InputPort",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "internal_only": true,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        [
+                                                            0.0
+                                                        ]
+                                                    ],
+                                                    "shadow_inputs": null,
+                                                    "require_projection_in_composition": true,
+                                                    "default_input": null,
+                                                    "exponent": null,
+                                                    "projections": [
+                                                        [
+                                                            "reward.output_ports.RESULT",
+                                                            null,
+                                                            null,
+                                                            {
+                                                                "PROJECTION_TYPE": "MappingProjection"
+                                                            }
+                                                        ]
+                                                    ],
+                                                    "combine": null,
+                                                    "weight": null
+                                                }
+                                            },
+                                            "ObjectiveMechanism_0_Value_of_Decision__PROBABILITY_UPPER_THRESHOLD_": {
+                                                "shape": "(1, 1)",
+                                                "type": "float64",
+                                                "metadata": {
+                                                    "type": "InputPort",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "internal_only": true,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        [
+                                                            0.0
+                                                        ]
+                                                    ],
+                                                    "shadow_inputs": null,
+                                                    "require_projection_in_composition": true,
+                                                    "default_input": null,
+                                                    "exponent": null,
+                                                    "projections": [
+                                                        [
+                                                            "Decision.output_ports.PROBABILITY_UPPER_THRESHOLD",
+                                                            null,
+                                                            null,
+                                                            {
+                                                                "PROJECTION_TYPE": "MappingProjection"
+                                                            }
+                                                        ]
+                                                    ],
+                                                    "combine": null,
+                                                    "weight": null
+                                                }
+                                            },
+                                            "ObjectiveMechanism_0_port_spec": {
+                                                "shape": "(1, 1)",
+                                                "type": "float64",
+                                                "metadata": {
+                                                    "type": "InputPort",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "internal_only": true,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        [
+                                                            0.0
+                                                        ]
+                                                    ],
+                                                    "shadow_inputs": null,
+                                                    "require_projection_in_composition": true,
+                                                    "default_input": null,
+                                                    "projections": [
+                                                        [
+                                                            "Decision.output_ports.RESPONSE_TIME",
+                                                            null,
+                                                            null,
+                                                            {
+                                                                "PROJECTION_TYPE": "MappingProjection"
+                                                            }
+                                                        ]
+                                                    ],
+                                                    "combine": null
+                                                }
+                                            }
+                                        },
+                                        "functions": {
+                                            "LinearCombination_Function_1": {
+                                                "function": {
+                                                    "linearcombination": {
+                                                        "offset": 0.0,
+                                                        "scale": 1.0,
+                                                        "variable0": "ObjectiveMechanism_0_Value_of_reward__RESULT_"
+                                                    }
+                                                },
+                                                "args": {
+                                                    "offset": 0.0,
+                                                    "scale": 1.0,
+                                                    "variable0": "ObjectiveMechanism_0_Value_of_reward__RESULT_"
+                                                },
+                                                "metadata": {
+                                                    "type": "LinearCombination",
+                                                    "has_initializers": false,
+                                                    "max_executions_before_finished": 1000,
+                                                    "execute_until_finished": true,
+                                                    "variable": [
+                                                        [
+                                                            0.0
+                                                        ],
+                                                        [
+                                                            0.0
+                                                        ],
+                                                        [
+                                                            0.0
+                                                        ]
+                                                    ],
+                                                    "changes_shape": false,
+                                                    "enable_output_type_conversion": true,
+                                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                    "operation": "product",
+                                                    "weights": null,
+                                                    "exponents": null,
+                                                    "function_stateful_params": {}
+                                                }
+                                            }
+                                        },
+                                        "output_ports": {
+                                            "ObjectiveMechanism_0_OUTCOME": {
+                                                "value": "LinearCombination_Function_1",
+                                                "metadata": {
+                                                    "type": "OutputPort",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        0.0
+                                                    ],
+                                                    "require_projection_in_composition": true,
+                                                    "projections": null
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "saved_samples": null,
+                                "control_allocation_search_space": null,
+                                "default_allocation": null,
+                                "monitor_for_control": [],
+                                "search_function": null,
+                                "state_input_ports": "[(InputPort SHADOWED INPUT OF Input[InputPort-0] FOR reward[InputPort-0]), (InputPort SHADOWED INPUT OF reward[InputPort-0] FOR Input[InputPort-0])]",
+                                "random_variables": "all",
+                                "num_estimates": null,
+                                "search_space": null,
+                                "num_trials_per_estimate": null,
+                                "state_feature_specs": [
+                                    "Input.input_ports.InputPort-0",
+                                    "reward.input_ports.InputPort-0"
+                                ],
+                                "state_feature_default_spec": "shadow_inputs",
+                                "combine_costs": "gASVEQAAAAAAAACMBW51bXB5lIwDc3VtlJOULg==\n",
+                                "input_ports": [
+                                    "OUTCOME"
+                                ],
+                                "outcome_input_ports_option": "concatenate",
+                                "reconfiguration_cost": null,
+                                "compute_reconfiguration_cost": null,
+                                "search_termination_function": null,
+                                "output_ports": [
+                                    {
+                                        "allocation_samples": [
+                                            0.1,
+                                            0.4,
+                                            0.7000000000000001,
+                                            1.0000000000000002
+                                        ],
+                                        "name": "drift_rate",
+                                        "MECHANISM": {
+                                            "Decision": {
+                                                "metadata": {
+                                                    "type": "DDM",
+                                                    "has_initializers": false,
+                                                    "max_executions_before_finished": 1000,
+                                                    "execute_until_finished": true,
+                                                    "variable": [
+                                                        [
+                                                            0
+                                                        ]
+                                                    ],
+                                                    "output_labels_dict": {},
+                                                    "input_port_variables": null,
+                                                    "input_labels_dict": {},
+                                                    "input_ports": null,
+                                                    "input_format": "SCALAR",
+                                                    "output_ports": [
+                                                        "DECISION_VARIABLE",
+                                                        "RESPONSE_TIME",
+                                                        "PROBABILITY_UPPER_THRESHOLD"
+                                                    ],
+                                                    "random_state": null
+                                                },
+                                                "input_ports": {
+                                                    "Decision_InputPort_0": {
+                                                        "shape": "(1,)",
+                                                        "type": "int64",
+                                                        "metadata": {
+                                                            "type": "InputPort",
+                                                            "has_initializers": false,
+                                                            "execute_until_finished": true,
+                                                            "internal_only": false,
+                                                            "max_executions_before_finished": 1000,
+                                                            "variable": [
+                                                                0
+                                                            ],
+                                                            "shadow_inputs": null,
+                                                            "require_projection_in_composition": true,
+                                                            "default_input": null,
+                                                            "exponent": null,
+                                                            "projections": null,
+                                                            "combine": null,
+                                                            "weight": null
+                                                        }
+                                                    }
+                                                },
+                                                "functions": {
+                                                    "Drift_Diffusion_Analytical_Function_0": {
+                                                        "function": {
+                                                            "driftdiffusionanalytical": {
+                                                                "starting_value": 0,
+                                                                "noise": 0.5,
+                                                                "bias": 0.5,
+                                                                "non_decision_time": 0.45,
+                                                                "shape": [
+                                                                    1,
+                                                                    1
+                                                                ],
+                                                                "variable0": "Decision_InputPort_0"
+                                                            }
+                                                        },
+                                                        "args": {
+                                                            "starting_value": 0,
+                                                            "noise": 0.5,
+                                                            "bias": 0.5,
+                                                            "non_decision_time": 0.45,
+                                                            "shape": [
+                                                                1,
+                                                                1
+                                                            ],
+                                                            "variable0": "Decision_InputPort_0"
+                                                        },
+                                                        "metadata": {
+                                                            "type": "DriftDiffusionAnalytical",
+                                                            "has_initializers": false,
+                                                            "max_executions_before_finished": 1000,
+                                                            "execute_until_finished": true,
+                                                            "variable": [
+                                                                [
+                                                                    0
+                                                                ]
+                                                            ],
+                                                            "changes_shape": false,
+                                                            "enable_output_type_conversion": true,
+                                                            "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                            "threshold": [
+                                                                1.0,
+                                                                {
+                                                                    "ControlProjection_for_Decision_threshold_": {
+                                                                        "parameters": {
+                                                                            "weight": 1
+                                                                        },
+                                                                        "sender": "None",
+                                                                        "receiver": "Decision",
+                                                                        "sender_port": "None_None",
+                                                                        "receiver_port": "Decision_threshold",
+                                                                        "metadata": {
+                                                                            "type": "ControlProjection",
+                                                                            "has_initializers": false,
+                                                                            "execute_until_finished": true,
+                                                                            "max_executions_before_finished": 1000,
+                                                                            "control_signal_params": {
+                                                                                "allocation_samples": [
+                                                                                    0.1,
+                                                                                    0.4,
+                                                                                    0.7000000000000001,
+                                                                                    1.0000000000000002
+                                                                                ]
+                                                                            },
+                                                                            "exponent": null,
+                                                                            "weight": null
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "drift_rate": [
+                                                                1.0,
+                                                                {
+                                                                    "ControlProjection_for_Decision_drift_rate_": {
+                                                                        "parameters": {
+                                                                            "weight": 1
+                                                                        },
+                                                                        "sender": "None",
+                                                                        "receiver": "Decision",
+                                                                        "sender_port": "None_None",
+                                                                        "receiver_port": "Decision_drift_rate",
+                                                                        "metadata": {
+                                                                            "type": "ControlProjection",
+                                                                            "has_initializers": false,
+                                                                            "execute_until_finished": true,
+                                                                            "max_executions_before_finished": 1000,
+                                                                            "control_signal_params": {
+                                                                                "allocation_samples": [
+                                                                                    0.1,
+                                                                                    0.4,
+                                                                                    0.7000000000000001,
+                                                                                    1.0000000000000002
+                                                                                ]
+                                                                            },
+                                                                            "exponent": null,
+                                                                            "weight": null
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "function_stateful_params": {}
+                                                        }
+                                                    }
+                                                },
+                                                "parameters": {
+                                                    "seed": {
+                                                        "value": -1
+                                                    },
+                                                    "initializer": {
+                                                        "value": [
+                                                            [
+                                                                0
+                                                            ]
+                                                        ]
+                                                    }
+                                                },
+                                                "output_ports": {
+                                                    "Decision_DECISION_VARIABLE": {
+                                                        "value": "Drift_Diffusion_Analytical_Function_0[0]",
+                                                        "metadata": {
+                                                            "type": "OutputPort",
+                                                            "has_initializers": false,
+                                                            "execute_until_finished": true,
+                                                            "max_executions_before_finished": 1000,
+                                                            "variable": [
+                                                                1.0
+                                                            ],
+                                                            "require_projection_in_composition": true,
+                                                            "projections": null
+                                                        }
+                                                    },
+                                                    "Decision_RESPONSE_TIME": {
+                                                        "value": "Drift_Diffusion_Analytical_Function_0[1]",
+                                                        "metadata": {
+                                                            "type": "OutputPort",
+                                                            "has_initializers": false,
+                                                            "execute_until_finished": true,
+                                                            "max_executions_before_finished": 1000,
+                                                            "variable": [
+                                                                4.45
+                                                            ],
+                                                            "require_projection_in_composition": true,
+                                                            "projections": null
+                                                        }
+                                                    },
+                                                    "Decision_PROBABILITY_UPPER_THRESHOLD": {
+                                                        "value": "Drift_Diffusion_Analytical_Function_0[2]",
+                                                        "metadata": {
+                                                            "type": "OutputPort",
+                                                            "has_initializers": false,
+                                                            "execute_until_finished": true,
+                                                            "max_executions_before_finished": 1000,
+                                                            "variable": [
+                                                                0.5
+                                                            ],
+                                                            "require_projection_in_composition": true,
+                                                            "projections": null
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "allocation_samples": [
+                                            0.1,
+                                            0.4,
+                                            0.7000000000000001,
+                                            1.0000000000000002
+                                        ],
+                                        "name": "threshold",
+                                        "MECHANISM": {
+                                            "Decision": {
+                                                "metadata": {
+                                                    "type": "DDM",
+                                                    "has_initializers": false,
+                                                    "max_executions_before_finished": 1000,
+                                                    "execute_until_finished": true,
+                                                    "variable": [
+                                                        [
+                                                            0
+                                                        ]
+                                                    ],
+                                                    "output_labels_dict": {},
+                                                    "input_port_variables": null,
+                                                    "input_labels_dict": {},
+                                                    "input_ports": null,
+                                                    "input_format": "SCALAR",
+                                                    "output_ports": [
+                                                        "DECISION_VARIABLE",
+                                                        "RESPONSE_TIME",
+                                                        "PROBABILITY_UPPER_THRESHOLD"
+                                                    ],
+                                                    "random_state": null
+                                                },
+                                                "input_ports": {
+                                                    "Decision_InputPort_0": {
+                                                        "shape": "(1,)",
+                                                        "type": "int64",
+                                                        "metadata": {
+                                                            "type": "InputPort",
+                                                            "has_initializers": false,
+                                                            "execute_until_finished": true,
+                                                            "internal_only": false,
+                                                            "max_executions_before_finished": 1000,
+                                                            "variable": [
+                                                                0
+                                                            ],
+                                                            "shadow_inputs": null,
+                                                            "require_projection_in_composition": true,
+                                                            "default_input": null,
+                                                            "exponent": null,
+                                                            "projections": null,
+                                                            "combine": null,
+                                                            "weight": null
+                                                        }
+                                                    }
+                                                },
+                                                "functions": {
+                                                    "Drift_Diffusion_Analytical_Function_0": {
+                                                        "function": {
+                                                            "driftdiffusionanalytical": {
+                                                                "starting_value": 0,
+                                                                "noise": 0.5,
+                                                                "bias": 0.5,
+                                                                "non_decision_time": 0.45,
+                                                                "shape": [
+                                                                    1,
+                                                                    1
+                                                                ],
+                                                                "variable0": "Decision_InputPort_0"
+                                                            }
+                                                        },
+                                                        "args": {
+                                                            "starting_value": 0,
+                                                            "noise": 0.5,
+                                                            "bias": 0.5,
+                                                            "non_decision_time": 0.45,
+                                                            "shape": [
+                                                                1,
+                                                                1
+                                                            ],
+                                                            "variable0": "Decision_InputPort_0"
+                                                        },
+                                                        "metadata": {
+                                                            "type": "DriftDiffusionAnalytical",
+                                                            "has_initializers": false,
+                                                            "max_executions_before_finished": 1000,
+                                                            "execute_until_finished": true,
+                                                            "variable": [
+                                                                [
+                                                                    0
+                                                                ]
+                                                            ],
+                                                            "changes_shape": false,
+                                                            "enable_output_type_conversion": true,
+                                                            "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                            "threshold": [
+                                                                1.0,
+                                                                {
+                                                                    "ControlProjection_for_Decision_threshold_": {
+                                                                        "parameters": {
+                                                                            "weight": 1
+                                                                        },
+                                                                        "sender": "None",
+                                                                        "receiver": "Decision",
+                                                                        "sender_port": "None_None",
+                                                                        "receiver_port": "Decision_threshold",
+                                                                        "metadata": {
+                                                                            "type": "ControlProjection",
+                                                                            "has_initializers": false,
+                                                                            "execute_until_finished": true,
+                                                                            "max_executions_before_finished": 1000,
+                                                                            "control_signal_params": {
+                                                                                "allocation_samples": [
+                                                                                    0.1,
+                                                                                    0.4,
+                                                                                    0.7000000000000001,
+                                                                                    1.0000000000000002
+                                                                                ]
+                                                                            },
+                                                                            "exponent": null,
+                                                                            "weight": null
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "drift_rate": [
+                                                                1.0,
+                                                                {
+                                                                    "ControlProjection_for_Decision_drift_rate_": {
+                                                                        "parameters": {
+                                                                            "weight": 1
+                                                                        },
+                                                                        "sender": "None",
+                                                                        "receiver": "Decision",
+                                                                        "sender_port": "None_None",
+                                                                        "receiver_port": "Decision_drift_rate",
+                                                                        "metadata": {
+                                                                            "type": "ControlProjection",
+                                                                            "has_initializers": false,
+                                                                            "execute_until_finished": true,
+                                                                            "max_executions_before_finished": 1000,
+                                                                            "control_signal_params": {
+                                                                                "allocation_samples": [
+                                                                                    0.1,
+                                                                                    0.4,
+                                                                                    0.7000000000000001,
+                                                                                    1.0000000000000002
+                                                                                ]
+                                                                            },
+                                                                            "exponent": null,
+                                                                            "weight": null
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "function_stateful_params": {}
+                                                        }
+                                                    }
+                                                },
+                                                "parameters": {
+                                                    "seed": {
+                                                        "value": -1
+                                                    },
+                                                    "initializer": {
+                                                        "value": [
+                                                            [
+                                                                0
+                                                            ]
+                                                        ]
+                                                    }
+                                                },
+                                                "output_ports": {
+                                                    "Decision_DECISION_VARIABLE": {
+                                                        "value": "Drift_Diffusion_Analytical_Function_0[0]",
+                                                        "metadata": {
+                                                            "type": "OutputPort",
+                                                            "has_initializers": false,
+                                                            "execute_until_finished": true,
+                                                            "max_executions_before_finished": 1000,
+                                                            "variable": [
+                                                                1.0
+                                                            ],
+                                                            "require_projection_in_composition": true,
+                                                            "projections": null
+                                                        }
+                                                    },
+                                                    "Decision_RESPONSE_TIME": {
+                                                        "value": "Drift_Diffusion_Analytical_Function_0[1]",
+                                                        "metadata": {
+                                                            "type": "OutputPort",
+                                                            "has_initializers": false,
+                                                            "execute_until_finished": true,
+                                                            "max_executions_before_finished": 1000,
+                                                            "variable": [
+                                                                4.45
+                                                            ],
+                                                            "require_projection_in_composition": true,
+                                                            "projections": null
+                                                        }
+                                                    },
+                                                    "Decision_PROBABILITY_UPPER_THRESHOLD": {
+                                                        "value": "Drift_Diffusion_Analytical_Function_0[2]",
+                                                        "metadata": {
+                                                            "type": "OutputPort",
+                                                            "has_initializers": false,
+                                                            "execute_until_finished": true,
+                                                            "max_executions_before_finished": 1000,
+                                                            "variable": [
+                                                                0.5
+                                                            ],
+                                                            "require_projection_in_composition": true,
+                                                            "projections": null
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                ],
+                                "same_seed_for_all_allocations": false,
+                                "search_statefulness": true
+                            },
+                            "input_ports": {
+                                "OptimizationControlMechanism_0_OUTCOME": {
+                                    "shape": "(1,)",
+                                    "type": "float64",
+                                    "metadata": {
+                                        "type": "InputPort",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "internal_only": true,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            0.0
+                                        ],
+                                        "shadow_inputs": null,
+                                        "require_projection_in_composition": true,
+                                        "default_input": null,
+                                        "exponent": null,
+                                        "projections": null,
+                                        "combine": null,
+                                        "weight": null
+                                    }
+                                },
+                                "OptimizationControlMechanism_0_SHADOWED_INPUT_OF_Input_InputPort_0__FOR_reward_InputPort_0_": {
+                                    "shape": "(1,)",
+                                    "type": "int64",
+                                    "metadata": {
+                                        "type": "InputPort",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "internal_only": [
+                                            true
+                                        ],
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            0
+                                        ],
+                                        "shadow_inputs": "Input.input_ports.InputPort-0",
+                                        "require_projection_in_composition": true,
+                                        "default_input": null,
+                                        "exponent": null,
+                                        "projections": null,
+                                        "combine": null,
+                                        "weight": null
+                                    }
+                                },
+                                "OptimizationControlMechanism_0_SHADOWED_INPUT_OF_reward_InputPort_0__FOR_Input_InputPort_0_": {
+                                    "shape": "(1,)",
+                                    "type": "int64",
+                                    "metadata": {
+                                        "type": "InputPort",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "internal_only": [
+                                            true
+                                        ],
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            0
+                                        ],
+                                        "shadow_inputs": "reward.input_ports.InputPort-0",
+                                        "require_projection_in_composition": true,
+                                        "default_input": null,
+                                        "exponent": null,
+                                        "projections": null,
+                                        "combine": null,
+                                        "weight": null
+                                    }
+                                }
+                            },
+                            "functions": {
+                                "GridSearch_Function_0": {
+                                    "function": {
+                                        "gridsearch": {
+                                            "seed": -1,
+                                            "variable0": "OptimizationControlMechanism_0_OUTCOME"
+                                        }
+                                    },
+                                    "args": {
+                                        "seed": -1,
+                                        "variable0": "OptimizationControlMechanism_0_OUTCOME"
+                                    },
+                                    "metadata": {
+                                        "type": "GridSearch",
+                                        "has_initializers": false,
+                                        "max_executions_before_finished": 1000,
+                                        "saved_values": [],
+                                        "saved_samples": [],
+                                        "execute_until_finished": true,
+                                        "save_samples": false,
+                                        "variable": [
+                                            [
+                                                1.0
+                                            ],
+                                            [
+                                                1.0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": true,
+                                        "save_values": false,
+                                        "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                        "aggregation_function": "gASVXAEAAAAAAACMCmRpbGwuX2RpbGyUjBBfY3JlYXRlX2Z1bmN0aW9ulJOUKGgAjAxfY3JlYXRl\nX2NvZGWUk5QoSwFLAEsASwFLBEtDQw50AGoBfABkAWQCjQJTAJROSwGMBGF4aXOUhZSHlIwCbnCU\njARtZWFulIaUjAF4lIWUjG8vVXNlcnMvamRjL1B5Q2hhcm1Qcm9qZWN0cy9Qc3lOZXVMaW5rL3Bz\neW5ldWxpbmsvY29yZS9jb21wb25lbnRzL2Z1bmN0aW9ucy9ub25zdGF0ZWZ1bC9vcHRpbWl6YXRp\nb25mdW5jdGlvbnMucHmUjAg8bGFtYmRhPpRNhQFDAJQpKXSUUpRjcHN5bmV1bGluay5jb3JlLmNv\nbXBvbmVudHMuZnVuY3Rpb25zLm5vbnN0YXRlZnVsLm9wdGltaXphdGlvbmZ1bmN0aW9ucwpfX2Rp\nY3RfXwpoD05OfZROdJRSlC4=\n",
+                                        "search_function": null,
+                                        "randomization_dimension": null,
+                                        "grid": null,
+                                        "num_estimates": null,
+                                        "objective_function": null,
+                                        "select_randomly_from_optimal_values": false,
+                                        "search_space": [
+                                            "SampleIterator([0.1, 0.4, 0.7000000000000001, 1.0000000000000002])",
+                                            "SampleIterator([0.1, 0.4, 0.7000000000000001, 1.0000000000000002])"
+                                        ],
+                                        "direction": "maximize",
+                                        "max_iterations": null,
+                                        "search_termination_function": null,
+                                        "random_state": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "output_ports": {
+                                "OptimizationControlMechanism_0_Decision_drift_rate__ControlSignal": {
+                                    "value": "GridSearch_Function_0[0]",
+                                    "metadata": {
+                                        "type": "ControlSignal",
+                                        "has_initializers": false,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            1.0
+                                        ],
+                                        "require_projection_in_composition": true,
+                                        "modulation": "multiplicative_param",
+                                        "projections": [
+                                            [
+                                                "Decision.input_ports.drift_rate",
+                                                null,
+                                                null,
+                                                {
+                                                    "PROJECTION_TYPE": "ControlProjection"
+                                                }
+                                            ]
+                                        ]
+                                    }
+                                },
+                                "OptimizationControlMechanism_0_Decision_threshold__ControlSignal": {
+                                    "value": "GridSearch_Function_0[1]",
+                                    "metadata": {
+                                        "type": "ControlSignal",
+                                        "has_initializers": false,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            1.0
+                                        ],
+                                        "require_projection_in_composition": true,
+                                        "modulation": "multiplicative_param",
+                                        "projections": [
+                                            [
+                                                "Decision.input_ports.threshold",
+                                                null,
+                                                null,
+                                                {
+                                                    "PROJECTION_TYPE": "ControlProjection"
+                                                }
+                                            ]
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "nodes": {
+                    "reward": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_1": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_1"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_3": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULT",
+                                "MEAN",
+                                "variance"
+                            ]
+                        },
+                        "input_ports": {
+                            "reward_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_14": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "reward_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "reward_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "reward_RESULT": {
+                                "value": "Linear_Function_14",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            },
+                            "reward_MEAN": {
+                                "value": "Linear_Function_14",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            },
+                            "reward_variance": {
+                                "value": "Linear_Function_14",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "Decision": {
+                        "metadata": {
+                            "type": "DDM",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "input_ports": null,
+                            "input_format": "SCALAR",
+                            "output_ports": [
+                                "DECISION_VARIABLE",
+                                "RESPONSE_TIME",
+                                "PROBABILITY_UPPER_THRESHOLD"
+                            ],
+                            "random_state": null
+                        },
+                        "input_ports": {
+                            "Decision_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Drift_Diffusion_Analytical_Function_0": {
+                                "function": {
+                                    "driftdiffusionanalytical": {
+                                        "starting_value": 0,
+                                        "noise": 0.5,
+                                        "bias": 0.5,
+                                        "non_decision_time": 0.45,
+                                        "shape": [
+                                            1,
+                                            1
+                                        ],
+                                        "variable0": "Decision_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "starting_value": 0,
+                                    "noise": 0.5,
+                                    "bias": 0.5,
+                                    "non_decision_time": 0.45,
+                                    "shape": [
+                                        1,
+                                        1
+                                    ],
+                                    "variable0": "Decision_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "DriftDiffusionAnalytical",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "threshold": [
+                                        1.0,
+                                        {
+                                            "ControlProjection_for_Decision_threshold_": {
+                                                "parameters": {
+                                                    "weight": 1
+                                                },
+                                                "sender": "None",
+                                                "receiver": "Decision",
+                                                "sender_port": "None_None",
+                                                "receiver_port": "Decision_threshold",
+                                                "metadata": {
+                                                    "type": "ControlProjection",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "max_executions_before_finished": 1000,
+                                                    "control_signal_params": {
+                                                        "allocation_samples": [
+                                                            0.1,
+                                                            0.4,
+                                                            0.7000000000000001,
+                                                            1.0000000000000002
+                                                        ]
+                                                    },
+                                                    "exponent": null,
+                                                    "weight": null
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "drift_rate": [
+                                        1.0,
+                                        {
+                                            "ControlProjection_for_Decision_drift_rate_": {
+                                                "parameters": {
+                                                    "weight": 1
+                                                },
+                                                "sender": "None",
+                                                "receiver": "Decision",
+                                                "sender_port": "None_None",
+                                                "receiver_port": "Decision_drift_rate",
+                                                "metadata": {
+                                                    "type": "ControlProjection",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "max_executions_before_finished": 1000,
+                                                    "control_signal_params": {
+                                                        "allocation_samples": [
+                                                            0.1,
+                                                            0.4,
+                                                            0.7000000000000001,
+                                                            1.0000000000000002
+                                                        ]
+                                                    },
+                                                    "exponent": null,
+                                                    "weight": null
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "seed": {
+                                "value": -1
+                            },
+                            "initializer": {
+                                "value": [
+                                    [
+                                        0
+                                    ]
+                                ]
+                            }
+                        },
+                        "output_ports": {
+                            "Decision_DECISION_VARIABLE": {
+                                "value": "Drift_Diffusion_Analytical_Function_0[0]",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        1.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            },
+                            "Decision_RESPONSE_TIME": {
+                                "value": "Drift_Diffusion_Analytical_Function_0[1]",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        4.45
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            },
+                            "Decision_PROBABILITY_UPPER_THRESHOLD": {
+                                "value": "Drift_Diffusion_Analytical_Function_0[2]",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.5
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "Input": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_0": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_0"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_1": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "Input_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_5": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "Input_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "Input_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "Input_RESULT": {
+                                "value": "Linear_Function_5",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "ObjectiveMechanism_0": {
+                        "metadata": {
+                            "type": "ObjectiveMechanism",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0.0
+                                ],
+                                [
+                                    0.0
+                                ],
+                                [
+                                    0.0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": [
+                                "OUTCOME"
+                            ],
+                            "input_ports": [
+                                {
+                                    "reward": {
+                                        "metadata": {
+                                            "type": "TransferMechanism",
+                                            "has_initializers": false,
+                                            "max_executions_before_finished": 1000,
+                                            "execute_until_finished": true,
+                                            "variable": [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            "termination_measure_value": 0.0,
+                                            "output_labels_dict": {},
+                                            "input_port_variables": null,
+                                            "input_labels_dict": {},
+                                            "integrator_function_value": [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            "integrator_function": {
+                                                "AdaptiveIntegrator_Function_1": {
+                                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                                    "args": {
+                                                        "offset": 0.0,
+                                                        "rate": 0.5,
+                                                        "noise": 0.0
+                                                    },
+                                                    "metadata": {
+                                                        "type": "AdaptiveIntegrator",
+                                                        "has_initializers": true,
+                                                        "max_executions_before_finished": 1000,
+                                                        "execute_until_finished": true,
+                                                        "variable": [
+                                                            [
+                                                                0
+                                                            ]
+                                                        ],
+                                                        "changes_shape": false,
+                                                        "enable_output_type_conversion": false,
+                                                        "output_type": "FunctionOutputType.DEFAULT",
+                                                        "initializer": [
+                                                            [
+                                                                0
+                                                            ]
+                                                        ],
+                                                        "function_stateful_params": {
+                                                            "previous_value": {
+                                                                "id": "previous_value",
+                                                                "default_initial_value": [
+                                                                    [
+                                                                        0
+                                                                    ]
+                                                                ],
+                                                                "value": "AdaptiveIntegrator_Function_1"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "termination_comparison_op": "<=",
+                                            "termination_threshold": null,
+                                            "clip": null,
+                                            "termination_measure": {
+                                                "Distance_Function_2_3": {
+                                                    "function": {
+                                                        "distance": {}
+                                                    },
+                                                    "args": {},
+                                                    "metadata": {
+                                                        "type": "Distance",
+                                                        "has_initializers": false,
+                                                        "execute_until_finished": true,
+                                                        "enable_output_type_conversion": false,
+                                                        "max_executions_before_finished": 1000,
+                                                        "variable": [
+                                                            [
+                                                                [
+                                                                    0
+                                                                ]
+                                                            ],
+                                                            [
+                                                                [
+                                                                    0
+                                                                ]
+                                                            ]
+                                                        ],
+                                                        "changes_shape": false,
+                                                        "output_type": "FunctionOutputType.DEFAULT",
+                                                        "normalize": false,
+                                                        "metric": "max_abs_diff",
+                                                        "function_stateful_params": {}
+                                                    }
+                                                }
+                                            },
+                                            "input_ports": null,
+                                            "integrator_mode": false,
+                                            "on_resume_integrator_mode": "current_value",
+                                            "output_ports": [
+                                                "RESULT",
+                                                "MEAN",
+                                                "variance"
+                                            ]
+                                        },
+                                        "input_ports": {
+                                            "reward_InputPort_0": {
+                                                "shape": "(1,)",
+                                                "type": "int64",
+                                                "metadata": {
+                                                    "type": "InputPort",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "internal_only": false,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        0
+                                                    ],
+                                                    "shadow_inputs": null,
+                                                    "require_projection_in_composition": true,
+                                                    "default_input": null,
+                                                    "exponent": null,
+                                                    "projections": null,
+                                                    "combine": null,
+                                                    "weight": null
+                                                }
+                                            }
+                                        },
+                                        "functions": {
+                                            "Linear_Function_14": {
+                                                "function": {
+                                                    "linear": {
+                                                        "intercept": 0.0,
+                                                        "slope": 1.0,
+                                                        "variable0": "reward_InputPort_0"
+                                                    }
+                                                },
+                                                "args": {
+                                                    "intercept": 0.0,
+                                                    "slope": 1.0,
+                                                    "variable0": "reward_InputPort_0"
+                                                },
+                                                "metadata": {
+                                                    "type": "Linear",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "enable_output_type_conversion": true,
+                                                    "max_executions_before_finished": 1000,
+                                                    "changes_shape": false,
+                                                    "variable": [
+                                                        [
+                                                            0
+                                                        ]
+                                                    ],
+                                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                    "bounds": null,
+                                                    "function_stateful_params": {}
+                                                }
+                                            }
+                                        },
+                                        "output_ports": {
+                                            "reward_RESULT": {
+                                                "value": "Linear_Function_14",
+                                                "metadata": {
+                                                    "type": "OutputPort",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        0.0
+                                                    ],
+                                                    "require_projection_in_composition": true,
+                                                    "projections": null
+                                                }
+                                            },
+                                            "reward_MEAN": {
+                                                "value": "Linear_Function_14",
+                                                "metadata": {
+                                                    "type": "OutputPort",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        0.0
+                                                    ],
+                                                    "require_projection_in_composition": true,
+                                                    "projections": null
+                                                }
+                                            },
+                                            "reward_variance": {
+                                                "value": "Linear_Function_14",
+                                                "metadata": {
+                                                    "type": "OutputPort",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        0.0
+                                                    ],
+                                                    "require_projection_in_composition": true,
+                                                    "projections": null
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "Decision.output_ports.PROBABILITY_UPPER_THRESHOLD",
+                                {
+                                    "port_spec": "Decision.output_ports.RESPONSE_TIME",
+                                    "weight": -1,
+                                    "exponent": 1
+                                }
+                            ]
+                        },
+                        "input_ports": {
+                            "ObjectiveMechanism_0_Value_of_reward__RESULT_": {
+                                "shape": "(1, 1)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            0.0
+                                        ]
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": [
+                                        [
+                                            "reward.output_ports.RESULT",
+                                            null,
+                                            null,
+                                            {
+                                                "PROJECTION_TYPE": "MappingProjection"
+                                            }
+                                        ]
+                                    ],
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            },
+                            "ObjectiveMechanism_0_Value_of_Decision__PROBABILITY_UPPER_THRESHOLD_": {
+                                "shape": "(1, 1)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            0.0
+                                        ]
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": [
+                                        [
+                                            "Decision.output_ports.PROBABILITY_UPPER_THRESHOLD",
+                                            null,
+                                            null,
+                                            {
+                                                "PROJECTION_TYPE": "MappingProjection"
+                                            }
+                                        ]
+                                    ],
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            },
+                            "ObjectiveMechanism_0_port_spec": {
+                                "shape": "(1, 1)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            0.0
+                                        ]
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "projections": [
+                                        [
+                                            "Decision.output_ports.RESPONSE_TIME",
+                                            null,
+                                            null,
+                                            {
+                                                "PROJECTION_TYPE": "MappingProjection"
+                                            }
+                                        ]
+                                    ],
+                                    "combine": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "LinearCombination_Function_1": {
+                                "function": {
+                                    "linearcombination": {
+                                        "offset": 0.0,
+                                        "scale": 1.0,
+                                        "variable0": "ObjectiveMechanism_0_Value_of_reward__RESULT_"
+                                    }
+                                },
+                                "args": {
+                                    "offset": 0.0,
+                                    "scale": 1.0,
+                                    "variable0": "ObjectiveMechanism_0_Value_of_reward__RESULT_"
+                                },
+                                "metadata": {
+                                    "type": "LinearCombination",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0.0
+                                        ],
+                                        [
+                                            0.0
+                                        ],
+                                        [
+                                            0.0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "operation": "product",
+                                    "weights": null,
+                                    "exponents": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "ObjectiveMechanism_0_OUTCOME": {
+                                "value": "LinearCombination_Function_1",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "OptimizationControlMechanism_0": {
+                        "metadata": {
+                            "type": "OptimizationControlMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "simulation_ids": [],
+                            "execute_until_finished": true,
+                            "modulation": "multiplicative_param",
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "outcome": null,
+                            "net_outcome": null,
+                            "agent_rep": "comp",
+                            "state_feature_values": null,
+                            "control_signal_costs": null,
+                            "input_labels_dict": {},
+                            "comp_execution_mode": "Python",
+                            "compute_net_outcome": "gASVUQEAAAAAAACMCmRpbGwuX2RpbGyUjBBfY3JlYXRlX2Z1bmN0aW9ulJOUKGgAjAxfY3JlYXRl\nX2NvZGWUk5QoSwJLAEsASwJLAktDQwh8AHwBGABTAJROhZQpjAdvdXRjb21llIwEY29zdJSGlIxy\nL1VzZXJzL2pkYy9QeUNoYXJtUHJvamVjdHMvUHN5TmV1TGluay9wc3luZXVsaW5rL2NvcmUvY29t\ncG9uZW50cy9tZWNoYW5pc21zL21vZHVsYXRvcnkvY29udHJvbC9jb250cm9sbWVjaGFuaXNtLnB5\nlIwIPGxhbWJkYT6UTWkEQwCUKSl0lFKUY3BzeW5ldWxpbmsuY29yZS5jb21wb25lbnRzLm1lY2hh\nbmlzbXMubW9kdWxhdG9yeS5jb250cm9sLmNvbnRyb2xtZWNoYW5pc20KX19kaWN0X18KaAtOTn2U\nTnSUUpQu\n",
+                            "initial_seed": null,
+                            "saved_values": null,
+                            "outcome_input_ports": "[(InputPort OUTCOME)]",
+                            "costs": null,
+                            "state_feature_function": {
+                                "AdaptiveIntegrator_Function_2": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            0
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            0
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    0
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_2"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "objective_mechanism": {
+                                "ObjectiveMechanism_0": {
+                                    "metadata": {
+                                        "type": "ObjectiveMechanism",
+                                        "has_initializers": false,
+                                        "input_port_variables": null,
+                                        "execute_until_finished": true,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                0.0
+                                            ],
+                                            [
+                                                0.0
+                                            ],
+                                            [
+                                                0.0
+                                            ]
+                                        ],
+                                        "input_labels_dict": {},
+                                        "output_labels_dict": {},
+                                        "output_ports": [
+                                            "OUTCOME"
+                                        ],
+                                        "input_ports": [
+                                            {
+                                                "reward": {
+                                                    "metadata": {
+                                                        "type": "TransferMechanism",
+                                                        "has_initializers": false,
+                                                        "max_executions_before_finished": 1000,
+                                                        "execute_until_finished": true,
+                                                        "variable": [
+                                                            [
+                                                                0
+                                                            ]
+                                                        ],
+                                                        "termination_measure_value": 0.0,
+                                                        "output_labels_dict": {},
+                                                        "input_port_variables": null,
+                                                        "input_labels_dict": {},
+                                                        "integrator_function_value": [
+                                                            [
+                                                                0
+                                                            ]
+                                                        ],
+                                                        "integrator_function": {
+                                                            "AdaptiveIntegrator_Function_1": {
+                                                                "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                                                "args": {
+                                                                    "offset": 0.0,
+                                                                    "rate": 0.5,
+                                                                    "noise": 0.0
+                                                                },
+                                                                "metadata": {
+                                                                    "type": "AdaptiveIntegrator",
+                                                                    "has_initializers": true,
+                                                                    "max_executions_before_finished": 1000,
+                                                                    "execute_until_finished": true,
+                                                                    "variable": [
+                                                                        [
+                                                                            0
+                                                                        ]
+                                                                    ],
+                                                                    "changes_shape": false,
+                                                                    "enable_output_type_conversion": false,
+                                                                    "output_type": "FunctionOutputType.DEFAULT",
+                                                                    "initializer": [
+                                                                        [
+                                                                            0
+                                                                        ]
+                                                                    ],
+                                                                    "function_stateful_params": {
+                                                                        "previous_value": {
+                                                                            "id": "previous_value",
+                                                                            "default_initial_value": [
+                                                                                [
+                                                                                    0
+                                                                                ]
+                                                                            ],
+                                                                            "value": "AdaptiveIntegrator_Function_1"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "termination_comparison_op": "<=",
+                                                        "termination_threshold": null,
+                                                        "clip": null,
+                                                        "termination_measure": {
+                                                            "Distance_Function_2_3": {
+                                                                "function": {
+                                                                    "distance": {}
+                                                                },
+                                                                "args": {},
+                                                                "metadata": {
+                                                                    "type": "Distance",
+                                                                    "has_initializers": false,
+                                                                    "execute_until_finished": true,
+                                                                    "enable_output_type_conversion": false,
+                                                                    "max_executions_before_finished": 1000,
+                                                                    "variable": [
+                                                                        [
+                                                                            [
+                                                                                0
+                                                                            ]
+                                                                        ],
+                                                                        [
+                                                                            [
+                                                                                0
+                                                                            ]
+                                                                        ]
+                                                                    ],
+                                                                    "changes_shape": false,
+                                                                    "output_type": "FunctionOutputType.DEFAULT",
+                                                                    "normalize": false,
+                                                                    "metric": "max_abs_diff",
+                                                                    "function_stateful_params": {}
+                                                                }
+                                                            }
+                                                        },
+                                                        "input_ports": null,
+                                                        "integrator_mode": false,
+                                                        "on_resume_integrator_mode": "current_value",
+                                                        "output_ports": [
+                                                            "RESULT",
+                                                            "MEAN",
+                                                            "variance"
+                                                        ]
+                                                    },
+                                                    "input_ports": {
+                                                        "reward_InputPort_0": {
+                                                            "shape": "(1,)",
+                                                            "type": "int64",
+                                                            "metadata": {
+                                                                "type": "InputPort",
+                                                                "has_initializers": false,
+                                                                "execute_until_finished": true,
+                                                                "internal_only": false,
+                                                                "max_executions_before_finished": 1000,
+                                                                "variable": [
+                                                                    0
+                                                                ],
+                                                                "shadow_inputs": null,
+                                                                "require_projection_in_composition": true,
+                                                                "default_input": null,
+                                                                "exponent": null,
+                                                                "projections": null,
+                                                                "combine": null,
+                                                                "weight": null
+                                                            }
+                                                        }
+                                                    },
+                                                    "functions": {
+                                                        "Linear_Function_14": {
+                                                            "function": {
+                                                                "linear": {
+                                                                    "intercept": 0.0,
+                                                                    "slope": 1.0,
+                                                                    "variable0": "reward_InputPort_0"
+                                                                }
+                                                            },
+                                                            "args": {
+                                                                "intercept": 0.0,
+                                                                "slope": 1.0,
+                                                                "variable0": "reward_InputPort_0"
+                                                            },
+                                                            "metadata": {
+                                                                "type": "Linear",
+                                                                "has_initializers": false,
+                                                                "execute_until_finished": true,
+                                                                "enable_output_type_conversion": true,
+                                                                "max_executions_before_finished": 1000,
+                                                                "changes_shape": false,
+                                                                "variable": [
+                                                                    [
+                                                                        0
+                                                                    ]
+                                                                ],
+                                                                "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                                "bounds": null,
+                                                                "function_stateful_params": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "output_ports": {
+                                                        "reward_RESULT": {
+                                                            "value": "Linear_Function_14",
+                                                            "metadata": {
+                                                                "type": "OutputPort",
+                                                                "has_initializers": false,
+                                                                "execute_until_finished": true,
+                                                                "max_executions_before_finished": 1000,
+                                                                "variable": [
+                                                                    0.0
+                                                                ],
+                                                                "require_projection_in_composition": true,
+                                                                "projections": null
+                                                            }
+                                                        },
+                                                        "reward_MEAN": {
+                                                            "value": "Linear_Function_14",
+                                                            "metadata": {
+                                                                "type": "OutputPort",
+                                                                "has_initializers": false,
+                                                                "execute_until_finished": true,
+                                                                "max_executions_before_finished": 1000,
+                                                                "variable": [
+                                                                    0.0
+                                                                ],
+                                                                "require_projection_in_composition": true,
+                                                                "projections": null
+                                                            }
+                                                        },
+                                                        "reward_variance": {
+                                                            "value": "Linear_Function_14",
+                                                            "metadata": {
+                                                                "type": "OutputPort",
+                                                                "has_initializers": false,
+                                                                "execute_until_finished": true,
+                                                                "max_executions_before_finished": 1000,
+                                                                "variable": [
+                                                                    0.0
+                                                                ],
+                                                                "require_projection_in_composition": true,
+                                                                "projections": null
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "Decision.output_ports.PROBABILITY_UPPER_THRESHOLD",
+                                            {
+                                                "port_spec": "Decision.output_ports.RESPONSE_TIME",
+                                                "weight": -1,
+                                                "exponent": 1
+                                            }
+                                        ]
+                                    },
+                                    "input_ports": {
+                                        "ObjectiveMechanism_0_Value_of_reward__RESULT_": {
+                                            "shape": "(1, 1)",
+                                            "type": "float64",
+                                            "metadata": {
+                                                "type": "InputPort",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "internal_only": true,
+                                                "max_executions_before_finished": 1000,
+                                                "variable": [
+                                                    [
+                                                        0.0
+                                                    ]
+                                                ],
+                                                "shadow_inputs": null,
+                                                "require_projection_in_composition": true,
+                                                "default_input": null,
+                                                "exponent": null,
+                                                "projections": [
+                                                    [
+                                                        "reward.output_ports.RESULT",
+                                                        null,
+                                                        null,
+                                                        {
+                                                            "PROJECTION_TYPE": "MappingProjection"
+                                                        }
+                                                    ]
+                                                ],
+                                                "combine": null,
+                                                "weight": null
+                                            }
+                                        },
+                                        "ObjectiveMechanism_0_Value_of_Decision__PROBABILITY_UPPER_THRESHOLD_": {
+                                            "shape": "(1, 1)",
+                                            "type": "float64",
+                                            "metadata": {
+                                                "type": "InputPort",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "internal_only": true,
+                                                "max_executions_before_finished": 1000,
+                                                "variable": [
+                                                    [
+                                                        0.0
+                                                    ]
+                                                ],
+                                                "shadow_inputs": null,
+                                                "require_projection_in_composition": true,
+                                                "default_input": null,
+                                                "exponent": null,
+                                                "projections": [
+                                                    [
+                                                        "Decision.output_ports.PROBABILITY_UPPER_THRESHOLD",
+                                                        null,
+                                                        null,
+                                                        {
+                                                            "PROJECTION_TYPE": "MappingProjection"
+                                                        }
+                                                    ]
+                                                ],
+                                                "combine": null,
+                                                "weight": null
+                                            }
+                                        },
+                                        "ObjectiveMechanism_0_port_spec": {
+                                            "shape": "(1, 1)",
+                                            "type": "float64",
+                                            "metadata": {
+                                                "type": "InputPort",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "internal_only": true,
+                                                "max_executions_before_finished": 1000,
+                                                "variable": [
+                                                    [
+                                                        0.0
+                                                    ]
+                                                ],
+                                                "shadow_inputs": null,
+                                                "require_projection_in_composition": true,
+                                                "default_input": null,
+                                                "projections": [
+                                                    [
+                                                        "Decision.output_ports.RESPONSE_TIME",
+                                                        null,
+                                                        null,
+                                                        {
+                                                            "PROJECTION_TYPE": "MappingProjection"
+                                                        }
+                                                    ]
+                                                ],
+                                                "combine": null
+                                            }
+                                        }
+                                    },
+                                    "functions": {
+                                        "LinearCombination_Function_1": {
+                                            "function": {
+                                                "linearcombination": {
+                                                    "offset": 0.0,
+                                                    "scale": 1.0,
+                                                    "variable0": "ObjectiveMechanism_0_Value_of_reward__RESULT_"
+                                                }
+                                            },
+                                            "args": {
+                                                "offset": 0.0,
+                                                "scale": 1.0,
+                                                "variable0": "ObjectiveMechanism_0_Value_of_reward__RESULT_"
+                                            },
+                                            "metadata": {
+                                                "type": "LinearCombination",
+                                                "has_initializers": false,
+                                                "max_executions_before_finished": 1000,
+                                                "execute_until_finished": true,
+                                                "variable": [
+                                                    [
+                                                        0.0
+                                                    ],
+                                                    [
+                                                        0.0
+                                                    ],
+                                                    [
+                                                        0.0
+                                                    ]
+                                                ],
+                                                "changes_shape": false,
+                                                "enable_output_type_conversion": true,
+                                                "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                "operation": "product",
+                                                "weights": null,
+                                                "exponents": null,
+                                                "function_stateful_params": {}
+                                            }
+                                        }
+                                    },
+                                    "output_ports": {
+                                        "ObjectiveMechanism_0_OUTCOME": {
+                                            "value": "LinearCombination_Function_1",
+                                            "metadata": {
+                                                "type": "OutputPort",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "max_executions_before_finished": 1000,
+                                                "variable": [
+                                                    0.0
+                                                ],
+                                                "require_projection_in_composition": true,
+                                                "projections": null
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "saved_samples": null,
+                            "control_allocation_search_space": null,
+                            "default_allocation": null,
+                            "monitor_for_control": [],
+                            "search_function": null,
+                            "state_input_ports": "[(InputPort SHADOWED INPUT OF Input[InputPort-0] FOR reward[InputPort-0]), (InputPort SHADOWED INPUT OF reward[InputPort-0] FOR Input[InputPort-0])]",
+                            "random_variables": "all",
+                            "num_estimates": null,
+                            "search_space": null,
+                            "num_trials_per_estimate": null,
+                            "state_feature_specs": [
+                                "Input.input_ports.InputPort-0",
+                                "reward.input_ports.InputPort-0"
+                            ],
+                            "state_feature_default_spec": "shadow_inputs",
+                            "combine_costs": "gASVEQAAAAAAAACMBW51bXB5lIwDc3VtlJOULg==\n",
+                            "input_ports": [
+                                "OUTCOME"
+                            ],
+                            "outcome_input_ports_option": "concatenate",
+                            "reconfiguration_cost": null,
+                            "compute_reconfiguration_cost": null,
+                            "search_termination_function": null,
+                            "output_ports": [
+                                {
+                                    "allocation_samples": [
+                                        0.1,
+                                        0.4,
+                                        0.7000000000000001,
+                                        1.0000000000000002
+                                    ],
+                                    "name": "drift_rate",
+                                    "MECHANISM": {
+                                        "Decision": {
+                                            "metadata": {
+                                                "type": "DDM",
+                                                "has_initializers": false,
+                                                "max_executions_before_finished": 1000,
+                                                "execute_until_finished": true,
+                                                "variable": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "output_labels_dict": {},
+                                                "input_port_variables": null,
+                                                "input_labels_dict": {},
+                                                "input_ports": null,
+                                                "input_format": "SCALAR",
+                                                "output_ports": [
+                                                    "DECISION_VARIABLE",
+                                                    "RESPONSE_TIME",
+                                                    "PROBABILITY_UPPER_THRESHOLD"
+                                                ],
+                                                "random_state": null
+                                            },
+                                            "input_ports": {
+                                                "Decision_InputPort_0": {
+                                                    "shape": "(1,)",
+                                                    "type": "int64",
+                                                    "metadata": {
+                                                        "type": "InputPort",
+                                                        "has_initializers": false,
+                                                        "execute_until_finished": true,
+                                                        "internal_only": false,
+                                                        "max_executions_before_finished": 1000,
+                                                        "variable": [
+                                                            0
+                                                        ],
+                                                        "shadow_inputs": null,
+                                                        "require_projection_in_composition": true,
+                                                        "default_input": null,
+                                                        "exponent": null,
+                                                        "projections": null,
+                                                        "combine": null,
+                                                        "weight": null
+                                                    }
+                                                }
+                                            },
+                                            "functions": {
+                                                "Drift_Diffusion_Analytical_Function_0": {
+                                                    "function": {
+                                                        "driftdiffusionanalytical": {
+                                                            "starting_value": 0,
+                                                            "noise": 0.5,
+                                                            "bias": 0.5,
+                                                            "non_decision_time": 0.45,
+                                                            "shape": [
+                                                                1,
+                                                                1
+                                                            ],
+                                                            "variable0": "Decision_InputPort_0"
+                                                        }
+                                                    },
+                                                    "args": {
+                                                        "starting_value": 0,
+                                                        "noise": 0.5,
+                                                        "bias": 0.5,
+                                                        "non_decision_time": 0.45,
+                                                        "shape": [
+                                                            1,
+                                                            1
+                                                        ],
+                                                        "variable0": "Decision_InputPort_0"
+                                                    },
+                                                    "metadata": {
+                                                        "type": "DriftDiffusionAnalytical",
+                                                        "has_initializers": false,
+                                                        "max_executions_before_finished": 1000,
+                                                        "execute_until_finished": true,
+                                                        "variable": [
+                                                            [
+                                                                0
+                                                            ]
+                                                        ],
+                                                        "changes_shape": false,
+                                                        "enable_output_type_conversion": true,
+                                                        "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                        "threshold": [
+                                                            1.0,
+                                                            {
+                                                                "ControlProjection_for_Decision_threshold_": {
+                                                                    "parameters": {
+                                                                        "weight": 1
+                                                                    },
+                                                                    "sender": "None",
+                                                                    "receiver": "Decision",
+                                                                    "sender_port": "None_None",
+                                                                    "receiver_port": "Decision_threshold",
+                                                                    "metadata": {
+                                                                        "type": "ControlProjection",
+                                                                        "has_initializers": false,
+                                                                        "execute_until_finished": true,
+                                                                        "max_executions_before_finished": 1000,
+                                                                        "control_signal_params": {
+                                                                            "allocation_samples": [
+                                                                                0.1,
+                                                                                0.4,
+                                                                                0.7000000000000001,
+                                                                                1.0000000000000002
+                                                                            ]
+                                                                        },
+                                                                        "exponent": null,
+                                                                        "weight": null
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "drift_rate": [
+                                                            1.0,
+                                                            {
+                                                                "ControlProjection_for_Decision_drift_rate_": {
+                                                                    "parameters": {
+                                                                        "weight": 1
+                                                                    },
+                                                                    "sender": "None",
+                                                                    "receiver": "Decision",
+                                                                    "sender_port": "None_None",
+                                                                    "receiver_port": "Decision_drift_rate",
+                                                                    "metadata": {
+                                                                        "type": "ControlProjection",
+                                                                        "has_initializers": false,
+                                                                        "execute_until_finished": true,
+                                                                        "max_executions_before_finished": 1000,
+                                                                        "control_signal_params": {
+                                                                            "allocation_samples": [
+                                                                                0.1,
+                                                                                0.4,
+                                                                                0.7000000000000001,
+                                                                                1.0000000000000002
+                                                                            ]
+                                                                        },
+                                                                        "exponent": null,
+                                                                        "weight": null
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "function_stateful_params": {}
+                                                    }
+                                                }
+                                            },
+                                            "parameters": {
+                                                "seed": {
+                                                    "value": -1
+                                                },
+                                                "initializer": {
+                                                    "value": [
+                                                        [
+                                                            0
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "output_ports": {
+                                                "Decision_DECISION_VARIABLE": {
+                                                    "value": "Drift_Diffusion_Analytical_Function_0[0]",
+                                                    "metadata": {
+                                                        "type": "OutputPort",
+                                                        "has_initializers": false,
+                                                        "execute_until_finished": true,
+                                                        "max_executions_before_finished": 1000,
+                                                        "variable": [
+                                                            1.0
+                                                        ],
+                                                        "require_projection_in_composition": true,
+                                                        "projections": null
+                                                    }
+                                                },
+                                                "Decision_RESPONSE_TIME": {
+                                                    "value": "Drift_Diffusion_Analytical_Function_0[1]",
+                                                    "metadata": {
+                                                        "type": "OutputPort",
+                                                        "has_initializers": false,
+                                                        "execute_until_finished": true,
+                                                        "max_executions_before_finished": 1000,
+                                                        "variable": [
+                                                            4.45
+                                                        ],
+                                                        "require_projection_in_composition": true,
+                                                        "projections": null
+                                                    }
+                                                },
+                                                "Decision_PROBABILITY_UPPER_THRESHOLD": {
+                                                    "value": "Drift_Diffusion_Analytical_Function_0[2]",
+                                                    "metadata": {
+                                                        "type": "OutputPort",
+                                                        "has_initializers": false,
+                                                        "execute_until_finished": true,
+                                                        "max_executions_before_finished": 1000,
+                                                        "variable": [
+                                                            0.5
+                                                        ],
+                                                        "require_projection_in_composition": true,
+                                                        "projections": null
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "allocation_samples": [
+                                        0.1,
+                                        0.4,
+                                        0.7000000000000001,
+                                        1.0000000000000002
+                                    ],
+                                    "name": "threshold",
+                                    "MECHANISM": {
+                                        "Decision": {
+                                            "metadata": {
+                                                "type": "DDM",
+                                                "has_initializers": false,
+                                                "max_executions_before_finished": 1000,
+                                                "execute_until_finished": true,
+                                                "variable": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "output_labels_dict": {},
+                                                "input_port_variables": null,
+                                                "input_labels_dict": {},
+                                                "input_ports": null,
+                                                "input_format": "SCALAR",
+                                                "output_ports": [
+                                                    "DECISION_VARIABLE",
+                                                    "RESPONSE_TIME",
+                                                    "PROBABILITY_UPPER_THRESHOLD"
+                                                ],
+                                                "random_state": null
+                                            },
+                                            "input_ports": {
+                                                "Decision_InputPort_0": {
+                                                    "shape": "(1,)",
+                                                    "type": "int64",
+                                                    "metadata": {
+                                                        "type": "InputPort",
+                                                        "has_initializers": false,
+                                                        "execute_until_finished": true,
+                                                        "internal_only": false,
+                                                        "max_executions_before_finished": 1000,
+                                                        "variable": [
+                                                            0
+                                                        ],
+                                                        "shadow_inputs": null,
+                                                        "require_projection_in_composition": true,
+                                                        "default_input": null,
+                                                        "exponent": null,
+                                                        "projections": null,
+                                                        "combine": null,
+                                                        "weight": null
+                                                    }
+                                                }
+                                            },
+                                            "functions": {
+                                                "Drift_Diffusion_Analytical_Function_0": {
+                                                    "function": {
+                                                        "driftdiffusionanalytical": {
+                                                            "starting_value": 0,
+                                                            "noise": 0.5,
+                                                            "bias": 0.5,
+                                                            "non_decision_time": 0.45,
+                                                            "shape": [
+                                                                1,
+                                                                1
+                                                            ],
+                                                            "variable0": "Decision_InputPort_0"
+                                                        }
+                                                    },
+                                                    "args": {
+                                                        "starting_value": 0,
+                                                        "noise": 0.5,
+                                                        "bias": 0.5,
+                                                        "non_decision_time": 0.45,
+                                                        "shape": [
+                                                            1,
+                                                            1
+                                                        ],
+                                                        "variable0": "Decision_InputPort_0"
+                                                    },
+                                                    "metadata": {
+                                                        "type": "DriftDiffusionAnalytical",
+                                                        "has_initializers": false,
+                                                        "max_executions_before_finished": 1000,
+                                                        "execute_until_finished": true,
+                                                        "variable": [
+                                                            [
+                                                                0
+                                                            ]
+                                                        ],
+                                                        "changes_shape": false,
+                                                        "enable_output_type_conversion": true,
+                                                        "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                        "threshold": [
+                                                            1.0,
+                                                            {
+                                                                "ControlProjection_for_Decision_threshold_": {
+                                                                    "parameters": {
+                                                                        "weight": 1
+                                                                    },
+                                                                    "sender": "None",
+                                                                    "receiver": "Decision",
+                                                                    "sender_port": "None_None",
+                                                                    "receiver_port": "Decision_threshold",
+                                                                    "metadata": {
+                                                                        "type": "ControlProjection",
+                                                                        "has_initializers": false,
+                                                                        "execute_until_finished": true,
+                                                                        "max_executions_before_finished": 1000,
+                                                                        "control_signal_params": {
+                                                                            "allocation_samples": [
+                                                                                0.1,
+                                                                                0.4,
+                                                                                0.7000000000000001,
+                                                                                1.0000000000000002
+                                                                            ]
+                                                                        },
+                                                                        "exponent": null,
+                                                                        "weight": null
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "drift_rate": [
+                                                            1.0,
+                                                            {
+                                                                "ControlProjection_for_Decision_drift_rate_": {
+                                                                    "parameters": {
+                                                                        "weight": 1
+                                                                    },
+                                                                    "sender": "None",
+                                                                    "receiver": "Decision",
+                                                                    "sender_port": "None_None",
+                                                                    "receiver_port": "Decision_drift_rate",
+                                                                    "metadata": {
+                                                                        "type": "ControlProjection",
+                                                                        "has_initializers": false,
+                                                                        "execute_until_finished": true,
+                                                                        "max_executions_before_finished": 1000,
+                                                                        "control_signal_params": {
+                                                                            "allocation_samples": [
+                                                                                0.1,
+                                                                                0.4,
+                                                                                0.7000000000000001,
+                                                                                1.0000000000000002
+                                                                            ]
+                                                                        },
+                                                                        "exponent": null,
+                                                                        "weight": null
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "function_stateful_params": {}
+                                                    }
+                                                }
+                                            },
+                                            "parameters": {
+                                                "seed": {
+                                                    "value": -1
+                                                },
+                                                "initializer": {
+                                                    "value": [
+                                                        [
+                                                            0
+                                                        ]
+                                                    ]
+                                                }
+                                            },
+                                            "output_ports": {
+                                                "Decision_DECISION_VARIABLE": {
+                                                    "value": "Drift_Diffusion_Analytical_Function_0[0]",
+                                                    "metadata": {
+                                                        "type": "OutputPort",
+                                                        "has_initializers": false,
+                                                        "execute_until_finished": true,
+                                                        "max_executions_before_finished": 1000,
+                                                        "variable": [
+                                                            1.0
+                                                        ],
+                                                        "require_projection_in_composition": true,
+                                                        "projections": null
+                                                    }
+                                                },
+                                                "Decision_RESPONSE_TIME": {
+                                                    "value": "Drift_Diffusion_Analytical_Function_0[1]",
+                                                    "metadata": {
+                                                        "type": "OutputPort",
+                                                        "has_initializers": false,
+                                                        "execute_until_finished": true,
+                                                        "max_executions_before_finished": 1000,
+                                                        "variable": [
+                                                            4.45
+                                                        ],
+                                                        "require_projection_in_composition": true,
+                                                        "projections": null
+                                                    }
+                                                },
+                                                "Decision_PROBABILITY_UPPER_THRESHOLD": {
+                                                    "value": "Drift_Diffusion_Analytical_Function_0[2]",
+                                                    "metadata": {
+                                                        "type": "OutputPort",
+                                                        "has_initializers": false,
+                                                        "execute_until_finished": true,
+                                                        "max_executions_before_finished": 1000,
+                                                        "variable": [
+                                                            0.5
+                                                        ],
+                                                        "require_projection_in_composition": true,
+                                                        "projections": null
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "same_seed_for_all_allocations": false,
+                            "search_statefulness": true
+                        },
+                        "input_ports": {
+                            "OptimizationControlMechanism_0_OUTCOME": {
+                                "shape": "(1,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            },
+                            "OptimizationControlMechanism_0_SHADOWED_INPUT_OF_Input_InputPort_0__FOR_reward_InputPort_0_": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": [
+                                        true
+                                    ],
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": "Input.input_ports.InputPort-0",
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            },
+                            "OptimizationControlMechanism_0_SHADOWED_INPUT_OF_reward_InputPort_0__FOR_Input_InputPort_0_": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": [
+                                        true
+                                    ],
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": "reward.input_ports.InputPort-0",
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "GridSearch_Function_0": {
+                                "function": {
+                                    "gridsearch": {
+                                        "seed": -1,
+                                        "variable0": "OptimizationControlMechanism_0_OUTCOME"
+                                    }
+                                },
+                                "args": {
+                                    "seed": -1,
+                                    "variable0": "OptimizationControlMechanism_0_OUTCOME"
+                                },
+                                "metadata": {
+                                    "type": "GridSearch",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "saved_values": [],
+                                    "saved_samples": [],
+                                    "execute_until_finished": true,
+                                    "save_samples": false,
+                                    "variable": [
+                                        [
+                                            1.0
+                                        ],
+                                        [
+                                            1.0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "save_values": false,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "aggregation_function": "gASVXAEAAAAAAACMCmRpbGwuX2RpbGyUjBBfY3JlYXRlX2Z1bmN0aW9ulJOUKGgAjAxfY3JlYXRl\nX2NvZGWUk5QoSwFLAEsASwFLBEtDQw50AGoBfABkAWQCjQJTAJROSwGMBGF4aXOUhZSHlIwCbnCU\njARtZWFulIaUjAF4lIWUjG8vVXNlcnMvamRjL1B5Q2hhcm1Qcm9qZWN0cy9Qc3lOZXVMaW5rL3Bz\neW5ldWxpbmsvY29yZS9jb21wb25lbnRzL2Z1bmN0aW9ucy9ub25zdGF0ZWZ1bC9vcHRpbWl6YXRp\nb25mdW5jdGlvbnMucHmUjAg8bGFtYmRhPpRNhQFDAJQpKXSUUpRjcHN5bmV1bGluay5jb3JlLmNv\nbXBvbmVudHMuZnVuY3Rpb25zLm5vbnN0YXRlZnVsLm9wdGltaXphdGlvbmZ1bmN0aW9ucwpfX2Rp\nY3RfXwpoD05OfZROdJRSlC4=\n",
+                                    "search_function": null,
+                                    "randomization_dimension": null,
+                                    "grid": null,
+                                    "num_estimates": null,
+                                    "objective_function": null,
+                                    "select_randomly_from_optimal_values": false,
+                                    "search_space": [
+                                        "SampleIterator([0.1, 0.4, 0.7000000000000001, 1.0000000000000002])",
+                                        "SampleIterator([0.1, 0.4, 0.7000000000000001, 1.0000000000000002])"
+                                    ],
+                                    "direction": "maximize",
+                                    "max_iterations": null,
+                                    "search_termination_function": null,
+                                    "random_state": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "OptimizationControlMechanism_0_Decision_drift_rate__ControlSignal": {
+                                "value": "GridSearch_Function_0[0]",
+                                "metadata": {
+                                    "type": "ControlSignal",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        1.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "modulation": "multiplicative_param",
+                                    "projections": [
+                                        [
+                                            "Decision.input_ports.drift_rate",
+                                            null,
+                                            null,
+                                            {
+                                                "PROJECTION_TYPE": "ControlProjection"
+                                            }
+                                        ]
+                                    ]
+                                }
+                            },
+                            "OptimizationControlMechanism_0_Decision_threshold__ControlSignal": {
+                                "value": "GridSearch_Function_0[1]",
+                                "metadata": {
+                                    "type": "ControlSignal",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        1.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "modulation": "multiplicative_param",
+                                    "projections": [
+                                        [
+                                            "Decision.input_ports.threshold",
+                                            null,
+                                            null,
+                                            {
+                                                "PROJECTION_TYPE": "ControlProjection"
+                                            }
+                                        ]
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "edges": {
+                    "MappingProjection_from_Input_RESULT__to_Decision_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "Input",
+                        "receiver": "Decision",
+                        "sender_port": "Input_RESULT",
+                        "receiver_port": "Decision_InputPort_0",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_0": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_reward_RESULT__to_ObjectiveMechanism_0_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "reward",
+                        "receiver": "ObjectiveMechanism_0",
+                        "sender_port": "reward_RESULT",
+                        "receiver_port": "ObjectiveMechanism_0_Value_of_reward__RESULT_",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_9": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_Decision_PROBABILITY_UPPER_THRESHOLD__to_ObjectiveMechanism_0_InputPort_1_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "Decision",
+                        "receiver": "ObjectiveMechanism_0",
+                        "sender_port": "Decision_PROBABILITY_UPPER_THRESHOLD",
+                        "receiver_port": "ObjectiveMechanism_0_Value_of_Decision__PROBABILITY_UPPER_THRESHOLD_",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_10": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.5
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_Decision_RESPONSE_TIME__to_ObjectiveMechanism_0_port_spec_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "Decision",
+                        "receiver": "ObjectiveMechanism_0",
+                        "sender_port": "Decision_RESPONSE_TIME",
+                        "receiver_port": "ObjectiveMechanism_0_port_spec",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_11": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            4.45
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/json/model_with_two_conjoint_comps.json
+++ b/tests/json/model_with_two_conjoint_comps.json
@@ -1,0 +1,931 @@
+{
+    "comp_comp2": {
+        "format": "ModECI MDF v0.3.3",
+        "generating_application": "PsyNeuLink v0.10.0.0+808.gd0848c3ecf.dirty",
+        "graphs": {
+            "comp": {
+                "conditions": {
+                    "node_specific": {
+                        "A": {
+                            "type": "EveryNPasses",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                            }
+                        },
+                        "B": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "A",
+                                "n": 2
+                            }
+                        }
+                    },
+                    "termination": {
+                        "environment_sequence": {
+                            "type": "AfterNEnvironmentStateUpdates",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_SEQUENCE"
+                            }
+                        },
+                        "environment_state_update": {
+                            "type": "AfterNCalls",
+                            "args": {
+                                "dependency": "B",
+                                "n": 4,
+                                "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                            }
+                        }
+                    }
+                },
+                "metadata": {
+                    "type": "Composition",
+                    "execute_until_finished": true,
+                    "max_executions_before_finished": 1000,
+                    "variable": [
+                        0
+                    ],
+                    "results": [],
+                    "simulation_results": [],
+                    "retain_old_simulation_data": false,
+                    "has_initializers": false,
+                    "input_specification": null,
+                    "node_ordering": [
+                        "A",
+                        "B"
+                    ],
+                    "required_node_roles": [],
+                    "controller": null
+                },
+                "nodes": {
+                    "A": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "termination_measure_value": 0.0,
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "output_labels_dict": {},
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "has_initializers": false,
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "on_resume_integrator_mode": "current_value",
+                            "input_ports": null,
+                            "output_ports": [
+                                "RESULTS"
+                            ],
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure": {
+                                "Distance_Function_2_1": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "execute_until_finished": true,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "has_initializers": false,
+                                        "enable_output_type_conversion": false,
+                                        "metric": "max_abs_diff",
+                                        "normalize": false,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "clip": null,
+                            "integrator_mode": false,
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_0": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "noise": 0.0,
+                                        "offset": 0.0,
+                                        "rate": 0.5
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "execute_until_finished": true,
+                                        "max_executions_before_finished": 1000,
+                                        "enable_output_type_conversion": false,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "has_initializers": true,
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_0"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "input_ports": {
+                            "A_input_port__INPUT_CIM_A_InputPort_0__to__A_InputPort_0_": {
+                                "shape": "(1,)",
+                                "type": "float64"
+                            },
+                            "A_input_port__INPUT_CIM_A_InputPort_0__to__A_InputPort_0__1": {
+                                "shape": "(1,)",
+                                "type": "float64"
+                            }
+                        },
+                        "functions": {
+                            "A_input_combination_function": {
+                                "function": {
+                                    "onnx::ReduceSum": {
+                                        "data": "combination_function_input_data",
+                                        "axes": 0
+                                    }
+                                },
+                                "args": {
+                                    "data": "combination_function_input_data",
+                                    "axes": 0
+                                }
+                            },
+                            "A_input_combination_function_dimreduce": {
+                                "value": "A_input_combination_function[0][0]",
+                                "args": {
+                                    "variable0": "A_input_combination_function"
+                                }
+                            },
+                            "Linear_Function_6": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 2.0,
+                                        "slope": 5.0,
+                                        "variable0": "A_input_combination_function_dimreduce"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 2.0,
+                                    "slope": 5.0,
+                                    "variable0": "A_input_combination_function_dimreduce"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "has_initializers": false,
+                                    "enable_output_type_conversion": true,
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "combination_function_input_data": {
+                                "value": "[A_input_port__INPUT_CIM_A_InputPort_0__to__A_InputPort_0_, A_input_port__INPUT_CIM_A_InputPort_0__to__A_InputPort_0__1]"
+                            }
+                        },
+                        "output_ports": {
+                            "A_RESULT": {
+                                "value": "Linear_Function_6",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        2.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "has_initializers": false,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "B": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "termination_measure_value": 0.0,
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "output_labels_dict": {},
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "has_initializers": false,
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "on_resume_integrator_mode": "current_value",
+                            "input_ports": null,
+                            "output_ports": [
+                                "RESULTS"
+                            ],
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure": {
+                                "Distance_Function_2_3": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "execute_until_finished": true,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "has_initializers": false,
+                                        "enable_output_type_conversion": false,
+                                        "metric": "max_abs_diff",
+                                        "normalize": false,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "clip": null,
+                            "integrator_mode": false,
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_1": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "noise": 0.0,
+                                        "offset": 0.0,
+                                        "rate": 0.5
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "execute_until_finished": true,
+                                        "max_executions_before_finished": 1000,
+                                        "enable_output_type_conversion": false,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "has_initializers": true,
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_1"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "input_ports": {
+                            "B_input_port_MappingProjection_from_A_RESULT__to_B_InputPort_0_": {
+                                "shape": "(1,)",
+                                "type": "float64"
+                            },
+                            "B_input_port__INPUT_CIM_B_InputPort_0__to__B_InputPort_0_": {
+                                "shape": "(1,)",
+                                "type": "float64"
+                            }
+                        },
+                        "functions": {
+                            "B_input_combination_function": {
+                                "function": {
+                                    "onnx::ReduceSum": {
+                                        "data": "combination_function_input_data",
+                                        "axes": 0
+                                    }
+                                },
+                                "args": {
+                                    "data": "combination_function_input_data",
+                                    "axes": 0
+                                }
+                            },
+                            "B_input_combination_function_dimreduce": {
+                                "value": "B_input_combination_function[0][0]",
+                                "args": {
+                                    "variable0": "B_input_combination_function"
+                                }
+                            },
+                            "Logistic_Function_0": {
+                                "function": {
+                                    "logistic": {
+                                        "scale": 1.0,
+                                        "bias": 0.0,
+                                        "x_0": 0,
+                                        "offset": 0.0,
+                                        "gain": 1.0,
+                                        "variable0": "B_input_combination_function_dimreduce"
+                                    }
+                                },
+                                "args": {
+                                    "scale": 1.0,
+                                    "bias": 0.0,
+                                    "x_0": 0,
+                                    "offset": 0.0,
+                                    "gain": 1.0,
+                                    "variable0": "B_input_combination_function_dimreduce"
+                                },
+                                "metadata": {
+                                    "type": "Logistic",
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "enable_output_type_conversion": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "has_initializers": false,
+                                    "bounds": [
+                                        0,
+                                        1
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "combination_function_input_data": {
+                                "value": "[B_input_port_MappingProjection_from_A_RESULT__to_B_InputPort_0_, B_input_port__INPUT_CIM_B_InputPort_0__to__B_InputPort_0_]"
+                            }
+                        },
+                        "output_ports": {
+                            "B_RESULT": {
+                                "value": "Logistic_Function_0",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.5
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "has_initializers": false,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    }
+                },
+                "edges": {
+                    "MappingProjection_from_A_RESULT__to_B_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "A",
+                        "receiver": "B",
+                        "sender_port": "A_RESULT",
+                        "receiver_port": "B_input_port_MappingProjection_from_A_RESULT__to_B_InputPort_0_",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "has_initializers": false,
+                            "weight": null,
+                            "exponent": null,
+                            "functions": {
+                                "LinearMatrix_Function_0": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "execute_until_finished": true,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            2.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "has_initializers": false,
+                                        "enable_output_type_conversion": false,
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "comp2": {
+                "conditions": {
+                    "node_specific": {
+                        "A": {
+                            "type": "EveryNPasses",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                            }
+                        },
+                        "B": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "A",
+                                "n": 4
+                            }
+                        }
+                    },
+                    "termination": {
+                        "environment_sequence": {
+                            "type": "AfterNEnvironmentStateUpdates",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_SEQUENCE"
+                            }
+                        },
+                        "environment_state_update": {
+                            "type": "AfterNCalls",
+                            "args": {
+                                "dependency": "B",
+                                "n": 8,
+                                "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                            }
+                        }
+                    }
+                },
+                "metadata": {
+                    "type": "Composition",
+                    "execute_until_finished": true,
+                    "max_executions_before_finished": 1000,
+                    "variable": [
+                        0
+                    ],
+                    "results": [],
+                    "simulation_results": [],
+                    "retain_old_simulation_data": false,
+                    "has_initializers": false,
+                    "input_specification": null,
+                    "node_ordering": [
+                        "A",
+                        "B"
+                    ],
+                    "required_node_roles": [],
+                    "controller": null
+                },
+                "nodes": {
+                    "A": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "termination_measure_value": 0.0,
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "output_labels_dict": {},
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "has_initializers": false,
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "on_resume_integrator_mode": "current_value",
+                            "input_ports": null,
+                            "output_ports": [
+                                "RESULTS"
+                            ],
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure": {
+                                "Distance_Function_2_1": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "execute_until_finished": true,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "has_initializers": false,
+                                        "enable_output_type_conversion": false,
+                                        "metric": "max_abs_diff",
+                                        "normalize": false,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "clip": null,
+                            "integrator_mode": false,
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_0": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "noise": 0.0,
+                                        "offset": 0.0,
+                                        "rate": 0.5
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "execute_until_finished": true,
+                                        "max_executions_before_finished": 1000,
+                                        "enable_output_type_conversion": false,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "has_initializers": true,
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_0"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "input_ports": {
+                            "A_input_port__INPUT_CIM_A_InputPort_0__to__A_InputPort_0_": {
+                                "shape": "(1,)",
+                                "type": "float64"
+                            },
+                            "A_input_port__INPUT_CIM_A_InputPort_0__to__A_InputPort_0__1": {
+                                "shape": "(1,)",
+                                "type": "float64"
+                            }
+                        },
+                        "functions": {
+                            "A_input_combination_function": {
+                                "function": {
+                                    "onnx::ReduceSum": {
+                                        "data": "combination_function_input_data",
+                                        "axes": 0
+                                    }
+                                },
+                                "args": {
+                                    "data": "combination_function_input_data",
+                                    "axes": 0
+                                }
+                            },
+                            "A_input_combination_function_dimreduce": {
+                                "value": "A_input_combination_function[0][0]",
+                                "args": {
+                                    "variable0": "A_input_combination_function"
+                                }
+                            },
+                            "Linear_Function_6": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 2.0,
+                                        "slope": 5.0,
+                                        "variable0": "A_input_combination_function_dimreduce"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 2.0,
+                                    "slope": 5.0,
+                                    "variable0": "A_input_combination_function_dimreduce"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "has_initializers": false,
+                                    "enable_output_type_conversion": true,
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "combination_function_input_data": {
+                                "value": "[A_input_port__INPUT_CIM_A_InputPort_0__to__A_InputPort_0_, A_input_port__INPUT_CIM_A_InputPort_0__to__A_InputPort_0__1]"
+                            }
+                        },
+                        "output_ports": {
+                            "A_RESULT": {
+                                "value": "Linear_Function_6",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        2.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "has_initializers": false,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "B": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "termination_measure_value": 0.0,
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "output_labels_dict": {},
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "has_initializers": false,
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "on_resume_integrator_mode": "current_value",
+                            "input_ports": null,
+                            "output_ports": [
+                                "RESULTS"
+                            ],
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure": {
+                                "Distance_Function_2_3": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "execute_until_finished": true,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "has_initializers": false,
+                                        "enable_output_type_conversion": false,
+                                        "metric": "max_abs_diff",
+                                        "normalize": false,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "clip": null,
+                            "integrator_mode": false,
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_1": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "noise": 0.0,
+                                        "offset": 0.0,
+                                        "rate": 0.5
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "execute_until_finished": true,
+                                        "max_executions_before_finished": 1000,
+                                        "enable_output_type_conversion": false,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "has_initializers": true,
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_1"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "input_ports": {
+                            "B_input_port_MappingProjection_from_A_RESULT__to_B_InputPort_0_": {
+                                "shape": "(1,)",
+                                "type": "float64"
+                            },
+                            "B_input_port__INPUT_CIM_B_InputPort_0__to__B_InputPort_0_": {
+                                "shape": "(1,)",
+                                "type": "float64"
+                            }
+                        },
+                        "functions": {
+                            "B_input_combination_function": {
+                                "function": {
+                                    "onnx::ReduceSum": {
+                                        "data": "combination_function_input_data",
+                                        "axes": 0
+                                    }
+                                },
+                                "args": {
+                                    "data": "combination_function_input_data",
+                                    "axes": 0
+                                }
+                            },
+                            "B_input_combination_function_dimreduce": {
+                                "value": "B_input_combination_function[0][0]",
+                                "args": {
+                                    "variable0": "B_input_combination_function"
+                                }
+                            },
+                            "Logistic_Function_0": {
+                                "function": {
+                                    "logistic": {
+                                        "scale": 1.0,
+                                        "bias": 0.0,
+                                        "x_0": 0,
+                                        "offset": 0.0,
+                                        "gain": 1.0,
+                                        "variable0": "B_input_combination_function_dimreduce"
+                                    }
+                                },
+                                "args": {
+                                    "scale": 1.0,
+                                    "bias": 0.0,
+                                    "x_0": 0,
+                                    "offset": 0.0,
+                                    "gain": 1.0,
+                                    "variable0": "B_input_combination_function_dimreduce"
+                                },
+                                "metadata": {
+                                    "type": "Logistic",
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "enable_output_type_conversion": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "has_initializers": false,
+                                    "bounds": [
+                                        0,
+                                        1
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "combination_function_input_data": {
+                                "value": "[B_input_port_MappingProjection_from_A_RESULT__to_B_InputPort_0_, B_input_port__INPUT_CIM_B_InputPort_0__to__B_InputPort_0_]"
+                            }
+                        },
+                        "output_ports": {
+                            "B_RESULT": {
+                                "value": "Logistic_Function_0",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.5
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "has_initializers": false,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/json/model_with_two_disjoint_comps.json
+++ b/tests/json/model_with_two_disjoint_comps.json
@@ -1,0 +1,944 @@
+{
+    "comp_comp2": {
+        "format": "ModECI MDF v0.3.3",
+        "generating_application": "PsyNeuLink v0.11.0.0+343.gfba4374945",
+        "graphs": {
+            "comp": {
+                "conditions": {
+                    "node_specific": {
+                        "A": {
+                            "type": "EveryNPasses",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                            }
+                        },
+                        "B": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "A",
+                                "n": 2
+                            }
+                        }
+                    },
+                    "termination": {
+                        "environment_sequence": {
+                            "type": "AfterNEnvironmentStateUpdates",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_SEQUENCE"
+                            }
+                        },
+                        "environment_state_update": {
+                            "type": "AfterNCalls",
+                            "args": {
+                                "dependency": "B",
+                                "n": 4,
+                                "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                            }
+                        }
+                    }
+                },
+                "metadata": {
+                    "type": "Composition",
+                    "input_specification": null,
+                    "has_initializers": false,
+                    "retain_old_simulation_data": false,
+                    "execute_until_finished": true,
+                    "max_executions_before_finished": 1000,
+                    "results": [],
+                    "variable": [
+                        0
+                    ],
+                    "simulation_results": [],
+                    "node_ordering": [
+                        "A",
+                        "B"
+                    ],
+                    "required_node_roles": [],
+                    "controller": null
+                },
+                "nodes": {
+                    "A": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_0": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_0"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_1": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "A_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_6": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 2.0,
+                                        "slope": 5.0,
+                                        "variable0": "A_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 2.0,
+                                    "slope": 5.0,
+                                    "variable0": "A_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "A_RESULT": {
+                                "value": "Linear_Function_6",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        2.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "B": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_1": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_1"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_3": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "B_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Logistic_Function_0": {
+                                "function": {
+                                    "logistic": {
+                                        "offset": 0.0,
+                                        "gain": 1.0,
+                                        "scale": 1.0,
+                                        "bias": 0.0,
+                                        "x_0": 0,
+                                        "variable0": "B_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "offset": 0.0,
+                                    "gain": 1.0,
+                                    "scale": 1.0,
+                                    "bias": 0.0,
+                                    "x_0": 0,
+                                    "variable0": "B_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Logistic",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": [
+                                        0,
+                                        1
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "B_RESULT": {
+                                "value": "Logistic_Function_0",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.5
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    }
+                },
+                "edges": {
+                    "MappingProjection_from_A_RESULT__to_B_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "A",
+                        "receiver": "B",
+                        "sender_port": "A_RESULT",
+                        "receiver_port": "B_InputPort_0",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_0": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            2.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "comp2": {
+                "conditions": {
+                    "node_specific": {
+                        "C": {
+                            "type": "EveryNPasses",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                            }
+                        },
+                        "D": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "C",
+                                "n": 4
+                            }
+                        }
+                    },
+                    "termination": {
+                        "environment_sequence": {
+                            "type": "AfterNEnvironmentStateUpdates",
+                            "args": {
+                                "n": 1,
+                                "time_scale": "TimeScale.ENVIRONMENT_SEQUENCE"
+                            }
+                        },
+                        "environment_state_update": {
+                            "type": "AfterNCalls",
+                            "args": {
+                                "dependency": "D",
+                                "n": 8,
+                                "time_scale": "TimeScale.ENVIRONMENT_STATE_UPDATE"
+                            }
+                        }
+                    }
+                },
+                "metadata": {
+                    "type": "Composition",
+                    "input_specification": null,
+                    "has_initializers": false,
+                    "retain_old_simulation_data": false,
+                    "execute_until_finished": true,
+                    "max_executions_before_finished": 1000,
+                    "results": [],
+                    "variable": [
+                        0
+                    ],
+                    "simulation_results": [],
+                    "node_ordering": [
+                        "C",
+                        "D"
+                    ],
+                    "required_node_roles": [],
+                    "controller": null
+                },
+                "nodes": {
+                    "C": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_2": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_2"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_5": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "C_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_35": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 2.0,
+                                        "slope": 5.0,
+                                        "variable0": "C_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 2.0,
+                                    "slope": 5.0,
+                                    "variable0": "C_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "C_RESULT": {
+                                "value": "Linear_Function_35",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        2.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "D": {
+                        "metadata": {
+                            "type": "TransferMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "AdaptiveIntegrator_Function_3": {
+                                    "value": "(1 - rate) * previous_value + rate * variable0 + noise + offset",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "AdaptiveIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "value": "AdaptiveIntegrator_Function_3"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "termination_comparison_op": "<=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "termination_measure": {
+                                "Distance_Function_2_7": {
+                                    "function": {
+                                        "distance": {}
+                                    },
+                                    "args": {},
+                                    "metadata": {
+                                        "type": "Distance",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ],
+                                            [
+                                                [
+                                                    0
+                                                ]
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "normalize": false,
+                                        "metric": "max_abs_diff",
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "input_ports": null,
+                            "integrator_mode": false,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ]
+                        },
+                        "input_ports": {
+                            "D_InputPort_0": {
+                                "shape": "(1,)",
+                                "type": "int64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Logistic_Function_1": {
+                                "function": {
+                                    "logistic": {
+                                        "offset": 0.0,
+                                        "gain": 1.0,
+                                        "scale": 1.0,
+                                        "bias": 0.0,
+                                        "x_0": 0,
+                                        "variable0": "D_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "offset": 0.0,
+                                    "gain": 1.0,
+                                    "scale": 1.0,
+                                    "bias": 0.0,
+                                    "x_0": 0,
+                                    "variable0": "D_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Logistic",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": [
+                                        0,
+                                        1
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "D_RESULT": {
+                                "value": "Logistic_Function_1",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.5
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    }
+                },
+                "edges": {
+                    "MappingProjection_from_C_RESULT__to_D_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "C",
+                        "receiver": "D",
+                        "sender_port": "C_RESULT",
+                        "receiver_port": "D_InputPort_0",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_1": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            2.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/json/stroop_conflict_monitoring.json
+++ b/tests/json/stroop_conflict_monitoring.json
@@ -1,0 +1,3367 @@
+{
+    "Stroop_model": {
+        "format": "ModECI MDF v0.3.3",
+        "generating_application": "PsyNeuLink v0.11.0.0+343.gfba4374945",
+        "graphs": {
+            "Stroop_model": {
+                "conditions": {
+                    "node_specific": {
+                        "word_input": {
+                            "type": "Always",
+                            "args": {}
+                        },
+                        "task_input": {
+                            "type": "Always",
+                            "args": {}
+                        },
+                        "color_input": {
+                            "type": "Always",
+                            "args": {}
+                        },
+                        "TASK": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "task_input",
+                                "n": 1
+                            }
+                        },
+                        "color_hidden": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "TASK",
+                                "n": 10
+                            }
+                        },
+                        "word_hidden": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "TASK",
+                                "n": 10
+                            }
+                        },
+                        "OUTPUT": {
+                            "type": "All",
+                            "args": {
+                                "args": [
+                                    {
+                                        "type": "EveryNCalls",
+                                        "args": {
+                                            "dependency": "color_hidden",
+                                            "n": 1
+                                        }
+                                    },
+                                    {
+                                        "type": "EveryNCalls",
+                                        "args": {
+                                            "dependency": "word_hidden",
+                                            "n": 1
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Conflict_Monitor": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "OUTPUT",
+                                "n": 1
+                            }
+                        },
+                        "DECISION": {
+                            "type": "EveryNCalls",
+                            "args": {
+                                "dependency": "OUTPUT",
+                                "n": 1
+                            }
+                        }
+                    },
+                    "termination": {
+                        "environment_sequence": {
+                            "type": "Never",
+                            "args": {}
+                        },
+                        "environment_state_update": {
+                            "type": "AllHaveRun",
+                            "args": {
+                                "dependencies": []
+                            }
+                        }
+                    }
+                },
+                "metadata": {
+                    "type": "Composition",
+                    "input_specification": null,
+                    "has_initializers": false,
+                    "retain_old_simulation_data": false,
+                    "execute_until_finished": true,
+                    "max_executions_before_finished": 1000,
+                    "results": [],
+                    "variable": [
+                        0
+                    ],
+                    "simulation_results": [],
+                    "node_ordering": [
+                        "color_input",
+                        "color_hidden",
+                        "OUTPUT",
+                        "word_input",
+                        "word_hidden",
+                        "task_input",
+                        "TASK",
+                        "DECISION",
+                        "Conflict_Monitor",
+                        "CONTROL"
+                    ],
+                    "required_node_roles": [
+                        [
+                            "Conflict_Monitor",
+                            "NodeRole.CONTROLLER_OBJECTIVE"
+                        ]
+                    ],
+                    "controller": {
+                        "CONTROL": {
+                            "metadata": {
+                                "type": "ControlMechanism",
+                                "has_initializers": false,
+                                "max_executions_before_finished": 1000,
+                                "simulation_ids": [],
+                                "execute_until_finished": true,
+                                "variable": [
+                                    [
+                                        1.0
+                                    ]
+                                ],
+                                "modulation": "multiplicative_param",
+                                "output_labels_dict": {},
+                                "input_port_variables": null,
+                                "outcome": null,
+                                "net_outcome": null,
+                                "control_signal_costs": null,
+                                "input_labels_dict": {},
+                                "compute_net_outcome": "gASVUQEAAAAAAACMCmRpbGwuX2RpbGyUjBBfY3JlYXRlX2Z1bmN0aW9ulJOUKGgAjAxfY3JlYXRl\nX2NvZGWUk5QoSwJLAEsASwJLAktDQwh8AHwBGABTAJROhZQpjAdvdXRjb21llIwEY29zdJSGlIxy\nL1VzZXJzL2pkYy9QeUNoYXJtUHJvamVjdHMvUHN5TmV1TGluay9wc3luZXVsaW5rL2NvcmUvY29t\ncG9uZW50cy9tZWNoYW5pc21zL21vZHVsYXRvcnkvY29udHJvbC9jb250cm9sbWVjaGFuaXNtLnB5\nlIwIPGxhbWJkYT6UTWkEQwCUKSl0lFKUY3BzeW5ldWxpbmsuY29yZS5jb21wb25lbnRzLm1lY2hh\nbmlzbXMubW9kdWxhdG9yeS5jb250cm9sLmNvbnRyb2xtZWNoYW5pc20KX19kaWN0X18KaAtOTn2U\nTnSUUpQu\n",
+                                "outcome_input_ports": "[(InputPort OUTCOME)]",
+                                "costs": null,
+                                "objective_mechanism": {
+                                    "Conflict_Monitor": {
+                                        "metadata": {
+                                            "type": "ObjectiveMechanism",
+                                            "has_initializers": false,
+                                            "input_port_variables": null,
+                                            "execute_until_finished": true,
+                                            "max_executions_before_finished": 1000,
+                                            "variable": [
+                                                [
+                                                    0.0,
+                                                    0.0
+                                                ]
+                                            ],
+                                            "input_labels_dict": {},
+                                            "output_labels_dict": {},
+                                            "output_ports": [
+                                                "OUTCOME"
+                                            ],
+                                            "input_ports": [
+                                                {
+                                                    "OUTPUT": {
+                                                        "metadata": {
+                                                            "type": "ProcessingMechanism",
+                                                            "has_initializers": false,
+                                                            "input_port_variables": null,
+                                                            "execute_until_finished": true,
+                                                            "max_executions_before_finished": 1000,
+                                                            "variable": [
+                                                                [
+                                                                    0.0,
+                                                                    0.0
+                                                                ]
+                                                            ],
+                                                            "input_labels_dict": {},
+                                                            "output_labels_dict": {},
+                                                            "output_ports": null,
+                                                            "input_ports": null
+                                                        },
+                                                        "input_ports": {
+                                                            "OUTPUT_input_port_MappingProjection_from_color_hidden_OutputPort_0__to_OUTPUT_InputPort_0_": {
+                                                                "shape": "(2,)",
+                                                                "type": "float64"
+                                                            },
+                                                            "OUTPUT_input_port_MappingProjection_from_word_hidden_OutputPort_0__to_OUTPUT_InputPort_0_": {
+                                                                "shape": "(2,)",
+                                                                "type": "float64"
+                                                            }
+                                                        },
+                                                        "functions": {
+                                                            "OUTPUT_input_combination_function": {
+                                                                "function": {
+                                                                    "onnx::ReduceSum": {
+                                                                        "data": "combination_function_input_data",
+                                                                        "axes": 0
+                                                                    }
+                                                                },
+                                                                "args": {
+                                                                    "data": "combination_function_input_data",
+                                                                    "axes": 0
+                                                                }
+                                                            },
+                                                            "OUTPUT_input_combination_function_dimreduce": {
+                                                                "value": "OUTPUT_input_combination_function[0][0]",
+                                                                "args": {
+                                                                    "variable0": "OUTPUT_input_combination_function"
+                                                                }
+                                                            },
+                                                            "Logistic_Function_3": {
+                                                                "function": {
+                                                                    "logistic": {
+                                                                        "offset": 0.0,
+                                                                        "gain": 1.0,
+                                                                        "scale": 1.0,
+                                                                        "bias": 0.0,
+                                                                        "x_0": 0,
+                                                                        "variable0": "OUTPUT_input_combination_function_dimreduce"
+                                                                    }
+                                                                },
+                                                                "args": {
+                                                                    "offset": 0.0,
+                                                                    "gain": 1.0,
+                                                                    "scale": 1.0,
+                                                                    "bias": 0.0,
+                                                                    "x_0": 0,
+                                                                    "variable0": "OUTPUT_input_combination_function_dimreduce"
+                                                                },
+                                                                "metadata": {
+                                                                    "type": "Logistic",
+                                                                    "has_initializers": false,
+                                                                    "max_executions_before_finished": 1000,
+                                                                    "execute_until_finished": true,
+                                                                    "variable": [
+                                                                        [
+                                                                            0.0,
+                                                                            0.0
+                                                                        ]
+                                                                    ],
+                                                                    "changes_shape": false,
+                                                                    "enable_output_type_conversion": true,
+                                                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                                    "bounds": [
+                                                                        0,
+                                                                        1
+                                                                    ],
+                                                                    "function_stateful_params": {}
+                                                                }
+                                                            }
+                                                        },
+                                                        "parameters": {
+                                                            "combination_function_input_data": {
+                                                                "value": "[OUTPUT_input_port_MappingProjection_from_color_hidden_OutputPort_0__to_OUTPUT_InputPort_0_, OUTPUT_input_port_MappingProjection_from_word_hidden_OutputPort_0__to_OUTPUT_InputPort_0_]"
+                                                            }
+                                                        },
+                                                        "output_ports": {
+                                                            "OUTPUT_OutputPort_0": {
+                                                                "value": "Logistic_Function_3",
+                                                                "metadata": {
+                                                                    "type": "OutputPort",
+                                                                    "has_initializers": false,
+                                                                    "execute_until_finished": true,
+                                                                    "max_executions_before_finished": 1000,
+                                                                    "variable": [
+                                                                        0.5,
+                                                                        0.5
+                                                                    ],
+                                                                    "require_projection_in_composition": true,
+                                                                    "projections": null
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "input_ports": {
+                                            "Conflict_Monitor_Value_of_OUTPUT__OutputPort_0_": {
+                                                "shape": "(1, 2)",
+                                                "type": "float64",
+                                                "metadata": {
+                                                    "type": "InputPort",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "internal_only": true,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        [
+                                                            0.0,
+                                                            0.0
+                                                        ]
+                                                    ],
+                                                    "shadow_inputs": null,
+                                                    "require_projection_in_composition": true,
+                                                    "default_input": null,
+                                                    "exponent": null,
+                                                    "projections": [
+                                                        [
+                                                            "OUTPUT.output_ports.OutputPort-0",
+                                                            null,
+                                                            null,
+                                                            {
+                                                                "PROJECTION_TYPE": "MappingProjection"
+                                                            }
+                                                        ]
+                                                    ],
+                                                    "combine": null,
+                                                    "weight": null
+                                                }
+                                            }
+                                        },
+                                        "functions": {
+                                            "Stability_Function_0": {
+                                                "function": {
+                                                    "energy": {
+                                                        "variable0": "Conflict_Monitor_Value_of_OUTPUT__OutputPort_0_"
+                                                    }
+                                                },
+                                                "args": {
+                                                    "variable0": "Conflict_Monitor_Value_of_OUTPUT__OutputPort_0_"
+                                                },
+                                                "metadata": {
+                                                    "type": "Energy",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "enable_output_type_conversion": true,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        [
+                                                            0.0,
+                                                            0.0
+                                                        ]
+                                                    ],
+                                                    "changes_shape": false,
+                                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                    "metric_fct": {
+                                                        "Distance_Function_0": {
+                                                            "function": {
+                                                                "distance": {}
+                                                            },
+                                                            "args": {},
+                                                            "metadata": {
+                                                                "type": "Distance",
+                                                                "has_initializers": false,
+                                                                "execute_until_finished": true,
+                                                                "enable_output_type_conversion": false,
+                                                                "max_executions_before_finished": 1000,
+                                                                "variable": [
+                                                                    [
+                                                                        [
+                                                                            0.0,
+                                                                            0.0
+                                                                        ]
+                                                                    ],
+                                                                    [
+                                                                        [
+                                                                            0.0,
+                                                                            0.0
+                                                                        ]
+                                                                    ]
+                                                                ],
+                                                                "changes_shape": false,
+                                                                "output_type": "FunctionOutputType.DEFAULT",
+                                                                "normalize": false,
+                                                                "metric": "energy",
+                                                                "function_stateful_params": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "transfer_fct": null,
+                                                    "normalize": false,
+                                                    "metric": "energy",
+                                                    "matrix": [
+                                                        [
+                                                            0,
+                                                            -2.5
+                                                        ],
+                                                        [
+                                                            -2.5,
+                                                            0
+                                                        ]
+                                                    ],
+                                                    "function_stateful_params": {}
+                                                }
+                                            }
+                                        },
+                                        "output_ports": {
+                                            "Conflict_Monitor_OUTCOME": {
+                                                "value": "Stability_Function_0",
+                                                "metadata": {
+                                                    "type": "OutputPort",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        -0.0
+                                                    ],
+                                                    "require_projection_in_composition": true,
+                                                    "projections": null
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "default_allocation": [
+                                    0.5
+                                ],
+                                "monitor_for_control": [],
+                                "combine_costs": "gASVEQAAAAAAAACMBW51bXB5lIwDc3VtlJOULg==\n",
+                                "input_ports": [
+                                    "OUTCOME"
+                                ],
+                                "outcome_input_ports_option": "separate",
+                                "reconfiguration_cost": null,
+                                "compute_reconfiguration_cost": null,
+                                "output_ports": [
+                                    {
+                                        "name": "gain",
+                                        "MECHANISM": {
+                                            "TASK": {
+                                                "metadata": {
+                                                    "type": "LCAMechanism",
+                                                    "has_initializers": false,
+                                                    "max_executions_before_finished": 1000,
+                                                    "execute_until_finished": true,
+                                                    "variable": [
+                                                        [
+                                                            0.0,
+                                                            0.0
+                                                        ]
+                                                    ],
+                                                    "termination_measure_value": 0.0,
+                                                    "output_labels_dict": {},
+                                                    "input_port_variables": null,
+                                                    "input_labels_dict": {},
+                                                    "integrator_function_value": [
+                                                        [
+                                                            0
+                                                        ]
+                                                    ],
+                                                    "integrator_function": {
+                                                        "LeakyCompetingIntegrator_Function_0": {
+                                                            "value": "previous_value + (-rate * previous_value + variable0) * time_step_size + noise * (time_step_size ** 0.5)",
+                                                            "args": {
+                                                                "offset": 0.0,
+                                                                "time_step_size": 0.1,
+                                                                "rate": 0.5,
+                                                                "noise": 0.0
+                                                            },
+                                                            "metadata": {
+                                                                "type": "LeakyCompetingIntegrator",
+                                                                "has_initializers": true,
+                                                                "max_executions_before_finished": 1000,
+                                                                "execute_until_finished": true,
+                                                                "variable": [
+                                                                    [
+                                                                        0.0,
+                                                                        0.0
+                                                                    ]
+                                                                ],
+                                                                "changes_shape": false,
+                                                                "enable_output_type_conversion": false,
+                                                                "output_type": "FunctionOutputType.DEFAULT",
+                                                                "initializer": [
+                                                                    [
+                                                                        0.5,
+                                                                        0.5
+                                                                    ]
+                                                                ],
+                                                                "function_stateful_params": {
+                                                                    "previous_value": {
+                                                                        "id": "previous_value",
+                                                                        "default_initial_value": [
+                                                                            [
+                                                                                0.5,
+                                                                                0.5
+                                                                            ]
+                                                                        ],
+                                                                        "value": "LeakyCompetingIntegrator_Function_0"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "has_recurrent_input_port": false,
+                                                    "termination_comparison_op": ">=",
+                                                    "termination_threshold": null,
+                                                    "clip": null,
+                                                    "combination_function": {
+                                                        "LinearCombination_Function_1": {
+                                                            "function": {
+                                                                "linearcombination": {
+                                                                    "offset": 0.0,
+                                                                    "scale": 1.0
+                                                                }
+                                                            },
+                                                            "args": {
+                                                                "offset": 0.0,
+                                                                "scale": 1.0
+                                                            },
+                                                            "metadata": {
+                                                                "type": "LinearCombination",
+                                                                "has_initializers": false,
+                                                                "max_executions_before_finished": 1000,
+                                                                "execute_until_finished": true,
+                                                                "variable": [
+                                                                    [
+                                                                        0.0,
+                                                                        0.0
+                                                                    ]
+                                                                ],
+                                                                "changes_shape": false,
+                                                                "enable_output_type_conversion": false,
+                                                                "output_type": "FunctionOutputType.DEFAULT",
+                                                                "operation": "sum",
+                                                                "weights": null,
+                                                                "exponents": null,
+                                                                "function_stateful_params": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "enable_learning": false,
+                                                    "termination_measure": "max",
+                                                    "input_ports": null,
+                                                    "integrator_mode": true,
+                                                    "on_resume_integrator_mode": "current_value",
+                                                    "output_ports": [
+                                                        "RESULTS"
+                                                    ],
+                                                    "matrix": "InverseHollowMatrix"
+                                                },
+                                                "input_ports": {
+                                                    "TASK_input_port_TASK_recurrent_projection": {
+                                                        "shape": "(2,)",
+                                                        "type": "float64"
+                                                    },
+                                                    "TASK_input_port_MappingProjection_from_task_input_OutputPort_0__to_TASK_InputPort_0_": {
+                                                        "shape": "(2,)",
+                                                        "type": "float64"
+                                                    }
+                                                },
+                                                "functions": {
+                                                    "TASK_input_combination_function": {
+                                                        "function": {
+                                                            "onnx::ReduceSum": {
+                                                                "data": "combination_function_input_data",
+                                                                "axes": 0
+                                                            }
+                                                        },
+                                                        "args": {
+                                                            "data": "combination_function_input_data",
+                                                            "axes": 0
+                                                        }
+                                                    },
+                                                    "TASK_input_combination_function_dimreduce": {
+                                                        "value": "TASK_input_combination_function[0][0]",
+                                                        "args": {
+                                                            "variable0": "TASK_input_combination_function"
+                                                        }
+                                                    },
+                                                    "Logistic_Function_7": {
+                                                        "function": {
+                                                            "logistic": {
+                                                                "offset": 0.0,
+                                                                "gain": 1.0,
+                                                                "scale": 1.0,
+                                                                "bias": 0.0,
+                                                                "x_0": 0,
+                                                                "variable0": "LeakyCompetingIntegrator_Function_0"
+                                                            }
+                                                        },
+                                                        "args": {
+                                                            "offset": 0.0,
+                                                            "gain": 1.0,
+                                                            "scale": 1.0,
+                                                            "bias": 0.0,
+                                                            "x_0": 0,
+                                                            "variable0": "LeakyCompetingIntegrator_Function_0"
+                                                        },
+                                                        "metadata": {
+                                                            "type": "Logistic",
+                                                            "has_initializers": false,
+                                                            "max_executions_before_finished": 1000,
+                                                            "execute_until_finished": true,
+                                                            "variable": [
+                                                                [
+                                                                    0.0,
+                                                                    0.0
+                                                                ]
+                                                            ],
+                                                            "changes_shape": false,
+                                                            "enable_output_type_conversion": true,
+                                                            "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                            "bounds": [
+                                                                0,
+                                                                1
+                                                            ],
+                                                            "function_stateful_params": {}
+                                                        }
+                                                    },
+                                                    "LeakyCompetingIntegrator_Function_0": {
+                                                        "value": "previous_value + (-0.5 * previous_value + TASK_input_combination_function_dimreduce) * 0.1 + 0.0 * (0.1 ** 0.5)",
+                                                        "args": {
+                                                            "offset": 0.0,
+                                                            "time_step_size": 0.1,
+                                                            "rate": 0.5,
+                                                            "noise": 0.0,
+                                                            "variable0": "TASK_input_combination_function_dimreduce"
+                                                        },
+                                                        "metadata": {
+                                                            "type": "LeakyCompetingIntegrator",
+                                                            "has_initializers": true,
+                                                            "max_executions_before_finished": 1000,
+                                                            "execute_until_finished": true,
+                                                            "variable": [
+                                                                [
+                                                                    0.0,
+                                                                    0.0
+                                                                ]
+                                                            ],
+                                                            "changes_shape": false,
+                                                            "enable_output_type_conversion": false,
+                                                            "output_type": "FunctionOutputType.DEFAULT",
+                                                            "initializer": [
+                                                                [
+                                                                    0.5,
+                                                                    0.5
+                                                                ]
+                                                            ],
+                                                            "function_stateful_params": {
+                                                                "previous_value": {
+                                                                    "id": "previous_value",
+                                                                    "default_initial_value": [
+                                                                        [
+                                                                            0.5,
+                                                                            0.5
+                                                                        ]
+                                                                    ],
+                                                                    "value": "LeakyCompetingIntegrator_Function_0"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "parameters": {
+                                                    "hetero": {
+                                                        "value": -1.0
+                                                    },
+                                                    "smoothing_factor": {
+                                                        "value": 0.5
+                                                    },
+                                                    "auto": {
+                                                        "value": 0.0
+                                                    },
+                                                    "competition": {
+                                                        "value": 1.0
+                                                    },
+                                                    "combination_function_input_data": {
+                                                        "value": "[TASK_input_port_TASK_recurrent_projection, TASK_input_port_MappingProjection_from_task_input_OutputPort_0__to_TASK_InputPort_0_]"
+                                                    },
+                                                    "previous_value": {
+                                                        "default_initial_value": [
+                                                            [
+                                                                0.5,
+                                                                0.5
+                                                            ]
+                                                        ],
+                                                        "value": "LeakyCompetingIntegrator_Function_0"
+                                                    }
+                                                },
+                                                "output_ports": {
+                                                    "TASK_RESULT": {
+                                                        "value": "Logistic_Function_7",
+                                                        "metadata": {
+                                                            "type": "OutputPort",
+                                                            "has_initializers": false,
+                                                            "execute_until_finished": true,
+                                                            "max_executions_before_finished": 1000,
+                                                            "variable": [
+                                                                0.5,
+                                                                0.5
+                                                            ],
+                                                            "require_projection_in_composition": true,
+                                                            "projections": null
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "input_ports": {
+                                "CONTROL_OUTCOME": {
+                                    "shape": "(1,)",
+                                    "type": "float64",
+                                    "metadata": {
+                                        "type": "InputPort",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "internal_only": true,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            0.0
+                                        ],
+                                        "shadow_inputs": null,
+                                        "require_projection_in_composition": true,
+                                        "default_input": null,
+                                        "exponent": null,
+                                        "projections": null,
+                                        "combine": null,
+                                        "weight": null
+                                    }
+                                }
+                            },
+                            "functions": {
+                                "Identity_Function_0": {
+                                    "function": {
+                                        "identity": {
+                                            "variable0": "CONTROL_OUTCOME"
+                                        }
+                                    },
+                                    "args": {
+                                        "variable0": "CONTROL_OUTCOME"
+                                    },
+                                    "metadata": {
+                                        "type": "Identity",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": true,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                1.0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "output_ports": {
+                                "CONTROL_TASK_gain__ControlSignal": {
+                                    "value": "Identity_Function_0",
+                                    "metadata": {
+                                        "type": "ControlSignal",
+                                        "has_initializers": false,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            0.5
+                                        ],
+                                        "require_projection_in_composition": true,
+                                        "allocation_samples": null,
+                                        "modulation": "multiplicative_param",
+                                        "projections": [
+                                            [
+                                                "TASK.input_ports.gain",
+                                                null,
+                                                null,
+                                                {
+                                                    "PROJECTION_TYPE": "ControlProjection"
+                                                }
+                                            ]
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "nodes": {
+                    "color_input": {
+                        "metadata": {
+                            "type": "ProcessingMechanism",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null
+                        },
+                        "input_ports": {
+                            "color_input_InputPort_0": {
+                                "shape": "(2,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_2": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "color_input_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "color_input_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "color_input_OutputPort_0": {
+                                "value": "Linear_Function_2",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "color_hidden": {
+                        "metadata": {
+                            "type": "ProcessingMechanism",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null
+                        },
+                        "input_ports": {
+                            "color_hidden_input_port_MappingProjection_from_color_input_OutputPort_0__to_color_hidden_InputPort_0_": {
+                                "shape": "(2,)",
+                                "type": "float64"
+                            },
+                            "color_hidden_input_port_MappingProjection_from_TASK_RESULT__to_color_hidden_InputPort_0_": {
+                                "shape": "(2,)",
+                                "type": "float64"
+                            }
+                        },
+                        "functions": {
+                            "color_hidden_input_combination_function": {
+                                "function": {
+                                    "onnx::ReduceSum": {
+                                        "data": "combination_function_input_data",
+                                        "axes": 0
+                                    }
+                                },
+                                "args": {
+                                    "data": "combination_function_input_data",
+                                    "axes": 0
+                                }
+                            },
+                            "color_hidden_input_combination_function_dimreduce": {
+                                "value": "color_hidden_input_combination_function[0][0]",
+                                "args": {
+                                    "variable0": "color_hidden_input_combination_function"
+                                }
+                            },
+                            "Logistic_Function_0": {
+                                "function": {
+                                    "logistic": {
+                                        "offset": 0.0,
+                                        "gain": 1.0,
+                                        "scale": 1.0,
+                                        "bias": -4.0,
+                                        "x_0": 0,
+                                        "variable0": "color_hidden_input_combination_function_dimreduce"
+                                    }
+                                },
+                                "args": {
+                                    "offset": 0.0,
+                                    "gain": 1.0,
+                                    "scale": 1.0,
+                                    "bias": -4.0,
+                                    "x_0": 0,
+                                    "variable0": "color_hidden_input_combination_function_dimreduce"
+                                },
+                                "metadata": {
+                                    "type": "Logistic",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": [
+                                        0,
+                                        1
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "combination_function_input_data": {
+                                "value": "[color_hidden_input_port_MappingProjection_from_color_input_OutputPort_0__to_color_hidden_InputPort_0_, color_hidden_input_port_MappingProjection_from_TASK_RESULT__to_color_hidden_InputPort_0_]"
+                            }
+                        },
+                        "output_ports": {
+                            "color_hidden_OutputPort_0": {
+                                "value": "Logistic_Function_0",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.017986209962091562,
+                                        0.017986209962091562
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "OUTPUT": {
+                        "metadata": {
+                            "type": "ProcessingMechanism",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null
+                        },
+                        "input_ports": {
+                            "OUTPUT_input_port_MappingProjection_from_color_hidden_OutputPort_0__to_OUTPUT_InputPort_0_": {
+                                "shape": "(2,)",
+                                "type": "float64"
+                            },
+                            "OUTPUT_input_port_MappingProjection_from_word_hidden_OutputPort_0__to_OUTPUT_InputPort_0_": {
+                                "shape": "(2,)",
+                                "type": "float64"
+                            }
+                        },
+                        "functions": {
+                            "OUTPUT_input_combination_function": {
+                                "function": {
+                                    "onnx::ReduceSum": {
+                                        "data": "combination_function_input_data",
+                                        "axes": 0
+                                    }
+                                },
+                                "args": {
+                                    "data": "combination_function_input_data",
+                                    "axes": 0
+                                }
+                            },
+                            "OUTPUT_input_combination_function_dimreduce": {
+                                "value": "OUTPUT_input_combination_function[0][0]",
+                                "args": {
+                                    "variable0": "OUTPUT_input_combination_function"
+                                }
+                            },
+                            "Logistic_Function_3": {
+                                "function": {
+                                    "logistic": {
+                                        "offset": 0.0,
+                                        "gain": 1.0,
+                                        "scale": 1.0,
+                                        "bias": 0.0,
+                                        "x_0": 0,
+                                        "variable0": "OUTPUT_input_combination_function_dimreduce"
+                                    }
+                                },
+                                "args": {
+                                    "offset": 0.0,
+                                    "gain": 1.0,
+                                    "scale": 1.0,
+                                    "bias": 0.0,
+                                    "x_0": 0,
+                                    "variable0": "OUTPUT_input_combination_function_dimreduce"
+                                },
+                                "metadata": {
+                                    "type": "Logistic",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": [
+                                        0,
+                                        1
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "combination_function_input_data": {
+                                "value": "[OUTPUT_input_port_MappingProjection_from_color_hidden_OutputPort_0__to_OUTPUT_InputPort_0_, OUTPUT_input_port_MappingProjection_from_word_hidden_OutputPort_0__to_OUTPUT_InputPort_0_]"
+                            }
+                        },
+                        "output_ports": {
+                            "OUTPUT_OutputPort_0": {
+                                "value": "Logistic_Function_3",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.5,
+                                        0.5
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "word_input": {
+                        "metadata": {
+                            "type": "ProcessingMechanism",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null
+                        },
+                        "input_ports": {
+                            "word_input_InputPort_0": {
+                                "shape": "(2,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_21": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "word_input_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "word_input_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "word_input_OutputPort_0": {
+                                "value": "Linear_Function_21",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "word_hidden": {
+                        "metadata": {
+                            "type": "ProcessingMechanism",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null
+                        },
+                        "input_ports": {
+                            "word_hidden_input_port_MappingProjection_from_word_input_OutputPort_0__to_word_hidden_InputPort_0_": {
+                                "shape": "(2,)",
+                                "type": "float64"
+                            },
+                            "word_hidden_input_port_MappingProjection_from_TASK_RESULT__to_word_hidden_InputPort_0_": {
+                                "shape": "(2,)",
+                                "type": "float64"
+                            }
+                        },
+                        "functions": {
+                            "word_hidden_input_combination_function": {
+                                "function": {
+                                    "onnx::ReduceSum": {
+                                        "data": "combination_function_input_data",
+                                        "axes": 0
+                                    }
+                                },
+                                "args": {
+                                    "data": "combination_function_input_data",
+                                    "axes": 0
+                                }
+                            },
+                            "word_hidden_input_combination_function_dimreduce": {
+                                "value": "word_hidden_input_combination_function[0][0]",
+                                "args": {
+                                    "variable0": "word_hidden_input_combination_function"
+                                }
+                            },
+                            "Logistic_Function_4": {
+                                "function": {
+                                    "logistic": {
+                                        "offset": 0.0,
+                                        "gain": 1.0,
+                                        "scale": 1.0,
+                                        "bias": -4.0,
+                                        "x_0": 0,
+                                        "variable0": "word_hidden_input_combination_function_dimreduce"
+                                    }
+                                },
+                                "args": {
+                                    "offset": 0.0,
+                                    "gain": 1.0,
+                                    "scale": 1.0,
+                                    "bias": -4.0,
+                                    "x_0": 0,
+                                    "variable0": "word_hidden_input_combination_function_dimreduce"
+                                },
+                                "metadata": {
+                                    "type": "Logistic",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": [
+                                        0,
+                                        1
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "combination_function_input_data": {
+                                "value": "[word_hidden_input_port_MappingProjection_from_word_input_OutputPort_0__to_word_hidden_InputPort_0_, word_hidden_input_port_MappingProjection_from_TASK_RESULT__to_word_hidden_InputPort_0_]"
+                            }
+                        },
+                        "output_ports": {
+                            "word_hidden_OutputPort_0": {
+                                "value": "Logistic_Function_4",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.017986209962091562,
+                                        0.017986209962091562
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "task_input": {
+                        "metadata": {
+                            "type": "ProcessingMechanism",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": null,
+                            "input_ports": null
+                        },
+                        "input_ports": {
+                            "task_input_InputPort_0": {
+                                "shape": "(2,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Linear_Function_33": {
+                                "function": {
+                                    "linear": {
+                                        "intercept": 0.0,
+                                        "slope": 1.0,
+                                        "variable0": "task_input_InputPort_0"
+                                    }
+                                },
+                                "args": {
+                                    "intercept": 0.0,
+                                    "slope": 1.0,
+                                    "variable0": "task_input_InputPort_0"
+                                },
+                                "metadata": {
+                                    "type": "Linear",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "changes_shape": false,
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "task_input_OutputPort_0": {
+                                "value": "Linear_Function_33",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "TASK": {
+                        "metadata": {
+                            "type": "LCAMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "termination_measure_value": 0.0,
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "integrator_function_value": [
+                                [
+                                    0
+                                ]
+                            ],
+                            "integrator_function": {
+                                "LeakyCompetingIntegrator_Function_0": {
+                                    "value": "previous_value + (-rate * previous_value + variable0) * time_step_size + noise * (time_step_size ** 0.5)",
+                                    "args": {
+                                        "offset": 0.0,
+                                        "time_step_size": 0.1,
+                                        "rate": 0.5,
+                                        "noise": 0.0
+                                    },
+                                    "metadata": {
+                                        "type": "LeakyCompetingIntegrator",
+                                        "has_initializers": true,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0.0,
+                                                0.0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "initializer": [
+                                            [
+                                                0.5,
+                                                0.5
+                                            ]
+                                        ],
+                                        "function_stateful_params": {
+                                            "previous_value": {
+                                                "id": "previous_value",
+                                                "default_initial_value": [
+                                                    [
+                                                        0.5,
+                                                        0.5
+                                                    ]
+                                                ],
+                                                "value": "LeakyCompetingIntegrator_Function_0"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "has_recurrent_input_port": false,
+                            "termination_comparison_op": ">=",
+                            "termination_threshold": null,
+                            "clip": null,
+                            "combination_function": {
+                                "LinearCombination_Function_1": {
+                                    "function": {
+                                        "linearcombination": {
+                                            "offset": 0.0,
+                                            "scale": 1.0
+                                        }
+                                    },
+                                    "args": {
+                                        "offset": 0.0,
+                                        "scale": 1.0
+                                    },
+                                    "metadata": {
+                                        "type": "LinearCombination",
+                                        "has_initializers": false,
+                                        "max_executions_before_finished": 1000,
+                                        "execute_until_finished": true,
+                                        "variable": [
+                                            [
+                                                0.0,
+                                                0.0
+                                            ]
+                                        ],
+                                        "changes_shape": false,
+                                        "enable_output_type_conversion": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "operation": "sum",
+                                        "weights": null,
+                                        "exponents": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            },
+                            "enable_learning": false,
+                            "termination_measure": "max",
+                            "input_ports": null,
+                            "integrator_mode": true,
+                            "on_resume_integrator_mode": "current_value",
+                            "output_ports": [
+                                "RESULTS"
+                            ],
+                            "matrix": "InverseHollowMatrix"
+                        },
+                        "input_ports": {
+                            "TASK_input_port_TASK_recurrent_projection": {
+                                "shape": "(2,)",
+                                "type": "float64"
+                            },
+                            "TASK_input_port_MappingProjection_from_task_input_OutputPort_0__to_TASK_InputPort_0_": {
+                                "shape": "(2,)",
+                                "type": "float64"
+                            }
+                        },
+                        "functions": {
+                            "TASK_input_combination_function": {
+                                "function": {
+                                    "onnx::ReduceSum": {
+                                        "data": "combination_function_input_data",
+                                        "axes": 0
+                                    }
+                                },
+                                "args": {
+                                    "data": "combination_function_input_data",
+                                    "axes": 0
+                                }
+                            },
+                            "TASK_input_combination_function_dimreduce": {
+                                "value": "TASK_input_combination_function[0][0]",
+                                "args": {
+                                    "variable0": "TASK_input_combination_function"
+                                }
+                            },
+                            "Logistic_Function_7": {
+                                "function": {
+                                    "logistic": {
+                                        "offset": 0.0,
+                                        "gain": 1.0,
+                                        "scale": 1.0,
+                                        "bias": 0.0,
+                                        "x_0": 0,
+                                        "variable0": "LeakyCompetingIntegrator_Function_0"
+                                    }
+                                },
+                                "args": {
+                                    "offset": 0.0,
+                                    "gain": 1.0,
+                                    "scale": 1.0,
+                                    "bias": 0.0,
+                                    "x_0": 0,
+                                    "variable0": "LeakyCompetingIntegrator_Function_0"
+                                },
+                                "metadata": {
+                                    "type": "Logistic",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": [
+                                        0,
+                                        1
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            },
+                            "LeakyCompetingIntegrator_Function_0": {
+                                "value": "previous_value + (-0.5 * previous_value + TASK_input_combination_function_dimreduce) * 0.1 + 0.0 * (0.1 ** 0.5)",
+                                "args": {
+                                    "offset": 0.0,
+                                    "time_step_size": 0.1,
+                                    "rate": 0.5,
+                                    "noise": 0.0,
+                                    "variable0": "TASK_input_combination_function_dimreduce"
+                                },
+                                "metadata": {
+                                    "type": "LeakyCompetingIntegrator",
+                                    "has_initializers": true,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": false,
+                                    "output_type": "FunctionOutputType.DEFAULT",
+                                    "initializer": [
+                                        [
+                                            0.5,
+                                            0.5
+                                        ]
+                                    ],
+                                    "function_stateful_params": {
+                                        "previous_value": {
+                                            "id": "previous_value",
+                                            "default_initial_value": [
+                                                [
+                                                    0.5,
+                                                    0.5
+                                                ]
+                                            ],
+                                            "value": "LeakyCompetingIntegrator_Function_0"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "hetero": {
+                                "value": -1.0
+                            },
+                            "smoothing_factor": {
+                                "value": 0.5
+                            },
+                            "auto": {
+                                "value": 0.0
+                            },
+                            "competition": {
+                                "value": 1.0
+                            },
+                            "combination_function_input_data": {
+                                "value": "[TASK_input_port_TASK_recurrent_projection, TASK_input_port_MappingProjection_from_task_input_OutputPort_0__to_TASK_InputPort_0_]"
+                            },
+                            "previous_value": {
+                                "default_initial_value": [
+                                    [
+                                        0.5,
+                                        0.5
+                                    ]
+                                ],
+                                "value": "LeakyCompetingIntegrator_Function_0"
+                            }
+                        },
+                        "output_ports": {
+                            "TASK_RESULT": {
+                                "value": "Logistic_Function_7",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.5,
+                                        0.5
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "DECISION": {
+                        "metadata": {
+                            "type": "DDM",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    0.0
+                                ]
+                            ],
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "input_labels_dict": {},
+                            "input_ports": [
+                                {
+                                    "name": "ARRAY",
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "function": {
+                                        "Reduce_Function_3": {
+                                            "function": {
+                                                "reduce": {
+                                                    "offset": 0.0,
+                                                    "scale": 1.0
+                                                }
+                                            },
+                                            "args": {
+                                                "offset": 0.0,
+                                                "scale": 1.0
+                                            },
+                                            "metadata": {
+                                                "type": "Reduce",
+                                                "has_initializers": false,
+                                                "max_executions_before_finished": 1000,
+                                                "execute_until_finished": true,
+                                                "variable": [
+                                                    0
+                                                ],
+                                                "changes_shape": true,
+                                                "enable_output_type_conversion": false,
+                                                "output_type": "FunctionOutputType.DEFAULT",
+                                                "operation": "sum",
+                                                "weights": [
+                                                    1,
+                                                    -1
+                                                ],
+                                                "exponents": null,
+                                                "function_stateful_params": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "input_format": "SCALAR",
+                            "output_ports": [
+                                "DECISION_VARIABLE",
+                                "RESPONSE_TIME"
+                            ],
+                            "random_state": null
+                        },
+                        "input_ports": {
+                            "DECISION_ARRAY": {
+                                "shape": "(1, 2)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": false,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Drift_Diffusion_Analytical_Function_0_2": {
+                                "function": {
+                                    "driftdiffusionanalytical": {
+                                        "threshold": 1.0,
+                                        "starting_value": 0.0,
+                                        "noise": 0.5,
+                                        "bias": 0.5,
+                                        "non_decision_time": 0.2,
+                                        "drift_rate": 1.0,
+                                        "shape": [
+                                            1,
+                                            1
+                                        ],
+                                        "variable0": "DECISION_ARRAY"
+                                    }
+                                },
+                                "args": {
+                                    "threshold": 1.0,
+                                    "starting_value": 0.0,
+                                    "noise": 0.5,
+                                    "bias": 0.5,
+                                    "non_decision_time": 0.2,
+                                    "drift_rate": 1.0,
+                                    "shape": [
+                                        1,
+                                        1
+                                    ],
+                                    "variable0": "DECISION_ARRAY"
+                                },
+                                "metadata": {
+                                    "type": "DriftDiffusionAnalytical",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        [
+                                            0.0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "enable_output_type_conversion": true,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "parameters": {
+                            "seed": {
+                                "value": -1
+                            },
+                            "initializer": {
+                                "value": [
+                                    [
+                                        0
+                                    ]
+                                ]
+                            }
+                        },
+                        "output_ports": {
+                            "DECISION_DECISION_VARIABLE": {
+                                "value": "Drift_Diffusion_Analytical_Function_0_2[0]",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        1.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            },
+                            "DECISION_RESPONSE_TIME": {
+                                "value": "Drift_Diffusion_Analytical_Function_0_2[1]",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        4.2
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "Conflict_Monitor": {
+                        "metadata": {
+                            "type": "ObjectiveMechanism",
+                            "has_initializers": false,
+                            "input_port_variables": null,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "variable": [
+                                [
+                                    0.0,
+                                    0.0
+                                ]
+                            ],
+                            "input_labels_dict": {},
+                            "output_labels_dict": {},
+                            "output_ports": [
+                                "OUTCOME"
+                            ],
+                            "input_ports": [
+                                {
+                                    "OUTPUT": {
+                                        "metadata": {
+                                            "type": "ProcessingMechanism",
+                                            "has_initializers": false,
+                                            "input_port_variables": null,
+                                            "execute_until_finished": true,
+                                            "max_executions_before_finished": 1000,
+                                            "variable": [
+                                                [
+                                                    0.0,
+                                                    0.0
+                                                ]
+                                            ],
+                                            "input_labels_dict": {},
+                                            "output_labels_dict": {},
+                                            "output_ports": null,
+                                            "input_ports": null
+                                        },
+                                        "input_ports": {
+                                            "OUTPUT_input_port_MappingProjection_from_color_hidden_OutputPort_0__to_OUTPUT_InputPort_0_": {
+                                                "shape": "(2,)",
+                                                "type": "float64"
+                                            },
+                                            "OUTPUT_input_port_MappingProjection_from_word_hidden_OutputPort_0__to_OUTPUT_InputPort_0_": {
+                                                "shape": "(2,)",
+                                                "type": "float64"
+                                            }
+                                        },
+                                        "functions": {
+                                            "OUTPUT_input_combination_function": {
+                                                "function": {
+                                                    "onnx::ReduceSum": {
+                                                        "data": "combination_function_input_data",
+                                                        "axes": 0
+                                                    }
+                                                },
+                                                "args": {
+                                                    "data": "combination_function_input_data",
+                                                    "axes": 0
+                                                }
+                                            },
+                                            "OUTPUT_input_combination_function_dimreduce": {
+                                                "value": "OUTPUT_input_combination_function[0][0]",
+                                                "args": {
+                                                    "variable0": "OUTPUT_input_combination_function"
+                                                }
+                                            },
+                                            "Logistic_Function_3": {
+                                                "function": {
+                                                    "logistic": {
+                                                        "offset": 0.0,
+                                                        "gain": 1.0,
+                                                        "scale": 1.0,
+                                                        "bias": 0.0,
+                                                        "x_0": 0,
+                                                        "variable0": "OUTPUT_input_combination_function_dimreduce"
+                                                    }
+                                                },
+                                                "args": {
+                                                    "offset": 0.0,
+                                                    "gain": 1.0,
+                                                    "scale": 1.0,
+                                                    "bias": 0.0,
+                                                    "x_0": 0,
+                                                    "variable0": "OUTPUT_input_combination_function_dimreduce"
+                                                },
+                                                "metadata": {
+                                                    "type": "Logistic",
+                                                    "has_initializers": false,
+                                                    "max_executions_before_finished": 1000,
+                                                    "execute_until_finished": true,
+                                                    "variable": [
+                                                        [
+                                                            0.0,
+                                                            0.0
+                                                        ]
+                                                    ],
+                                                    "changes_shape": false,
+                                                    "enable_output_type_conversion": true,
+                                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                    "bounds": [
+                                                        0,
+                                                        1
+                                                    ],
+                                                    "function_stateful_params": {}
+                                                }
+                                            }
+                                        },
+                                        "parameters": {
+                                            "combination_function_input_data": {
+                                                "value": "[OUTPUT_input_port_MappingProjection_from_color_hidden_OutputPort_0__to_OUTPUT_InputPort_0_, OUTPUT_input_port_MappingProjection_from_word_hidden_OutputPort_0__to_OUTPUT_InputPort_0_]"
+                                            }
+                                        },
+                                        "output_ports": {
+                                            "OUTPUT_OutputPort_0": {
+                                                "value": "Logistic_Function_3",
+                                                "metadata": {
+                                                    "type": "OutputPort",
+                                                    "has_initializers": false,
+                                                    "execute_until_finished": true,
+                                                    "max_executions_before_finished": 1000,
+                                                    "variable": [
+                                                        0.5,
+                                                        0.5
+                                                    ],
+                                                    "require_projection_in_composition": true,
+                                                    "projections": null
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "input_ports": {
+                            "Conflict_Monitor_Value_of_OUTPUT__OutputPort_0_": {
+                                "shape": "(1, 2)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": [
+                                        [
+                                            "OUTPUT.output_ports.OutputPort-0",
+                                            null,
+                                            null,
+                                            {
+                                                "PROJECTION_TYPE": "MappingProjection"
+                                            }
+                                        ]
+                                    ],
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Stability_Function_0": {
+                                "function": {
+                                    "energy": {
+                                        "variable0": "Conflict_Monitor_Value_of_OUTPUT__OutputPort_0_"
+                                    }
+                                },
+                                "args": {
+                                    "variable0": "Conflict_Monitor_Value_of_OUTPUT__OutputPort_0_"
+                                },
+                                "metadata": {
+                                    "type": "Energy",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            0.0,
+                                            0.0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "metric_fct": {
+                                        "Distance_Function_0": {
+                                            "function": {
+                                                "distance": {}
+                                            },
+                                            "args": {},
+                                            "metadata": {
+                                                "type": "Distance",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "enable_output_type_conversion": false,
+                                                "max_executions_before_finished": 1000,
+                                                "variable": [
+                                                    [
+                                                        [
+                                                            0.0,
+                                                            0.0
+                                                        ]
+                                                    ],
+                                                    [
+                                                        [
+                                                            0.0,
+                                                            0.0
+                                                        ]
+                                                    ]
+                                                ],
+                                                "changes_shape": false,
+                                                "output_type": "FunctionOutputType.DEFAULT",
+                                                "normalize": false,
+                                                "metric": "energy",
+                                                "function_stateful_params": {}
+                                            }
+                                        }
+                                    },
+                                    "transfer_fct": null,
+                                    "normalize": false,
+                                    "metric": "energy",
+                                    "matrix": [
+                                        [
+                                            0,
+                                            -2.5
+                                        ],
+                                        [
+                                            -2.5,
+                                            0
+                                        ]
+                                    ],
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "Conflict_Monitor_OUTCOME": {
+                                "value": "Stability_Function_0",
+                                "metadata": {
+                                    "type": "OutputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        -0.0
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "projections": null
+                                }
+                            }
+                        }
+                    },
+                    "CONTROL": {
+                        "metadata": {
+                            "type": "ControlMechanism",
+                            "has_initializers": false,
+                            "max_executions_before_finished": 1000,
+                            "simulation_ids": [],
+                            "execute_until_finished": true,
+                            "variable": [
+                                [
+                                    1.0
+                                ]
+                            ],
+                            "modulation": "multiplicative_param",
+                            "output_labels_dict": {},
+                            "input_port_variables": null,
+                            "outcome": null,
+                            "net_outcome": null,
+                            "control_signal_costs": null,
+                            "input_labels_dict": {},
+                            "compute_net_outcome": "gASVUQEAAAAAAACMCmRpbGwuX2RpbGyUjBBfY3JlYXRlX2Z1bmN0aW9ulJOUKGgAjAxfY3JlYXRl\nX2NvZGWUk5QoSwJLAEsASwJLAktDQwh8AHwBGABTAJROhZQpjAdvdXRjb21llIwEY29zdJSGlIxy\nL1VzZXJzL2pkYy9QeUNoYXJtUHJvamVjdHMvUHN5TmV1TGluay9wc3luZXVsaW5rL2NvcmUvY29t\ncG9uZW50cy9tZWNoYW5pc21zL21vZHVsYXRvcnkvY29udHJvbC9jb250cm9sbWVjaGFuaXNtLnB5\nlIwIPGxhbWJkYT6UTWkEQwCUKSl0lFKUY3BzeW5ldWxpbmsuY29yZS5jb21wb25lbnRzLm1lY2hh\nbmlzbXMubW9kdWxhdG9yeS5jb250cm9sLmNvbnRyb2xtZWNoYW5pc20KX19kaWN0X18KaAtOTn2U\nTnSUUpQu\n",
+                            "outcome_input_ports": "[(InputPort OUTCOME)]",
+                            "costs": null,
+                            "objective_mechanism": {
+                                "Conflict_Monitor": {
+                                    "metadata": {
+                                        "type": "ObjectiveMechanism",
+                                        "has_initializers": false,
+                                        "input_port_variables": null,
+                                        "execute_until_finished": true,
+                                        "max_executions_before_finished": 1000,
+                                        "variable": [
+                                            [
+                                                0.0,
+                                                0.0
+                                            ]
+                                        ],
+                                        "input_labels_dict": {},
+                                        "output_labels_dict": {},
+                                        "output_ports": [
+                                            "OUTCOME"
+                                        ],
+                                        "input_ports": [
+                                            {
+                                                "OUTPUT": {
+                                                    "metadata": {
+                                                        "type": "ProcessingMechanism",
+                                                        "has_initializers": false,
+                                                        "input_port_variables": null,
+                                                        "execute_until_finished": true,
+                                                        "max_executions_before_finished": 1000,
+                                                        "variable": [
+                                                            [
+                                                                0.0,
+                                                                0.0
+                                                            ]
+                                                        ],
+                                                        "input_labels_dict": {},
+                                                        "output_labels_dict": {},
+                                                        "output_ports": null,
+                                                        "input_ports": null
+                                                    },
+                                                    "input_ports": {
+                                                        "OUTPUT_input_port_MappingProjection_from_color_hidden_OutputPort_0__to_OUTPUT_InputPort_0_": {
+                                                            "shape": "(2,)",
+                                                            "type": "float64"
+                                                        },
+                                                        "OUTPUT_input_port_MappingProjection_from_word_hidden_OutputPort_0__to_OUTPUT_InputPort_0_": {
+                                                            "shape": "(2,)",
+                                                            "type": "float64"
+                                                        }
+                                                    },
+                                                    "functions": {
+                                                        "OUTPUT_input_combination_function": {
+                                                            "function": {
+                                                                "onnx::ReduceSum": {
+                                                                    "data": "combination_function_input_data",
+                                                                    "axes": 0
+                                                                }
+                                                            },
+                                                            "args": {
+                                                                "data": "combination_function_input_data",
+                                                                "axes": 0
+                                                            }
+                                                        },
+                                                        "OUTPUT_input_combination_function_dimreduce": {
+                                                            "value": "OUTPUT_input_combination_function[0][0]",
+                                                            "args": {
+                                                                "variable0": "OUTPUT_input_combination_function"
+                                                            }
+                                                        },
+                                                        "Logistic_Function_3": {
+                                                            "function": {
+                                                                "logistic": {
+                                                                    "offset": 0.0,
+                                                                    "gain": 1.0,
+                                                                    "scale": 1.0,
+                                                                    "bias": 0.0,
+                                                                    "x_0": 0,
+                                                                    "variable0": "OUTPUT_input_combination_function_dimreduce"
+                                                                }
+                                                            },
+                                                            "args": {
+                                                                "offset": 0.0,
+                                                                "gain": 1.0,
+                                                                "scale": 1.0,
+                                                                "bias": 0.0,
+                                                                "x_0": 0,
+                                                                "variable0": "OUTPUT_input_combination_function_dimreduce"
+                                                            },
+                                                            "metadata": {
+                                                                "type": "Logistic",
+                                                                "has_initializers": false,
+                                                                "max_executions_before_finished": 1000,
+                                                                "execute_until_finished": true,
+                                                                "variable": [
+                                                                    [
+                                                                        0.0,
+                                                                        0.0
+                                                                    ]
+                                                                ],
+                                                                "changes_shape": false,
+                                                                "enable_output_type_conversion": true,
+                                                                "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                                "bounds": [
+                                                                    0,
+                                                                    1
+                                                                ],
+                                                                "function_stateful_params": {}
+                                                            }
+                                                        }
+                                                    },
+                                                    "parameters": {
+                                                        "combination_function_input_data": {
+                                                            "value": "[OUTPUT_input_port_MappingProjection_from_color_hidden_OutputPort_0__to_OUTPUT_InputPort_0_, OUTPUT_input_port_MappingProjection_from_word_hidden_OutputPort_0__to_OUTPUT_InputPort_0_]"
+                                                        }
+                                                    },
+                                                    "output_ports": {
+                                                        "OUTPUT_OutputPort_0": {
+                                                            "value": "Logistic_Function_3",
+                                                            "metadata": {
+                                                                "type": "OutputPort",
+                                                                "has_initializers": false,
+                                                                "execute_until_finished": true,
+                                                                "max_executions_before_finished": 1000,
+                                                                "variable": [
+                                                                    0.5,
+                                                                    0.5
+                                                                ],
+                                                                "require_projection_in_composition": true,
+                                                                "projections": null
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "input_ports": {
+                                        "Conflict_Monitor_Value_of_OUTPUT__OutputPort_0_": {
+                                            "shape": "(1, 2)",
+                                            "type": "float64",
+                                            "metadata": {
+                                                "type": "InputPort",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "internal_only": true,
+                                                "max_executions_before_finished": 1000,
+                                                "variable": [
+                                                    [
+                                                        0.0,
+                                                        0.0
+                                                    ]
+                                                ],
+                                                "shadow_inputs": null,
+                                                "require_projection_in_composition": true,
+                                                "default_input": null,
+                                                "exponent": null,
+                                                "projections": [
+                                                    [
+                                                        "OUTPUT.output_ports.OutputPort-0",
+                                                        null,
+                                                        null,
+                                                        {
+                                                            "PROJECTION_TYPE": "MappingProjection"
+                                                        }
+                                                    ]
+                                                ],
+                                                "combine": null,
+                                                "weight": null
+                                            }
+                                        }
+                                    },
+                                    "functions": {
+                                        "Stability_Function_0": {
+                                            "function": {
+                                                "energy": {
+                                                    "variable0": "Conflict_Monitor_Value_of_OUTPUT__OutputPort_0_"
+                                                }
+                                            },
+                                            "args": {
+                                                "variable0": "Conflict_Monitor_Value_of_OUTPUT__OutputPort_0_"
+                                            },
+                                            "metadata": {
+                                                "type": "Energy",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "enable_output_type_conversion": true,
+                                                "max_executions_before_finished": 1000,
+                                                "variable": [
+                                                    [
+                                                        0.0,
+                                                        0.0
+                                                    ]
+                                                ],
+                                                "changes_shape": false,
+                                                "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                "metric_fct": {
+                                                    "Distance_Function_0": {
+                                                        "function": {
+                                                            "distance": {}
+                                                        },
+                                                        "args": {},
+                                                        "metadata": {
+                                                            "type": "Distance",
+                                                            "has_initializers": false,
+                                                            "execute_until_finished": true,
+                                                            "enable_output_type_conversion": false,
+                                                            "max_executions_before_finished": 1000,
+                                                            "variable": [
+                                                                [
+                                                                    [
+                                                                        0.0,
+                                                                        0.0
+                                                                    ]
+                                                                ],
+                                                                [
+                                                                    [
+                                                                        0.0,
+                                                                        0.0
+                                                                    ]
+                                                                ]
+                                                            ],
+                                                            "changes_shape": false,
+                                                            "output_type": "FunctionOutputType.DEFAULT",
+                                                            "normalize": false,
+                                                            "metric": "energy",
+                                                            "function_stateful_params": {}
+                                                        }
+                                                    }
+                                                },
+                                                "transfer_fct": null,
+                                                "normalize": false,
+                                                "metric": "energy",
+                                                "matrix": [
+                                                    [
+                                                        0,
+                                                        -2.5
+                                                    ],
+                                                    [
+                                                        -2.5,
+                                                        0
+                                                    ]
+                                                ],
+                                                "function_stateful_params": {}
+                                            }
+                                        }
+                                    },
+                                    "output_ports": {
+                                        "Conflict_Monitor_OUTCOME": {
+                                            "value": "Stability_Function_0",
+                                            "metadata": {
+                                                "type": "OutputPort",
+                                                "has_initializers": false,
+                                                "execute_until_finished": true,
+                                                "max_executions_before_finished": 1000,
+                                                "variable": [
+                                                    -0.0
+                                                ],
+                                                "require_projection_in_composition": true,
+                                                "projections": null
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "default_allocation": [
+                                0.5
+                            ],
+                            "monitor_for_control": [],
+                            "combine_costs": "gASVEQAAAAAAAACMBW51bXB5lIwDc3VtlJOULg==\n",
+                            "input_ports": [
+                                "OUTCOME"
+                            ],
+                            "outcome_input_ports_option": "separate",
+                            "reconfiguration_cost": null,
+                            "compute_reconfiguration_cost": null,
+                            "output_ports": [
+                                {
+                                    "name": "gain",
+                                    "MECHANISM": {
+                                        "TASK": {
+                                            "metadata": {
+                                                "type": "LCAMechanism",
+                                                "has_initializers": false,
+                                                "max_executions_before_finished": 1000,
+                                                "execute_until_finished": true,
+                                                "variable": [
+                                                    [
+                                                        0.0,
+                                                        0.0
+                                                    ]
+                                                ],
+                                                "termination_measure_value": 0.0,
+                                                "output_labels_dict": {},
+                                                "input_port_variables": null,
+                                                "input_labels_dict": {},
+                                                "integrator_function_value": [
+                                                    [
+                                                        0
+                                                    ]
+                                                ],
+                                                "integrator_function": {
+                                                    "LeakyCompetingIntegrator_Function_0": {
+                                                        "value": "previous_value + (-rate * previous_value + variable0) * time_step_size + noise * (time_step_size ** 0.5)",
+                                                        "args": {
+                                                            "offset": 0.0,
+                                                            "time_step_size": 0.1,
+                                                            "rate": 0.5,
+                                                            "noise": 0.0
+                                                        },
+                                                        "metadata": {
+                                                            "type": "LeakyCompetingIntegrator",
+                                                            "has_initializers": true,
+                                                            "max_executions_before_finished": 1000,
+                                                            "execute_until_finished": true,
+                                                            "variable": [
+                                                                [
+                                                                    0.0,
+                                                                    0.0
+                                                                ]
+                                                            ],
+                                                            "changes_shape": false,
+                                                            "enable_output_type_conversion": false,
+                                                            "output_type": "FunctionOutputType.DEFAULT",
+                                                            "initializer": [
+                                                                [
+                                                                    0.5,
+                                                                    0.5
+                                                                ]
+                                                            ],
+                                                            "function_stateful_params": {
+                                                                "previous_value": {
+                                                                    "id": "previous_value",
+                                                                    "default_initial_value": [
+                                                                        [
+                                                                            0.5,
+                                                                            0.5
+                                                                        ]
+                                                                    ],
+                                                                    "value": "LeakyCompetingIntegrator_Function_0"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "has_recurrent_input_port": false,
+                                                "termination_comparison_op": ">=",
+                                                "termination_threshold": null,
+                                                "clip": null,
+                                                "combination_function": {
+                                                    "LinearCombination_Function_1": {
+                                                        "function": {
+                                                            "linearcombination": {
+                                                                "offset": 0.0,
+                                                                "scale": 1.0
+                                                            }
+                                                        },
+                                                        "args": {
+                                                            "offset": 0.0,
+                                                            "scale": 1.0
+                                                        },
+                                                        "metadata": {
+                                                            "type": "LinearCombination",
+                                                            "has_initializers": false,
+                                                            "max_executions_before_finished": 1000,
+                                                            "execute_until_finished": true,
+                                                            "variable": [
+                                                                [
+                                                                    0.0,
+                                                                    0.0
+                                                                ]
+                                                            ],
+                                                            "changes_shape": false,
+                                                            "enable_output_type_conversion": false,
+                                                            "output_type": "FunctionOutputType.DEFAULT",
+                                                            "operation": "sum",
+                                                            "weights": null,
+                                                            "exponents": null,
+                                                            "function_stateful_params": {}
+                                                        }
+                                                    }
+                                                },
+                                                "enable_learning": false,
+                                                "termination_measure": "max",
+                                                "input_ports": null,
+                                                "integrator_mode": true,
+                                                "on_resume_integrator_mode": "current_value",
+                                                "output_ports": [
+                                                    "RESULTS"
+                                                ],
+                                                "matrix": "InverseHollowMatrix"
+                                            },
+                                            "input_ports": {
+                                                "TASK_input_port_TASK_recurrent_projection": {
+                                                    "shape": "(2,)",
+                                                    "type": "float64"
+                                                },
+                                                "TASK_input_port_MappingProjection_from_task_input_OutputPort_0__to_TASK_InputPort_0_": {
+                                                    "shape": "(2,)",
+                                                    "type": "float64"
+                                                }
+                                            },
+                                            "functions": {
+                                                "TASK_input_combination_function": {
+                                                    "function": {
+                                                        "onnx::ReduceSum": {
+                                                            "data": "combination_function_input_data",
+                                                            "axes": 0
+                                                        }
+                                                    },
+                                                    "args": {
+                                                        "data": "combination_function_input_data",
+                                                        "axes": 0
+                                                    }
+                                                },
+                                                "TASK_input_combination_function_dimreduce": {
+                                                    "value": "TASK_input_combination_function[0][0]",
+                                                    "args": {
+                                                        "variable0": "TASK_input_combination_function"
+                                                    }
+                                                },
+                                                "Logistic_Function_7": {
+                                                    "function": {
+                                                        "logistic": {
+                                                            "offset": 0.0,
+                                                            "gain": 1.0,
+                                                            "scale": 1.0,
+                                                            "bias": 0.0,
+                                                            "x_0": 0,
+                                                            "variable0": "LeakyCompetingIntegrator_Function_0"
+                                                        }
+                                                    },
+                                                    "args": {
+                                                        "offset": 0.0,
+                                                        "gain": 1.0,
+                                                        "scale": 1.0,
+                                                        "bias": 0.0,
+                                                        "x_0": 0,
+                                                        "variable0": "LeakyCompetingIntegrator_Function_0"
+                                                    },
+                                                    "metadata": {
+                                                        "type": "Logistic",
+                                                        "has_initializers": false,
+                                                        "max_executions_before_finished": 1000,
+                                                        "execute_until_finished": true,
+                                                        "variable": [
+                                                            [
+                                                                0.0,
+                                                                0.0
+                                                            ]
+                                                        ],
+                                                        "changes_shape": false,
+                                                        "enable_output_type_conversion": true,
+                                                        "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                                        "bounds": [
+                                                            0,
+                                                            1
+                                                        ],
+                                                        "function_stateful_params": {}
+                                                    }
+                                                },
+                                                "LeakyCompetingIntegrator_Function_0": {
+                                                    "value": "previous_value + (-0.5 * previous_value + TASK_input_combination_function_dimreduce) * 0.1 + 0.0 * (0.1 ** 0.5)",
+                                                    "args": {
+                                                        "offset": 0.0,
+                                                        "time_step_size": 0.1,
+                                                        "rate": 0.5,
+                                                        "noise": 0.0,
+                                                        "variable0": "TASK_input_combination_function_dimreduce"
+                                                    },
+                                                    "metadata": {
+                                                        "type": "LeakyCompetingIntegrator",
+                                                        "has_initializers": true,
+                                                        "max_executions_before_finished": 1000,
+                                                        "execute_until_finished": true,
+                                                        "variable": [
+                                                            [
+                                                                0.0,
+                                                                0.0
+                                                            ]
+                                                        ],
+                                                        "changes_shape": false,
+                                                        "enable_output_type_conversion": false,
+                                                        "output_type": "FunctionOutputType.DEFAULT",
+                                                        "initializer": [
+                                                            [
+                                                                0.5,
+                                                                0.5
+                                                            ]
+                                                        ],
+                                                        "function_stateful_params": {
+                                                            "previous_value": {
+                                                                "id": "previous_value",
+                                                                "default_initial_value": [
+                                                                    [
+                                                                        0.5,
+                                                                        0.5
+                                                                    ]
+                                                                ],
+                                                                "value": "LeakyCompetingIntegrator_Function_0"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "parameters": {
+                                                "hetero": {
+                                                    "value": -1.0
+                                                },
+                                                "smoothing_factor": {
+                                                    "value": 0.5
+                                                },
+                                                "auto": {
+                                                    "value": 0.0
+                                                },
+                                                "competition": {
+                                                    "value": 1.0
+                                                },
+                                                "combination_function_input_data": {
+                                                    "value": "[TASK_input_port_TASK_recurrent_projection, TASK_input_port_MappingProjection_from_task_input_OutputPort_0__to_TASK_InputPort_0_]"
+                                                },
+                                                "previous_value": {
+                                                    "default_initial_value": [
+                                                        [
+                                                            0.5,
+                                                            0.5
+                                                        ]
+                                                    ],
+                                                    "value": "LeakyCompetingIntegrator_Function_0"
+                                                }
+                                            },
+                                            "output_ports": {
+                                                "TASK_RESULT": {
+                                                    "value": "Logistic_Function_7",
+                                                    "metadata": {
+                                                        "type": "OutputPort",
+                                                        "has_initializers": false,
+                                                        "execute_until_finished": true,
+                                                        "max_executions_before_finished": 1000,
+                                                        "variable": [
+                                                            0.5,
+                                                            0.5
+                                                        ],
+                                                        "require_projection_in_composition": true,
+                                                        "projections": null
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "input_ports": {
+                            "CONTROL_OUTCOME": {
+                                "shape": "(1,)",
+                                "type": "float64",
+                                "metadata": {
+                                    "type": "InputPort",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "internal_only": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        0.0
+                                    ],
+                                    "shadow_inputs": null,
+                                    "require_projection_in_composition": true,
+                                    "default_input": null,
+                                    "exponent": null,
+                                    "projections": null,
+                                    "combine": null,
+                                    "weight": null
+                                }
+                            }
+                        },
+                        "functions": {
+                            "Identity_Function_0": {
+                                "function": {
+                                    "identity": {
+                                        "variable0": "CONTROL_OUTCOME"
+                                    }
+                                },
+                                "args": {
+                                    "variable0": "CONTROL_OUTCOME"
+                                },
+                                "metadata": {
+                                    "type": "Identity",
+                                    "has_initializers": false,
+                                    "execute_until_finished": true,
+                                    "enable_output_type_conversion": true,
+                                    "max_executions_before_finished": 1000,
+                                    "variable": [
+                                        [
+                                            1.0
+                                        ]
+                                    ],
+                                    "changes_shape": false,
+                                    "output_type": "FunctionOutputType.NP_2D_ARRAY",
+                                    "bounds": null,
+                                    "function_stateful_params": {}
+                                }
+                            }
+                        },
+                        "output_ports": {
+                            "CONTROL_TASK_gain__ControlSignal": {
+                                "value": "Identity_Function_0",
+                                "metadata": {
+                                    "type": "ControlSignal",
+                                    "has_initializers": false,
+                                    "max_executions_before_finished": 1000,
+                                    "execute_until_finished": true,
+                                    "variable": [
+                                        0.5
+                                    ],
+                                    "require_projection_in_composition": true,
+                                    "allocation_samples": null,
+                                    "modulation": "multiplicative_param",
+                                    "projections": [
+                                        [
+                                            "TASK.input_ports.gain",
+                                            null,
+                                            null,
+                                            {
+                                                "PROJECTION_TYPE": "ControlProjection"
+                                            }
+                                        ]
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "edges": {
+                    "MappingProjection_from_color_input_OutputPort_0__to_color_hidden_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "color_input",
+                        "receiver": "color_hidden",
+                        "sender_port": "color_input_OutputPort_0",
+                        "receiver_port": "color_hidden_input_port_MappingProjection_from_color_input_OutputPort_0__to_color_hidden_InputPort_0_",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_3": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    2.0,
+                                                    -2.0
+                                                ],
+                                                [
+                                                    -2.0,
+                                                    2.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                2.0,
+                                                -2.0
+                                            ],
+                                            [
+                                                -2.0,
+                                                2.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_color_hidden_OutputPort_0__to_OUTPUT_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "color_hidden",
+                        "receiver": "OUTPUT",
+                        "sender_port": "color_hidden_OutputPort_0",
+                        "receiver_port": "OUTPUT_input_port_MappingProjection_from_color_hidden_OutputPort_0__to_OUTPUT_InputPort_0_",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_4": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    2.0,
+                                                    -2.0
+                                                ],
+                                                [
+                                                    -2.0,
+                                                    2.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                2.0,
+                                                -2.0
+                                            ],
+                                            [
+                                                -2.0,
+                                                2.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.017986209962091562,
+                                            0.017986209962091562
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_word_input_OutputPort_0__to_word_hidden_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "word_input",
+                        "receiver": "word_hidden",
+                        "sender_port": "word_input_OutputPort_0",
+                        "receiver_port": "word_hidden_input_port_MappingProjection_from_word_input_OutputPort_0__to_word_hidden_InputPort_0_",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_7": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    3.0,
+                                                    -3.0
+                                                ],
+                                                [
+                                                    -3.0,
+                                                    3.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                3.0,
+                                                -3.0
+                                            ],
+                                            [
+                                                -3.0,
+                                                3.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_word_hidden_OutputPort_0__to_OUTPUT_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "word_hidden",
+                        "receiver": "OUTPUT",
+                        "sender_port": "word_hidden_OutputPort_0",
+                        "receiver_port": "OUTPUT_input_port_MappingProjection_from_word_hidden_OutputPort_0__to_OUTPUT_InputPort_0_",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_8": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    3.0,
+                                                    -3.0
+                                                ],
+                                                [
+                                                    -3.0,
+                                                    3.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                3.0,
+                                                -3.0
+                                            ],
+                                            [
+                                                -3.0,
+                                                3.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.017986209962091562,
+                                            0.017986209962091562
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_task_input_OutputPort_0__to_TASK_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "task_input",
+                        "receiver": "TASK",
+                        "sender_port": "task_input_OutputPort_0",
+                        "receiver_port": "TASK_input_port_MappingProjection_from_task_input_OutputPort_0__to_TASK_InputPort_0_",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_10": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0,
+                                                    0.0
+                                                ],
+                                                [
+                                                    0.0,
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0,
+                                                0.0
+                                            ],
+                                            [
+                                                0.0,
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_TASK_RESULT__to_color_hidden_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "TASK",
+                        "receiver": "color_hidden",
+                        "sender_port": "TASK_RESULT",
+                        "receiver_port": "color_hidden_input_port_MappingProjection_from_TASK_RESULT__to_color_hidden_InputPort_0_",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_11": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    4.0,
+                                                    4.0
+                                                ],
+                                                [
+                                                    0.0,
+                                                    0.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                4.0,
+                                                4.0
+                                            ],
+                                            [
+                                                0.0,
+                                                0.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.5,
+                                            0.5
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_TASK_RESULT__to_word_hidden_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "TASK",
+                        "receiver": "word_hidden",
+                        "sender_port": "TASK_RESULT",
+                        "receiver_port": "word_hidden_input_port_MappingProjection_from_TASK_RESULT__to_word_hidden_InputPort_0_",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_13": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                [
+                                                    4.0,
+                                                    4.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                0.0,
+                                                0.0
+                                            ],
+                                            [
+                                                4.0,
+                                                4.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.5,
+                                            0.5
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_OUTPUT_OutputPort_0__to_DECISION_ARRAY_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "OUTPUT",
+                        "receiver": "DECISION",
+                        "sender_port": "OUTPUT_OutputPort_0",
+                        "receiver_port": "DECISION_ARRAY",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_14": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0,
+                                                    0.0
+                                                ],
+                                                [
+                                                    0.0,
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0,
+                                                0.0
+                                            ],
+                                            [
+                                                0.0,
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.5,
+                                            0.5
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_OUTPUT_OutputPort_0__to_Conflict_Monitor_InputPort_0_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "OUTPUT",
+                        "receiver": "Conflict_Monitor",
+                        "sender_port": "OUTPUT_OutputPort_0",
+                        "receiver_port": "Conflict_Monitor_Value_of_OUTPUT__OutputPort_0_",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_1": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0,
+                                                    0.0
+                                                ],
+                                                [
+                                                    0.0,
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0,
+                                                0.0
+                                            ],
+                                            [
+                                                0.0,
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.5,
+                                            0.5
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MappingProjection_from_Conflict_Monitor_OUTCOME__to_CONTROL_OUTCOME_": {
+                        "parameters": {
+                            "weight": 1
+                        },
+                        "sender": "Conflict_Monitor",
+                        "receiver": "CONTROL",
+                        "sender_port": "Conflict_Monitor_OUTCOME",
+                        "receiver_port": "CONTROL_OUTCOME",
+                        "metadata": {
+                            "type": "MappingProjection",
+                            "has_initializers": false,
+                            "execute_until_finished": true,
+                            "max_executions_before_finished": 1000,
+                            "exponent": null,
+                            "weight": null,
+                            "functions": {
+                                "LinearMatrix_Function_2": {
+                                    "function": {
+                                        "onnx::MatMul": {
+                                            "B": [
+                                                [
+                                                    1.0
+                                                ]
+                                            ]
+                                        }
+                                    },
+                                    "args": {
+                                        "B": [
+                                            [
+                                                1.0
+                                            ]
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "LinearMatrix",
+                                        "has_initializers": false,
+                                        "execute_until_finished": true,
+                                        "enable_output_type_conversion": false,
+                                        "max_executions_before_finished": 1000,
+                                        "A": [
+                                            0.0
+                                        ],
+                                        "changes_shape": false,
+                                        "output_type": "FunctionOutputType.DEFAULT",
+                                        "bounds": null,
+                                        "function_stateful_params": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
• memoryfunctions.py
 - ContentAddressableMemory._get_distance():
   - handle [] as a item in field_weights
   - report None for fields in which cue, candidate or field is None

• test_memory.py:
  - test_ContentAddressableMemory_simple_distances:
    - replace some calls to np.allclose with direct asserts of ==
    - add test for empty list in call to c.distances_by_field
    - add tests for [] in field_weights
