### PR TITLE
ControlSignal: Do not recalculate costs on Port._update

### DIFF
--- a/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
@@ -1077,15 +1077,6 @@ class ControlSignal(ModulatorySignal):
 
         return port_spec, params_dict
 
-    def _update(self, params=None, context=None):
-        """Update value (intensity) and costs
-        """
-        super()._update(params=params, context=context)
-
-        if self.parameters.cost_options._get(context):
-            intensity = self.parameters.value._get(context)
-            self.parameters.cost._set(self.compute_costs(intensity, context), context)
-
     def compute_costs(self, intensity, context=None):
         """Compute costs based on self.value (`intensity <ControlSignal.intensity>`)."""
         # FIX 8/30/19: NEED TO DEAL WITH DURATION_COST AS STATEFUL:  DON'T WANT TO MESS UP MAIN VALUE

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -2402,7 +2402,7 @@ class TestControlMechanisms:
         (pnl.CostFunctions.INTENSITY, 3, [0.2817181715409549, -3.3890560989306495, -15.085536923187664, -48.59815003314423, -141.41315910257657]),
         (pnl.CostFunctions.ADJUSTMENT, 3, [3, 3, 3, 3, 3] ),
         (pnl.CostFunctions.INTENSITY | pnl.CostFunctions.ADJUSTMENT, 3, [0.2817181715409549, -4.389056098930649, -17.085536923187664, -51.59815003314423, -145.41315910257657]),
-        (pnl.CostFunctions.DURATION, 3, [-17, -20, -23, -26, -29]),
+        (pnl.CostFunctions.DURATION, 3, [-7, -8, -9, -10, -11]),
         # FIXME: combinations with DURATION are broken
         # (pnl.CostFunctions.DURATION | pnl.CostFunctions.ADJUSTMENT, ,),
         # (pnl.CostFunctions.ALL, ,),


### PR DESCRIPTION
The function (TransferWithCosts) calculates costs during execution. The expected results for the modulation simple test reflect halving of calculated costs: [20, 24, 28, 32, 36] -> [10, 12, 14, 16, 18]

Partly closes: https://github.com/PrincetonUniversity/PsyNeuLink/issues/2721