### PR TITLE
tests: mark em_composition TestExecution as pytorch

### DIFF
--- a/tests/composition/test_emcomposition.py
+++ b/tests/composition/test_emcomposition.py
@@ -270,6 +270,7 @@ class TestConstruction:
             test_memory_fill(start=repeat, memory_fill=memory_fill)
 
 
+@pytest.mark.pytorch
 class TestExecution:
 
     # TEST:


### PR DESCRIPTION
mark is used to skip pytorch tests on some CI runs