### PR TITLE
deps: Restrict pillow to < 10.0.0 on x86 (32-bit)

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -58,6 +58,8 @@ runs:
           echo "scikit-learn<1.1.3" >> env_constraints.txt
           # countourpy >=1.1.0 doesn't provide win32 wheel
           echo "contourpy<1.1.0" >> env_constraints.txt
+          # pillow >= 10.0.0 doesn't provide win32 wheel
+          echo "pillow < 10.0.0" >> env_constraints.txt
         fi
 
     - name: Install updated package


### PR DESCRIPTION
win32 wheel is no longer provided