### PR TITLE
tests: test_call_after_construction_with_learning_pathway: fix missing assert

### DIFF
--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -122,7 +122,7 @@ class TestConstructor:
         # Run with learning
         target = c.pathways['LEARNING_PATHWAY'].target
         result = c(inputs={A:[[1],[100]],B:[[2],[1]],target:[[3],[300]]})
-        np.allclose(result, [[[1.], [0.73105858]], [[100.], [0.62507661]]])
+        np.testing.assert_allclose(c.results[-2:], [[[1.], [0.73105858]], [[100.], [0.62768661]]])
 
 
 class TestAddMechanism:


### PR DESCRIPTION
np.allclose call was not asserted since this test was added. The results for this call changed in
0946af083f2f1cab23f0dfd6c0ee05b81b765500 (#1639) due to a change in default for argument loss_spec (formerly loss_function) from None to MSE in add_linear_learning_pathway and
_create_backpropagation_learning_pathway.

As of this commit, changing these defaults back to None produces the numeric results that were present when this test was created.

The allclose call also misinterpreted the return value for Composition.run as producing multiple trial outputs that are instead in Composition.results