### PR TITLE
ci/github-actions: Make sure the uploaded artifacts are unique

### DIFF
--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -131,11 +131,13 @@ jobs:
         path: docs/build/html
 
     - name: Store PR number
-      if: ${{ github.event_name == 'pull_request' }}
+      # The 'base' variant runs only on pull requests and has only one job
+      if: ${{ matrix.pnl-version == 'base' }}
       run: echo ${{ github.event.pull_request.number }} > ./pr_number.txt
 
     - name: Upload PR number for other workflows
-      if: ${{ github.event_name == 'pull_request' }}
+      # The 'base' variant runs only on pull requests and has only one job
+      if: ${{ matrix.pnl-version == 'base' }}
       uses: actions/upload-artifact@v3
       with:
           name: pr_number

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -203,6 +203,7 @@ jobs:
 
     - name: Upload dist packages
       uses: actions/upload-artifact@v3
+      if: matrix.version-restrict == ''
       with:
         name: dist-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}
         path: dist/

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -178,7 +178,7 @@ jobs:
     - name: Upload test results
       uses: actions/upload-artifact@v3
       with:
-        name: test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}
+        name: test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}-${{ matrix.version-restrict }}
         path: tests_out.xml
         retention-days: 5
       if: (success() || failure()) && ! contains(matrix.extra-args, 'forked')


### PR DESCRIPTION
Restrict upload of "pr_number" artifact to "base" job, it only runs in pull_requests and there is only one such job.
Add version restriction to the name of test result artifact.
Do not upload built dist packages for "min" version test run, they are not different from the standard run.