### PR TITLE
Clean up interface to for specifying seeds to optuna samplers with PEC.

### DIFF
--- a/Scripts/Debug/stability_flexibility/stability_flexibility_pec_optimize.py
+++ b/Scripts/Debug/stability_flexibility/stability_flexibility_pec_optimize.py
@@ -114,7 +114,7 @@ pec = pnl.ParameterEstimationComposition(
         responseGate.output_ports[0],
     ],
     objective_function=reward_rate,
-    optimization_function=pnl.PECOptimizationFunction(method=optuna.samplers.CmaEsSampler(),
+    optimization_function=pnl.PECOptimizationFunction(method=optuna.samplers.QMCSampler(),
                                                       max_iterations=50,
                                                       direction='minimize'),
     num_estimates=num_estimates,

--- a/psyneulink/core/components/functions/nonstateful/fitfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/fitfunctions.py
@@ -268,7 +268,7 @@ class PECOptimizationFunction(OptimizationFunction):
 
             - 'differential_evolution' : Differential evolution as implemented by scipy.optimize.differential_evolution
             - optuna.samplers: Pass any instance of an optuna sampler to use optuna for optimization.
-            - type[optuna.samplers.BaseSampler]: Pass a class of type optuna.samplers.BaseSampler to use optuna
+            - Type[optuna.samplers.BaseSampler]: Pass a class of type optuna.samplers.BaseSampler to use optuna
             for optimization. In this case, the random seed used for the sampler will be the same as the seed used
             as the intial_seed passed to PEC at contruction. Additonal desired keyword arguments can be passed to the
             sampler via the optuna_kwargs argument.
@@ -302,7 +302,7 @@ class PECOptimizationFunction(OptimizationFunction):
     @beartype
     def __init__(
         self,
-        method: Union[Literal["differential_evolution"], optuna.samplers.BaseSampler, type[optuna.samplers.BaseSampler]],
+        method: Union[Literal["differential_evolution"], optuna.samplers.BaseSampler, Type[optuna.samplers.BaseSampler]],
         optuna_kwargs: Optional[Dict] = None,
         objective_function: Optional[Callable] = None,
         search_space=None,

--- a/psyneulink/core/components/functions/nonstateful/fitfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/fitfunctions.py
@@ -798,11 +798,6 @@ class PECOptimizationFunction(OptimizationFunction):
 
                     progress.update(opt_task, advance=1)
 
-                # We need to hook into Optuna's random number generator. We set the seed and make sure to call
-                # reseed_rng method.
-                opt_func.seed = self.owner.initial_seed
-                opt_func.reseed_rng()
-
                 # Turn off optuna logging except for errors or warnings, it doesn't work well with our PNL progress bar
                 optuna.logging.set_verbosity(optuna.logging.WARNING)
 

--- a/psyneulink/core/components/functions/nonstateful/fitfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/fitfunctions.py
@@ -798,9 +798,10 @@ class PECOptimizationFunction(OptimizationFunction):
 
                     progress.update(opt_task, advance=1)
 
-                # We need to hook into Optuna's random number generator here so that we can allow PsyNeuLink's RNS to
-                # determine the seed for Optuna's RNG. Pretty hacky unfortunately.
-                opt_func._rng = np.random.RandomState(self.owner.initial_seed)
+                # We need to hook into Optuna's random number generator. We set the seed and make sure to call
+                # reseed_rng method.
+                opt_func.seed = self.owner.initial_seed
+                opt_func.reseed_rng()
 
                 # Turn off optuna logging except for errors or warnings, it doesn't work well with our PNL progress bar
                 optuna.logging.set_verbosity(optuna.logging.WARNING)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ matplotlib<3.7.3
 modeci_mdf<0.5, >=0.4.3; (platform_machine == 'AMD64' or platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
 networkx<3.3
 numpy>=1.21.0, <1.24.5
-optuna<3.4.0
+optuna<3.6.0
 packaging<24.0
 pandas<2.1.5
 pillow<10.3.0

--- a/tests/composition/test_parameterestimationcomposition.py
+++ b/tests/composition/test_parameterestimationcomposition.py
@@ -129,9 +129,9 @@ def test_pec_run_input_formats(inputs_dict, error_msg):
     [
         ("differential_evolution", [0.010363518438648106]),
         (optuna.samplers.RandomSampler(), [0.01]),
-        (optuna.samplers.CmaEsSampler(), [0.01]),
+        (optuna.samplers.QMCSampler(), [0.01]),
     ],
-    ids=["differential_evolultion", "optuna_random_sampler", "optuna_cmaes_sampler"],
+    ids=["differential_evolultion", "optuna_random_sampler", "optuna_qmc_sampler"],
 )
 def test_parameter_optimization_ddm(func_mode, opt_method, result):
     """Test parameter optimization of a DDM in integrator mode"""


### PR DESCRIPTION
Some small modifications to PEC\Optuna RNG seeding interface based on suggestions from @jvesely and @jdcpni.

- Hack was removed that set optuna RandomState object under the hood.
- Added ability to pass un-instantiated optuna sampler to `PECOptimizationFunction` and added an argument called `optuna_kwargs` for specifying any desired sampler construction args. This allows use the PEC `initial_seed` if it is specified. 
- Added a warning to the user if they have specified a PEC `initial_seed` with an already instantiated optuna sampler. 

Fixes issue #2874