### PR TITLE
requirements: update numpy requirement from <1.22.5 to <1.23.6

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -140,6 +140,14 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
+    - name: Print test machine/env info
+      shell: bash
+      run: |
+        python -c "import numpy; numpy.show_config()"
+        case "$RUNNER_OS" in
+          Linux*) lscpu;;
+        esac
+
     - name: Test with pytest
       timeout-minutes: 180
       run: pytest --junit-xml=tests_out.xml --verbosity=0 -n auto ${{ matrix.extra-args }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ llvmlite<0.41
 matplotlib<3.7.2
 modeci_mdf<0.5, >=0.3.4; (platform_machine == 'AMD64' or platform_machine == 'x86_64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
 networkx<3.2
-numpy<1.22.5, >=1.19.0
+numpy>=1.19.0, <1.23.6
 optuna<3.2.0
 packaging<24.0
 pandas<2.0.2

--- a/tests/functions/test_distribution.py
+++ b/tests/functions/test_distribution.py
@@ -41,6 +41,15 @@ if sys.platform.startswith("win") or \
                           0.5324710838150166, 0.09633802135385469, 6.117763080882898,
                           1.58212076767016, 0.5392724012504414, 1.8064031532265)
 
+# Numpy 1.23+ reimplemented tanh to roughly follow SVML but not enough to match
+# the above results [1,2]
+# [1] https://github.com/numpy/numpy/pull/20363
+# [2] https://github.com/numpy/numpy/commit/75edab9f7a7d95ecc62efc1b3b92642b6d45762d
+elif pversion.parse(np.version.version) >= pversion.parse('1.23'):
+    dda_expected_small = (0.5828813465336954, 0.04801236718458773,
+                          0.5324710838150166, 0.09633801169277778, 6.111024594252574,
+                          1.58212076767016, 0.5392724012504414, 1.8064031532265)
+
 normal_expected_mt = (1.0890232855122397)
 uniform_expected_mt = (0.6879771504250405)
 normal_expected_philox = (0.5910357654927911)


### PR DESCRIPTION
Numpy 1.23 reimplemented tanh function [0,1], which changed the result of
positive skew result for small drift rate.

[0] numpy/numpy#20363
[1] numpy/numpy@75edab9