### PR TITLE
llvm: Reduce overhead of compiled parameters

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1419,7 +1419,16 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
             blacklist.update(['combination_function'])
 
         def _is_compilation_param(p):
-            if p.name not in blacklist and not isinstance(p, (ParameterAlias, SharedParameter)):
+            def _is_user_only_param(p):
+                if p.read_only and p.getter is not None:
+                    return True
+                if isinstance(p, (ParameterAlias, SharedParameter)):
+                    return True
+
+                return False
+
+
+            if p.name not in blacklist and not _is_user_only_param(p):
                 # FIXME: this should use defaults
                 val = p.get()
                 # Check if the value type is valid for compilation

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1397,7 +1397,10 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                      "enabled_cost_functions", "control_signal_costs",
                      "default_allocation", "same_seed_for_all_allocations",
                      "search_statefulness", "initial_seed", "combine",
-                     "random_variables", "smoothing_factor",
+                     "random_variables", "smoothing_factor", "per_item",
+                     "key_size", "val_size", "max_entries", "random_draw",
+                     "randomization_dimension", "save_values", "save_samples",
+                     "max_iterations",
                      # not used in compiled learning
                      "learning_results", "learning_signal", "learning_signals",
                      "error_matrix", "error_signal", "activation_input",

--- a/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
@@ -1747,8 +1747,7 @@ class GridSearch(OptimizationFunction):
         # remove the attribute for 'samples_ptr'.
         samples_ptr.attributes.remove('nonnull')
 
-        random_state = pnlvm.helpers.get_state_ptr(builder, self, state,
-                                                   self.parameters.random_state.name)
+        random_state = ctx.get_random_state_ptr(builder, self, state, params)
         select_random_ptr = pnlvm.helpers.get_param_ptr(builder, self, params,
                                                         self.parameters.select_randomly_from_optimal_values.name)
 

--- a/psyneulink/core/components/functions/nonstateful/transferfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/transferfunctions.py
@@ -4885,7 +4885,7 @@ class TransferWithCosts(TransferFunction):
         trans_in = arg_in
         trans_out = arg_out
         builder.call(trans_f, [trans_p, trans_s, trans_in, trans_out])
-        intensity_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, self.parameters.intensity.name)
+        intensity_ptr = pnlvm.helpers.get_state_space(builder, self, state, self.parameters.intensity.name)
 
         costs = [(self.parameters.intensity_cost_fct, CostFunctions.INTENSITY, self.parameters.intensity_cost),
                  (self.parameters.adjustment_cost_fct, CostFunctions.ADJUSTMENT, self.parameters.adjustment_cost),
@@ -4899,7 +4899,7 @@ class TransferWithCosts(TransferFunction):
                 cost_f = ctx.import_llvm_function(func.get())
                 cost_p = pnlvm.helpers.get_param_ptr(builder, self, params, func.name)
                 cost_s = pnlvm.helpers.get_state_ptr(builder, self, state, func.name)
-                cost_out = pnlvm.helpers.get_state_ptr(builder, self, state, out.name)
+                cost_out = pnlvm.helpers.get_state_space(builder, self, state, out.name)
                 cost_in = trans_out
 
                 if flag == CostFunctions.ADJUSTMENT:


### PR DESCRIPTION
Use get_random_state_ptr helper in GridSearch function instead of accessing the random state directly.
The helper handles reseeding the random state if the seed has changed.
Remove unneeded parameters from compiled structures; read-only parameters with custom getters are user-only and not used in compilation.