### PR TITLE
llvm: Type annotation fixes

### DIFF
--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -352,11 +352,11 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
         values = list(self.visit(value) for value in node.values)
 
         self._update_debug_metadata(self.builder, node)
-        values = (self.get_rval(v) for v in values)
-        ret_val = next(values)
-        for value in values:
-            assert ret_val.type == value.type, "Don't know how to mix types in boolean expressions!"
-            ret_val = operator(self.builder, ret_val, value)
+        rvals = (self.get_rval(v) for v in values)
+        ret_val = next(rvals)
+        for val in rvals:
+            assert ret_val.type == val.type, "Don't know how to mix types in boolean expressions!"
+            ret_val = operator(self.builder, ret_val, val)
         return ret_val
 
     def visit_And(self, node):

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -8,8 +8,6 @@
 
 # ********************************************* Binary Execution Wrappers **************************************************************
 
-from psyneulink.core.globals.context import Context
-
 from collections import Counter
 import concurrent.futures
 import copy
@@ -19,9 +17,11 @@ from inspect import isgenerator
 import os
 import sys
 import time
+from typing import Callable, Optional
 
 
 from psyneulink.core import llvm as pnlvm
+from psyneulink.core.globals.context import Context
 from . import helpers, jit_engine, builder_context
 from .debug import debug_env
 
@@ -114,7 +114,7 @@ class Execution:
         return struct
 
 
-    def writeback_params_to_pnl(self, params=None, ids:str=None, condition:callable=lambda p: True):
+    def writeback_params_to_pnl(self, params=None, ids:Optional[str]=None, condition:Callable=lambda p: True):
 
         assert (params is None) == (ids is None), "Either both 'params' and 'ids' have to be set or neither"
 
@@ -126,7 +126,7 @@ class Execution:
         self._copy_params_to_pnl(self._execution_contexts[0], self._obj, params, ids, condition)
 
 
-    def _copy_params_to_pnl(self, context, component, params, ids:str, condition:callable):
+    def _copy_params_to_pnl(self, context, component, params, ids:str, condition:Callable):
 
         for idx, attribute in enumerate(getattr(component, ids)):
             compiled_attribute_param = getattr(params, params._fields_[idx][0])


### PR DESCRIPTION
Do not reuse variable name for different type.
Use 'Callable' instead of 'callable' to annotate callable argument type