### PR TITLE
Component: don't prune args to function init 

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -538,7 +538,7 @@ from psyneulink.core.globals.registry import register_category, _get_auto_name_p
 from psyneulink.core.globals.sampleiterator import SampleIterator
 from psyneulink.core.globals.utilities import \
     ContentAddressableList, convert_all_elements_to_np_array, convert_to_np_array, get_deepcopy_with_shared, \
-    is_instance_or_subclass, is_matrix, iscompatible, kwCompatibilityLength, prune_unused_args, \
+    is_instance_or_subclass, is_matrix, iscompatible, kwCompatibilityLength, \
     get_all_explicit_arguments, call_with_pruned_args, safe_equals, safe_len, parse_valid_identifier
 from psyneulink.core.scheduling.condition import Never
 from psyneulink.core.scheduling.time import Time, TimeScale
@@ -2983,8 +2983,13 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                     except (AttributeError, KeyError, TypeError):
                         pass
 
-            _, kwargs = prune_unused_args(function.__init__, args=[], kwargs=kwargs_to_instantiate)
-            function = function(default_variable=function_variable, owner=self, **kwargs)
+            try:
+                function = function(default_variable=function_variable, owner=self, **kwargs_to_instantiate)
+            except TypeError as e:
+                if 'unexpected keyword argument' in str(e):
+                    raise ComponentError(f'(function): {function} {e}', component=self) from e
+                else:
+                    raise
 
         else:
             raise ComponentError(f'Unsupported function type: {type(function)}, function={function}.')

--- a/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
+++ b/psyneulink/library/components/projections/pathway/autoassociativeprojection.py
@@ -275,7 +275,9 @@ class AutoAssociativeProjection(MappingProjection):
     def _instantiate_parameter_classes(self, context):
         if FUNCTION not in self.initial_shared_parameters:
             try:
-                self.initial_shared_parameters[FUNCTION] = self.initial_shared_parameters[OWNER_MECH]
+                self.initial_shared_parameters[FUNCTION] = {
+                    'matrix': self.initial_shared_parameters[OWNER_MECH]['matrix']
+                }
             except KeyError:
                 pass
 

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -173,6 +173,7 @@ class TestConstructorArguments:
                 pnl.ProcessingMechanism, pnl.LeakyCompetingIntegrator, {'invalid_arg': 0}, {},
                 marks=pytest.mark.xfail(reason='kwargs are not passed up __init__, are just for backward compatibility for single parameter')
             ),
+            (pnl.ProcessingMechanism, pnl.Linear, {'invalid_arg': 0}, "unexpected keyword argument 'invalid_arg'"),
         ]
     )
     @pytest.mark.parametrize('params_dict_entry', [NotImplemented, 'params'])

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -165,6 +165,26 @@ class TestConstructorArguments:
             np.testing.assert_array_equal(getattr(m.function.defaults, k), v)
 
     @pytest.mark.parametrize(
+        'cls_, function, function_params, err_msg',
+        [
+            (pnl.ProcessingMechanism, pnl.DriftDiffusionIntegrator, {'invalid_arg': 0}, 'Unrecognized argument in constructor for DriftDiffusionIntegrator'),
+            (pnl.ProcessingMechanism, pnl.DriftDiffusionIntegrator, {'initializer': 0, 'starting_value': 1}, 'starting_value is an alias of initializer'),
+            pytest.param(
+                pnl.ProcessingMechanism, pnl.LeakyCompetingIntegrator, {'invalid_arg': 0}, {},
+                marks=pytest.mark.xfail(reason='kwargs are not passed up __init__, are just for backward compatibility for single parameter')
+            ),
+        ]
+    )
+    @pytest.mark.parametrize('params_dict_entry', [NotImplemented, 'params'])
+    def test_function_params_invalid(self, cls_, function, function_params, err_msg, params_dict_entry):
+        with pytest.raises(pnl.ComponentError) as err:
+            cls_(
+                function=function,
+                **nest_dictionary({'function_params': function_params}, params_dict_entry)
+            )
+        assert err_msg in str(err.value)
+
+    @pytest.mark.parametrize(
         'cls_, param_name, argument_name, param_value',
         [
             (pnl.TransferMechanism, 'variable', 'default_variable', [[10]]),


### PR DESCRIPTION
- these should be passed to throw standard python or psyneulink errors
- in this case, make the source of a python unexpected argument error more clear

- remove unexpected arguments auto and hetero from AutoAssociativeProjection function init