### PR TITLE
ci: Disable pytest-xdist in benchmark ci job

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -77,7 +77,11 @@ jobs:
           # --benchmark-enable run on macos python 3.10
           - python-version: '3.10'
             os: macos
-            extra-args: '--benchmark-enable -m benchmark -n0 --benchmark-min-rounds=2 --benchmark-max-time=0.001 --benchmark-warmup=off'
+            # pytest needs both '--benchmark-only' and '-m benchmark'
+            # The former fails the test if benchamrks cannot be enabled
+            # The latter works around a crash in pytest when collecting tests:
+            # https://github.com/ionelmc/pytest-benchmark/issues/243
+            extra-args: '-m benchmark --benchmark-enable --benchmark-only --benchmark-min-rounds=2 --benchmark-max-time=0.001 --benchmark-warmup=off -n0 --dist=no'
 
           # add python 3.8 build on macos since 3.7 is broken
           # https://github.com/actions/virtual-environments/issues/4230


### PR DESCRIPTION
Use "--benchmark-only" together "-m benchmark".
The former will fail if benchmarking is not available. The latter works around a bug in pytest test collection:
	https://github.com/ionelmc/pytest-benchmark/issues/243

Fixes: d6f8e35c49fed00468944a3e868e0132ebeb83f2
	("tests: Use worksteal xdist balancer (#2670)")