### PR TITLE
Fix/default control allocation

### DIFF
--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -411,7 +411,7 @@ specify a  default allocation for ControlSignals that have not been assigned the
 determine its `intensity <ControlSignal.intensity>`, which is then assigned to the `value <ControlProjection.value>`
 of the ControlSignal's `ControlProjection`.   The `value <ControlProjection.value>` of the ControlProjection is used
 by the `ParameterPort` to which it projects to modify the value of the parameter it controls (see
-`ControlSignal_Modulation` for description of how a ControlSignal modulates the value of a parameter).
+`ControlSignal_Modulation` for a description of how a ControlSignal modulates the value of a parameter).
 
 .. _ControlMechanism_Costs_NetOutcome:
 
@@ -1772,7 +1772,10 @@ class ControlMechanism(ModulatoryMechanism_Base):
             # default_variable for example, it should be used here
             # instead of the "global default" defaultControlAllocation
             if len(self.defaults.value) == 1:
-                allocation_parameter_default = copy.deepcopy(self.defaults.value)
+                if self.defaults.default_allocation is not None:
+                    allocation_parameter_default = copy.deepcopy(self.defaults.default_allocation)
+                else:
+                    allocation_parameter_default = copy.deepcopy(self.defaults.control_allocation)
             else:
                 allocation_parameter_default = copy.deepcopy(defaultControlAllocation)
 

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -402,15 +402,39 @@ The OutputPorts of a ControlMechanism are `ControlSignals <ControlSignal>` (list
 corresponding parameter.  The ControlSignals are listed in the `control_signals <ControlMechanism.control_signals>`
 attribute;  since they are a type of `OutputPort`, they are also listed in the ControlMechanism's `output_ports
 <Mechanism_Base.output_ports>` attribute. The parameters modulated by a ControlMechanism's ControlSignals can be
-displayed using its `show <ControlMechanism.show>` method. By default, each `ControlSignal` is assigned as its
-`allocation <ControlSignal.allocation>` the value of the  corresponding item of the ControlMechanism's
-`control_allocation <ControlMechanism.control_allocation>`;  however, subtypes of ControlMechanism may assign
-allocations differently. The `default_allocation  <ControlMechanism.default_allocation>` attribute can be used to
-specify a  default allocation for ControlSignals that have not been assigned their own `default_allocation
-<ControlSignal.default_allocation>`. The `allocation <ControlSignal.allocation>` is used by each ControlSignal to
-determine its `intensity <ControlSignal.intensity>`, which is then assigned to the `value <ControlProjection.value>`
-of the ControlSignal's `ControlProjection`.   The `value <ControlProjection.value>` of the ControlProjection is used
-by the `ParameterPort` to which it projects to modify the value of the parameter it controls (see
+displayed using its `show <ControlMechanism.show>` method.
+
+By default, each `ControlSignal` is assigned as its `allocation <ControlSignal.allocation>` the value of the
+corresponding item of the ControlMechanism's `control_allocation <ControlMechanism.control_allocation>`;  however,
+subtypes of ControlMechanism may assign allocations differently. The `default_allocation
+<ControlMechanism.default_allocation>` attribute can be used to specify a  default allocation for ControlSignals that
+have not been assigned their own `default_allocation <ControlSignal.default_allocation>`.
+
+.. warning::
+    the **default_variable** argument of the ControlMechanism's constructor is **not** used to specify a default
+    allocation;  the **default_allocation** argument must be used for that purpose.  The **default_variable** argument
+    should only be used to specify the format of the `value <ControlMechanism.value>` of the ControlMechanism's
+    `input_port (see `Mechanism_InputPorts` for additional details), and its default input when it does not receive
+    any Projections (see `default_variable <Component_Variable>` for additional details).
+
+.. note::
+   While specifying **default_allocation** will take effect the first time the ControlMechanism is executed,
+   a value specified for **default_variable** will not take effect (i.e., in determining `control_allocation
+   <ControlMechanism.control_allocation>` or `value <ControlSignal.value>`\\s of the ControlSignals) until after
+   the ControlMechahnism is executed, and thus will not influence the parameters it controls until the next round of
+   execution (see `Composition_Timing` for a detailed description of the sequence of events during a Composition's
+   execution).
+
+COMMENT:
+    The `value <ControlSignal.value>` of a ControlSignal is not necessarily the same as its `allocation.
+    <ControlSignal.allocation>`  The former is the result of the ControlSignal's `function <ControlSignal.function>`,
+    which is executed when the ControlSignal is updated;  the latter is the value assigned to the ControlSignal's
+COMMENT
+
+The `allocation <ControlSignal.allocation>` is used by each ControlSignal to determine its `intensity
+<ControlSignal.intensity>`, which is then assigned to the `value <ControlProjection.value>`
+of the ControlSignal's `ControlProjection`.   The `value <ControlProjection.value>` of the ControlProjection
+is used by the `ParameterPort` to which it projects to modify the value of the parameter it controls (see
 `ControlSignal_Modulation` for a description of how a ControlSignal modulates the value of a parameter).
 
 .. _ControlMechanism_Costs_NetOutcome:

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2388,13 +2388,17 @@ class Port_Base(Port):
                 name = None
             elif afferent.sender.modulation == OVERRIDE:
                 # Directly store the value in the output array
-                if f_mod_ptr.type != arg_out.type:
-                    assert len(f_mod_ptr.type.pointee) == 1
-                    warnings.warn("Shape mismatch: Overriding modulation should match parameter port output: {} vs. {}".format(
-                                  afferent.defaults.value, self.defaults.value),
-                                  pnlvm.PNLCompilerWarning)
-                    f_mod_ptr = builder.gep(f_mod_ptr, [ctx.int32_ty(0), ctx.int32_ty(0)])
-                builder.store(builder.load(f_mod_ptr), arg_out)
+                try:
+                    builder.store(builder.load(f_mod_ptr), arg_out)
+                except:
+                    raise PortError("Shape mismatch: Value of '{}' for '{}' ({}) should match value of '{}'s '{}' ({})".
+                                    format(afferent.sender.name,
+                                           afferent.sender.owner.name,
+                                           self.defaults.value,
+                                           self.owner.name,
+                                           self.name,
+                                           afferent.defaults.value),
+                                    pnlvm.PNLCompilerWarning)
                 return builder
             else:
                 assert False, "Unsupported modulation parameter: {}".format(afferent.sender.modulation)

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2387,7 +2387,6 @@ class Port_Base(Port):
             elif afferent.sender.modulation == DISABLE:
                 name = None
             elif afferent.sender.modulation == OVERRIDE:
-                # Directly store the value in the output array
                 assert f_mod_ptr.type == arg_out.type, \
                     "Shape mismatch: Value of '{}' for '{}' ({}) " \
                     "should match value of '{}'s '{}' ({})".format(afferent.sender.name,
@@ -2396,6 +2395,7 @@ class Port_Base(Port):
                                                                    self.owner.name,
                                                                    self.name,
                                                                    afferent.defaults.value)
+                # Directly store the value in the output array
                 builder.store(builder.load(f_mod_ptr), arg_out)
                 return builder
             else:

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2388,17 +2388,15 @@ class Port_Base(Port):
                 name = None
             elif afferent.sender.modulation == OVERRIDE:
                 # Directly store the value in the output array
-                try:
-                    builder.store(builder.load(f_mod_ptr), arg_out)
-                except:
-                    raise PortError("Shape mismatch: Value of '{}' for '{}' ({}) should match value of '{}'s '{}' ({})".
-                                    format(afferent.sender.name,
-                                           afferent.sender.owner.name,
-                                           self.defaults.value,
-                                           self.owner.name,
-                                           self.name,
-                                           afferent.defaults.value),
-                                    pnlvm.PNLCompilerWarning)
+                assert f_mod_ptr.type == arg_out.type, \
+                    "Shape mismatch: Value of '{}' for '{}' ({}) " \
+                    "should match value of '{}'s '{}' ({})".format(afferent.sender.name,
+                                                                   afferent.sender.owner.name,
+                                                                   self.defaults.value,
+                                                                   self.owner.name,
+                                                                   self.name,
+                                                                   afferent.defaults.value)
+                builder.store(builder.load(f_mod_ptr), arg_out)
                 return builder
             else:
                 assert False, "Unsupported modulation parameter: {}".format(afferent.sender.modulation)

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -782,7 +782,7 @@ class TestControlSpecification:
 
         controller = pnl.ControlMechanism(
             name='controller',
-            default_variable=5
+            default_allocation=5
         )
 
         outer_comp = pnl.Composition(
@@ -798,7 +798,7 @@ class TestControlSpecification:
     def test_hanging_control_spec_nearest_controller(self):
         inner_controller = pnl.ControlMechanism(
             name='inner_controller',
-            default_variable=5
+            default_allocation=5
         )
 
         inner_comp = pnl.Composition(
@@ -808,7 +808,7 @@ class TestControlSpecification:
 
         outer_controller = pnl.ControlMechanism(
             name='outer_controller',
-            default_variable=10
+            default_allocation=10
         )
 
         outer_comp = pnl.Composition(
@@ -3936,7 +3936,7 @@ class TestControlTimeScales:
         a = pnl.ProcessingMechanism()
         b = pnl.ProcessingMechanism()
         c = pnl.ControlMechanism(
-            default_variable=1,
+            default_allocation=1,
             function=pnl.SimpleIntegrator,
             control=pnl.ControlSignal(modulates=(pnl.SLOPE, b))
         )
@@ -3964,7 +3964,7 @@ class TestControlTimeScales:
         a = pnl.ProcessingMechanism()
         b = pnl.ProcessingMechanism()
         c = pnl.ControlMechanism(
-            default_variable=1,
+            default_allocation=1,
             function=pnl.SimpleIntegrator,
             control=pnl.ControlSignal(modulates=(pnl.SLOPE, b))
         )
@@ -3992,7 +3992,7 @@ class TestControlTimeScales:
         a = pnl.ProcessingMechanism()
         b = pnl.ProcessingMechanism()
         c = pnl.ControlMechanism(
-            default_variable=1,
+            default_allocation=1,
             function=pnl.SimpleIntegrator,
             control=pnl.ControlSignal(modulates=(pnl.SLOPE, b))
         )
@@ -4032,7 +4032,7 @@ class TestControlTimeScales:
         a = pnl.ProcessingMechanism()
         b = pnl.ProcessingMechanism()
         c = pnl.ControlMechanism(
-            default_variable=1,
+            default_allocation=1,
             function=pnl.SimpleIntegrator,
             control=pnl.ControlSignal(modulates=(pnl.SLOPE, b))
         )
@@ -4078,7 +4078,7 @@ class TestControlTimeScales:
         a = pnl.ProcessingMechanism()
         b = pnl.ProcessingMechanism()
         c = pnl.ControlMechanism(
-            default_variable=1,
+            default_allocation=1,
             function=pnl.SimpleIntegrator,
             control=pnl.ControlSignal(modulates=(pnl.SLOPE, b))
         )
@@ -4106,7 +4106,7 @@ class TestControlTimeScales:
         a = pnl.ProcessingMechanism()
         b = pnl.ProcessingMechanism()
         c = pnl.ControlMechanism(
-            default_variable=1,
+            default_allocation=1,
             function=pnl.SimpleIntegrator,
             control=pnl.ControlSignal(modulates=(pnl.SLOPE, b))
         )
@@ -4136,7 +4136,7 @@ class TestControlTimeScales:
         a = pnl.ProcessingMechanism()
         b = pnl.ProcessingMechanism()
         c = pnl.ControlMechanism(
-            default_variable=1,
+            default_allocation=1,
             function=pnl.SimpleIntegrator,
             control=pnl.ControlSignal(modulates=(pnl.SLOPE, b))
         )
@@ -4171,7 +4171,7 @@ class TestControlTimeScales:
         a = pnl.ProcessingMechanism()
         b = pnl.ProcessingMechanism()
         c = pnl.ControlMechanism(
-            default_variable=1,
+            default_allocation=1,
             function=pnl.SimpleIntegrator,
             control=pnl.ControlSignal(modulates=(pnl.SLOPE, b))
         )

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -2357,19 +2357,22 @@ class TestControlMechanisms:
     @pytest.mark.composition
     @pytest.mark.parametrize("modulation, expected", [
                               (pnl.OVERRIDE, 0.2),
-                              (pnl.DISABLE, 0.5),
-                              (pnl.MULTIPLICATIVE, 0.1),
-                              (pnl.ADDITIVE, 0.7),
+                              # (pnl.DISABLE, 0.5),
+                              # (pnl.MULTIPLICATIVE, 0.1),
+                              # (pnl.ADDITIVE, 0.7),
                              ])
-    @pytest.mark.parametrize("specification", [ pnl.OWNER_VALUE, (pnl.OWNER_VALUE, 0)])
+    @pytest.mark.parametrize("specification", [pnl.OWNER_VALUE,
+                                               # (pnl.OWNER_VALUE, 0)
+                                               ])
     def test_control_of_mech_output_port(self, comp_mode, modulation, expected, specification):
         mech = pnl.TransferMechanism(output_ports=[pnl.OutputPort(variable=specification)])
-        control_mech = pnl.ControlMechanism(
-                control_signals=pnl.ControlSignal(modulation=modulation,
-                                                  modulates=mech.output_port))
+        control_mech = pnl.ControlMechanism(control_signals=pnl.ControlSignal(modulation=modulation,
+                                                                              modulates=mech.output_port),
+                                            default_allocation=mech.value if specification is pnl.OWNER_VALUE else mech.value[0]
+                                            )
         comp = pnl.Composition()
         comp.add_nodes([(mech, pnl.NodeRole.INPUT), (control_mech, pnl.NodeRole.INPUT)])
-        inputs = {mech:[[0.5]], control_mech:[0.2]}
+        inputs = {mech:[[0.5]], control_mech:[[0.2]]}
         results = comp.run(inputs=inputs, num_trials=1, execution_mode=comp_mode)
         np.testing.assert_allclose(results, expected)
 

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -2357,12 +2357,12 @@ class TestControlMechanisms:
     @pytest.mark.composition
     @pytest.mark.parametrize("modulation, expected", [
                               (pnl.OVERRIDE, 0.2),
-                              # (pnl.DISABLE, 0.5),
-                              # (pnl.MULTIPLICATIVE, 0.1),
-                              # (pnl.ADDITIVE, 0.7),
+                              (pnl.DISABLE, 0.5),
+                              (pnl.MULTIPLICATIVE, 0.1),
+                              (pnl.ADDITIVE, 0.7),
                              ])
     @pytest.mark.parametrize("specification", [pnl.OWNER_VALUE,
-                                               # (pnl.OWNER_VALUE, 0)
+                                               (pnl.OWNER_VALUE, 0)
                                                ])
     def test_control_of_mech_output_port(self, comp_mode, modulation, expected, specification):
         mech = pnl.TransferMechanism(output_ports=[pnl.OutputPort(variable=specification)])

--- a/tests/mechanisms/test_control_mechanism.py
+++ b/tests/mechanisms/test_control_mechanism.py
@@ -230,14 +230,13 @@ class TestControlMechanism:
 
         # default_allocation *not* specified in constructor of pnl.ControlMechanism,
         #     so should be set to defaultControlAllocation (=[1])
-        c1 = pnl.ControlMechanism(
-            name='C1',
-            default_variable=[10],
-            control_signals=[pnl.ControlSignal(modulates=(pnl.SLOPE, m1)),  # test for assignment to defaultControlAllocation
-                             pnl.ControlSignal(default_allocation=2,  # test for scalar assignment
-                                               modulates=(pnl.SLOPE, m2)),
-                             pnl.ControlSignal(default_allocation=[3],  # test for array assignment
-                                               modulates=(pnl.SLOPE, m3))])
+        c1 = pnl.ControlMechanism(name='C1',
+                                  default_variable=[10],
+                                  control_signals=[pnl.ControlSignal(modulates=(pnl.SLOPE, m1)), # test for assignment to defaultControlAllocation
+                                                   pnl.ControlSignal(default_allocation=2,       # test for scalar assignment
+                                                                     modulates=(pnl.SLOPE, m2)),
+                                                   pnl.ControlSignal(default_allocation=[3],     # test for array assignment
+                                                                     modulates=(pnl.SLOPE, m3))])
         comp = pnl.Composition()
         comp.add_nodes([m1,m2,m3])
         comp.add_controller(c1)


### PR DESCRIPTION
• controlmechanism.py:
  - _instantiate_control_signal_type(): fix assignment of allocation_parameter_default
  - docstring: note to use default_allocation rather than default_variable to set allocation default

• port.py:
  - _gen_llvm_function_body(): got rid of OVERRIDE mismatch workaround, and replaced with test and error.
  
• test_control.py:
  - test_control_of_mech_output_port():
      fix: use shape of specification parameter
           to set default_allocation of ControlMechanism
  - test_hanging_control_spec_outer_controller() and
     test_hanging_control_spec_nearest_controller():
      change: specification of default_variable to default_allocation in ControlMechanisms
  - test_control_signal_default_allocation_specification: fix to accomodate mods above