### PR TITLE
llvm: Minimize and track parameters used in compiled structures

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1321,7 +1321,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
 
         # Drop combination function params from RTM if not needed
         if getattr(self.parameters, 'has_recurrent_input_port', False):
-            blacklist.update(['combination_function'])
+            blacklist.add('combination_function')
 
         # Drop integrator function if integrator_mode is not enabled
         if not getattr(self, 'integrator_mode', False):
@@ -1439,7 +1439,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
 
         # Drop combination function params from RTM if not needed
         if getattr(self.parameters, 'has_recurrent_input_port', False):
-            blacklist.update(['combination_function'])
+            blacklist.add('combination_function')
 
         # Drop integrator function if integrator_mode is not enabled
         if not getattr(self, 'integrator_mode', False):

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1417,8 +1417,9 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
         # * matrix -- is never used directly, and is flatened below
         # * integration rate -- shape mismatch with param port input
         # * initializer -- only present on DDM and never used
+        # * search_space -- duplicated between OCM and its function
         if hasattr(self, 'ports'):
-            blacklist.update(["matrix", "integration_rate", "initializer"])
+            blacklist.update(["matrix", "integration_rate", "initializer", "search_space"])
         else:
             # Execute until finished is only used by mechanisms
             blacklist.update(["execute_until_finished", "max_executions_before_finished"])

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1309,6 +1309,12 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
             whitelist.update({"value", "num_executions_before_finished",
                               "num_executions", "is_finished_flag"})
 
+            # If both the mechanism and its functoin use random_state it's DDM
+            # with integrator function. The mechanism's random_state is not used.
+            if hasattr(self.parameters, 'random_state') and hasattr(self.function.parameters, 'random_state'):
+                whitelist.remove('random_state')
+
+
         # Only mechanisms and compositions need 'num_executions'
         if hasattr(self, 'nodes'):
             whitelist.add("num_executions")

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1410,7 +1410,8 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                      # not used in compiled learning
                      "learning_results", "learning_signal", "learning_signals",
                      "error_matrix", "error_signal", "activation_input",
-                     "activation_output", "error_sources", "covariates_sources"
+                     "activation_output", "error_sources", "covariates_sources",
+                     "target", "sample",
                      }
         # Mechanism's need few extra entries:
         # * matrix -- is never used directly, and is flatened below

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1327,6 +1327,16 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
         if not getattr(self, 'integrator_mode', False):
             blacklist.add('integrator_function')
 
+        # Drop unused cost functions
+        cost_functions = getattr(self, 'enabled_cost_functions', None)
+        if cost_functions is not None:
+            if cost_functions.INTENSITY not in cost_functions:
+                blacklist.add('intensity_cost_fct')
+            if cost_functions.ADJUSTMENT not in cost_functions:
+                blacklist.add('adjustment_cost_fct')
+            if cost_functions.DURATION not in cost_functions:
+                blacklist.add('duration_cost_fct')
+
         # Drop previous_value from MemoryFunctions
         if hasattr(self.parameters, 'duplicate_keys'):
             blacklist.add("previous_value")
@@ -1444,6 +1454,16 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
         # Drop integrator function if integrator_mode is not enabled
         if not getattr(self, 'integrator_mode', False):
             blacklist.add('integrator_function')
+
+        # Drop unused cost functions
+        cost_functions = getattr(self, 'enabled_cost_functions', None)
+        if cost_functions is not None:
+            if cost_functions.INTENSITY not in cost_functions:
+                blacklist.add('intensity_cost_fct')
+            if cost_functions.ADJUSTMENT not in cost_functions:
+                blacklist.add('adjustment_cost_fct')
+            if cost_functions.DURATION not in cost_functions:
+                blacklist.add('duration_cost_fct')
 
         def _is_compilation_param(p):
             def _is_user_only_param(p):

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1405,6 +1405,8 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                      "key_size", "val_size", "max_entries", "random_draw",
                      "randomization_dimension", "save_values", "save_samples",
                      "max_iterations", "duplicate_keys",
+                     "search_termination_function", "state_feature_function",
+                     "search_function",
                      # not used in compiled learning
                      "learning_results", "learning_signal", "learning_signals",
                      "error_matrix", "error_signal", "activation_input",

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1317,6 +1317,10 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
         if getattr(self.parameters, 'has_recurrent_input_port', False):
             blacklist.update(['combination_function'])
 
+        # Drop integrator function if integrator_mode is not enabled
+        if not getattr(self, 'integrator_mode', False):
+            blacklist.add('integrator_function')
+
         # Drop previous_value from MemoryFunctions
         if hasattr(self.parameters, 'duplicate_keys'):
             blacklist.add("previous_value")
@@ -1430,6 +1434,10 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
         # Drop combination function params from RTM if not needed
         if getattr(self.parameters, 'has_recurrent_input_port', False):
             blacklist.update(['combination_function'])
+
+        # Drop integrator function if integrator_mode is not enabled
+        if not getattr(self, 'integrator_mode', False):
+            blacklist.add('integrator_function')
 
         def _is_compilation_param(p):
             def _is_user_only_param(p):

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1413,13 +1413,15 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
         # Mechanism's need few extra entries:
         # * matrix -- is never used directly, and is flatened below
         # * integration rate -- shape mismatch with param port input
+        # * initializer -- only present on DDM and never used
         if hasattr(self, 'ports'):
-            blacklist.update(["matrix", "integration_rate"])
+            blacklist.update(["matrix", "integration_rate", "initializer"])
         else:
             # Execute until finished is only used by mechanisms
             blacklist.update(["execute_until_finished", "max_executions_before_finished"])
+
             # "has_initializers" is only used by RTM
-            blacklist.update(["has_initializers"])
+            blacklist.add('has_initializers')
 
         # Drop combination function params from RTM if not needed
         if getattr(self.parameters, 'has_recurrent_input_port', False):

--- a/psyneulink/core/components/functions/nonstateful/combinationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/combinationfunctions.py
@@ -85,7 +85,7 @@ class CombinationFunction(Function_Base):
         variable = Parameter(np.array([0]), read_only=True, pnl_internal=True, constructor_argument='default_variable')
 
     def _gen_llvm_load_param(self, ctx, builder, params, param_name, index, default):
-        param_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, param_name)
+        param_ptr = ctx.get_param_or_state_ptr(builder, self, param_name, param_struct_ptr=params)
         param_type = param_ptr.type.pointee
         if isinstance(param_type, pnlvm.ir.LiteralStructType):
             assert len(param_type) == 0

--- a/psyneulink/core/components/functions/nonstateful/distributionfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/distributionfunctions.py
@@ -205,8 +205,8 @@ class NormalDist(DistributionFunction):
 
     def _gen_llvm_function_body(self, ctx, builder, params, state, _, arg_out, *, tags:frozenset):
         random_state = ctx.get_random_state_ptr(builder, self, state, params)
-        mean_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, "mean")
-        std_dev_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, "standard_deviation")
+        mean_ptr = ctx.get_param_or_state_ptr(builder, self, DIST_MEAN, param_struct_ptr=params)
+        std_dev_ptr = ctx.get_param_or_state_ptr(builder, self, STANDARD_DEVIATION, param_struct_ptr=params)
         ret_val_ptr = builder.alloca(ctx.float_ty)
         norm_rand_f = ctx.get_normal_dist_function_by_state(random_state)
         builder.call(norm_rand_f, [random_state, ret_val_ptr])
@@ -634,8 +634,8 @@ class UniformDist(DistributionFunction):
 
     def _gen_llvm_function_body(self, ctx, builder, params, state, _, arg_out, *, tags:frozenset):
         random_state = ctx.get_random_state_ptr(builder, self, state, params)
-        low_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, LOW)
-        high_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, HIGH)
+        low_ptr = ctx.get_param_or_state_ptr(builder, self, LOW, param_struct_ptr=params)
+        high_ptr = ctx.get_param_or_state_ptr(builder, self, HIGH, param_struct_ptr=params)
         ret_val_ptr = builder.alloca(ctx.float_ty)
         norm_rand_f = ctx.get_uniform_dist_function_by_state(random_state)
         builder.call(norm_rand_f, [random_state, ret_val_ptr])
@@ -1421,7 +1421,7 @@ class DriftDiffusionAnalytical(DistributionFunction):  # -----------------------
     def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:frozenset):
 
         def load_scalar_param(name):
-            param_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, name)
+            param_ptr = ctx.get_param_or_state_ptr(builder, self, name, param_struct_ptr=params)
             return pnlvm.helpers.load_extract_scalar_array_one(builder, param_ptr)
 
         attentional_drift_rate = load_scalar_param(DRIFT_RATE)

--- a/psyneulink/core/components/functions/nonstateful/transferfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/transferfunctions.py
@@ -510,8 +510,8 @@ class Linear(TransferFunction):  # ---------------------------------------------
     def _gen_llvm_transfer(self, builder, index, ctx, vi, vo, params, state, *, tags:frozenset):
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
-        slope_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, SLOPE)
-        intercept_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, INTERCEPT)
+        slope_ptr = ctx.get_param_or_state_ptr(builder, self, SLOPE, param_struct_ptr=params)
+        intercept_ptr = ctx.get_param_or_state_ptr(builder, self, INTERCEPT, param_struct_ptr=params)
 
         slope = pnlvm.helpers.load_extract_scalar_array_one(builder, slope_ptr)
         intercept = pnlvm.helpers.load_extract_scalar_array_one(builder, intercept_ptr)
@@ -755,10 +755,10 @@ class Exponential(TransferFunction):  # ----------------------------------------
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
 
-        rate_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, RATE)
-        bias_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, BIAS)
-        scale_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, SCALE)
-        offset_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, OFFSET)
+        rate_ptr = ctx.get_param_or_state_ptr(builder, self, RATE, param_struct_ptr=params)
+        bias_ptr = ctx.get_param_or_state_ptr(builder, self, BIAS, param_struct_ptr=params)
+        scale_ptr = ctx.get_param_or_state_ptr(builder, self, SCALE, param_struct_ptr=params)
+        offset_ptr = ctx.get_param_or_state_ptr(builder, self, OFFSET, param_struct_ptr=params)
 
         rate = pnlvm.helpers.load_extract_scalar_array_one(builder, rate_ptr)
         bias = pnlvm.helpers.load_extract_scalar_array_one(builder, bias_ptr)
@@ -1075,11 +1075,11 @@ class Logistic(TransferFunction):  # -------------------------------------------
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
 
-        gain_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, GAIN)
-        bias_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, BIAS)
-        x_0_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, X_0)
-        scale_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, SCALE)
-        offset_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, OFFSET)
+        gain_ptr = ctx.get_param_or_state_ptr(builder, self, GAIN, param_struct_ptr=params)
+        bias_ptr = ctx.get_param_or_state_ptr(builder, self, BIAS, param_struct_ptr=params)
+        x_0_ptr = ctx.get_param_or_state_ptr(builder, self, X_0, param_struct_ptr=params)
+        scale_ptr = ctx.get_param_or_state_ptr(builder, self, SCALE, param_struct_ptr=params)
+        offset_ptr = ctx.get_param_or_state_ptr(builder, self, OFFSET, param_struct_ptr=params)
 
         gain = pnlvm.helpers.load_extract_scalar_array_one(builder, gain_ptr)
         bias = pnlvm.helpers.load_extract_scalar_array_one(builder, bias_ptr)
@@ -1390,11 +1390,11 @@ class Tanh(TransferFunction):  # -----------------------------------------------
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
 
-        gain_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, GAIN)
-        bias_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, BIAS)
-        x_0_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, X_0)
-        offset_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, OFFSET)
-        scale_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, SCALE)
+        gain_ptr = ctx.get_param_or_state_ptr(builder, self, GAIN, param_struct_ptr=params)
+        bias_ptr = ctx.get_param_or_state_ptr(builder, self, BIAS, param_struct_ptr=params)
+        x_0_ptr = ctx.get_param_or_state_ptr(builder, self, X_0, param_struct_ptr=params)
+        offset_ptr = ctx.get_param_or_state_ptr(builder, self, OFFSET, param_struct_ptr=params)
+        scale_ptr = ctx.get_param_or_state_ptr(builder, self, SCALE, param_struct_ptr=params)
 
         gain = pnlvm.helpers.load_extract_scalar_array_one(builder, gain_ptr)
         bias = pnlvm.helpers.load_extract_scalar_array_one(builder, bias_ptr)
@@ -1652,9 +1652,9 @@ class ReLU(TransferFunction):  # -----------------------------------------------
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
 
-        gain_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, GAIN)
-        bias_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, BIAS)
-        leak_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, LEAK)
+        gain_ptr = ctx.get_param_or_state_ptr(builder, self, GAIN, param_struct_ptr=params)
+        bias_ptr = ctx.get_param_or_state_ptr(builder, self, BIAS, param_struct_ptr=params)
+        leak_ptr = ctx.get_param_or_state_ptr(builder, self, LEAK, param_struct_ptr=params)
 
         gain = pnlvm.helpers.load_extract_scalar_array_one(builder, gain_ptr)
         bias = pnlvm.helpers.load_extract_scalar_array_one(builder, bias_ptr)
@@ -2104,10 +2104,10 @@ class Gaussian(TransferFunction):  # -------------------------------------------
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
 
-        standard_deviation_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, STANDARD_DEVIATION)
-        bias_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, BIAS)
-        scale_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, SCALE)
-        offset_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, OFFSET)
+        standard_deviation_ptr = ctx.get_param_or_state_ptr(builder, self, STANDARD_DEVIATION, param_struct_ptr=params)
+        bias_ptr = ctx.get_param_or_state_ptr(builder, self, BIAS, param_struct_ptr=params)
+        scale_ptr = ctx.get_param_or_state_ptr(builder, self, SCALE, param_struct_ptr=params)
+        offset_ptr = ctx.get_param_or_state_ptr(builder, self, OFFSET, param_struct_ptr=params)
 
         standard_deviation = pnlvm.helpers.load_extract_scalar_array_one(builder, standard_deviation_ptr)
         bias = pnlvm.helpers.load_extract_scalar_array_one(builder, bias_ptr)
@@ -2381,10 +2381,10 @@ class GaussianDistort(TransferFunction):  #-------------------------------------
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
 
-        variance_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, VARIANCE)
-        bias_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, BIAS)
-        scale_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, SCALE)
-        offset_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, OFFSET)
+        variance_ptr = ctx.get_param_or_state_ptr(builder, self, VARIANCE, param_struct_ptr=params)
+        bias_ptr = ctx.get_param_or_state_ptr(builder, self, BIAS, param_struct_ptr=params)
+        scale_ptr = ctx.get_param_or_state_ptr(builder, self, SCALE, param_struct_ptr=params)
+        offset_ptr = ctx.get_param_or_state_ptr(builder, self, OFFSET, param_struct_ptr=params)
 
         variance = pnlvm.helpers.load_extract_scalar_array_one(builder, variance_ptr)
         bias = pnlvm.helpers.load_extract_scalar_array_one(builder, bias_ptr)
@@ -2600,7 +2600,7 @@ class BinomialDistort(TransferFunction):  #-------------------------------------
         ptri = builder.gep(vi, [ctx.int32_ty(0), index])
         ptro = builder.gep(vo, [ctx.int32_ty(0), index])
 
-        p_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, 'p')
+        p_ptr = ctx.get_param_or_state_ptr(builder, self, 'p', param_struct_ptr=params)
         p = builder.load(p_ptr)
         mod_p = builder.fsub(p.type(1), p)
         p_mod_ptr = builder.alloca(mod_p.type)
@@ -3268,7 +3268,7 @@ class SoftMax(TransferFunction):
         exp_sum_ptr = builder.alloca(ctx.float_ty)
         builder.store(exp_sum_ptr.type.pointee(0), exp_sum_ptr)
 
-        gain_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, GAIN)
+        gain_ptr = ctx.get_param_or_state_ptr(builder, self, GAIN, param_struct_ptr=params)
         gain = pnlvm.helpers.load_extract_scalar_array_one(builder, gain_ptr)
 
         with pnlvm.helpers.array_ptr_loop(builder, arg_in, "exp_sum_max") as args:
@@ -3278,14 +3278,18 @@ class SoftMax(TransferFunction):
         exp_sum = builder.load(exp_sum_ptr)
 
         if output_type == ALL:
+            one_hot_p = ctx.get_param_or_state_ptr(builder, self, 'one_hot_function', param_struct_ptr=params, state_struct_ptr=state)
+
+            # Derivative first gets the output_type == ALL result even if the selected output type is different.
+            assert self.output != output_type or one_hot_p.type.pointee.elements == (), \
+                "OneHot parameter should be empty for output_type == ALL: {}".format(one_hot_p)
             with pnlvm.helpers.array_ptr_loop(builder, arg_in, "exp_div") as args:
                 self.__gen_llvm_exp_div(ctx=ctx, vi=arg_in, vo=arg_out,
                                         gain=gain, exp_sum=exp_sum, *args)
             return builder
 
+        one_hot_p, one_hot_s = ctx.get_param_or_state_ptr(builder, self, 'one_hot_function', param_struct_ptr=params, state_struct_ptr=state)
         one_hot_f = ctx.import_llvm_function(self.one_hot_function, tags=tags)
-        one_hot_p = pnlvm.helpers.get_param_ptr(builder, self, params, 'one_hot_function')
-        one_hot_s = pnlvm.helpers.get_state_ptr(builder, self, state, 'one_hot_function')
 
         assert one_hot_f.args[3].type == arg_out.type
         one_hot_out = arg_out
@@ -3323,7 +3327,6 @@ class SoftMax(TransferFunction):
         forward_tags = tags.difference({"derivative", "derivative_out"})
 
         # SoftMax derivative is calculated from the "ALL" results.
-        # Those can provided from outside, but we don't support receiving data in arg_out
         if "derivative_out" in tags:
             all_out = arg_in
         else:
@@ -3896,8 +3899,8 @@ class LinearMatrix(TransferFunction):  # ---------------------------------------
                           pnlvm.PNLCompilerWarning)
             arg_out = builder.gep(arg_out, [ctx.int32_ty(0), ctx.int32_ty(0)])
 
-        matrix = pnlvm.helpers.get_param_ptr(builder, self, params, MATRIX)
-        normalize = pnlvm.helpers.get_param_ptr(builder, self, params, NORMALIZE)
+        matrix = ctx.get_param_or_state_ptr(builder, self, MATRIX, param_struct_ptr=params)
+        normalize = ctx.get_param_or_state_ptr(builder, self, NORMALIZE, param_struct_ptr=params)
 
         # Convert array pointer to pointer to the fist element
         matrix = builder.gep(matrix, [ctx.int32_ty(0), ctx.int32_ty(0)])
@@ -4929,27 +4932,34 @@ class TransferWithCosts(TransferFunction):
         # Run transfer function first
         transfer_f = self.parameters.transfer_fct
         trans_f = ctx.import_llvm_function(transfer_f.get())
-        trans_p = pnlvm.helpers.get_param_ptr(builder, self, params, transfer_f.name)
-        trans_s = pnlvm.helpers.get_state_ptr(builder, self, state, transfer_f.name)
+        trans_p, trans_s = ctx.get_param_or_state_ptr(builder,
+                                                      self,
+                                                      transfer_f.name,
+                                                      param_struct_ptr=params,
+                                                      state_struct_ptr=state)
         trans_in = arg_in
         trans_out = arg_out
         builder.call(trans_f, [trans_p, trans_s, trans_in, trans_out])
-        intensity_ptr = pnlvm.helpers.get_state_space(builder, self, state, self.parameters.intensity.name)
+        intensity_ptr = ctx.get_state_space(builder, self, state, self.parameters.intensity)
 
         costs = [(self.parameters.intensity_cost_fct, CostFunctions.INTENSITY, self.parameters.intensity_cost),
                  (self.parameters.adjustment_cost_fct, CostFunctions.ADJUSTMENT, self.parameters.adjustment_cost),
                  (self.parameters.duration_cost_fct, CostFunctions.DURATION, self.parameters.duration_cost)]
 
-        for (func, flag, out) in costs:
+        for (func, flag, res_param) in costs:
+
+            cost_in = trans_out
+            cost_out = ctx.get_state_space(builder, self, state, res_param)
 
             # The check for enablement is structural and has to be done in Python.
             # If a cost function is not enabled the cost parameter is None
             if flag in self.parameters.enabled_cost_functions.get():
                 cost_f = ctx.import_llvm_function(func.get())
-                cost_p = pnlvm.helpers.get_param_ptr(builder, self, params, func.name)
-                cost_s = pnlvm.helpers.get_state_ptr(builder, self, state, func.name)
-                cost_out = pnlvm.helpers.get_state_space(builder, self, state, out.name)
-                cost_in = trans_out
+                cost_p, cost_s = ctx.get_param_or_state_ptr(builder,
+                                                            self,
+                                                            func,
+                                                            param_struct_ptr=params,
+                                                            state_struct_ptr=state)
 
                 if flag == CostFunctions.ADJUSTMENT:
                     old_intensity = pnlvm.helpers.load_extract_scalar_array_one(builder, intensity_ptr)
@@ -4963,9 +4973,21 @@ class TransferWithCosts(TransferFunction):
                     builder.store(adjustment, builder.gep(cost_in, [ctx.int32_ty(0), ctx.int32_ty(0)]))
 
                 builder.call(cost_f, [cost_p, cost_s, cost_in, cost_out])
+            else:
+                # Intensity is [1] when the cost function is disabled but other cost functions are enabled
+                # https://github.com/PrincetonUniversity/PsyNeuLink/issues/2711
+                exp_out_len = 0 if self.parameters.enabled_cost_functions.get() == CostFunctions.NONE or flag != CostFunctions.INTENSITY else 1
+                assert len(cost_out.type.pointee) == exp_out_len, "Unexpected out sturct for {}: {}".format(flag, cost_out.type.pointee)
+
 
         # TODO: combine above costs via a call to combine_costs_fct
         # depends on: https://github.com/PrincetonUniversity/PsyNeuLink/issues/2712
+        # This function is still used in OCM so track both state and parameters
+        combine_p, combine_s = ctx.get_param_or_state_ptr(builder,
+                                                          self,
+                                                          self.parameters.combine_costs_fct,
+                                                          param_struct_ptr=params,
+                                                          state_struct_ptr=state)
 
         builder.store(builder.load(trans_out), intensity_ptr)
 

--- a/psyneulink/core/components/functions/nonstateful/transferfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/transferfunctions.py
@@ -139,8 +139,6 @@ class TransferFunction(Function_Base):
 
 
     def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags:frozenset):
-        # Pretend we have one huge array to work on
-        # TODO: should this be invoked in parts?
         assert isinstance(arg_in.type.pointee, pnlvm.ir.ArrayType)
         assert arg_in.type == arg_out.type
 

--- a/psyneulink/core/components/functions/stateful/integratorfunctions.py
+++ b/psyneulink/core/components/functions/stateful/integratorfunctions.py
@@ -49,7 +49,8 @@ from psyneulink.core.globals.keywords import \
     INCREMENT, INITIALIZER, INPUT_PORTS, INTEGRATOR_FUNCTION, INTEGRATOR_FUNCTION_TYPE, \
     INTERACTIVE_ACTIVATION_INTEGRATOR_FUNCTION, LEAKY_COMPETING_INTEGRATOR_FUNCTION, \
     MULTIPLICATIVE_PARAM, NOISE, OFFSET, OPERATION, ORNSTEIN_UHLENBECK_INTEGRATOR_FUNCTION, OUTPUT_PORTS, PRODUCT, \
-    RATE, REST, SIMPLE_INTEGRATOR_FUNCTION, SUM, TIME_STEP_SIZE, THRESHOLD, VARIABLE, MODEL_SPEC_ID_MDF_VARIABLE
+    RATE, REST, SIMPLE_INTEGRATOR_FUNCTION, SUM, TIME_STEP_SIZE, THRESHOLD, VARIABLE, MODEL_SPEC_ID_MDF_VARIABLE, \
+    PREVIOUS_VALUE
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
 from psyneulink.core.globals.utilities import ValidParamSpecType, all_within_range, \
@@ -382,17 +383,14 @@ class IntegratorFunction(StatefulFunction):  # ---------------------------------
 
         return builder
 
-    def _gen_llvm_load_param(self, ctx, builder, params, index, param, *,
-                             state=None):
-        param_p = pnlvm.helpers.get_param_ptr(builder, self, params, param)
-        if param == NOISE and isinstance(param_p.type.pointee, pnlvm.ir.LiteralStructType):
+    def _gen_llvm_load_param(self, ctx, builder, params, index, param, *, state=None):
+        param_p = ctx.get_param_or_state_ptr(builder, self, param, param_struct_ptr=params, state_struct_ptr=state)
+        if param == NOISE and isinstance(param_p, tuple):
             # This is a noise function so call it to get value
-            assert state is not None
-            state_p = pnlvm.helpers.get_state_ptr(builder, self, state, NOISE)
             noise_f = ctx.import_llvm_function(self.parameters.noise.get())
             noise_in = builder.alloca(noise_f.args[2].type.pointee)
             noise_out = builder.alloca(noise_f.args[3].type.pointee)
-            builder.call(noise_f, [param_p, state_p, noise_in, noise_out])
+            builder.call(noise_f, [param_p[0], param_p[1], noise_in, noise_out])
             value_p = noise_out
 
         elif isinstance(param_p.type.pointee, pnlvm.ir.ArrayType) and param_p.type.pointee.count > 1:
@@ -672,11 +670,11 @@ class AccumulatorIntegrator(IntegratorFunction):  # ----------------------------
     def _gen_llvm_integrate(self, builder, index, ctx, vi, vo, params, state):
         rate = self._gen_llvm_load_param(ctx, builder, params, index, RATE)
         increment = self._gen_llvm_load_param(ctx, builder, params, index, INCREMENT)
-        noise = self._gen_llvm_load_param(ctx, builder, params, index, NOISE,
-                                          state=state)
+        noise = self._gen_llvm_load_param(ctx, builder, params, index, NOISE, state=state)
 
-        # Get the only context member -- previous value
-        prev_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, "previous_value")
+        # Get the only state member; previous value
+        prev_ptr = ctx.get_param_or_state_ptr(builder, self, PREVIOUS_VALUE, state_struct_ptr=state)
+
         # Get rid of 2d array. When part of a Mechanism the input,
         # (and output, and context) are 2d arrays.
         prev_ptr = pnlvm.helpers.unwrap_2d_array(builder, prev_ptr)
@@ -899,11 +897,11 @@ class SimpleIntegrator(IntegratorFunction):  # ---------------------------------
     def _gen_llvm_integrate(self, builder, index, ctx, vi, vo, params, state):
         rate = self._gen_llvm_load_param(ctx, builder, params, index, RATE)
         offset = self._gen_llvm_load_param(ctx, builder, params, index, OFFSET)
-        noise = self._gen_llvm_load_param(ctx, builder, params, index, NOISE,
-                                          state=state)
+        noise = self._gen_llvm_load_param(ctx, builder, params, index, NOISE, state=state)
 
-        # Get the only context member -- previous value
-        prev_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, "previous_value")
+        # Get the only state member; previous value
+        prev_ptr = ctx.get_param_or_state_ptr(builder, self, PREVIOUS_VALUE, state_struct_ptr=state)
+
         # Get rid of 2d array. When part of a Mechanism the input,
         # (and output, and context) are 2d arrays.
         prev_ptr = pnlvm.helpers.unwrap_2d_array(builder, prev_ptr)
@@ -1164,11 +1162,11 @@ class AdaptiveIntegrator(IntegratorFunction):  # -------------------------------
     def _gen_llvm_integrate(self, builder, index, ctx, vi, vo, params, state):
         rate = self._gen_llvm_load_param(ctx, builder, params, index, RATE)
         offset = self._gen_llvm_load_param(ctx, builder, params, index, OFFSET)
-        noise = self._gen_llvm_load_param(ctx, builder, params, index, NOISE,
-                                          state=state)
+        noise = self._gen_llvm_load_param(ctx, builder, params, index, NOISE, state=state)
 
-        # Get the only context member -- previous value
-        prev_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, "previous_value")
+        # Get the only state member; previous value
+        prev_ptr = ctx.get_param_or_state_ptr(builder, self, PREVIOUS_VALUE, state_struct_ptr=state)
+
         # Get rid of 2d array. When part of a Mechanism the input,
         # (and output, and context) are 2d arrays.
         prev_ptr = pnlvm.helpers.unwrap_2d_array(builder, prev_ptr)
@@ -2558,8 +2556,7 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
     def _gen_llvm_integrate(self, builder, index, ctx, vi, vo, params, state):
         # Get parameter pointers
         rate = self._gen_llvm_load_param(ctx, builder, params, index, RATE)
-        noise = self._gen_llvm_load_param(ctx, builder, params, index, NOISE,
-                                          state=state)
+        noise = self._gen_llvm_load_param(ctx, builder, params, index, NOISE, state=state)
         offset = self._gen_llvm_load_param(ctx, builder, params, index, OFFSET)
         threshold = self._gen_llvm_load_param(ctx, builder, params, index, THRESHOLD)
         time_step_size = self._gen_llvm_load_param(ctx, builder, params, index, TIME_STEP_SIZE)
@@ -2571,8 +2568,8 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
         rand_val = builder.load(rand_val_ptr)
 
         # Get state pointers
-        prev_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, "previous_value")
-        prev_time_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, "previous_time")
+        prev_ptr = ctx.get_param_or_state_ptr(builder, self, PREVIOUS_VALUE, state_struct_ptr=state)
+        prev_time_ptr = ctx.get_param_or_state_ptr(builder, self, "previous_time", state_struct_ptr=state)
 
         # value = previous_value + rate * variable * time_step_size \
         #       + np.sqrt(time_step_size * noise) * random_state.normal()
@@ -3201,68 +3198,6 @@ class DriftOnASphereIntegrator(IntegratorFunction):  # -------------------------
         self.parameters.previous_value._set(value, context)
 
         return angle_function(value)
-
-    # def _gen_llvm_integrate(self, builder, index, ctx, vi, vo, params, state):
-    #     # Get parameter pointers
-    #     rate = self._gen_llvm_load_param(ctx, builder, params, index, RATE)
-    #     noise = self._gen_llvm_load_param(ctx, builder, params, index, NOISE,
-    #                                       state=state)
-    #     offset = self._gen_llvm_load_param(ctx, builder, params, index, OFFSET)
-    #     threshold = self._gen_llvm_load_param(ctx, builder, params, index, THRESHOLD)
-    #     time_step_size = self._gen_llvm_load_param(ctx, builder, params, index, TIME_STEP_SIZE)
-    #
-    #     random_state = pnlvm.helpers.get_state_ptr(builder, self, state, "random_state")
-    #     rand_val_ptr = builder.alloca(ctx.float_ty)
-    #     rand_f = ctx.import_llvm_function("__pnl_builtin_mt_rand_normal")
-    #     builder.call(rand_f, [random_state, rand_val_ptr])
-    #     rand_val = builder.load(rand_val_ptr)
-    #
-    #     if isinstance(rate.type, pnlvm.ir.ArrayType):
-    #         assert len(rate.type) == 1
-    #         rate = builder.extract_value(rate, 0)
-    #
-    #     # Get state pointers
-    #     prev_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, "previous_value")
-    #     prev_time_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, "previous_time")
-    #
-    #     # value = previous_value + rate * variable * time_step_size \
-    #     #       + np.sqrt(time_step_size * noise) * random_state.normal()
-    #     prev_val_ptr = builder.gep(prev_ptr, [ctx.int32_ty(0), index])
-    #     prev_val = builder.load(prev_val_ptr)
-    #     val = builder.load(builder.gep(vi, [ctx.int32_ty(0), index]))
-    #     if isinstance(val.type, pnlvm.ir.ArrayType):
-    #         assert len(val.type) == 1
-    #         val = builder.extract_value(val, 0)
-    #     val = builder.fmul(val, rate)
-    #     val = builder.fmul(val, time_step_size)
-    #     val = builder.fadd(val, prev_val)
-    #
-    #     factor = builder.fmul(noise, time_step_size)
-    #     sqrt_f = ctx.get_builtin("sqrt", [ctx.float_ty])
-    #     factor = builder.call(sqrt_f, [factor])
-    #
-    #     factor = builder.fmul(rand_val, factor)
-    #
-    #     val = builder.fadd(val, factor)
-    #
-    #     val = builder.fadd(val, offset)
-    #     neg_threshold = pnlvm.helpers.fneg(builder, threshold)
-    #     val = pnlvm.helpers.fclamp(builder, val, neg_threshold, threshold)
-    #
-    #     # Store value result
-    #     data_vo_ptr = builder.gep(vo, [ctx.int32_ty(0),
-    #                                    ctx.int32_ty(0), index])
-    #     builder.store(val, data_vo_ptr)
-    #     builder.store(val, prev_val_ptr)
-    #
-    #     # Update timestep
-    #     prev_time_ptr = builder.gep(prev_time_ptr, [ctx.int32_ty(0), index])
-    #     prev_time = builder.load(prev_time_ptr)
-    #     curr_time = builder.fadd(prev_time, time_step_size)
-    #     builder.store(curr_time, prev_time_ptr)
-    #
-    #     time_vo_ptr = builder.gep(vo, [ctx.int32_ty(0), ctx.int32_ty(1), index])
-    #     builder.store(curr_time, time_vo_ptr)
 
     def reset(self, previous_value=None, previous_time=None, context=None):
         return super().reset(
@@ -3912,8 +3847,9 @@ class LeakyCompetingIntegrator(IntegratorFunction):  # -------------------------
         offset = self._gen_llvm_load_param(ctx, builder, params, index, OFFSET)
         time_step = self._gen_llvm_load_param(ctx, builder, params, index, TIME_STEP_SIZE)
 
-        # Get the only context member -- previous value
-        prev_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, "previous_value")
+        # Get the only state member; previous value
+        prev_ptr = ctx.get_param_or_state_ptr(builder, self, PREVIOUS_VALUE, state_struct_ptr=state)
+
         # Get rid of 2d array. When part of a Mechanism the input,
         # (and output, and context) are 2d arrays.
         prev_ptr = pnlvm.helpers.unwrap_2d_array(builder, prev_ptr)
@@ -4944,21 +4880,23 @@ class FitzHughNagumoIntegrator(IntegratorFunction):  # -------------------------
 
         # Get state pointers
         def _get_state_ptr(x):
-            ptr = pnlvm.helpers.get_state_ptr(builder, self, state, x)
+            ptr = ctx.get_param_or_state_ptr(builder, self, x, state_struct_ptr=state)
             return pnlvm.helpers.unwrap_2d_array(builder, ptr)
+
         prev = {s: _get_state_ptr(s) for s in self.llvm_state_ids}
 
         # Output locations
         def _get_out_ptr(i):
             ptr = builder.gep(arg_out, [zero_i32, ctx.int32_ty(i)])
             return pnlvm.helpers.unwrap_2d_array(builder, ptr)
+
         out = {l: _get_out_ptr(i) for i, l in enumerate(('v', 'w', 'time'))}
 
         # Load parameters
-        def _get_param_val(x):
-            ptr = pnlvm.helpers.get_param_ptr(builder, self, params, x)
+        def _load_param(x):
+            ptr = ctx.get_param_or_state_ptr(builder, self, x, param_struct_ptr=params)
             return pnlvm.helpers.load_extract_scalar_array_one(builder, ptr)
-        param_vals = {p: _get_param_val(p) for p in self.llvm_param_ids}
+        param_vals = {p: _load_param(p) for p in self.llvm_param_ids}
 
         inner_args = {"ctx": ctx, "var_ptr": arg_in, "param_vals": param_vals,
                       "out_v": out['v'], "out_w": out['w'],

--- a/psyneulink/core/components/functions/stateful/statefulfunction.py
+++ b/psyneulink/core/components/functions/stateful/statefulfunction.py
@@ -539,8 +539,8 @@ class StatefulFunction(Function_Base): #  --------------------------------------
         assert "reset" in tags
         for a in self.stateful_attributes:
             initializer = getattr(self.parameters, a).initializer
-            source_ptr = pnlvm.helpers.get_param_ptr(builder, self, params, initializer)
-            dest_ptr = pnlvm.helpers.get_state_ptr(builder, self, state, a)
+            source_ptr = ctx.get_param_or_state_ptr(builder, self, initializer, param_struct_ptr=params)
+            dest_ptr = ctx.get_param_or_state_ptr(builder, self, a, state_struct_ptr=state)
             builder.store(builder.load(source_ptr), dest_ptr)
 
         return builder

--- a/psyneulink/core/components/functions/userdefinedfunction.py
+++ b/psyneulink/core/components/functions/userdefinedfunction.py
@@ -682,7 +682,7 @@ class UserDefinedFunction(Function_Base):
         assert len(func_globals) == 0 or (
                len(func_globals) == 1 and np in func_globals.values()), \
                "Compiling functions with global variables is not supported! ({})".format(closure_vars.globals)
-        func_params = {param_id: pnlvm.helpers.get_param_ptr(builder, self, params, param_id) for param_id in self.llvm_param_ids}
+        func_params = {param_id: ctx.get_param_or_state_ptr(builder, self, param_id, param_struct_ptr=params) for param_id in self.llvm_param_ids}
 
         pnlvm.codegen.UserDefinedFunctionVisitor(ctx, builder, func_globals, func_params, arg_in, arg_out).visit(func_ast)
 

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2834,6 +2834,8 @@ class Mechanism_Base(Mechanism):
         return port_param_dicts
 
     def _get_param_ids(self):
+        if len(self._parameter_ports) == 0:
+            return super()._get_param_ids()
         # FIXME: parameter ports should be part of generated params
         return ["_parameter_ports"] + super()._get_param_ids()
 
@@ -2841,11 +2843,15 @@ class Mechanism_Base(Mechanism):
         ports_params = (ctx.get_param_struct_type(s) for s in self._parameter_ports)
         ports_param_struct = pnlvm.ir.LiteralStructType(ports_params)
         mech_param_struct = ctx.get_param_struct_type(super())
+        if len(self._parameter_ports) == 0:
+            return mech_param_struct
 
         return pnlvm.ir.LiteralStructType((ports_param_struct,
                                            *mech_param_struct))
 
     def _get_state_ids(self):
+        if len(self._parameter_ports) == 0:
+            return super()._get_state_ids()
         # FIXME: parameter ports should be part of generated state
         return ["_parameter_ports"] + super()._get_state_ids()
 
@@ -2853,6 +2859,8 @@ class Mechanism_Base(Mechanism):
         ports_state = (ctx.get_state_struct_type(s) for s in self._parameter_ports)
         ports_state_struct = pnlvm.ir.LiteralStructType(ports_state)
         mech_state_struct = ctx.get_state_struct_type(super())
+        if len(self._parameter_ports) == 0:
+            return mech_state_struct
 
         return pnlvm.ir.LiteralStructType((ports_state_struct,
                                            *mech_state_struct))
@@ -2884,12 +2892,16 @@ class Mechanism_Base(Mechanism):
     def _get_param_initializer(self, context):
         port_param_init = tuple(s._get_param_initializer(context) for s in self._parameter_ports)
         mech_param_init = super()._get_param_initializer(context)
+        if len(self._parameter_ports) == 0:
+            return mech_param_init
 
         return (port_param_init, *mech_param_init)
 
     def _get_state_initializer(self, context):
         port_state_init = tuple(s._get_state_initializer(context) for s in self._parameter_ports)
         mech_state_init = super()._get_state_initializer(context)
+        if len(self._parameter_ports) == 0:
+            return mech_state_init
 
         return (port_state_init, *mech_state_init)
 

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -18,9 +18,9 @@ import numpy as np
 import os
 import re
 import time
-from psyneulink._typing import Set
 import weakref
 
+from psyneulink._typing import Set
 from psyneulink.core.scheduling.time import Time, TimeScale
 from psyneulink.core.globals.sampleiterator import SampleIterator
 from psyneulink.core.globals.utilities import ContentAddressableList
@@ -96,6 +96,8 @@ class LLVMBuilderContext:
         assert LLVMBuilderContext.__current_context is None
         self._modules = []
         self._cache = weakref.WeakKeyDictionary()
+        self._component_param_use = weakref.WeakKeyDictionary()
+        self._component_state_use = weakref.WeakKeyDictionary()
 
         # Supported stats are listed explicitly to catch typos
         self._stats = { "function_cache_misses":0,
@@ -268,6 +270,8 @@ class LLVMBuilderContext:
             self._stats["function_cache_misses"] += 1
             with self:
                 obj_cache[tags] = obj._gen_llvm_function(ctx=self, tags=tags)
+                self.check_used_params(obj, tags=tags)
+
         return obj_cache[tags]
 
     def import_llvm_function(self, fun, *, tags:frozenset=frozenset()) -> ir.Function:
@@ -288,15 +292,14 @@ class LLVMBuilderContext:
         return f
 
     def get_random_state_ptr(self, builder, component, state, params):
-        random_state_ptr = helpers.get_state_ptr(builder, component, state, "random_state")
-
+        random_state_ptr = self.get_param_or_state_ptr(builder, component, "random_state", state_struct_ptr=state)
 
         # Used seed is the last member of both MT state and Philox state
         seed_idx = len(random_state_ptr.type.pointee) - 1
         used_seed_ptr = builder.gep(random_state_ptr, [self.int32_ty(0), self.int32_ty(seed_idx)])
         used_seed = builder.load(used_seed_ptr)
 
-        seed_ptr = helpers.get_param_ptr(builder, component, params, "seed")
+        seed_ptr = self.get_param_or_state_ptr(builder, component, "seed", param_struct_ptr=params)
         new_seed = pnlvm.helpers.load_extract_scalar_array_one(builder, seed_ptr)
         # FIXME: The seed should ideally be integer already.
         #        However, it can be modulated and we don't support
@@ -315,6 +318,67 @@ class LLVMBuilderContext:
             builder.call(reseed_f, [random_state_ptr, new_seed])
 
         return random_state_ptr
+
+    def get_param_or_state_ptr(self, builder, component, param, *, param_struct_ptr=None, state_struct_ptr=None, history=0):
+        param_name = getattr(param, "name", param)
+        param = None
+        state = None
+
+        if param_name in component.llvm_param_ids:
+            assert param_struct_ptr is not None, "Can't get param ptr for: {}".format(param_name)
+            self._component_param_use.setdefault(component, set()).add(param_name)
+            param = helpers.get_param_ptr(builder, component, param_struct_ptr, param_name)
+
+        if param_name in component.llvm_state_ids:
+            assert state_struct_ptr is not None, "Can't get state ptr for: {}".format(param_name)
+            self._component_state_use.setdefault(component, set()).add(param_name)
+            state = helpers.get_state_ptr(builder, component, state_struct_ptr, param_name, history)
+
+        if param is not None and state is not None:
+            return (param, state)
+
+        return param or state
+
+    def get_state_space(self, builder, component, state_ptr, param):
+        param_name = getattr(param, "name", param)
+        self._component_state_use.setdefault(component, set()).add(param_name)
+        return helpers.get_state_space(builder, component, state_ptr, param_name)
+
+    def check_used_params(self, component, *, tags:frozenset):
+        # Skip the check if the parameter use is not tracked. Some components (like node wrappers)
+        # don't even have parameters.
+        if component not in self._component_state_use and component not in self._component_param_use:
+            return
+
+        # Skip the check for variant functions
+        if len(tags) != 0:
+            return
+
+        component_param_ids = set(component.llvm_param_ids)
+        component_state_ids = set(component.llvm_state_ids)
+
+        used_param_ids = self._component_param_use.get(component, set())
+        used_state_ids = self._component_state_use.get(component, set())
+
+        # initializers are  only used in "reset" variants
+        initializers = {p.initializer for p in component.parameters}
+
+        # has_initializers is only used in "reset" variants
+        initializers.add('has_initializers')
+
+        # 'termination_mesasure" is only used in "is_finished" variant
+        used_param_ids.add('termination_measure')
+        used_state_ids.add('termination_measure')
+
+        # 'num_trials_per_estimate' is only used in "evaluate" variants
+        if hasattr(component, 'evaluate_agent_rep'):
+            used_param_ids.add('num_trials_per_estimate')
+
+        unused_param_ids = component_param_ids - used_param_ids - initializers
+        unused_state_ids = component_state_ids - used_state_ids
+
+        assert len(unused_param_ids) == 0 and len(unused_state_ids) == 0, \
+            "Compiled component '{}'(tags: {}) unused parameters: {}, state: {}".format(component, list(tags), unused_param_ids, unused_state_ids)
 
     @staticmethod
     def get_debug_location(func: ir.Function, component):

--- a/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/control/agt/lccontrolmechanism.py
@@ -895,6 +895,7 @@ class LCControlMechanism(ControlMechanism):
                                                          "scaling_factor_gain")
         base_factor_ptr = pnlvm.helpers.get_param_ptr(builder, self, m_params,
                                                       "base_level_gain")
+
         # If modulated, parameters are single element array
         scaling_factor = pnlvm.helpers.load_extract_scalar_array_one(builder, scaling_factor_ptr)
         base_factor = pnlvm.helpers.load_extract_scalar_array_one(builder, base_factor_ptr)


### PR DESCRIPTION
Remove parameters blocked by structural parameters from compiled structures.
Add tracking of parameters used in compiled structures and assert that all those included are used.
Unify parameter and state substructure retrieval API.