### PR TITLE
component: Add unused learning parameters to compilation blocklist

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1421,7 +1421,11 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                      "enabled_cost_functions", "control_signal_costs",
                      "default_allocation", "same_seed_for_all_allocations",
                      "search_statefulness", "initial_seed", "combine",
-                     "smoothing_factor","learning_results"
+                     "smoothing_factor",
+                     # not used in compiled learning
+                     "learning_results", "learning_signal", "learning_signals",
+                     "error_matrix", "error_signal", "activation_input",
+                     "activation_output"
                      }
         # Mechanism's need few extra entires:
         # * matrix -- is never used directly, and is flatened below


### PR DESCRIPTION
This reduces the size of "params" compiled structure by 20-30% in learning tests in the test suite.