### PR TITLE
llvm: Only write back shareable data

### DIFF
--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -190,20 +190,21 @@ class Execution:
                     if attribute == "random_state":
                         continue
 
-                    value = np.ctypeslib.as_array(compiled_attribute_param)
-
-                    # Stateful parameters include history, get the most recent value
-                    if "state" in ids:
-                        value = value[-1]
-
                     # Replace empty structures with None
                     if ctypes.sizeof(compiled_attribute_param) == 0:
                         value = None
                     else:
+                        value = np.ctypeslib.as_array(compiled_attribute_param)
+
+                        # Stateful parameters include history, get the most recent value
+                        if "state" in ids:
+                            value = value[-1]
+
                         # Try to match the shape of the old value
                         old_value = pnl_param.get(context)
                         if hasattr(old_value, 'shape'):
                             value = value.reshape(old_value.shape)
+
                     pnl_param.set(value, context=context)
 
 

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -185,6 +185,11 @@ class Execution:
 
                 # Writeback parameter value if the condition matches
                 elif condition(pnl_param):
+
+                    # TODO: Reconstruct Python RandomState
+                    if attribute == "random_state":
+                        continue
+
                     value = np.ctypeslib.as_array(compiled_attribute_param)
 
                     # Stateful parameters include history, get the most recent value


### PR DESCRIPTION
"random_state" needs conversion to Python RandomState structure.
Do not create numpy arrays of empty structures.