### PR TITLE
ci: Add ipython 8.13.0 to blocklist for python <3.9

### DIFF
--- a/broken_trans_deps.txt
+++ b/broken_trans_deps.txt
@@ -3,3 +3,7 @@
 # onnxruntime-1.14.0 is broken on macos/x64
 # https://github.com/microsoft/onnxruntime/issues/14663
 onnxruntime != 1.14.0; platform_system=="Darwin"
+
+# ipython == 8.13.0 uses incorrect python requires and only works with 3.9+
+# https://github.com/ipython/ipython/issues/14053
+ipython != 8.13.0; python_version < '3.9'


### PR DESCRIPTION
https://github.com/ipython/ipython/issues/14053