### PR TITLE
Fix/ parse port spec port as sender or recvr

### DIFF
--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2885,21 +2885,36 @@ def _parse_port_spec(port_type=None,
         # If it is a Port specification dictionary
         if isinstance(port_spec[PORT_SPEC_ARG], dict):
 
-            # If the Port specification has a Projection that has a sender already assigned,
-            #    then return that Port with the Projection assigned to it
-            #    (this occurs, for example, if an instantiated ControlSignal is used to specify a parameter
+        # If it is a Port specification dictionary
+        if isinstance(port_spec[PORT_SPEC_ARG], dict):
+            # If the Port specification has a Projection specification (instantiated or in deferred_init)
+            # (used to define its connection) then return port specified in the Projection.
+            # This can either the sender or the receiver of the specified Projection, depending on the caller:
+            # - if the sender is specified in the Projection, return port = receiver
+            #   (e.g., projection is a ControlProjections with its receiver (ParameterPort) specified,
+            #          so return port = sender -- i.e., ControlSignal to which ControlProjection should be connected)
+            # - if the receiver is specified in the Projection, return port = sender
+            #   (e.g., projection is from an OutputPort with its sender specified,
+            #          so return the port = receiver -- i.e., InputPort to which Projection should be connected)
             # FIX: JDC 7/8/23 ??WHAT IF PORT SPECIFICATION DICT HAS OTHER SPECS, SUCH AS SIZE?
-            #      POSSIBLY THIS SHOULD ONLY BE CALLED IF DICT CONTAINS *ONLY* A PROJECTION SPEC?
+            # POSSIBLY THIS SHOULD BE CALLED ONLY IF DICT CONTAINS *ONLY* A PROJECTION SPEC?
+
+            # FIX: CHECK WHICH IS SPECIFIED IN THE PROJECTION -- SENDER OR RECEIVER - AND ASSIGN THE OTHER
+            #      RAISE EXCEPTION IF BOTH ARE SPECIFIED
             try:
                 projection = port_spec[PORT_SPEC_ARG][PROJECTIONS]
                 if isinstance(projection, list):
                     assert len(port_spec[PORT_SPEC_ARG][PROJECTIONS])==1
                     projection = port_spec[PORT_SPEC_ARG][PROJECTIONS][0]
-                    port = projection.sender
+                    # FIX: CAUSES TESTS FAILURES
+                    # port = projection.sender
+                    port = projection.receiver
                 elif projection.initialization_status == ContextFlags.DEFERRED_INIT:
-                    port = projection._init_args[SENDER]
+                    # port = projection._init_args[SENDER]
+                    port = projection._init_args[RECEIVER]
                 else:
-                    port = projection.sender
+                    # port = projection.sender
+                    port = projection.receiver
                 if port.initialization_status == ContextFlags.DEFERRED_INIT:
                     port._init_args[PROJECTIONS] = projection
                 else:
@@ -2907,6 +2922,7 @@ def _parse_port_spec(port_type=None,
                 return port
             except:
                 pass
+
 
             # Use the value of any standard args specified in the Port specification dictionary
             #    to replace those explicitly specified in the call to _instantiate_port (i.e., passed in standard_args)


### PR DESCRIPTION
• port.py
  _parse_port_spec(): fix assignment of port if port_spec[PORT_SPEC_ARG] is a dict with a projection specified