### PR TITLE
llvm, functions: Implement cost calculation in TransferWithCosts functions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -191,11 +191,29 @@ def cuda_param(val):
     return pytest.param(val, marks=[pytest.mark.llvm, pytest.mark.cuda])
 
 @pytest.helpers.register
-def get_func_execution(func, func_mode):
+def get_func_execution(func, func_mode, *, writeback:bool=True):
     if func_mode == 'LLVM':
-        return pnlvm.execution.FuncExecution(func).execute
+        ex = pnlvm.execution.FuncExecution(func)
+
+        # Calling writeback here will replace parameter values
+        # with numpy instances that share memory with the binary
+        # structure used by the compiled function
+        if writeback:
+            ex.writeback_params_to_pnl()
+
+        return ex.execute
+
     elif func_mode == 'PTX':
-        return pnlvm.execution.FuncExecution(func).cuda_execute
+        ex = pnlvm.execution.FuncExecution(func)
+
+        # Calling writeback here will replace parameter values
+        # with numpy instances that share memory with the binary
+        # structure used by the compiled function
+        if writeback:
+            ex.writeback_params_to_pnl()
+
+        return ex.cuda_execute
+
     elif func_mode == 'Python':
         return func.function
     else:

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1334,7 +1334,9 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
         # FIXME: MAGIC LIST, Use stateful tag for this
         whitelist = {"previous_time", "previous_value", "previous_v",
                      "previous_w", "random_state",
-                     "input_ports", "output_ports"}
+                     "input_ports", "output_ports",
+                     "adjustment_cost", "intensity_cost", "duration_cost",
+                     "intensity"}
         # Prune subcomponents (which are enabled by type rather than a list)
         # that should be omitted
         blacklist = { "objective_mechanism", "agent_rep", "projections"}
@@ -1354,7 +1356,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
             blacklist.update(['combination_function'])
 
         def _is_compilation_state(p):
-            #FIXME: This should use defaults instead of 'p.get'
+            # FIXME: This should use defaults instead of 'p.get'
             return p.name not in blacklist and \
                    not isinstance(p, (ParameterAlias, SharedParameter)) and \
                    (p.name in whitelist or isinstance(p.get(), Component))
@@ -1374,6 +1376,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
 
     def _get_state_initializer(self, context):
         def _convert(p):
+            # FIXME: This should use defaults instead of 'p.get'
             x = p.get(context)
             if isinstance(x, np.random.RandomState):
                 # Skip first element of random state (id string)
@@ -1404,7 +1407,8 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                      "num_executions_before_finished", "num_executions",
                      "variable", "value", "saved_values", "saved_samples",
                      "integrator_function_value", "termination_measure_value",
-                     "execution_count",
+                     "execution_count", "intensity", "combined_costs",
+                     "adjustment_cost", "intensity_cost", "duration_cost",
                      # Invalid types
                      "input_port_variables", "results", "simulation_results",
                      "monitor_for_control", "state_feature_values", "simulation_ids",
@@ -1420,15 +1424,14 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                      # duplicate
                      "allocation_samples", "control_allocation_search_space",
                      # not used in computation
-                     "auto", "hetero", "cost", "costs", "combined_costs",
-                     "control_signal", "intensity", "competition",
+                     "auto", "hetero", "cost", "costs",
+                     "control_signal", "competition",
                      "has_recurrent_input_port", "enable_learning",
                      "enable_output_type_conversion", "changes_shape",
                      "output_type", "bounds", "internal_only",
                      "require_projection_in_composition", "default_input",
                      "shadow_inputs", "compute_reconfiguration_cost",
                      "reconfiguration_cost", "net_outcome", "outcome",
-                     "adjustment_cost", "intensity_cost", "duration_cost",
                      "enabled_cost_functions", "control_signal_costs",
                      "default_allocation", "same_seed_for_all_allocations",
                      "search_statefulness", "initial_seed", "combine",
@@ -1455,7 +1458,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
 
         def _is_compilation_param(p):
             if p.name not in blacklist and not isinstance(p, (ParameterAlias, SharedParameter)):
-                #FIXME: this should use defaults
+                # FIXME: this should use defaults
                 val = p.get()
                 # Check if the value type is valid for compilation
                 return not isinstance(val, (str, ComponentsMeta,

--- a/psyneulink/core/components/functions/nonstateful/transferfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/transferfunctions.py
@@ -66,7 +66,7 @@ TranferFunction Class References
 import numbers
 import types
 import warnings
-from enum import IntFlag
+from enum import Flag, auto
 from math import e, pi, sqrt
 
 import numpy as np
@@ -3979,7 +3979,7 @@ costFunctionNames = [INTENSITY_COST_FUNCTION,
                      COMBINE_COSTS_FUNCTION]
 
 
-class CostFunctions(IntFlag):
+class CostFunctions(Flag):
     """Options for selecting constituent cost functions to be used by a `TransferWithCosts` Function.
 
     These can be used alone or in combination with one another, by enabling or disabling each using the
@@ -4013,9 +4013,9 @@ class CostFunctions(IntFlag):
 
     """
     NONE          = 0
-    INTENSITY     = 1 << 1
-    ADJUSTMENT    = 1 << 2
-    DURATION      = 1 << 3
+    INTENSITY     = auto()
+    ADJUSTMENT    = auto()
+    DURATION      = auto()
     ALL           = INTENSITY | ADJUSTMENT | DURATION
     DEFAULTS      = NONE
 

--- a/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
@@ -1150,7 +1150,7 @@ class ControlSignal(ModulatorySignal):
                                                  "function")
 
         # FIXME: This allows INTENSITY and NONE
-        assert self.cost_options & ~CostFunctions.INTENSITY == 0
+        assert self.cost_options & ~CostFunctions.INTENSITY == CostFunctions.NONE
 
         cfunc = ctx.import_llvm_function(self.function.combine_costs_fct)
         cfunc_in = builder.alloca(cfunc.args[2].type.pointee,

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -10212,8 +10212,7 @@ _
 
                     if self._is_learning(context):
                         # copies back matrix to pnl from param struct (after learning)
-                        _comp_ex.writeback_params_to_pnl(context=context,
-                                                         params=_comp_ex._param_struct,
+                        _comp_ex.writeback_params_to_pnl(params=_comp_ex._param_struct,
                                                          ids="llvm_param_ids",
                                                          condition=lambda p: p.name == "matrix")
 

--- a/tests/functions/test_memory.py
+++ b/tests/functions/test_memory.py
@@ -146,7 +146,10 @@ def test_basic(func, variable, params, expected, benchmark, func_mode):
     f = func(default_variable=variable, **params)
     if variable is philox_var:
         f.parameters.random_state.set(_SeededPhilox([module_seed]))
-    EX = pytest.helpers.get_func_execution(f, func_mode)
+
+    # Do not allow writeback. "ring_memory" used by DictionaryMemory is a
+    # custom structure, not a PNL parameter
+    EX = pytest.helpers.get_func_execution(f, func_mode, writeback=False)
 
     EX(variable)
     res = benchmark(EX, variable)

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -263,9 +263,6 @@ def combine_costs(costs):
 @pytest.mark.benchmark
 def test_transfer_with_costs(cost_functions, func_mode, benchmark):
 
-    if func_mode == "PTX":
-        pytest.skip("Synchronization of stateful params not supported on CUDA!")
-
     f = Functions.TransferWithCosts(enabled_cost_functions=cost_functions)
 
     def check(cost_function, if_enabled, if_disabled, observed):

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -229,7 +229,7 @@ derivative_out_test_data = [
 @pytest.mark.parametrize("func, variable, params, expected", derivative_out_test_data, ids=lambda x: getattr(x, 'name', None) or getattr(x, 'get', lambda p, q: None)(kw.OUTPUT_TYPE, None))
 def test_transfer_derivative_out(func, variable, params, expected, benchmark, func_mode):
     if func == Functions.SoftMax and params[kw.OUTPUT_TYPE] == kw.ALL and func_mode != "Python":
-        pytest.skip("Compiled derivative using 'ALL' is not implemented")
+        pytest.skip("Compiled SoftMax derivative using 'ALL' is not implemented")
 
     f = func(default_variable=variable, **params)
     benchmark.group = "TransferFunction " + func.componentName + " Derivative"
@@ -245,7 +245,7 @@ def test_transfer_derivative_out(func, variable, params, expected, benchmark, fu
 
     res = benchmark(ex, variable)
 
-    # Logistic needs reduced accuracy in single precision mode
+    # Logistic needs reduced accuracy in single precision mode because it uses exp()
     if func_mode != 'Python' and func is Functions.Logistic and pytest.helpers.llvm_current_fp_precision() == 'fp32':
         tolerance = {'rtol': 1e-7, 'atol': 1e-8}
     else:
@@ -258,6 +258,7 @@ def test_transfer_with_costs_function():
     result = f(1)
     np.testing.assert_allclose(result, 1)
     f.toggle_cost(Functions.CostFunctions.INTENSITY)
+
     f = Functions.TransferWithCosts(enabled_cost_functions=Functions.CostFunctions.INTENSITY)
     result = f(2)
     np.testing.assert_allclose(result, 2)
@@ -265,6 +266,7 @@ def test_transfer_with_costs_function():
     assert f.adjustment_cost is None
     assert f.duration_cost is None
     np.testing.assert_allclose(f.combined_costs, 7.38905609893065)
+
     f.toggle_cost(Functions.CostFunctions.ADJUSTMENT)
     result = f(3)
     np.testing.assert_allclose(result, 3)
@@ -272,6 +274,7 @@ def test_transfer_with_costs_function():
     np.testing.assert_allclose(f.adjustment_cost, 1)
     assert f.duration_cost is None
     np.testing.assert_allclose(f.combined_costs, 21.085536923187668)
+
     f.toggle_cost(Functions.CostFunctions.DURATION)
     result = f(5)
     np.testing.assert_allclose(result, 5)


### PR DESCRIPTION
Use Flag instead of IntFlag for cost flags.
Add test testing all cost combinations.
Implement invocation of cost functions.
Writeback stateful parameters after execution of compiled functions and mechanisms.
Writeback stateful parameters back to CPU memory after GPU execution.