### PR TITLE
Parameters: handle Parameters as dependencies

### DIFF
--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -2124,8 +2124,15 @@ class ParametersBase(ParametersTemplate):
         for alias_name in aliases_to_create:
             setattr(self, alias_name, ParameterAlias(name=alias_name, source=getattr(self, alias_name).source))
 
-        for param, value in self.values(show_all=True).items():
+        values = self.values(show_all=True)
+        for param, value in values.items():
             self._validate(param, value.default_value)
+
+            if value.dependencies is not None:
+                value.dependencies = {getattr(d, 'name', d) for d in value.dependencies}
+                assert all(dep in values for dep in value.dependencies), (
+                    f'invalid Parameter name among {param} dependencies: {value.dependencies}'
+                )
 
         self._initializing = False
 

--- a/tests/misc/test_parameters.py
+++ b/tests/misc/test_parameters.py
@@ -670,3 +670,15 @@ def test_dependent_parameter_validate():
         r"Value \(3\) assigned to parameter 'b'.*is not valid: invalid",
         str(err.value)
     )
+
+
+def test_dependency_from_parameter():
+    class NewM(pnl.ProcessingMechanism):
+        class Parameters(pnl.ProcessingMechanism.Parameters):
+            a = pnl.Parameter(None)
+            b = pnl.Parameter(None, dependencies='a')
+            c = pnl.Parameter(None, dependencies=b)
+
+    m = NewM()
+    param_order = m.parameters._in_dependency_order
+    assert param_order.index(m.parameters.c) > param_order.index(m.parameters.b)


### PR DESCRIPTION
Correct bug where a Parameter dependency would fail to be respected if a Parameter P specified its dependency on Parameter Q as a Parameter and not the string 'Q', and Q had a dependency of its own