### PR TITLE
llvm/cuda: Do not use shared memory for inputs

### DIFF
--- a/tests/composition/test_parameterestimationcomposition.py
+++ b/tests/composition/test_parameterestimationcomposition.py
@@ -141,9 +141,6 @@ def test_parameter_optimization_ddm(func_mode, opt_method):
             "Test not yet implemented for Python. Parameter estimation is too slow."
         )
 
-    if func_mode == "PTX":
-        pytest.skip("Does not work on CUDA")
-
     # High-level parameters the impact performance of the test
     num_trials = 50
     time_step_size = 0.01
@@ -228,9 +225,6 @@ def test_parameter_estimation_ddm_mle(func_mode):
         pytest.skip(
             "Test not yet implemented for Python. Parameter estimate is too slow."
         )
-
-    if func_mode == "PTX":
-        pytest.skip("Does not work on CUDA")
 
     # High-level parameters the impact performance of the test
     num_trials = 50


### PR DESCRIPTION
The size of the input array is dynamically determined so it can't use static allocation of GPU shared memory.
Enable PEC GPU tests.