### PR TITLE
models/MontagueDayanSejnowski: Use versioned seaborn style

### DIFF
--- a/psyneulink/library/models/MontagueDayanSejnowski96.py
+++ b/psyneulink/library/models/MontagueDayanSejnowski96.py
@@ -113,7 +113,7 @@ def figure_5a():
         delta_vals = prediction_error_mechanism.log.nparray_dictionary()[composition_name][pnl.VALUE]
 
         # Plot Delta Values form trials 1, 30, and 50
-        with plt.style.context('seaborn'):
+        with plt.style.context('seaborn-v0_8'):
             plt.plot(delta_vals[0][0], "-o", label="Trial 1")
             plt.plot(delta_vals[29][0], "-s", label="Trial 30")
             plt.plot(delta_vals[49][0], "-o", label="Trial 50")
@@ -176,7 +176,7 @@ def figure_5b():
         # Get Delta Values from Log
         delta_vals = prediction_error_mechanism.log.nparray_dictionary()[composition_name][pnl.VALUE]
 
-        with plt.style.context('seaborn'):
+        with plt.style.context('seaborn-v0_8'):
             fig = plt.figure()
             ax = fig.add_subplot(111, projection='3d')
             x_vals, y_vals = np.meshgrid(np.arange(120), np.arange(40, 60, step=1))
@@ -240,7 +240,7 @@ def figure_5c():
         # Get Delta Values from Log
         delta_vals = prediction_error_mechanism.log.nparray_dictionary()[composition_name][pnl.VALUE]
 
-        with plt.style.context('seaborn'):
+        with plt.style.context('seaborn-v0_8'):
             fig = plt.figure()
             ax = fig.add_subplot(111, projection='3d')
             x_vals, y_vals = np.meshgrid(np.arange(150), np.arange(40, 60, step=1))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ graphviz<0.21.0
 grpcio<1.70.0
 leabra-psyneulink<0.3.3
 llvmlite<0.44
-matplotlib<3.7.6
+matplotlib<3.7.6, >=3.7.0
 modeci_mdf<0.5, >=0.4.3; (platform_machine == 'AMD64' or platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
 networkx<3.5
 numpy>=1.21.0, <1.26.5


### PR DESCRIPTION
Plain names are deprecated in matplotlib and removed in matplotlib==3.8.0.
The versioned name with underscore was introduced in matplotlib==3.7.0, 6608eedfc6f33f723f1e13c6025a5b918c7c9f6d
	("Re-rename builtin seaborn styles to not include a dot.")