### PR TITLE
Simplify some ControlMechanism arg parsing/validation

### DIFF
--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -1202,8 +1202,10 @@ class ControlMechanism(ModulatoryMechanism_Base):
             def is_2tuple(o):
                 return isinstance(o, tuple) and len(o) == 2
 
-            if not isinstance(output_ports, list):
-                output_ports = [output_ports]
+            if output_ports is None:
+                return output_ports
+
+            output_ports = convert_to_list(output_ports)
 
             for i in range(len(output_ports)):
                 # handle 2-item tuple

--- a/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
@@ -488,16 +488,6 @@ class GatingMechanism(ControlMechanism):
                           registry=self._portRegistry,
                           )
 
-    def _validate_control_arg(self, gate):
-        """Overrided to handle GatingMechanism-specific specifications"""
-        assert isinstance(gate, list), \
-            f"PROGRAM ERROR: 'gate' arg ({gate}) of {self.name} should have been converted to a list."
-        for spec in gate:
-            spec = _parse_port_spec(port_type=GatingSignal, owner=self, port_spec=spec)
-            if not (isinstance(spec, GatingSignal)
-                    or (isinstance(spec, dict) and spec[PORT_TYPE] == GatingSignal)):
-                raise GatingMechanismError(f"Invalid specification for '{GATE}' argument of {self.name}: ({spec})")
-
     def _instantiate_control_signal_type(self, gating_signal_spec, context):
         """Instantiate actual ControlSignal, or subclass if overridden"""
         from psyneulink.core.components.ports.port import _instantiate_port


### PR DESCRIPTION
Avoid unnecessary parsing in `__init__`, and use Parameter parse/validate methods when possible. This avoids always indicating they are user-specified and also parses values if they are later set externally.