### PR TITLE
deps: Block sphinxcontrib-* that silently depend on sphinx >=5

### DIFF
--- a/broken_trans_deps.txt
+++ b/broken_trans_deps.txt
@@ -30,6 +30,10 @@ cattrs != 23.1.1; python_version < '3.8'
 # https://github.com/python-attrs/cattrs/issues/453
 cattrs != 23.2.1, != 23.2.2
 
-# sphinxcontrib-applehelp >=1.0.8, sphinxcontrib-devhelp >=1.0.6 needs at least sphinx-5
+# The following need at least sphinx-5 without indicating it in dependencies:
+# * sphinxcontrib-applehelp >=1.0.8,
+# * sphinxcontrib-devhelp >=1.0.6,
+# * sphinxcontrib-htmlhelp >=2.0.5,
 sphinxcontrib-applehelp <1.0.8
 sphinxcontrib-devhelp <1.0.6
+sphinxcontrib-htmlhelp <2.0.5

--- a/broken_trans_deps.txt
+++ b/broken_trans_deps.txt
@@ -34,8 +34,10 @@ cattrs != 23.2.1, != 23.2.2
 # * sphinxcontrib-applehelp >=1.0.8,
 # * sphinxcontrib-devhelp >=1.0.6,
 # * sphinxcontrib-htmlhelp >=2.0.5,
-# * sphinxcontrib-serializinghtml >=1.1.10
+# * sphinxcontrib-serializinghtml >=1.1.10,
+# * sphinxcontrib-qthelp >=1.0.7
 sphinxcontrib-applehelp <1.0.8
 sphinxcontrib-devhelp <1.0.6
 sphinxcontrib-htmlhelp <2.0.5
 sphinxcontrib-serializinghtml <1.1.10
+sphinxcontrib-qthelp <1.0.7

--- a/broken_trans_deps.txt
+++ b/broken_trans_deps.txt
@@ -30,5 +30,6 @@ cattrs != 23.1.1; python_version < '3.8'
 # https://github.com/python-attrs/cattrs/issues/453
 cattrs != 23.2.1, != 23.2.2
 
-# sphinxcontrib-applehelp >=1.0.8 needs at least sphinx-5
+# sphinxcontrib-applehelp >=1.0.8, sphinxcontrib-devhelp >=1.0.6 needs at least sphinx-5
 sphinxcontrib-applehelp <1.0.8
+sphinxcontrib-devhelp <1.0.6

--- a/broken_trans_deps.txt
+++ b/broken_trans_deps.txt
@@ -29,3 +29,6 @@ cattrs != 23.1.1; python_version < '3.8'
 # cattrs==23.2.{1,2} breaks json serialization
 # https://github.com/python-attrs/cattrs/issues/453
 cattrs != 23.2.1, != 23.2.2
+
+# sphinxcontrib-applehelp >=1.0.8 needs at least sphinx-5
+sphinxcontrib-applehelp <1.0.8

--- a/broken_trans_deps.txt
+++ b/broken_trans_deps.txt
@@ -34,6 +34,8 @@ cattrs != 23.2.1, != 23.2.2
 # * sphinxcontrib-applehelp >=1.0.8,
 # * sphinxcontrib-devhelp >=1.0.6,
 # * sphinxcontrib-htmlhelp >=2.0.5,
+# * sphinxcontrib-serializinghtml >=1.1.10
 sphinxcontrib-applehelp <1.0.8
 sphinxcontrib-devhelp <1.0.6
 sphinxcontrib-htmlhelp <2.0.5
+sphinxcontrib-serializinghtml <1.1.10


### PR DESCRIPTION
The following packages need at least sphinx-5 without indicating it in dependencies:
 * sphinxcontrib-applehelp >=1.0.8,
 * sphinxcontrib-devhelp >=1.0.6,
 * sphinxcontrib-htmlhelp >=2.0.5,
 * sphinxcontrib-serializinghtml >=1.1.10,
 * sphinxcontrib-qthelp >=1.0.7
