### PR TITLE
PredictionErrorMechanism: pass up only sample and target

### DIFF
--- a/psyneulink/library/components/mechanisms/processing/objective/predictionerrormechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/objective/predictionerrormechanism.py
@@ -299,11 +299,9 @@ class PredictionErrorMechanism(ComparatorMechanism):
                  **kwargs
                  ):
 
-        input_ports = [sample, target]
         super().__init__(
             sample=sample,
             target=target,
-            input_ports=input_ports,
             function=function,
             output_ports=output_ports,
             learning_rate=learning_rate,


### PR DESCRIPTION
input_ports from sample and target is handled in ComparatorMechanism