### PR TITLE
tests: Seed optuna samplers

### DIFF
--- a/psyneulink/core/components/functions/nonstateful/fitfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/fitfunctions.py
@@ -806,7 +806,7 @@ class PECOptimizationFunction(OptimizationFunction):
                 optuna.logging.set_verbosity(optuna.logging.WARNING)
 
                 study = optuna.create_study(
-                    sampler=self.method, direction=self.direction
+                    sampler=opt_func, direction=self.direction
                 )
                 study.optimize(
                     objfunc_wrapper_wrapper,

--- a/tests/composition/test_parameterestimationcomposition.py
+++ b/tests/composition/test_parameterestimationcomposition.py
@@ -128,8 +128,8 @@ def test_pec_run_input_formats(inputs_dict, error_msg):
     "opt_method, result",
     [
         ("differential_evolution", [0.010363518438648106]),
-        (optuna.samplers.RandomSampler(), [0.01]),
-        (optuna.samplers.CmaEsSampler(), [0.01]),
+        (optuna.samplers.RandomSampler(seed=0), [0.01]),
+        (optuna.samplers.CmaEsSampler(seed=0), [0.01]),
     ],
     ids=["differential_evolultion", "optuna_random_sampler", "optuna_cmaes_sampler"],
 )


### PR DESCRIPTION
Replacing `sampler._rng`, as done in `PECOptimizationFunction`, only works for `optuna.RandomSampler`.
