### PR TITLE
Support graph-scheduler graph structure conditions

### DIFF
--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -101,12 +101,14 @@ CONTENTS
 import collections
 import copy
 import inspect
+import itertools
 import logging
 import psyneulink
 import re
 import time
 import warnings
 import weakref
+import toposort
 import types
 import typing
 from beartype import beartype
@@ -2060,3 +2062,30 @@ def get_function_sig_default_value(
         return sig.parameters[parameter].default
     except KeyError:
         return inspect._empty
+
+
+def toposort_key(
+    dependency_dict: typing.Dict[typing.Hashable, typing.Iterable[typing.Any]]
+) -> typing.Callable[[typing.Any], int]:
+    """
+    Creates a key function for python sorting that causes all items in
+    **dependency_dict** to be sorted after their dependencies
+
+    Args:
+        dependency_dict (typing.Dict[typing.Hashable, typing.Iterable[typing.Any]]):
+        a dictionary where values are the dependencies of keys
+
+    Returns:
+        typing.Callable[[typing.Any], int]: a key function for python
+        sorting
+    """
+    topo_ordering = list(toposort.toposort(dependency_dict))
+    topo_ordering = list(itertools.chain.from_iterable(topo_ordering))
+
+    def _generated_toposort_key(obj):
+        try:
+            return topo_ordering.index(obj)
+        except ValueError:
+            return -1
+
+    return _generated_toposort_key

--- a/psyneulink/core/scheduling/__init__.py
+++ b/psyneulink/core/scheduling/__init__.py
@@ -59,12 +59,15 @@ for module in ['scheduler', 'condition', 'time']:
 
             if cls.__doc__ is None:
                 try:
-                    cls.__doc__ = f'{getattr(ext_module, cls_name).__doc__}'
+                    ext_cls = getattr(ext_module, cls_name)
                 except AttributeError:
                     # PNL-exclusive object
                     continue
+                else:
+                    cls.__doc__ = ext_cls.__doc__
 
-            cls.__doc__ = re.sub(pattern, repl, cls.__doc__, flags=re.MULTILINE | re.DOTALL)
+            if cls.__doc__ is not None:
+                cls.__doc__ = re.sub(pattern, repl, cls.__doc__, flags=re.MULTILINE | re.DOTALL)
 
     for cls, repls in module._doc_subs.items():
         if cls is None:
@@ -73,7 +76,8 @@ for module in ['scheduler', 'condition', 'time']:
             cls = getattr(module, cls)
 
         for pattern, repl in repls:
-            cls.__doc__ = re.sub(pattern, repl, cls.__doc__, flags=re.MULTILINE | re.DOTALL)
+            if cls.__doc__ is not None:
+                cls.__doc__ = re.sub(pattern, repl, cls.__doc__, flags=re.MULTILINE | re.DOTALL)
 
 del graph_scheduler
 del re

--- a/psyneulink/core/scheduling/condition.py
+++ b/psyneulink/core/scheduling/condition.py
@@ -10,7 +10,6 @@
 
 import collections
 import copy
-import functools
 import inspect
 import numbers
 import warnings
@@ -23,10 +22,42 @@ from psyneulink.core.globals.context import handle_external_context
 from psyneulink.core.globals.mdf import MDFSerializable
 from psyneulink.core.globals.keywords import MODEL_SPEC_ID_TYPE, comparison_operators
 from psyneulink.core.globals.parameters import parse_context
-from psyneulink.core.globals.utilities import parse_valid_identifier
+from psyneulink.core.globals.utilities import parse_valid_identifier, toposort_key
 
 __all__ = copy.copy(graph_scheduler.condition.__all__)
 __all__.extend(['Threshold'])
+
+
+# avoid restricting graph_scheduler versions for this code
+# ConditionBase was introduced with graph structure conditions
+gs_condition_base_class = graph_scheduler.condition.Condition
+condition_class_parents = [graph_scheduler.condition.Condition]
+
+
+try:
+    gs_condition_base_class = graph_scheduler.condition.ConditionBase
+except AttributeError:
+    pass
+else:
+    class ConditionBase(graph_scheduler.condition.ConditionBase, MDFSerializable):
+        def as_mdf_model(self):
+            raise graph_scheduler.ConditionError(
+                f'MDF support not yet implemented for {type(self)}'
+            )
+    condition_class_parents.append(ConditionBase)
+
+
+try:
+    graph_scheduler.condition.GraphStructureCondition
+except AttributeError:
+    graph_structure_conditions_available = False
+    gsc_unavailable_message = (
+        'Graph structure conditions are not available'
+        f'in your installed graph-scheduler v{graph_scheduler.__version__}'
+    )
+else:
+    graph_structure_conditions_available = True
+    gsc_unavailable_message = ''
 
 
 def _create_as_pnl_condition(condition):
@@ -38,11 +69,23 @@ def _create_as_pnl_condition(condition):
         return condition
 
     # already a pnl Condition
-    if isinstance(condition, Condition):
+    if isinstance(condition, pnl_condition_base_class):
         return condition
 
-    if not issubclass(pnl_class, graph_scheduler.Condition):
+    if not issubclass(pnl_class, gs_condition_base_class):
         return None
+
+    if (
+        graph_structure_conditions_available
+        and isinstance(condition, graph_scheduler.condition.GraphStructureCondition)
+    ):
+        try:
+            return pnl_class(
+                *condition.nodes,
+                **{k: v for k, v in condition.kwargs.items() if k != 'nodes'}
+            )
+        except AttributeError:
+            return pnl_class(**condition.kwargs)
 
     new_args = [_create_as_pnl_condition(a) or a for a in condition.args]
     new_kwargs = {k: _create_as_pnl_condition(v) or v for k, v in condition.kwargs.items()}
@@ -58,7 +101,7 @@ def _create_as_pnl_condition(condition):
     return res
 
 
-class Condition(graph_scheduler.Condition, MDFSerializable):
+class Condition(*condition_class_parents, MDFSerializable):
     @handle_external_context()
     def is_satisfied(self, *args, context=None, execution_id=None, **kwargs):
         if execution_id is None:
@@ -81,7 +124,7 @@ class Condition(graph_scheduler.Condition, MDFSerializable):
         def _parse_condition_arg(arg):
             if isinstance(arg, Component):
                 return parse_valid_identifier(arg.name)
-            elif isinstance(arg, graph_scheduler.Condition):
+            elif isinstance(arg, Condition):
                 return arg.as_mdf_model()
             elif arg is None or isinstance(arg, numbers.Number):
                 return arg
@@ -112,7 +155,7 @@ class Condition(graph_scheduler.Condition, MDFSerializable):
                 for a in self.args:
                     if isinstance(a, Component):
                         a = parse_valid_identifier(a.name)
-                    elif isinstance(a, graph_scheduler.Condition):
+                    elif isinstance(a, Condition):
                         a = a.as_mdf_model()
                     args_list.append(a)
                 extra_args[name] = args_list
@@ -139,40 +182,47 @@ class Condition(graph_scheduler.Condition, MDFSerializable):
 # below produces psyneulink versions of each Condition class so that
 # they are compatible with the extra changes made in Condition above
 # (the scheduler does not handle Context objects or mdf/json export)
-cond_dependencies = {}
+gs_class_dependencies = {}
+gs_classes_to_copy_as_pnl = []
 pnl_conditions_module = locals()  # inserting into locals defines the classes
+pnl_condition_base_class = pnl_conditions_module[gs_condition_base_class.__name__]
 
-for cond_name in graph_scheduler.condition.__all__:
-    sched_module_cond_obj = getattr(graph_scheduler.condition, cond_name)
-    cond_dependencies[cond_name] = {c.__name__ for c in sched_module_cond_obj.__mro__ if c.__name__ != cond_name}
+for class_name in graph_scheduler.condition.__dict__:
+    cls_ = getattr(graph_scheduler.condition, class_name)
+    if inspect.isclass(cls_):
+        # don't substitute classes explicitly defined above
+        if class_name not in pnl_conditions_module:
+            if issubclass(cls_, gs_condition_base_class):
+                gs_classes_to_copy_as_pnl.append(class_name)
+            else:
+                pnl_conditions_module[class_name] = cls_
+
+        gs_class_dependencies[class_name] = {
+            c.__name__ for c in cls_.__mro__ if c.__name__ != class_name
+        }
 
 # iterate in order such that superclass types are before subclass types
 for cond_name in sorted(
-    graph_scheduler.condition.__all__,
-    key=functools.cmp_to_key(lambda a, b: -1 if b in cond_dependencies[a] else 1)
+    gs_classes_to_copy_as_pnl,
+    key=toposort_key(gs_class_dependencies)
 ):
-    # don't substitute Condition because it is explicitly defined above
-    if cond_name == 'Condition':
-        continue
-
     sched_module_cond_obj = getattr(graph_scheduler.condition, cond_name)
-    if (
-        inspect.isclass(sched_module_cond_obj)
-        and issubclass(sched_module_cond_obj, graph_scheduler.Condition)
-    ):
-        new_mro = []
-        for cls_ in sched_module_cond_obj.__mro__:
-            if cls_ is not graph_scheduler.Condition:
-                try:
-                    new_mro.append(pnl_conditions_module[cls_.__name__])
+    new_bases = []
+    for cls_ in sched_module_cond_obj.__mro__:
+        try:
+            new_bases.append(pnl_conditions_module[cls_.__name__])
+        except KeyError:
+            new_bases.append(cls_)
+        if cls_ is gs_condition_base_class:
+            break
 
-                except KeyError:
-                    new_mro.append(cls_)
-            else:
-                new_mro.extend(Condition.__mro__[:-1])
-        pnl_conditions_module[cond_name] = type(cond_name, tuple(new_mro), {})
-    elif isinstance(sched_module_cond_obj, type):
-        pnl_conditions_module[cond_name] = sched_module_cond_obj
+    new_meta = type(new_bases[0])
+    if new_meta is not type:
+        pnl_conditions_module[cond_name] = new_meta(
+            cond_name, tuple(new_bases), {'__module__': Condition.__module__}
+        )
+    else:
+        pnl_conditions_module[cond_name] = type(cond_name, tuple(new_bases), {})
 
     pnl_conditions_module[cond_name].__doc__ = sched_module_cond_obj.__doc__
 

--- a/psyneulink/core/scheduling/condition.py
+++ b/psyneulink/core/scheduling/condition.py
@@ -144,7 +144,7 @@ pnl_conditions_module = locals()  # inserting into locals defines the classes
 
 for cond_name in graph_scheduler.condition.__all__:
     sched_module_cond_obj = getattr(graph_scheduler.condition, cond_name)
-    cond_dependencies[cond_name] = set(sched_module_cond_obj.__mro__[1:])
+    cond_dependencies[cond_name] = {c.__name__ for c in sched_module_cond_obj.__mro__ if c.__name__ != cond_name}
 
 # iterate in order such that superclass types are before subclass types
 for cond_name in sorted(

--- a/psyneulink/core/scheduling/scheduler.py
+++ b/psyneulink/core/scheduling/scheduler.py
@@ -52,7 +52,9 @@ class Scheduler(graph_scheduler.Scheduler, MDFSerializable):
                 default_execution_id = composition.default_execution_id
 
         # TODO: consider integrating something like this into graph-scheduler?
-        self._user_specified_conds = copy.copy(conditions) if conditions is not None else {}
+        self._user_specified_conds = graph_scheduler.ConditionSet()
+        if conditions is not None:
+            self._user_specified_conds.add_condition_set(copy.copy(conditions))
         self._user_specified_termination_conds = copy.copy(termination_conds) if termination_conds is not None else {}
 
         super().__init__(
@@ -96,7 +98,7 @@ class Scheduler(graph_scheduler.Scheduler, MDFSerializable):
             )
 
     def add_condition(self, owner, condition):
-        self._user_specified_conds[owner] = condition
+        self._user_specified_conds.add_condition(owner, condition)
         self._add_condition(owner, condition)
 
     def _add_condition(self, owner, condition):
@@ -104,7 +106,7 @@ class Scheduler(graph_scheduler.Scheduler, MDFSerializable):
         super().add_condition(owner, condition)
 
     def add_condition_set(self, conditions):
-        self._user_specified_conds.update(conditions)
+        self._user_specified_conds.add_condition_set(conditions)
         self._add_condition_set(conditions)
 
     def _add_condition_set(self, conditions):
@@ -114,8 +116,8 @@ class Scheduler(graph_scheduler.Scheduler, MDFSerializable):
             pass
 
         conditions = {
-            node: _create_as_pnl_condition(cond)
-            for node, cond in conditions.items()
+            node: _create_as_pnl_condition(conditions[node])
+            for node in conditions
         }
         super().add_condition_set(conditions)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ autograd<1.7
 beartype<0.16.0
 dill<0.3.8
 fastkde>=1.0.24, <1.0.31
-graph-scheduler>=1.1.1, <1.1.3
+graph-scheduler>=1.1.1, <1.3.0
 graphviz<0.21.0
 grpcio<1.60.0
 leabra-psyneulink<0.3.3

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -7932,7 +7932,7 @@ class TestMisc:
         assert comp.scheduler.conditions[C].args == (A, 2)
 
         assert comp.scheduler.execution_list[comp.default_execution_id] == [{A}, {A, B}, {C}]
-        assert set(comp.scheduler._user_specified_conds.keys()) == {B, C}
+        assert set(comp.scheduler._user_specified_conds.conditions.keys()) == {B, C}
 
     def test_rebuild_scheduler_after_remove_node(self):
         A = ProcessingMechanism(name='A')
@@ -7952,7 +7952,7 @@ class TestMisc:
         assert comp.scheduler.conditions[C].args == (A, 2)
 
         assert comp.scheduler.execution_list[comp.default_execution_id] == [{A}, {A}, {C}]
-        assert set(comp.scheduler._user_specified_conds.keys()) == {C}
+        assert set(comp.scheduler._user_specified_conds.conditions.keys()) == {C}
 
 
 class TestInputSpecsDocumentationExamples:

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -40,7 +40,7 @@ from psyneulink.core.globals.keywords import \
     NAME, PROJECTIONS, RESULT, OBJECTIVE_MECHANISM, OUTPUT_MECHANISM, OVERRIDE,
      PARAMS, SLOPE, TARGET_MECHANISM,
     VARIABLE, VARIANCE)
-from psyneulink.core.scheduling.condition import AtTimeStep, AtTrial, Never, TimeInterval
+from psyneulink.core.scheduling.condition import AtTimeStep, AtTrial, Never, TimeInterval, graph_structure_conditions_available, gsc_unavailable_message
 from psyneulink.core.scheduling.condition import EveryNCalls
 from psyneulink.core.scheduling.scheduler import Scheduler, SchedulingMode
 from psyneulink.core.scheduling.time import TimeScale
@@ -7670,6 +7670,23 @@ class TestNodeRoles:
             icomp: {NodeRole.INTERNAL},
             B: {NodeRole.TERMINAL, NodeRole.OUTPUT, NodeRole.FEEDBACK_SENDER},
         }
+
+    @pytest.mark.skipif(
+        not graph_structure_conditions_available,
+        reason=gsc_unavailable_message
+    )
+    def test_graph_structure_condition_role_changes(self):
+        A = pnl.ProcessingMechanism(name='A')
+        B = pnl.ProcessingMechanism(name='B')
+        C = pnl.ProcessingMechanism(name='C')
+
+        comp = Composition(pathways=[A, B, C])
+
+        comp.scheduler.add_condition(C, pnl.BeforeNode(A))
+
+        assert comp.nodes_to_roles[A] == {NodeRole.INPUT}
+        assert comp.nodes_to_roles[B] == {NodeRole.INTERNAL, NodeRole.TERMINAL}
+        assert comp.nodes_to_roles[C] == {NodeRole.OUTPUT, NodeRole.ORIGIN}
 
 
 class TestMisc:

--- a/tests/documentation/test_module_docs.py
+++ b/tests/documentation/test_module_docs.py
@@ -47,6 +47,13 @@ def test_other_docs(mod, capsys):
             fail, total, captured.err, captured.out), pytrace=False)
 
 
+def consistent_doc_attrs(*objs):
+    return (
+        all(o.__doc__ is None for o in objs)
+        or all(isinstance(o.__doc__, str) for o in objs)
+    )
+
+
 @pytest.mark.parametrize(
     'mod',
     [
@@ -77,8 +84,11 @@ def test_scheduler_substitutions(mod):
             except AttributeError:
                 continue
 
+            assert consistent_doc_attrs(cls, ext_cls)
             # global replacements may not happen in every docstring
-            assert re.sub(r'\\\d', '', repl) in cls.__doc__ or not re.match(pattern, ext_cls.__doc__)
+            if cls.__doc__ is not None:
+                assert re.sub(r'\\\d', '', repl) in cls.__doc__ or not re.match(pattern, ext_cls.__doc__)
 
-        ext_module_docstring = getattr(graph_scheduler, mod.__name__.split('.')[-1]).__doc__
-        assert re.sub(r'\\\d', '', repl) in mod.__doc__ or not re.match(pattern, ext_module_docstring)
+        ext_module = getattr(graph_scheduler, mod.__name__.split('.')[-1]).__doc__
+        assert consistent_doc_attrs(mod, ext_module)
+        assert re.sub(r'\\\d', '', repl) in mod.__doc__ or not re.match(pattern, ext_module.__doc__)

--- a/tests/mdf/test_mdf.py
+++ b/tests/mdf/test_mdf.py
@@ -303,7 +303,8 @@ def test_mdf_equivalence_individual_functions(mech_type, function, runtime_param
         trial_termination_cond = eval(trial_termination_cond)
     except TypeError:
         pass
-    comp.scheduler.termination_conds = {pnl.TimeScale.TRIAL: trial_termination_cond}
+    if trial_termination_cond is not None:
+        comp.scheduler.termination_conds = {pnl.TimeScale.TRIAL: trial_termination_cond}
 
     comp.run(inputs={A: [[1.0]]}, runtime_params=eval(runtime_params))
 

--- a/tests/scheduling/conftest.py
+++ b/tests/scheduling/conftest.py
@@ -34,3 +34,25 @@ def three_node_linear_composition():
     comp.add_linear_processing_pathway([A, B, C])
 
     return comp.nodes, comp
+
+
+@pytest.helpers.register
+def composition_from_string_pathways(pathways):
+    mechanisms = {}
+    pathways_as_mechs = []
+
+    for p in pathways:
+        p_as_mechs = []
+        assert not isinstance(p, str), 'pathways must be a list of lists'
+        for m in p:
+            try:
+                mech = mechanisms[m]
+            except KeyError:
+                mech = pnl.ProcessingMechanism(name=m)
+                mechanisms[m] = mech
+            p_as_mechs.append(mech)
+        pathways_as_mechs.append(p_as_mechs)
+
+    comp = pnl.Composition(pathways=pathways_as_mechs)
+
+    return comp, mechanisms, mechanisms.values()


### PR DESCRIPTION
- correct bug in autogenerating pnl Conditions from graph-scheduler Conditions
- modify Scheduler wrappers to support both basic and structural Conditions
- add wrappers for new graph_scheduler.Scheduler methods:
    - remove_condition
    - add_graph_edge
    - remove_graph_edge
- update requirements to graph-scheduler<1.3.0 to include graph structure conditions release
