### PR TITLE
Rework Parameter parse/validation method calling

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2061,10 +2061,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
 
                 if parameter_obj.modulable:
                     # later, validate this
-                    modulable_param_parser = self.parameters._get_prefixed_method(
-                        parse=True,
-                        modulable=True
-                    )
+                    modulable_param_parser = self.parameters._get_parse_method('modulable')
                     if modulable_param_parser is not None:
                         parsed = modulable_param_parser(name, value)
 
@@ -2692,10 +2689,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                             try:
                                 target_set[param_name] = param_value.copy()
                             except AttributeError:
-                                modulable_param_parser = self.parameters._get_prefixed_method(
-                                    parse=True,
-                                    modulable=True
-                                )
+                                modulable_param_parser = self.parameters._get_parse_method('modulable')
                                 if modulable_param_parser is not None:
                                     param_value = modulable_param_parser(param_name, param_value)
                                     target_set[param_name] = param_value

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2061,11 +2061,11 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
 
                 if parameter_obj.modulable:
                     # later, validate this
-                    try:
-                        modulable_param_parser = self.parameters._get_prefixed_method(
-                            parse=True,
-                            modulable=True
-                        )
+                    modulable_param_parser = self.parameters._get_prefixed_method(
+                        parse=True,
+                        modulable=True
+                    )
+                    if modulable_param_parser is not None:
                         parsed = modulable_param_parser(name, value)
 
                         if parsed is not value:
@@ -2073,8 +2073,6 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                             parameter_obj.spec = value
                             value = parsed
                             param_defaults[name] = parsed
-                    except AttributeError:
-                        pass
 
                 if value is not None or parameter_obj.specify_none:
                     defaults[name] = value
@@ -2694,14 +2692,14 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                             try:
                                 target_set[param_name] = param_value.copy()
                             except AttributeError:
-                                try:
-                                    modulable_param_parser = self.parameters._get_prefixed_method(
-                                        parse=True,
-                                        modulable=True
-                                    )
+                                modulable_param_parser = self.parameters._get_prefixed_method(
+                                    parse=True,
+                                    modulable=True
+                                )
+                                if modulable_param_parser is not None:
                                     param_value = modulable_param_parser(param_name, param_value)
                                     target_set[param_name] = param_value
-                                except AttributeError:
+                                else:
                                     target_set[param_name] = param_value.copy()
 
                         else:

--- a/psyneulink/core/components/functions/stateful/integratorfunctions.py
+++ b/psyneulink/core/components/functions/stateful/integratorfunctions.py
@@ -53,7 +53,7 @@ from psyneulink.core.globals.keywords import \
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
 from psyneulink.core.globals.utilities import ValidParamSpecType, all_within_range, \
-    convert_all_elements_to_np_array, parse_valid_identifier
+    convert_all_elements_to_np_array, parse_valid_identifier, safe_len
 
 __all__ = ['SimpleIntegrator', 'AdaptiveIntegrator', 'DriftDiffusionIntegrator', 'DriftOnASphereIntegrator',
            'OrnsteinUhlenbeckIntegrator', 'FitzHughNagumoIntegrator', 'AccumulatorIntegrator',
@@ -276,7 +276,7 @@ class IntegratorFunction(StatefulFunction):  # ---------------------------------
             # If param is in Parameter class for function and it is a function_arg:
             if (param in self.parameters.names() and getattr(self.parameters, param).function_arg
                     and getattr(self.parameters, param)._user_specified):
-                if value is not None and isinstance(value, (list, np.ndarray)) and len(value)>1:
+                if value is not None and isinstance(value, (list, np.ndarray)) and safe_len(value)>1:
                     # Store ones with length > 1 in dict for evaluation below
                     params_to_check.update({param:value})
 
@@ -305,7 +305,7 @@ class IntegratorFunction(StatefulFunction):  # ---------------------------------
             values_with_a_len = [param.default_value for param in self.parameters if
                                  param.function_arg and
                                  isinstance(param.default_value, (list, np.ndarray)) and
-                                 len(param.default_value)>1]
+                                 safe_len(param.default_value)>1]
             # One or more parameters are specified with length > 1 in the inner dimension
             if values_with_a_len:
                 # If shape already matches,
@@ -2427,6 +2427,7 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
         random_draw = Parameter()
 
         def _parse_initializer(self, initializer):
+            initializer = np.array(initializer)
             if initializer.ndim > 1:
                 return np.atleast_1d(initializer.squeeze())
             else:
@@ -2997,6 +2998,7 @@ class DriftOnASphereIntegrator(IntegratorFunction):  # -------------------------
 
         def _parse_initializer(self, initializer):
             """Assign initial value as array of random values of length dimension-1"""
+            initializer = np.array(initializer)
             initializer_dim = self.dimension.default_value - 1
             if initializer.ndim != 1 or len(initializer) != initializer_dim:
                 initializer = np.random.random(initializer_dim)
@@ -3519,6 +3521,7 @@ class OrnsteinUhlenbeckIntegrator(IntegratorFunction):  # ----------------------
         )
 
         def _parse_initializer(self, initializer):
+            initializer = np.array(initializer)
             if initializer.ndim > 1:
                 return np.atleast_1d(initializer.squeeze())
             else:

--- a/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
@@ -422,7 +422,7 @@ class LCAMechanism(RecurrentTransferMechanism):
         def _validate_competition(self, competition):
             if competition < 0:
                 warnings.warn(
-                    f"The 'competition' arg specified for {self.name} is a negative value ({competition}); "
+                    f"The 'competition' arg specified for {self._owner.name} is a negative value ({competition}); "
                     f"note that this will result in a matrix that has positive off-diagonal elements "
                     f"since 'competition' is assumed to specify the magnitude of inhibition."
                 )


### PR DESCRIPTION
- don't suppress AttributeError within _parse/_validate methods

removed:
- `Parameters._get_prefixed_method`

added:
- `Parameters._get_parse_method`
- `Parameters._get_validate_method`
