### PR TITLE
Component: Add predefined prefix to autogenerated names in deferred init

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -58,6 +58,12 @@ jobs:
             os: macos
             extra-args: '--cov=psyneulink'
 
+          # --forked run of python only tests
+          # Python tests are enough to test potential naming issues
+          - python-version: '3.9'
+            os: ubuntu
+            extra-args: '--forked -m "not llvm"'
+
           # add 32-bit build on windows
           - python-version: '3.8'
             python-architecture: 'x86'
@@ -141,10 +147,10 @@ jobs:
     - name: Upload test results
       uses: actions/upload-artifact@v3
       with:
-        name: test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}-${{ matrix.extra-args }}
+        name: test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}
         path: tests_out.xml
         retention-days: 5
-      if: success() || failure()
+      if: (success() || failure()) && ! contains(matrix.extra-args, 'forked')
 
     - name: Upload coveralls code coverage
       if: contains(matrix.extra-args, '--cov=psyneulink')

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,6 +3,7 @@ packaging<24.0
 pytest<7.3.2
 pytest-benchmark<4.0.1
 pytest-cov<4.0.1
+pytest-forked<1.7.0
 pytest-helpers-namespace<2021.12.30
 pytest-profiling<1.7.1
 pytest-pycodestyle<2.4.0

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -534,7 +534,7 @@ from psyneulink.core.globals.parameters import \
 from psyneulink.core.globals.preferences.basepreferenceset import BasePreferenceSet, VERBOSE_PREF
 from psyneulink.core.globals.preferences.preferenceset import \
     PreferenceLevel, PreferenceSet, _assign_prefs
-from psyneulink.core.globals.registry import register_category
+from psyneulink.core.globals.registry import register_category, _get_auto_name_prefix
 from psyneulink.core.globals.sampleiterator import SampleIterator
 from psyneulink.core.globals.utilities import \
     ContentAddressableList, convert_all_elements_to_np_array, convert_to_np_array, get_deepcopy_with_shared, \
@@ -1778,8 +1778,8 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
 
     def _assign_deferred_init_name(self, name):
 
-        name = "{} [{}]".format(name,DEFERRED_INITIALIZATION) if name \
-          else "{} {}".format(DEFERRED_INITIALIZATION,self.__class__.__name__)
+        name = "{} [{}]".format(name, DEFERRED_INITIALIZATION) if name \
+          else "{}{} {}".format(_get_auto_name_prefix(), DEFERRED_INITIALIZATION, self.__class__.__name__)
 
         # Register with ProjectionRegistry or create one
         register_category(entry=self,

--- a/psyneulink/core/globals/registry.py
+++ b/psyneulink/core/globals/registry.py
@@ -61,6 +61,9 @@ class RegistryError(Exception):
 
 _register_auto_name_prefix = ""
 
+def _get_auto_name_prefix():
+    return _register_auto_name_prefix
+
 def register_category(entry,
                       base_class,
                       name=None,


### PR DESCRIPTION
Fixes the "default_MappingProjection_names" test failure when the test is run as the first test in testing session:
            "pytest -n0 -k test_deferred_init_default_MappingProjection_names"