### PR TITLE
tests: Add helper to generate power set and use it to test compiler debug options

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,12 +1,13 @@
 import contextlib
 import doctest
 import io
+import itertools
 import numpy as np
-import psyneulink
 import pytest
 import re
 import sys
 
+import psyneulink
 from psyneulink import clear_registry, primary_registries, torch_available
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.globals.utilities import set_global_seed
@@ -245,6 +246,13 @@ def expand_np_ndarray(arr):
                 nested_elem = [nested_elem]
             results_list.extend(nested_elem)
     return results_list
+
+@pytest.helpers.register
+def power_set(s):
+    """Set of all potential subsets."""
+
+    vals = list(s)
+    return (c for l in range(len(vals) + 1) for c in itertools.combinations(vals, l))
 
 
 # flag when run from pytest

--- a/tests/llvm/test_debug_composition.py
+++ b/tests/llvm/test_debug_composition.py
@@ -9,7 +9,8 @@ from psyneulink.core.components.mechanisms.processing.integratormechanism import
 from psyneulink.core.components.mechanisms.processing.transfermechanism import TransferMechanism
 from psyneulink.core.compositions.composition import Composition
 
-debug_options=["const_input=[[[7]]]", "const_input", "const_data", "const_params", "const_data", "const_state", "stat", "time_stat", "unaligned_copy"]
+debug_options = ["const_input=[[[7]]]", "const_input", "const_params", "const_data", "const_state",
+                 "stat", "time_stat", "unaligned_copy"]
 options_combinations = (";".join(("", *c)) for i in range(len(debug_options) + 1) for c in combinations(debug_options, i))
 
 @pytest.mark.composition

--- a/tests/llvm/test_debug_composition.py
+++ b/tests/llvm/test_debug_composition.py
@@ -1,7 +1,6 @@
 import numpy as np
 import os
 import pytest
-from itertools import combinations
 
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.functions.nonstateful.transferfunctions import Linear
@@ -11,7 +10,7 @@ from psyneulink.core.compositions.composition import Composition
 
 debug_options = ["const_input=[[[7]]]", "const_input", "const_params", "const_data", "const_state",
                  "stat", "time_stat", "unaligned_copy"]
-options_combinations = (";".join(("", *c)) for i in range(len(debug_options) + 1) for c in combinations(debug_options, i))
+options_combinations = (";".join(c) for c in pytest.helpers.power_set(debug_options))
 
 @pytest.mark.composition
 @pytest.mark.parametrize("mode", [pytest.param(pnlvm.ExecutionMode.LLVMRun, marks=pytest.mark.llvm),


### PR DESCRIPTION
Add power_set helper.
Remove duplicate debug flag from the tested list.
Use the new helper to generate all test variants.