### PR TITLE
ci: Don't use python 3.7.17 on macos to build docs

### DIFF
--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -37,9 +37,13 @@ jobs:
             pnl-version: 'base'
           - os: windows-latest
             pnl-version: 'base'
-          - python-version: 3.8
+          - python-version: '3.8'
             pnl-version: 'base'
-          - python-version: 3.9
+          - python-version: '3.9'
+            pnl-version: 'base'
+          - python-version: '3.10'
+            pnl-version: 'base'
+          - python-version: '3.11'
             pnl-version: 'base'
 
     outputs:

--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -78,7 +78,9 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        # Block python3.7.17 on macos. see:
+        # https://github.com/actions/setup-python/issues/682
+        python-version: ${{ (matrix.os == 'macos-latest' && matrix.python-version == '3.7') && '3.7.16' || matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
 
     - name: Get pip cache location


### PR DESCRIPTION
Python version used by the setup-python action is missing bz2 module:
    https://github.com/actions/setup-python/issues/682

Don't build "base" version of docs using python 3.10 and 3.11