### PR TITLE
tests: Run all tests using --fp-precision=fp32

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -53,20 +53,21 @@ jobs:
         extra-args: ['']
         os: [ubuntu, macos, windows]
         include:
-          # add 32-bit build on windows
-          - python-version: '3.8'
-            python-architecture: 'x86'
-            os: windows
-
           # code-coverage build on macos python 3.9
           - python-version: '3.9'
             os: macos
             extra-args: '--cov=psyneulink'
 
-          # fp32 compiled run on linux python 3.9
-          - python-version: '3.9'
+          # add 32-bit build on windows
+          - python-version: '3.8'
+            python-architecture: 'x86'
+            os: windows
+
+          # fp32 run on linux python 3.8
+          - python-version: '3.8'
+            python-architecture: 'x64'
             os: ubuntu
-            extra-args: '-m llvm --fp-precision=fp32'
+            extra-args: '--fp-precision=fp32'
 
           # add python 3.8 build on macos since 3.7 is broken
           # https://github.com/actions/virtual-environments/issues/4230

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -1707,12 +1707,12 @@ class TestMiscTrainingFunctionality:
 
         # fp32 results are different due to rounding
         if pytest.helpers.llvm_current_fp_precision() == 'fp32' and \
-           autodiff_mode != pnl.ExecutionMode.Python and \
+           autodiff_mode != pnl.ExecutionMode.PyTorch and \
            optimizer_type == 'sgd' and \
            learning_rate == 10:
             expected = [[[0.9918830394744873]], [[0.9982172846794128]], [[0.9978305697441101]], [[0.9994590878486633]]]
         # FIXME: LLVM version is broken with learning rate == 1.5
-        if learning_rate != 1.5 or autodiff_mode == pnl.ExecutionMode.Python:
+        if learning_rate != 1.5 or autodiff_mode == pnl.ExecutionMode.PyTorch:
             assert np.allclose(xor.learning_results, expected)
 
 

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -2457,7 +2457,7 @@ class TestControlMechanisms:
             def get_val(s, dty):
                 return prngs[s].random(dtype=dty)
 
-        dty = np.float32 if pytest.helpers.llvm_current_fp_precision() == 'fp32' else np.float64
+        dty = np.float32 if pytest.helpers.llvm_current_fp_precision() == 'fp32' and comp_mode != pnl.ExecutionMode.Python else np.float64
         expected = [get_val(s, dty) for s in seeds] * 2
         assert np.allclose(np.squeeze(comp.results[:len(seeds) * 2]), expected)
 
@@ -2487,7 +2487,8 @@ class TestControlMechanisms:
         # cycle over the seeds twice setting and resetting the random state
         benchmark(comp.run, inputs={ctl_mech:seeds, mech:5.0}, num_trials=len(seeds) * 2, execution_mode=comp_mode)
 
-        precision = pytest.helpers.llvm_current_fp_precision()
+        # Python uses fp64 irrespective of the pytest precision setting
+        precision = 'fp64' if comp_mode == pnl.ExecutionMode.Python else pytest.helpers.llvm_current_fp_precision()
         if prng == 'Default':
             assert np.allclose(np.squeeze(comp.results[:len(seeds) * 2]), [[100, 21], [100, 23], [100, 20]] * 2)
         elif prng == 'Philox' and precision == 'fp64':
@@ -2599,7 +2600,8 @@ class TestControlMechanisms:
         # cycle over the seeds twice setting and resetting the random state
         benchmark(comp.run, inputs={ctl_mech:seeds, mech:0.1}, num_trials=len(seeds) * 2, execution_mode=comp_mode)
 
-        precision = pytest.helpers.llvm_current_fp_precision()
+        # Python uses fp64 irrespective of the pytest precision setting
+        precision = 'fp64' if comp_mode == pnl.ExecutionMode.Python else pytest.helpers.llvm_current_fp_precision()
         if prng == 'Default':
             assert np.allclose(np.squeeze(comp.results[:len(seeds) * 2]), [[-1, 3.99948962], [1, 3.99948962], [-1, 3.99948962]] * 2)
         elif prng == 'Philox' and precision == 'fp64':


### PR DESCRIPTION
Only check fp32 results if running compiled test variant.
Use correct execution mode checks in test_optimizer_specs.
Convert identicalness PyTorch vs. LLVM test to `autodiff_mode` fixture.

Enable the entire test suite running --fp-precision=fp32 in CI