### PR TITLE
ci/ga: Print additional CPU and memory info on all runners

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -163,12 +163,18 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-    - name: Print test machine/env info
+    - name: Print numpy info
       shell: bash
       run: |
         python -c "import numpy; numpy.show_config()"
+
+    - name: Print machine info
+      shell: bash
+      run: |
         case "$RUNNER_OS" in
-          Linux*) lscpu;;
+          Linux*) lscpu; lsmem;;
+          macOS*) sysctl -a | grep '^hw' ;;
+          Windows*) wmic cpu get description,currentclockspeed,NumberOfCores,NumberOfEnabledCore,NumberOfLogicalProcessors; wmic memorychip get capacity,speed,status,manufacturer ;;
         esac
 
     - name: Test with pytest


### PR DESCRIPTION
Split numpy info from OS machine info.