### PR TITLE
Support and test Python 3.11

### DIFF
--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -24,7 +24,7 @@ jobs:
       # The entire matrix is set up and 'base' builds are pruned based
       # on event name and final configuration (ubuntu, python3.7).
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         python-architecture: ['x64']
         os: [ubuntu-latest, macos-latest, windows-latest]
         event:

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.10']
+        python-version: ['3.7', '3.11']
         python-architecture: ['x64']
         extra-args: ['']
         os: [ubuntu, macos, windows]
@@ -69,13 +69,13 @@ jobs:
             python-architecture: 'x86'
             os: windows
 
-          # fp32 run on linux python 3.8
-          - python-version: '3.8'
+          # fp32 run on linux python 3.10
+          - python-version: '3.10'
             os: ubuntu
             extra-args: '--fp-precision=fp32'
 
-          # --benchmark-enable run on macos python 3.8
-          - python-version: '3.8'
+          # --benchmark-enable run on macos python 3.10
+          - python-version: '3.10'
             os: macos
             extra-args: '--benchmark-enable -m benchmark -n0 --benchmark-min-rounds=2 --benchmark-max-time=0.001 --benchmark-warmup=off'
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
 
-        # This project is liscensed as follows
+        # This project is licensed as follows
         'License :: OSI Approved :: Apache Software License',
 
         # Supported Python Versions
@@ -61,6 +61,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 
     # Require recent python


### PR DESCRIPTION
Add Python 3.11 to the list of supported Python versions.
Add documentation build using Python 3.10 and 3.11 to CI.
Bump used Python version in CI jobs to Python 3.11.
Switch "--benchmark-enable" and "--fp-precision=fp32"  CI jobs to Python 3.10.

Closes: https://github.com/PrincetonUniversity/PsyNeuLink/issues/2681