### PR TITLE
llvm, OptimizationControlMechanism: Reuse costs computed by TransferWithCosts

### DIFF
--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -3315,7 +3315,7 @@ class OptimizationControlMechanism(ControlMechanism):
                 data_out = builder.gep(op_in, [ctx.int32_ty(0), ctx.int32_ty(0)])
 
             if data_in.type != data_out.type:
-                warnings.warn("Shape mismatch: Allocation sample '{}' ({}) doesn't match input port input ({}).".format(
+                warnings.warn("Shape mismatch: Allocation sample '{}' ({}) doesn't match output port input ({}).".format(
                                i, self.parameters.control_allocation_search_space.get(), op.defaults.variable),
                                pnlvm.PNLCompilerWarning)
                 assert len(data_out.type.pointee) == 1

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -3444,13 +3444,12 @@ class OptimizationControlMechanism(ControlMechanism):
 
         # Apply allocation sample to simulation data
         assert len(self.output_ports) == len(allocation_sample.type.pointee)
-        idx = self.agent_rep._get_node_index(self)
-        ocm_out = builder.gep(comp_data, [ctx.int32_ty(0), ctx.int32_ty(0),
-                                          ctx.int32_ty(idx)])
+        controller_out = builder.gep(comp_data, [ctx.int32_ty(0), ctx.int32_ty(0),
+                                                 ctx.int32_ty(controller_idx)])
         for i, _ in enumerate(self.output_ports):
-            idx = ctx.int32_ty(i)
-            sample_ptr = builder.gep(allocation_sample, [ctx.int32_ty(0), idx])
-            sample_dst = builder.gep(ocm_out, [ctx.int32_ty(0), idx, ctx.int32_ty(0)])
+            op_idx = ctx.int32_ty(i)
+            sample_ptr = builder.gep(allocation_sample, [ctx.int32_ty(0), op_idx])
+            sample_dst = builder.gep(controller_out, [ctx.int32_ty(0), op_idx, ctx.int32_ty(0)])
             if sample_ptr.type != sample_dst.type:
                 assert len(sample_dst.type.pointee) == 1
                 sample_dst = builder.gep(sample_dst, [ctx.int32_ty(0),
@@ -3508,11 +3507,11 @@ class OptimizationControlMechanism(ControlMechanism):
             assert self.objective_mechanism, f"objective_mechanism on OptimizationControlMechanism cannot be None " \
                                              f"in compiled mode"
 
-            idx = self.agent_rep._get_node_index(self.objective_mechanism)
+            obj_idx = self.agent_rep._get_node_index(self.objective_mechanism)
             # Mechanisms' results are stored in the first substructure
             objective_op_ptr = builder.gep(comp_data, [ctx.int32_ty(0),
                                                        ctx.int32_ty(0),
-                                                       ctx.int32_ty(idx)])
+                                                       ctx.int32_ty(obj_idx)])
             # Objective mech output shape should be 1 single element 2d array
             objective_val_ptr = builder.gep(objective_op_ptr,
                                             [ctx.int32_ty(0), ctx.int32_ty(0),

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -3273,7 +3273,6 @@ class OptimizationControlMechanism(ControlMechanism):
         assert "net_outcome" in tags
         args = [ctx.get_param_struct_type(self).as_pointer(),
                 ctx.get_state_struct_type(self).as_pointer(),
-                self._get_evaluate_alloc_struct_type(ctx).as_pointer(),
                 ctx.float_ty.as_pointer(),
                 self._get_evaluate_output_struct_type(ctx, tags=tags).as_pointer()]
 
@@ -3281,64 +3280,61 @@ class OptimizationControlMechanism(ControlMechanism):
         llvm_func = builder.function
         for p in llvm_func.args:
             p.attributes.add('nonnull')
-        params, state, allocation_sample, objective_ptr, arg_out = llvm_func.args
+        _, state, objective_ptr, arg_out = llvm_func.args
 
-        op_params = pnlvm.helpers.get_param_ptr(builder, self, params,
-                                                "output_ports")
         op_states = pnlvm.helpers.get_state_ptr(builder, self, state,
                                                 "output_ports", None)
 
         # calculate cost function
-        total_cost = builder.alloca(ctx.float_ty, name="total_cost")
-        builder.store(ctx.float_ty(-0.0), total_cost)
+        total_cost_ptr = builder.alloca(ctx.float_ty, name="total_cost")
+        builder.store(total_cost_ptr.type.pointee(-0.0), total_cost_ptr)
+
         for i, op in enumerate(self.output_ports):
-            op_i_params = builder.gep(op_params, [ctx.int32_ty(0),
-                                                  ctx.int32_ty(i)])
+            # FIXME Issue #2712: Use port total cost here
+            port_cost_ptr = builder.alloca(ctx.float_ty, name="port_{}_total_cost".format(i))
+            builder.store(port_cost_ptr.type.pointee(-0.0), port_cost_ptr)
+
             op_i_state = builder.gep(op_states, [ctx.int32_ty(0),
                                                  ctx.int32_ty(i)])
 
-            op_f = ctx.import_llvm_function(op, tags=frozenset({"costs"}))
+            # Python uses alias-ed Parameters on Signals, but here we must get
+            # the function state values.
+            op_func = op.function
+            op_func_state = pnlvm.helpers.get_state_ptr(builder, op, op_i_state, "function")
 
-            op_in = builder.alloca(op_f.args[2].type.pointee,
-                                   name="output_port_cost_in")
+            costs = [(CostFunctions.INTENSITY, op_func.parameters.intensity_cost),
+                     (CostFunctions.ADJUSTMENT, op_func.parameters.adjustment_cost),
+                     (CostFunctions.DURATION, op_func.parameters.duration_cost)]
 
-            # copy allocation_sample, the input is 1-element array in a struct
-            data_in = builder.gep(allocation_sample, [ctx.int32_ty(0),
-                                                      ctx.int32_ty(i)])
+            for (flag, param) in costs:
 
-            # Port input struct is {data, modulation} if modulation is present,
-            # otherwise it's just data
-            if len(op.mod_afferents) > 0:
-                data_out = builder.gep(op_in, [ctx.int32_ty(0), ctx.int32_ty(0),
-                                               ctx.int32_ty(0)])
-            else:
-                data_out = builder.gep(op_in, [ctx.int32_ty(0), ctx.int32_ty(0)])
+                # The check for enablement is structural and has to be done in Python.
+                # If a cost function is not enabled the cost parameter is None
+                if flag in op.parameters.cost_options.get():
+                    cost_ptr = pnlvm.helpers.get_state_ptr(builder, op_func, op_func_state, param.name)
+                    cost = pnlvm.helpers.load_extract_scalar_array_one(builder, cost_ptr)
+                    port_cost = builder.load(port_cost_ptr)
 
-            if data_in.type != data_out.type:
-                warnings.warn("Shape mismatch: Allocation sample '{}' ({}) doesn't match output port input ({}).".format(
-                               i, self.parameters.control_allocation_search_space.get(), op.defaults.variable),
-                               pnlvm.PNLCompilerWarning)
-                assert len(data_out.type.pointee) == 1
-                data_out = builder.gep(data_out, [ctx.int32_ty(0), ctx.int32_ty(0)])
+                    # FIXME Issue #2712: This assume addition as port cost combination function
+                    port_cost = builder.fadd(port_cost, cost)
+                    builder.store(port_cost, port_cost_ptr)
 
-            builder.store(builder.load(data_in), data_out)
 
-            # Invoke cost function
-            cost = builder.call(op_f, [op_i_params, op_i_state, op_in])
+            port_cost = builder.load(port_cost_ptr)
 
             # simplified version of combination fmax(cost, 0)
-            ltz = builder.fcmp_ordered("<", cost, cost.type(0))
-            cost = builder.select(ltz, cost.type(0), cost)
+            ltz = builder.fcmp_ordered("<", port_cost, port_cost.type(0))
+            port_cost = builder.select(ltz, port_cost.type(0), port_cost)
 
             # combine is not a PNL function
             assert self.combine_costs is np.sum
-            val = builder.load(total_cost)
-            val = builder.fadd(val, cost)
-            builder.store(val, total_cost)
+            total_cost = builder.load(total_cost_ptr)
+            total_cost = builder.fadd(total_cost, port_cost)
+            builder.store(total_cost, total_cost_ptr)
 
         # compute net_outcome
-        objective = builder.load(objective_ptr)
-        net_outcome = builder.fsub(objective, builder.load(total_cost))
+        objective_val = builder.load(objective_ptr)
+        net_outcome = builder.fsub(objective_val, builder.load(total_cost_ptr))
         builder.store(net_outcome, arg_out)
 
         builder.ret_void()
@@ -3526,13 +3522,12 @@ class OptimizationControlMechanism(ControlMechanism):
                                                        ctx.int32_ty(obj_idx)])
             # Objective mech output shape should be 1 single element 2d array
             objective_val_ptr = builder.gep(objective_op_ptr,
-                                            [ctx.int32_ty(0), ctx.int32_ty(0),
-                                             ctx.int32_ty(0)], "obj_val_ptr")
+                                            [ctx.int32_ty(0), ctx.int32_ty(0), ctx.int32_ty(0)],
+                                            "obj_val_ptr")
 
+            # Apply total cost to objective value
             net_outcome_f = ctx.import_llvm_function(self, tags=tags.union({"net_outcome"}))
-            builder.call(net_outcome_f, [controller_params, controller_state,
-                                         allocation_sample, objective_val_ptr,
-                                         arg_out])
+            builder.call(net_outcome_f, [controller_params, controller_state, objective_val_ptr, arg_out])
         elif "evaluate_type_all_results" in tags:
             pass
         else:

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -3303,21 +3303,20 @@ class TestModelBasedOptimizationControlMechanisms_Execution:
                                                function=pnl.GridSearch(save_values=True),
                                                control_signals=[control_signal],
                                                comp_execution_mode=ocm_mode)
-        # objective_mech.log.set_log_conditions(pnl.OUTCOME)
 
         comp.add_controller(ocm)
 
         inputs = {A: [[[1.0]], [[2.0]], [[3.0]]]}
 
-        comp.run(inputs=inputs, execution_mode=mode)
+        def comp_run(inputs, execution_mode):
+            comp.run(inputs=inputs, execution_mode=execution_mode)
+            return comp.results.copy(), np.asfarray(ocm.function.saved_values)
 
-        # objective_mech.log.print_entries(pnl.OUTCOME)
-        np.testing.assert_allclose(comp.results, [[np.array([1.])], [np.array([1.5])], [np.array([2.25])]])
+        results, saved_values = benchmark(comp_run, inputs, mode)
+
+        np.testing.assert_allclose(results, [[np.array([1.])], [np.array([1.5])], [np.array([2.25])]])
         if mode == pnl.ExecutionMode.Python:
-            np.testing.assert_allclose(np.asfarray(ocm.function.saved_values).flatten(), [0.75, 1.5, 2.25])
-
-        if benchmark.enabled:
-            benchmark(comp.run, inputs, execution_mode=mode)
+            np.testing.assert_allclose(saved_values, [0.75, 1.5, 2.25])
 
     @pytest.mark.benchmark(group="Model Based OCM")
     @pytest.mark.parametrize("mode, ocm_mode", pytest.helpers.get_comp_and_ocm_execution_modes())
@@ -3344,21 +3343,20 @@ class TestModelBasedOptimizationControlMechanisms_Execution:
                                                function=pnl.GridSearch(save_values=True),
                                                control_signals=[control_signal],
                                                comp_execution_mode=ocm_mode)
-        # objective_mech.log.set_log_conditions(pnl.OUTCOME)
 
         comp.add_controller(ocm)
 
         inputs = {A: [[[1.0]], [[2.0]], [[3.0]]]}
 
-        comp.run(inputs=inputs, execution_mode=mode)
+        def comp_run(inputs, execution_mode):
+            comp.run(inputs=inputs, execution_mode=execution_mode)
+            return comp.results.copy(), np.asfarray(ocm.function.saved_values)
 
-        # objective_mech.log.print_entries(pnl.OUTCOME)
-        np.testing.assert_allclose(comp.results, [[np.array([0.75])], [np.array([1.5])], [np.array([2.25])]])
+        results, saved_values = benchmark(comp_run, inputs, mode)
+
+        np.testing.assert_allclose(results, [[np.array([0.75])], [np.array([1.5])], [np.array([2.25])]])
         if mode == pnl.ExecutionMode.Python:
-            np.testing.assert_allclose(np.asfarray(ocm.function.saved_values).flatten(), [0.75, 1.5, 2.25])
-
-        if benchmark.enabled:
-            benchmark(comp.run, inputs, execution_mode=mode)
+            np.testing.assert_allclose(saved_values, [0.75, 1.5, 2.25])
 
     def test_model_based_ocm_with_buffer(self):
 

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -2403,14 +2403,13 @@ class TestControlMechanisms:
         (pnl.CostFunctions.ADJUSTMENT, 3, [3, 3, 3, 3, 3] ),
         (pnl.CostFunctions.INTENSITY | pnl.CostFunctions.ADJUSTMENT, 3, [0.2817181715409549, -4.389056098930649, -17.085536923187664, -51.59815003314423, -145.41315910257657]),
         (pnl.CostFunctions.DURATION, 3, [-7, -8, -9, -10, -11]),
-        # FIXME: combinations with DURATION are broken
-        # (pnl.CostFunctions.DURATION | pnl.CostFunctions.ADJUSTMENT, ,),
-        # (pnl.CostFunctions.ALL, ,),
+        (pnl.CostFunctions.DURATION | pnl.CostFunctions.ADJUSTMENT, None ,None),
+        (pnl.CostFunctions.ALL, None, None),
         pytest.param(pnl.CostFunctions.DEFAULTS, 7, [3, 4, 5, 6, 7], id="CostFunctions.DEFAULT")],
         ids=lambda x: x if isinstance(x, pnl.CostFunctions) else "")
     def test_modulation_simple(self, cost, expected, exp_values, comp_mode):
-        if comp_mode != pnl.ExecutionMode.Python and cost not in {pnl.CostFunctions.NONE, pnl.CostFunctions.INTENSITY}:
-            pytest.skip("Not implemented!")
+        if cost != pnl.CostFunctions.DURATION and pnl.CostFunctions.DURATION in cost:
+            pytest.skip("Cost calculations using duration in combination with other costs are broken!")
 
         obj = pnl.ObjectiveMechanism()
         mech = pnl.ProcessingMechanism()
@@ -2431,7 +2430,7 @@ class TestControlMechanisms:
                 ),
 
                 # Need to specify GridSearch since save_values is False by default and we
-                # going to check these values later in the test.
+                # check these values below
                 function=pnl.GridSearch(save_values=True)
             )
         )
@@ -3316,7 +3315,7 @@ class TestModelBasedOptimizationControlMechanisms_Execution:
 
         np.testing.assert_allclose(results, [[np.array([1.])], [np.array([1.5])], [np.array([2.25])]])
         if mode == pnl.ExecutionMode.Python:
-            np.testing.assert_allclose(saved_values, [0.75, 1.5, 2.25])
+            np.testing.assert_allclose(saved_values.flatten(), [0.75, 1.5, 2.25])
 
     @pytest.mark.benchmark(group="Model Based OCM")
     @pytest.mark.parametrize("mode, ocm_mode", pytest.helpers.get_comp_and_ocm_execution_modes())
@@ -3356,7 +3355,7 @@ class TestModelBasedOptimizationControlMechanisms_Execution:
 
         np.testing.assert_allclose(results, [[np.array([0.75])], [np.array([1.5])], [np.array([2.25])]])
         if mode == pnl.ExecutionMode.Python:
-            np.testing.assert_allclose(saved_values, [0.75, 1.5, 2.25])
+            np.testing.assert_allclose(saved_values.flatten(), [0.75, 1.5, 2.25])
 
     def test_model_based_ocm_with_buffer(self):
 


### PR DESCRIPTION
Execute OCM ports when setting an allocation.
Reuse calculated costs from TransferWithCosts.
Drop "allocation" parameter to net_outcome.
Consolidate model_based_ocm tests.