### PR TITLE
deps: Don't use onnxruntime==1.16 on python 3.11

### DIFF
--- a/broken_trans_deps.txt
+++ b/broken_trans_deps.txt
@@ -12,6 +12,10 @@ ipython != 8.13.0; python_version < '3.9'
 # https://github.com/onnx/onnx/issues/5202
 onnx != 1.14.0
 
+# onnx >= 1.16.0 needs explicit setting of provider to use,
+# but modeci_mdf that's available for python 3.11 doesn't do that.
+onnxruntime != 1.16; python_version == '3.11'
+
 # torch wheels for win32 python3.10 are built against numpy>=1.23
 # https://github.com/pytorch/pytorch/issues/100690
 torch !=2.0.1, !=2.0.0, !=1.13.*, !=1.12.*; python_version == '3.10' and platform_system == 'Windows'


### PR DESCRIPTION
modeci_mdf available on python 3.11 doesn't set the provider to use as required by onnxruntime 1.16