### PR TITLE
tests: MDF: correct use of shared state

### DIFF
--- a/psyneulink/core/globals/mdf.py
+++ b/psyneulink/core/globals/mdf.py
@@ -1569,8 +1569,8 @@ def write_mdf_file(compositions, filename: str, path: str = None, fmt: str = Non
 
     if fmt is None:
         try:
-            fmt = re.match(r'(.*)\.(.*)$', filename).groups(1)
-        except AttributeError:
+            fmt = re.match(r'(.*)\.(.*)$', filename).groups()[1]
+        except (AttributeError, IndexError):
             fmt = 'json'
 
     if path is not None:

--- a/psyneulink/core/globals/mdf.py
+++ b/psyneulink/core/globals/mdf.py
@@ -1556,7 +1556,9 @@ def write_mdf_file(compositions, filename: str, path: str = None, fmt: str = Non
                 not specified then the current directory is used.
 
             fmt : str
-                specifies file format of output. Current options ('json', 'yml'/'yaml')
+                specifies file format of output. Auto-detect based on
+                **filename** extension if None.
+                Current options: 'json', 'yml'/'yaml'
 
             simple_edge_format : bool
                 specifies use of

--- a/psyneulink/core/globals/mdf.py
+++ b/psyneulink/core/globals/mdf.py
@@ -954,6 +954,10 @@ def _generate_composition_string(graph, component_identifiers):
         psyneulink.LearningMechanism,
         psyneulink.LearningProjection,
     )
+    implicit_roles = (
+        psyneulink.NodeRole.LEARNING,
+    )
+
     output = []
 
     comp_identifer = parse_valid_identifier(graph.id)
@@ -1090,6 +1094,22 @@ def _generate_composition_string(graph, component_identifiers):
     control_mechanisms = []
     implicit_mechanisms = []
 
+    try:
+        node_roles = {
+            parse_valid_identifier(node): role for (node, role) in
+            graph.metadata['required_node_roles']
+        }
+    except KeyError:
+        node_roles = []
+
+    try:
+        excluded_node_roles = {
+            parse_valid_identifier(node): role for (node, role) in
+            graph.metadata['excluded_node_roles']
+        }
+    except KeyError:
+        excluded_node_roles = []
+
     # add nested compositions and mechanisms in order they were added
     # to this composition
     for node in sorted(
@@ -1104,10 +1124,19 @@ def _generate_composition_string(graph, component_identifiers):
             except (AttributeError, KeyError):
                 component_type = default_node_type
             identifier = parse_valid_identifier(node.id)
+
+            try:
+                node_role = eval(_parse_parameter_value(node_roles[identifier]))
+            except (KeyError, TypeError):
+                node_role = None
+
             if issubclass(component_type, control_mechanism_types):
                 control_mechanisms.append(node)
                 component_identifiers[identifier] = True
-            elif issubclass(component_type, implicit_types):
+            elif (
+                issubclass(component_type, implicit_types)
+                or node_role in implicit_roles
+            ):
                 implicit_mechanisms.append(node)
             else:
                 mechanisms.append(node)
@@ -1165,23 +1194,6 @@ def _generate_composition_string(graph, component_identifiers):
         )
     if len(compositions) > 0:
         output.append('')
-
-    # generate string to add the nodes to this Composition
-    try:
-        node_roles = {
-            parse_valid_identifier(node): role for (node, role) in
-            graph.metadata['required_node_roles']
-        }
-    except KeyError:
-        node_roles = []
-
-    try:
-        excluded_node_roles = {
-            parse_valid_identifier(node): role for (node, role) in
-            graph.metadata['excluded_node_roles']
-        }
-    except KeyError:
-        excluded_node_roles = []
 
     # do not add the controller as a normal node
     try:

--- a/psyneulink/core/globals/mdf.py
+++ b/psyneulink/core/globals/mdf.py
@@ -1395,10 +1395,11 @@ def generate_script_from_mdf(model_input, outfile=None):
     for i in range(len(comp_strs)):
         # greedy and non-greedy
         for cs in comp_strs[i]:
-            potential_module_names = set([
+            cs_potential_names = set([
                 *re.findall(r'([A-Za-z_\.]+)\.', cs),
                 *re.findall(r'([A-Za-z_\.]+?)\.', cs)
             ])
+            potential_module_names.update(cs_potential_names)
 
         for module in potential_module_names:
             if module not in component_identifiers:

--- a/tests/mdf/model_backprop.py
+++ b/tests/mdf/model_backprop.py
@@ -1,10 +1,10 @@
 import psyneulink as pnl
 
-a = pnl.TransferMechanism()
-b = pnl.TransferMechanism()
-c = pnl.TransferMechanism()
+A = pnl.TransferMechanism(name='A')
+B = pnl.TransferMechanism(name='B')
+C = pnl.TransferMechanism(name='C')
 
-p = pnl.Pathway(pathway=[a, b, c])
+p = pnl.Pathway(pathway=[A, B, C])
 
-comp = pnl.Composition()
+comp = pnl.Composition(name='comp')
 comp.add_backpropagation_learning_pathway(pathway=p)

--- a/tests/mdf/test_mdf.py
+++ b/tests/mdf/test_mdf.py
@@ -147,12 +147,12 @@ def test_json_results_equivalence(
 
     # reset random seed
     pnl.core.globals.utilities.set_global_seed(0)
-    # Generate python script from JSON summary of composition and execute
-    json_summary = pnl.generate_json(
+    # Generate python script from MDF serialization of composition and execute
+    mdf_data = pnl.get_mdf_serialized(
         eval(f'{composition_name}', orig_globals, orig_locals),
         simple_edge_format=simple_edge_format
     )
-    new_script = pnl.generate_script_from_json(json_summary)
+    new_script = pnl.generate_script_from_mdf(mdf_data)
     new_results, _, _ = get_model_results_and_state(new_script, comp_inputs)
 
     assert_result_equality(orig_results, new_results)
@@ -179,15 +179,15 @@ def test_write_json_file(
     # reset random seed
     pnl.core.globals.utilities.set_global_seed(0)
 
-    # Save json_summary of Composition to file and read back in.
-    json_filename = filename.replace('.py','.json')
+    # Save MDF serialization of Composition to file and read back in.
+    mdf_fname = filename.replace('.py', '.json')
     exec(
-        f'pnl.write_json_file({composition_name}, "{json_filename}", simple_edge_format={simple_edge_format})',
+        f'pnl.write_mdf_file({composition_name}, "{mdf_fname}", simple_edge_format={simple_edge_format})',
         orig_globals,
         orig_locals,
     )
 
-    new_script = pnl.generate_script_from_json(json_filename)
+    new_script = pnl.generate_script_from_mdf(mdf_fname)
     new_results, _, _ = get_model_results_and_state(new_script, comp_inputs)
 
     assert_result_equality(orig_results, new_results)
@@ -216,16 +216,16 @@ def test_write_json_file_multiple_comps(
     # reset random seed
     pnl.core.globals.utilities.set_global_seed(0)
 
-    # Save json_summary of Composition to file and read back in.
-    json_filename = filename.replace('.py', '.json')
+    # Save MDF serialization of Composition to file and read back in.
+    mdf_fname = filename.replace('.py', '.json')
 
     exec(
-        f'pnl.write_json_file([{",".join(input_dict_strs)}], "{json_filename}")',
+        f'pnl.write_mdf_file([{",".join(input_dict_strs)}], "{mdf_fname}")',
         orig_globals,
         orig_locals
     )
 
-    new_script = pnl.generate_script_from_json(json_filename)
+    new_script = pnl.generate_script_from_mdf(mdf_fname)
     new_results, _, _ = get_model_results_and_state(new_script, input_dict_strs)
 
     assert_result_equality(orig_results, new_results)
@@ -319,12 +319,12 @@ def test_mdf_equivalence(filename, composition_name, input_dict, simple_edge_for
         orig_script, comp_inputs, run_args
     )
 
-    # Save json_summary of Composition to file and read back in.
-    json_filename = filename.replace('.py', '.json')
+    # Save MDF serialization of Composition to file and read back in.
+    mdf_fname = filename.replace('.py', '.json')
     composition = eval(composition_name, orig_globals, orig_locals)
-    pnl.write_json_file(composition, json_filename, simple_edge_format=simple_edge_format)
+    pnl.write_mdf_file(composition, mdf_fname, simple_edge_format=simple_edge_format)
 
-    m = load_mdf(json_filename)
+    m = load_mdf(mdf_fname)
     eg = ee.EvaluableGraph(m.graphs[0], verbose=True)
     eg.evaluate(initializer={f'{node}_InputPort_0': i for node, i in input_dict.items()})
 

--- a/tests/mdf/test_mdf.py
+++ b/tests/mdf/test_mdf.py
@@ -36,7 +36,7 @@ stroop_stimuli = {
 }
 
 
-json_results_parametrization = [
+pnl_mdf_results_parametrization = [
     ('model_basic.py', 'comp', '{A: 1}', True),
     ('model_basic.py', 'comp', '{A: 1}', False),
     ('model_basic_non_identity.py', 'comp', '{A: 1}', True),
@@ -152,9 +152,9 @@ def assert_result_equality(orig_results, new_results):
 
 @pytest.mark.parametrize(
     'filename, composition_name, input_dict_str, simple_edge_format',
-    json_results_parametrization
+    pnl_mdf_results_parametrization
 )
-def test_json_results_equivalence(
+def test_get_mdf_serialized_results_equivalence_pnl_only(
     filename,
     composition_name,
     input_dict_str,
@@ -183,9 +183,9 @@ def test_json_results_equivalence(
 
 @pytest.mark.parametrize(
     'filename, composition_name, input_dict_str, simple_edge_format',
-    json_results_parametrization
+    pnl_mdf_results_parametrization
 )
-def test_write_json_file(
+def test_write_mdf_file_results_equivalence_pnl_only(
     filename,
     composition_name,
     input_dict_str,
@@ -228,7 +228,7 @@ def test_write_json_file(
         ('model_with_two_disjoint_comps.py', {'comp': '{A: 1}', 'comp2': '{C: 1}'}),
     ]
 )
-def test_write_json_file_multiple_comps(
+def test_write_mdf_file_results_equivalence_pnl_only_multiple_comps(
     filename,
     input_dict_strs,
     tmp_path,
@@ -331,7 +331,7 @@ integrators_runtime_params = (
         ('model_integrators.py', 'comp', {'A': 1.0}, False, integrators_runtime_params),
     ]
 )
-def test_mdf_equivalence(filename, composition_name, input_dict, simple_edge_format, run_args, tmp_path):
+def test_mdf_pnl_results_equivalence(filename, composition_name, input_dict, simple_edge_format, run_args, tmp_path):
     from modeci_mdf.utils import load_mdf
     import modeci_mdf.execution_engine as ee
 
@@ -399,7 +399,7 @@ individual_functions_fhn_test_data = [
         *individual_functions_fhn_test_data,
     ]
 )
-def test_mdf_equivalence_individual_functions(mech_type, function, runtime_params, trial_termination_cond):
+def test_mdf_pnl_results_equivalence_individual_functions(mech_type, function, runtime_params, trial_termination_cond):
     import modeci_mdf.execution_engine as ee
 
     A = mech_type(name='A', function=copy.deepcopy(function))

--- a/tests/mdf/test_mdf.py
+++ b/tests/mdf/test_mdf.py
@@ -125,7 +125,7 @@ def test_write_json_file(
 
     # Save json_summary of Composition to file and read back in.
     json_filename = filename.replace('.py','.json')
-    exec(f'pnl.write_json_file({composition_name}, json_filename, simple_edge_format=simple_edge_format)')
+    exec(f'pnl.write_json_file({composition_name}, "{json_filename}", simple_edge_format={simple_edge_format})')
     exec(pnl.generate_script_from_json(json_filename))
     # exec(f'{composition_name}.run(inputs={input_dict_str})')
     exec(f'pnl.get_compositions()[0].run(inputs={input_dict_str})')
@@ -165,7 +165,7 @@ def test_write_json_file_multiple_comps(
     # Save json_summary of Composition to file and read back in.
     json_filename = filename.replace('.py', '.json')
 
-    exec(f'pnl.write_json_file([{",".join(input_dict_strs)}], json_filename)')
+    exec(f'pnl.write_json_file([{",".join(input_dict_strs)}], "{json_filename}")')
     exec(pnl.generate_script_from_json(json_filename))
 
     for composition_name in input_dict_strs:
@@ -316,15 +316,20 @@ def test_mdf_equivalence_individual_functions(mech_type, function, runtime_param
     assert pnl.safe_equals(comp.results, _get_mdf_model_results(eg))
 
 
-@pytest.mark.parametrize('filename', ['model_basic.py'])
+@pytest.mark.parametrize(
+    'filename, composition_name',
+    [
+        ('model_basic.py', 'comp'),
+    ]
+)
 @pytest.mark.parametrize('fmt', ['json', 'yml'])
-def test_generate_script_from_mdf(filename, fmt):
+def test_generate_script_from_mdf(filename, composition_name, fmt):
     filename = os.path.join(os.path.dirname(__file__), filename)
     outfi = filename.replace('.py', f'.{fmt}')
 
     with open(filename, 'r') as orig_file:
         exec(orig_file.read())
-        serialized = eval(f'pnl.get_mdf_serialized(comp, fmt="{fmt}")')
+        serialized = eval(f'pnl.get_mdf_serialized({composition_name}, fmt="{fmt}")')
 
     with open(outfi, 'w') as f:
         f.write(serialized)

--- a/tests/mdf/test_mdf.py
+++ b/tests/mdf/test_mdf.py
@@ -72,7 +72,7 @@ json_results_parametrization = [
         str(stroop_stimuli).replace("'", ''),
         False
     ),
-    ('model_backprop.py', 'comp', '{a: [1, 2, 3]}', False),
+    ('model_backprop.py', 'comp', '{A: [1, 2, 3]}', False),
 ]
 
 


### PR DESCRIPTION
globals/locals state was incorrectly shared between reference and test model output due to use of eval/exec, resulting in falsely passing tests