### PR TITLE
llvm: Add support for fp32 to printf helper

### DIFF
--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -436,7 +436,8 @@ def printf(builder, fmt, *args, override_debug=False):
     global_fmt.initializer = fmt_ty(fmt_data)
 
     fmt_ptr = builder.gep(global_fmt, [ir.IntType(32)(0), ir.IntType(32)(0)])
-    builder.call(printf, [fmt_ptr] + list(args))
+    conv_args = [builder.fpext(a, ir.DoubleType()) if is_floating_point(a) else a for a in args]
+    builder.call(printf, [fmt_ptr] + conv_args)
 
 
 def printf_float_array(builder, array, prefix="", suffix="\n", override_debug=False):

--- a/tests/llvm/test_helpers.py
+++ b/tests/llvm/test_helpers.py
@@ -224,10 +224,11 @@ def test_helper_all_close(mode, var1, var2, atol, rtol):
 
 @pytest.mark.llvm
 @pytest.mark.parametrize("ir_argtype,format_spec,values_to_check", [
-    (pnlvm.ir.IntType(32), "%u", range(0, 20)),
-    (pnlvm.ir.IntType(64), "%lld", [int(-4E10), int(-3E10), int(-2E10)]),
-    (pnlvm.ir.DoubleType(), "%lf", [x *.5 for x in range(0, 5)]),
-    ], ids=["i32", "i64", "double"])
+    pytest.param(pnlvm.ir.IntType(32), "%u", range(0, 20), id="i32"),
+    pytest.param(pnlvm.ir.IntType(64), "%lld", [int(-4E10), int(-3E10), int(-2E10)], id="i64"),
+    pytest.param(pnlvm.ir.DoubleType(), "%lf", [x *.5 for x in range(0, 5)], id="double"),
+    pytest.param(pnlvm.ir.FloatType(), "%lf", [x *.5 for x in range(0, 5)], id="float"),
+    ])
 def test_helper_printf(capfd, ir_argtype, format_spec, values_to_check):
 
     format_str = f"Hello {(format_spec + ' ') * len(values_to_check)}\n"


### PR DESCRIPTION
libc printf only supports fp64 and expects other float types to be extended to fp64.