### PR TITLE
ci/github-actions: Add CI run using lowest supported version of dependencies

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -52,6 +52,7 @@ jobs:
         python-architecture: ['x64']
         extra-args: ['']
         os: [ubuntu, macos, windows]
+        version-restrict: ['']
         include:
           # code-coverage build on macos python 3.9
           - python-version: '3.9'
@@ -78,10 +79,17 @@ jobs:
           - python-version: '3.10'
             os: macos
             # pytest needs both '--benchmark-only' and '-m benchmark'
-            # The former fails the test if benchamrks cannot be enabled
+            # The former fails the test if benchmarks cannot be enabled
+            # (e.g. due to --dist setting)
             # The latter works around a crash in pytest when collecting tests:
             # https://github.com/ionelmc/pytest-benchmark/issues/243
             extra-args: '-m benchmark --benchmark-enable --benchmark-only --benchmark-min-rounds=2 --benchmark-max-time=0.001 --benchmark-warmup=off -n0 --dist=no'
+
+          # add python 3.7 with deps restricted to min supported version
+          - python-version: '3.7'
+            python-architecture: 'x64'
+            os: ubuntu
+            version-restrict: 'min'
 
           # add python 3.8 build on macos since 3.7 is broken
           # https://github.com/actions/virtual-environments/issues/4230
@@ -114,6 +122,15 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.python-architecture }}
+
+    - name: Restrict version of direct dependencies
+      if: ${{ matrix.version-restrict == 'min' }}
+      shell: bash
+      run: |
+        sed -i '/^[^#]/s/>=/==/' *requirements.txt
+        git config user.name "github actions"
+        git config user.email "none"
+        git commit -a -m "Restrict version of direct dependencies to min"
 
     - name: Get pip cache location
       shell: bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ pint<0.22.0
 protobuf<3.20.4
 rich>=10.1, <10.13
 toposort<1.11
-torch>=1.8.0, <2.1.0; (platform_machine == 'AMD64' or platform_machine == 'x86_64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
+torch>=1.10.0, <2.1.0; (platform_machine == 'AMD64' or platform_machine == 'x86_64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ llvmlite<0.42
 matplotlib<3.7.3
 modeci_mdf<0.5, >=0.4.3; (platform_machine == 'AMD64' or platform_machine == 'x86_64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
 networkx<3.3
-numpy>=1.19.0, <1.24.5
+numpy>=1.21.0, <1.24.5
 optuna<3.4.0
 packaging<24.0
 pandas<2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,13 @@ autograd<1.7
 beartype<0.16.0
 dill<0.3.8
 fastkde>=1.0.24, <1.0.31
-graph-scheduler>=0.2.0, <1.1.3
+graph-scheduler>=1.1.1, <1.1.3
 graphviz<0.21.0
 grpcio<1.60.0
 leabra-psyneulink<0.3.3
 llvmlite<0.42
 matplotlib<3.7.3
-modeci_mdf<0.5, >=0.3.4; (platform_machine == 'AMD64' or platform_machine == 'x86_64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
+modeci_mdf<0.5, >=0.4.3; (platform_machine == 'AMD64' or platform_machine == 'x86_64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
 networkx<3.3
 numpy>=1.19.0, <1.24.5
 optuna<3.4.0


### PR DESCRIPTION
Only for dependencies that have lower bounds.
Bump lower bounds to pass tests.