### PR TITLE
Rework handling of parameter arguments to Component constructor

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2085,6 +2085,8 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                     defaults[name] = value
 
         for k in defaults:
+            if defaults[k] is None:
+                continue
             defaults[k] = copy_parameter_value(
                 defaults[k],
                 shared_types=shared_types

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -2176,6 +2176,9 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
 
         if param_defaults is not None:
             for name, value in copy.copy(param_defaults).items():
+                if name in alias_names:
+                    continue
+
                 try:
                     parameter_obj = getattr(self.parameters, name)
                 except AttributeError:

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1720,8 +1720,12 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
         )
         for p in self.parameters:
             # restrict to constructor argument, if both are desired, use alias
-            if p.constructor_argument is not None:
+            if p.constructor_argument is not None and p.constructor_argument != p.name:
                 allowed_kwargs.add(p.constructor_argument)
+                try:
+                    allowed_kwargs.remove(p.name)
+                except KeyError:
+                    pass
             else:
                 allowed_kwargs.add(p.name)
 

--- a/psyneulink/core/components/functions/userdefinedfunction.py
+++ b/psyneulink/core/components/functions/userdefinedfunction.py
@@ -600,10 +600,8 @@ class UserDefinedFunction(Function_Base):
             **self.cust_fct_params
         )
 
-    def _handle_illegal_kwargs(self, **kwargs):
-        super()._handle_illegal_kwargs(
-            **{k: kwargs[k] for k in kwargs if k not in self.cust_fct_params}
-        )
+    def _get_allowed_arguments(self):
+        return super()._get_allowed_arguments().union(self.cust_fct_params)
 
     def _validate_params(self, request_set, target_set=None, context=None):
         pass

--- a/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
@@ -474,7 +474,7 @@ class GatingMechanism(ControlMechanism):
                          monitor_for_control=monitor_for_gating,
                          function=function,
                          default_allocation=default_allocation,
-                         control=gate,
+                         gate=gate,
                          modulation=modulation,
                          params=params,
                          name=name,

--- a/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
@@ -584,14 +584,13 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
                           f'use {repr(MONITOR)} instead')
             monitor = kwargs.pop(MONITORED_OUTPUT_PORTS)
         monitor = monitor or None # deal with possibility of empty list
-        input_ports = monitor
         if output_ports is None or output_ports == OUTCOME:
             output_ports = [OUTCOME]
 
         super().__init__(
             default_variable=default_variable,
             size=size,
-                         input_ports=input_ports,
+                         monitor=monitor,
                          output_ports=output_ports,
                          function=function,
                          params=params,

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -204,13 +204,9 @@ class TestConstructorArguments:
             (pnl.TransferMechanism, 'variable', [[10]]),
         ]
     )
-    @pytest.mark.parametrize('params_dict_entry', [None, 'params'])
+    @pytest.mark.parametrize('params_dict_entry', [NotImplemented, 'params'])
     def test_invalid_argument(self, cls_, argument_name, param_value, params_dict_entry):
-        params = {argument_name: param_value}
-        if params_dict_entry is not None:
-            params = {params_dict_entry: params}
-
         with pytest.raises(pnl.ComponentError) as err:
-            cls_(**params)
+            cls_(**nest_dictionary({argument_name: param_value}, params_dict_entry))
         assert 'Unrecognized argument in constructor' in str(err)
         assert f"(type: {cls_.__name__}): '{argument_name}'" in str(err)

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -126,7 +126,7 @@ class TestComponent:
 
 
 class TestConstructorArguments:
-    class ComponentWithConstructorArg(pnl.Mechanism_Base):
+    class NewTestMech(pnl.Mechanism_Base):
         class Parameters(pnl.Mechanism_Base.Parameters):
             cca_param = pnl.Parameter('A', constructor_argument='cca_constr')
 
@@ -189,7 +189,7 @@ class TestConstructorArguments:
         'cls_, param_name, argument_name, param_value',
         [
             (pnl.TransferMechanism, 'variable', 'default_variable', [[10]]),
-            (ComponentWithConstructorArg, 'cca_param', 'cca_constr', 1),
+            (NewTestMech, 'cca_param', 'cca_constr', 1),
         ]
     )
     @pytest.mark.parametrize('params_dict_entry', [NotImplemented, 'params'])
@@ -200,7 +200,7 @@ class TestConstructorArguments:
     @pytest.mark.parametrize(
         'cls_, argument_name, param_value',
         [
-            (ComponentWithConstructorArg, 'cca_param', 1),
+            (NewTestMech, 'cca_param', 1),
             (pnl.TransferMechanism, 'variable', [[10]]),
         ]
     )

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -40,12 +40,15 @@ class TestComponent:
     def test_detection_of_illegal_arg_in_kwargs(self):
         with pytest.raises(pnl.ComponentError) as error_text:
             pnl.ProcessingMechanism(flim_flam=1)
-        assert "Unrecognized argument in constructor for ProcessingMechanism-0 (type: ProcessingMechanism): 'flim_flam'" in str(error_text)
+        assert "ProcessingMechanism-0: Illegal argument in constructor (type: ProcessingMechanism):" in str(error_text.value)
+        assert "'flim_flam'" in str(error_text.value)
 
     def test_detection_of_illegal_args_in_kwargs(self):
         with pytest.raises(pnl.ComponentError) as error_text:
             pnl.ProcessingMechanism(name='MY_MECH', flim_flam=1, grumblabble=2)
-        assert "Unrecognized arguments in constructor for MY_MECH (type: ProcessingMechanism): 'flim_flam, grumblabble'" in str(error_text)
+        assert "MY_MECH: Illegal arguments in constructor (type: ProcessingMechanism):" in str(error_text.value)
+        assert "'flim_flam'" in str(error_text.value)
+        assert "'grumblabble'" in str(error_text.value)
 
     def test_component_execution_counts_for_standalone_mechanism(self):
 
@@ -129,6 +132,8 @@ class TestConstructorArguments:
     class NewTestMech(pnl.Mechanism_Base):
         class Parameters(pnl.Mechanism_Base.Parameters):
             cca_param = pnl.Parameter('A', constructor_argument='cca_constr')
+            param_with_alias = pnl.Parameter(None, constructor_argument='pwa_constr_arg', aliases=['pwa_alias'])
+            param_with_alias_spec_none = pnl.Parameter(None, aliases=['pwasn_alias'], specify_none=True)
 
         def __init__(self, default_variable=None, **kwargs):
             super().__init__(default_variable=default_variable, **kwargs)
@@ -167,7 +172,7 @@ class TestConstructorArguments:
     @pytest.mark.parametrize(
         'cls_, function, function_params, err_msg',
         [
-            (pnl.ProcessingMechanism, pnl.DriftDiffusionIntegrator, {'invalid_arg': 0}, 'Unrecognized argument in constructor for DriftDiffusionIntegrator'),
+            (pnl.ProcessingMechanism, pnl.DriftDiffusionIntegrator, {'invalid_arg': 0}, 'Illegal argument in constructor (type: DriftDiffusionIntegrator)'),
             (pnl.ProcessingMechanism, pnl.DriftDiffusionIntegrator, {'initializer': 0, 'starting_value': 1}, 'starting_value is an alias of initializer'),
             pytest.param(
                 pnl.ProcessingMechanism, pnl.LeakyCompetingIntegrator, {'invalid_arg': 0}, {},
@@ -190,6 +195,8 @@ class TestConstructorArguments:
         [
             (pnl.TransferMechanism, 'variable', 'default_variable', [[10]]),
             (NewTestMech, 'cca_param', 'cca_constr', 1),
+            (NewTestMech, 'param_with_alias', 'pwa_constr_arg', 1),
+            (NewTestMech, 'param_with_alias', 'pwa_alias', 1),
         ]
     )
     @pytest.mark.parametrize('params_dict_entry', [NotImplemented, 'params'])
@@ -201,6 +208,7 @@ class TestConstructorArguments:
         'cls_, argument_name, param_value',
         [
             (NewTestMech, 'cca_param', 1),
+            (NewTestMech, 'param_with_alias', 1),
             (pnl.TransferMechanism, 'variable', [[10]]),
         ]
     )
@@ -208,5 +216,62 @@ class TestConstructorArguments:
     def test_invalid_argument(self, cls_, argument_name, param_value, params_dict_entry):
         with pytest.raises(pnl.ComponentError) as err:
             cls_(**nest_dictionary({argument_name: param_value}, params_dict_entry))
-        assert 'Unrecognized argument in constructor' in str(err)
-        assert f"(type: {cls_.__name__}): '{argument_name}'" in str(err)
+        assert 'Illegal argument in constructor' in str(err.value)
+        assert f'(type: {cls_.__name__})' in str(err.value)
+
+        constr_arg = getattr(cls_.parameters, argument_name).constructor_argument
+        assert f"'{argument_name}': must use '{constr_arg}' instead" in str(err.value)
+
+    @pytest.mark.parametrize(
+        'cls_, param_name, param_value, alias_name, alias_value',
+        [
+            (pnl.DriftDiffusionIntegrator, 'initializer', 1, 'starting_value', 2),
+            (NewTestMech, 'pwa_constr_arg', 1, 'pwa_alias', 2),
+            (NewTestMech, 'param_with_alias_spec_none', 1, 'pwasn_alias', None),
+            (NewTestMech, 'param_with_alias_spec_none', None, 'pwasn_alias', 1),
+        ]
+    )
+    @pytest.mark.parametrize('params_dict_entry', [NotImplemented, 'params'])
+    def test_conflicting_aliases(
+        self, cls_, param_name, param_value, alias_name, alias_value, params_dict_entry
+    ):
+        with pytest.raises(pnl.ComponentError) as err:
+            cls_(
+                **nest_dictionary(
+                    {param_name: param_value, alias_name: alias_value}, params_dict_entry
+                )
+            )
+
+        assert 'Multiple values' in str(err.value)
+        assert f'{param_name}: {param_value}' in str(err.value)
+        assert f'{alias_name}: {alias_value}' in str(err.value)
+        assert f'{alias_name} is an alias of {param_name}' in str(err.value)
+
+    @pytest.mark.parametrize(
+        'cls_, param_name, alias_name',
+        [
+            (pnl.DriftDiffusionIntegrator, 'initializer', 'starting_value'),
+            (NewTestMech, 'pwa_constr_arg', 'pwa_alias'),
+        ]
+    )
+    @pytest.mark.parametrize('param_value', [None, 1])
+    @pytest.mark.parametrize('alias_value', [None, 1])
+    @pytest.mark.parametrize('params_dict_entry', [NotImplemented, 'params'])
+    def test_nonconflicting_aliases(
+        self, cls_, param_name, alias_name, param_value, alias_value, params_dict_entry
+    ):
+        cls_(
+            **nest_dictionary(
+                {param_name: param_value, alias_name: alias_value}, params_dict_entry
+            )
+        )
+
+    @pytest.mark.parametrize('param_value, alias_value', [(None, None), (1, 1)])
+    @pytest.mark.parametrize('params_dict_entry', [NotImplemented, 'params'])
+    def test_nonconflicting_aliases_specify_none(self, param_value, alias_value, params_dict_entry):
+        self.NewTestMech(
+            **nest_dictionary(
+                {'param_with_alias_spec_none': param_value, 'pwasn_alias': alias_value},
+                params_dict_entry
+            )
+        )


### PR DESCRIPTION
- disallow using a Parameter's name as an argument when it has a constructor_argument
- add `Component._validate_arguments`
  - throw clearer errors for exact reason an argument is invalid (replacing generic message from former `_handle_illegal_kwargs`)
- add `Component._parse_arguments`
  - match parameter values from `Parameter.constructor_argument`s and aliases to their original names