### PR TITLE
Fix/input port combine

### DIFF
--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -1865,9 +1865,9 @@ class Mechanism_Base(Mechanism):
 
             try:
                 parsed_input_port_spec = _parse_port_spec(owner=self,
-                                                            port_type=InputPort,
-                                                            port_spec=s,
-                                                            )
+                                                          port_type=InputPort,
+                                                          port_spec=s,
+                                                          context=Context(string='handle_arg_input_ports'))
             except AttributeError as e:
                 if DEFER_VARIABLE_SPEC_TO_MECH_MSG in e.args[0]:
                     default_variable_from_input_ports.append(InputPort.defaults.variable)
@@ -1980,9 +1980,11 @@ class Mechanism_Base(Mechanism):
             try:
                 try:
                     for port_spec in params[INPUT_PORTS]:
-                        _parse_port_spec(owner=self, port_type=InputPort, port_spec=port_spec)
+                        _parse_port_spec(owner=self, port_type=InputPort, port_spec=port_spec,
+                                         context=Context(string='mechanism.validate_params'))
                 except TypeError:
-                    _parse_port_spec(owner=self, port_type=InputPort, port_spec=params[INPUT_PORTS])
+                    _parse_port_spec(owner=self, port_type=InputPort, port_spec=params[INPUT_PORTS],
+                                     context=Context(string='mechanism.validate_params'))
             except AttributeError as e:
                 if DEFER_VARIABLE_SPEC_TO_MECH_MSG in e.args[0]:
                     pass

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -2581,7 +2581,8 @@ class OptimizationControlMechanism(ControlMechanism):
                 self.state_feature_specs[i] = spec
 
             # Get InputPort specification dictionary for state_input_port and update its entries
-            parsed_spec = _parse_port_spec(owner=self, port_type=InputPort, port_spec=spec)
+            parsed_spec = _parse_port_spec(owner=self, port_type=InputPort, port_spec=spec,
+                                           context=Context(string='OptimizationControlMechanism._parse_specs'))
             parsed_spec[NAME] = state_input_port_names[i]
             if parsed_spec[PARAMS] and SHADOW_INPUTS in parsed_spec[PARAMS]:
                 # Composition._update_shadow_projections will take care of PROJECTIONS specification

--- a/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
@@ -544,7 +544,7 @@ from psyneulink.core.components.mechanisms.processing.objectivemechanism import 
 from psyneulink.core.components.ports.modulatorysignals.learningsignal import LearningSignal
 from psyneulink.core.components.ports.parameterport import ParameterPort
 from psyneulink.core.components.shellclasses import Mechanism
-from psyneulink.core.globals.context import ContextFlags, handle_external_context
+from psyneulink.core.globals.context import Context, ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import \
     ADDITIVE, ASSERT, ENABLED, INPUT_PORTS, \
     LEARNING, LEARNING_MECHANISM, LEARNING_PROJECTION, LEARNING_SIGNAL, LEARNING_SIGNALS, MATRIX, \
@@ -1161,7 +1161,8 @@ class LearningMechanism(ModulatoryMechanism_Base):
                                            format(LEARNING_SIGNAL, self.name))
 
             for spec in target_set[LEARNING_SIGNALS]:
-                learning_signal = _parse_port_spec(port_type=LearningSignal, owner=self, port_spec=spec)
+                learning_signal = _parse_port_spec(port_type=LearningSignal, owner=self, port_spec=spec,
+                                                   context=Context(string='LearningMechanism.validate_params'))
 
                 # Validate that the receiver of the LearningProjection (if specified)
                 #     is a MappingProjection and in the same Composition as self (if specified)

--- a/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/objectivemechanism.py
@@ -377,7 +377,7 @@ from psyneulink.core.components.mechanisms.processing.processingmechanism import
 from psyneulink.core.components.ports.inputport import InputPort, INPUT_PORT
 from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.components.ports.port import _parse_port_spec
-from psyneulink.core.globals.context import ContextFlags, handle_external_context
+from psyneulink.core.globals.context import Context, ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import \
     CONTROL, EXPONENT, EXPONENTS, LEARNING, MATRIX, NAME, OBJECTIVE_MECHANISM, OUTCOME, OWNER_VALUE, \
     PARAMS, PREFERENCE_SET_NAME, PROJECTION, PROJECTIONS, PORT_TYPE, VARIABLE, WEIGHT, WEIGHTS
@@ -714,7 +714,8 @@ class ObjectiveMechanism(ProcessingMechanism_Base):
                 monitor_specs[i] = spec
 
             # Parse spec to get value of OutputPort and (possibly) the Projection from it
-            input_port = _parse_port_spec(owner=self, port_type = InputPort, port_spec=spec)
+            input_port = _parse_port_spec(owner=self, port_type = InputPort, port_spec=spec,
+                                          context=Context(string='objective_mechanism.add_to_monitor'))
 
             # There should be only one ProjectionTuple specified,
             #    that designates the OutputPort and (possibly) a Projection from it

--- a/psyneulink/core/components/ports/inputport.py
+++ b/psyneulink/core/components/ports/inputport.py
@@ -519,14 +519,14 @@ following attributes, that includes ones specific to, and that can be used to cu
 
 .. _InputPort_Function:
 
-* `function <InputPort.function>` -- combines the `value <Projection_Base.value>` of all of the
-  `Projections <Projection>` received by the InputPort, and assigns the result to the InputPort's `value
-  <InputPort.value>` attribute.  The default function is `LinearCombination` that performs an elementwise (Hadamard)
-  sums the values. However, the parameters of the `function <InputPort.function>` -- and thus the `value
-  <InputPort.value>` of the InputPort -- can be modified by any `GatingProjections <GatingProjection>` received by
-  the InputPort (listed in its `mod_afferents <Port_Base.mod_afferents>` attribute.  A custom function can also be
-  specified, so long as it generates a result that is compatible with the item of the Mechanism's `variable
-  <Mechanism_Base.variable>` to which the `InputPort is assigned <Mechanism_InputPorts>`.
+* `function <InputPort.function>` -- combines the `value <Projection_Base.value>` of all of the `path_afferent
+  <InputPort.path_afferents>` `Projections <Projection>` received by the InputPort, and assigns the result to the
+  InputPort's `value <InputPort.value>` attribute.  The default function is `LinearCombination` that performs an
+  elementwise (Hadamard) sum of the afferent values. However, the parameters of the `function <InputPort.function>`
+  -- and thus the `value <InputPort.value>` of the InputPort -- can be modified by any `GatingProjections
+  <GatingProjection>` received by the InputPort (listed in its `mod_afferents <Port_Base.mod_afferents>` attribute.
+  A custom function can also be specified, so long as it generates a result that is compatible with the item of the
+  Mechanism's `variable <Mechanism_Base.variable>` to which the `InputPort is assigned <Mechanism_InputPorts>`.
 
 .. _InputPort_Value:
 
@@ -551,7 +551,7 @@ Execution
 
 An InputPort cannot be executed directly.  It is executed when the Mechanism to which it belongs is executed.
 When this occurs, the InputPort executes any `Projections <Projection>` it receives, calls its `function
-<InputPort.function>` to combines the values received from any `MappingProjections <MappingProjection>` it receives
+<InputPort.function>` to combine the values received from any `MappingProjections <MappingProjection>` it receives
 (listed in its its `path_afferents  <Port_Base.path_afferents>` attribute) and modulate them in response to any
 `GatingProjections <GatingProjection>` (listed in its `mod_afferents <Port_Base.mod_afferents>` attribute),
 and then assigns the result to the InputPort's `value <InputPort.value>` attribute. This, in turn, is assigned to
@@ -739,7 +739,7 @@ class InputPort(Port_Base):
         applied and it will generate a value that is the same length as the Projection's `value
         <Projection_Base.value>`. However, if the InputPort receives more than one Projection and
         uses a function other than a CombinationFunction, a warning is generated and only the `value
-        <Projection_Base.value>` of the first Projection list in `path_afferents <Port_Base.path_afferents>`
+        <Projection_Base.value>` of the first Projection listed in `path_afferents <Port_Base.path_afferents>`
         is used by the function, which may generate unexpected results when executing the Mechanism or Composition
         to which it belongs.
 
@@ -1153,7 +1153,29 @@ class InputPort(Port_Base):
                                          f"is already present in its port_specific_spec dict or port_dict.")
                 port_dict.update({VARIABLE:np.zeros(port_specific_spec[SIZE])})
                 del port_specific_spec[SIZE]
-                return port_dict, port_specific_spec
+            if COMBINE in port_specific_spec:
+                fct_err = None
+                if (FUNCTION in port_specific_spec and port_specific_spec[FUNCTION] is not None):
+                    fct_str = port_specific_spec[FUNCTION].componentName
+                    fct_err = port_specific_spec[FUNCTION].operation != port_specific_spec[COMBINE]
+                    del port_specific_spec[FUNCTION]
+                elif (FUNCTION in port_dict and port_dict[FUNCTION] is not None):
+                    fct_str = port_dict[FUNCTION].componentName
+                    fct_err = port_dict[FUNCTION].operation != port_specific_spec[COMBINE]
+                    del port_dict[FUNCTION]
+                if fct_err is True:
+                    raise InputPortError(f"COMBINE specification ('{port_specific_spec[COMBINE]}') found in InputPort "
+                                         f"specification dictionary for '{self.__name__}' of '{owner.name}' conflicts "
+                                         f"with FUNCTION specification ({fct_str}); remove one or the other.")
+                if fct_err is False:
+                    warnings.warn(f"Both COMBINE ('{port_specific_spec[COMBINE]}') and FUNCTION ({fct_str}) "
+                                  f"specifications found in InputPort specification dictionary for '{self.__name__}' "
+                                  f"of '{owner.name}'; no need to specify both.")
+                # port_dict.update({FUNCTION:LinearCombination(operation = port_specific_spec[COMBINE])})
+                port_specific_spec[FUNCTION] = LinearCombination(operation=port_specific_spec[COMBINE])
+                del port_specific_spec[COMBINE]
+
+            return port_dict, port_specific_spec
             return None, port_specific_spec
 
         elif isinstance(port_specific_spec, tuple):

--- a/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
@@ -1025,7 +1025,7 @@ class ControlSignal(ModulatorySignal):
             self.duration_cost = 0
             self.cost = self.defaults.cost = self.intensity_cost
 
-    def _parse_port_specific_specs(self, owner, port_dict, port_specific_spec):
+    def _parse_port_specific_specs(self, owner, port_dict, port_specific_spec, context=None):
         """Get ControlSignal specified for a parameter or in a 'control_signals' argument
 
         Tuple specification can be:

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -634,6 +634,7 @@ from psyneulink.core.globals.keywords import \
     VALUE, VARIABLE, \
     output_port_spec_to_parameter_name, INPUT_PORT_VARIABLES
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
+from psyneulink.core.globals.context import Context
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import \
@@ -1063,14 +1064,14 @@ class OutputPort(Port_Base):
         return _parse_output_port_variable(variable, self.owner)
 
     @beartype
-    def _parse_port_specific_specs(self, owner, port_dict, port_specific_spec):
+    def _parse_port_specific_specs(self, owner, port_dict, port_specific_spec, context=None):
         """Get variable spec and/or connections specified in an OutputPort specification tuple
 
         Tuple specification can be:
             (port_spec, connections)
             (port_spec, variable spec, connections)
 
-        See Port._parse_port_specific_spec for additional info.
+        See Port._parse_port_specific_specs for additional info.
 
         Returns:
              - port_spec:  1st item of tuple
@@ -1404,7 +1405,8 @@ def _instantiate_output_ports(owner, output_ports=None, context=None):
             else:
                 # parse output_port
                 from psyneulink.core.components.ports.port import _parse_port_spec
-                output_port = _parse_port_spec(port_type=OutputPort, owner=owner, port_spec=output_port)
+                output_port = _parse_port_spec(port_type=OutputPort, owner=owner, port_spec=output_port,
+                                               context=Context(string='OutputPort._instantiate_output_ports'))
 
                 _maintain_backward_compatibility(output_port, output_port[NAME], owner)
 
@@ -1456,6 +1458,7 @@ def _instantiate_output_ports(owner, output_ports=None, context=None):
         # Use OutputPort as default
         port_types = OutputPort
 
+    context.string = context.string or '_instantiate_output_ports'
     port_list = _instantiate_port_list(owner=owner,
                                          port_list=output_ports,
                                          port_types=port_types,

--- a/psyneulink/core/components/ports/parameterport.py
+++ b/psyneulink/core/components/ports/parameterport.py
@@ -802,7 +802,7 @@ class ParameterPort(Port_Base):
         return self.mod_afferents
 
     @beartype
-    def _parse_port_specific_specs(self, owner, port_dict, port_specific_spec):
+    def _parse_port_specific_specs(self, owner, port_dict, port_specific_spec, context=None):
         """Get connections specified in a ParameterPort specification tuple
 
         Tuple specification can be:

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -1842,7 +1842,7 @@ class Port_Base(Port):
     def _get_all_afferents(self):
         assert False, f"Subclass of Port ({self.__class__.__name__}) must implement '_get_all_afferents()' method."
 
-    def _parse_port_specific_specs(self, owner, port_dict, port_specific_spec):
+    def _parse_port_specific_specs(self, owner, port_dict, port_specific_spec, context=None):
         """Parse parameters in Port specification tuple specific to each subclass
 
         Called by _parse_port_spec()
@@ -3061,8 +3061,9 @@ def _parse_port_spec(port_type=None,
                                                                                      port_specification,
                                                                                      context)
                     port_specification = _parse_port_spec(port_type=port_type,
-                                                            owner=owner,
-                                                            port_spec=new_port_specification)
+                                                          owner=owner,
+                                                          port_spec=new_port_specification,
+                                                          context=context)
                     assert True
                 except AttributeError:
                     raise PortError("Attempt to assign a {} ({}) to {} that belongs to another {} ({})".
@@ -3210,9 +3211,10 @@ def _parse_port_spec(port_type=None,
 
         if port_specific_specs:
             port_spec, params = port_type._parse_port_specific_specs(port_type,
-                                                                         owner=owner,
-                                                                         port_dict=port_dict,
-                                                                         port_specific_spec = port_specific_specs)
+                                                                     owner=owner,
+                                                                     port_dict=port_dict,
+                                                                     port_specific_spec = port_specific_specs,
+                                                                     context=context)
             # Port subclass returned a port_spec, so call _parse_port_spec to parse it
             if port_spec is not None:
                 port_dict = _parse_port_spec(context=context, port_spec=port_spec, **standard_args)

--- a/psyneulink/library/compositions/regressioncfa.py
+++ b/psyneulink/library/compositions/regressioncfa.py
@@ -88,6 +88,7 @@ from psyneulink.core.components.ports.port import _parse_port_spec
 from psyneulink.core.compositions.compositionfunctionapproximator import CompositionFunctionApproximator, CompositionFunctionApproximatorError
 from psyneulink.core.globals.keywords import ALL, CONTROL_SIGNALS, DEFAULT_VARIABLE, VARIABLE
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
+from psyneulink.core.globals.context import Context
 from psyneulink.core.globals.utilities import get_deepcopy_with_shared, powerset, tensor_power
 
 __all__ = ['PREDICTION_TERMS', 'PV', 'RegressionCFA']
@@ -458,7 +459,8 @@ class RegressionCFA(CompositionFunctionApproximator):
                         assert False, "PROGRAM ERROR: unrecognized specification for {} arg of {}: {}".\
                                                       format(repr(CONTROL_SIGNALS), self.name, c)
                 else:
-                    port_spec_dict = _parse_port_spec(port_type=ControlSignal, owner=self, port_spec=c)
+                    port_spec_dict = _parse_port_spec(port_type=ControlSignal, owner=self, port_spec=c,
+                                                      context=Context(string='RegressionCFA.__init__'))
                     v = port_spec_dict[VARIABLE]
                     v = v or ControlSignal.defaults.variable
                 control_allocation.append(v)

--- a/tests/ports/test_input_ports.py
+++ b/tests/ports/test_input_ports.py
@@ -68,6 +68,10 @@ class TestInputPorts:
         t = pnl.TransferMechanism(input_ports={pnl.COMBINE: pnl.PRODUCT})
         assert t.input_port.function.operation == pnl.PRODUCT
 
+    def test_equivalent_function_dict_spec(self):
+        t = pnl.TransferMechanism(input_ports={pnl.FUNCTION:pnl.LinearCombination(operation=pnl.PRODUCT)})
+        assert t.input_port.function.operation == pnl.PRODUCT
+
     def test_combine_dict_spec_redundant_with_function(self):
         with pytest.warns(UserWarning) as warnings:  # Warn, since default_input is NOT set
             t = pnl.TransferMechanism(input_ports={pnl.COMBINE:pnl.PRODUCT,

--- a/tests/ports/test_input_ports.py
+++ b/tests/ports/test_input_ports.py
@@ -64,6 +64,28 @@ class TestInputPorts:
         assert "Specification of 'combine' argument (PRODUCT) conflicts with Function specified " \
                "in 'function' argument (Linear) for InputPort" in str(error_text.value)
 
+    def test_combine_dict_spec(self):
+        t = pnl.TransferMechanism(input_ports={pnl.COMBINE: pnl.PRODUCT})
+        assert t.input_port.function.operation == pnl.PRODUCT
+
+    def test_combine_dict_spec_redundant_with_function(self):
+        with pytest.warns(UserWarning) as warnings:  # Warn, since default_input is NOT set
+            t = pnl.TransferMechanism(input_ports={pnl.COMBINE:pnl.PRODUCT,
+                                                   pnl.FUNCTION:pnl.LinearCombination(operation=pnl.PRODUCT)})
+        assert any(w.message.args[0] == "Both COMBINE ('product') and FUNCTION (LinearCombination Function) "
+                                              "specifications found in InputPort specification dictionary for "
+                                              "'InputPort' of 'TransferMechanism-0'; no need to specify both."
+                   for w in warnings)
+        assert t.input_port.function.operation == pnl.PRODUCT
+
+    def test_combine_dict_spec_conflicts_with_function(self):
+        with pytest.raises(pnl.InputPortError) as error_text:
+            t = pnl.TransferMechanism(input_ports={pnl.COMBINE:pnl.PRODUCT,
+                                                   pnl.FUNCTION:pnl.LinearCombination})
+        assert "COMBINE entry (='product') of InputPort specification dictionary for 'InputPort' of " \
+               "'TransferMechanism-0' conflicts with FUNCTION entry (LinearCombination Function); " \
+               "remove one or the other." in str(error_text.value)
+
     def test_single_projection_variable(self):
         a = pnl.TransferMechanism()
         b = pnl.TransferMechanism()


### PR DESCRIPTION
• inputport.py
  - _parse_port_specific_specs(): fix bug in which COMBINE was not parsed when specified in an InputPort specification dict (though still some weirdness in passing spec through to constructor, requiring function assignment in place)

• port.py
  _parse_port_spec():
    add passing of Context.string for local handling based on caller (e.g., warning messages)