### PR TITLE
Revert "github-actions(deps): bump actions/download-artifact from 3 to 4 (#2865)"

### DIFF
--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -168,7 +168,7 @@ jobs:
         ref: gh-pages
 
     - name: Download branch docs
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: Documentation-head-${{ matrix.os }}-${{ matrix.python-version }}-x64
         path: _built_docs/${{ github.ref }}
@@ -185,7 +185,7 @@ jobs:
       if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/docs'
 
     - name: Download main docs
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: Documentation-head-${{ matrix.os }}-${{ matrix.python-version }}-x64
         # This overwrites files in current directory

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -78,7 +78,7 @@ jobs:
 
     steps:
     - name: Download dist files
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: Python-dist-files
         path: dist/
@@ -141,7 +141,7 @@ jobs:
 
     steps:
     - name: Download dist files
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: Python-dist-files
         path: dist/
@@ -175,7 +175,7 @@ jobs:
 
     steps:
     - name: Download dist files
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: Python-dist-files
         path: dist/


### PR DESCRIPTION
This reverts commit a73ab288e91da1ef4f2b2557110f2af86f6d51bd.

v4 fails to download documentation artifacts.