### PR TITLE
deps: Restrict contourpy to <1.1.0 on x86 (32-bit)

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -56,6 +56,8 @@ runs:
           echo "scipy<1.9.2" >> env_constraints.txt
           # scikit-learn >= 1.1.3 doesn't provide win32 wheel
           echo "scikit-learn<1.1.3" >> env_constraints.txt
+          # countourpy >=1.1.0 doesn't provide win32 wheel
+          echo "contourpy<1.1.0" >> env_constraints.txt
         fi
 
     - name: Install updated package


### PR DESCRIPTION
Wheel is no longer provided.