### PR TITLE
ci/ga: Use all logical cores to run tests

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -179,7 +179,7 @@ jobs:
 
     - name: Test with pytest
       timeout-minutes: 180
-      run: pytest --junit-xml=tests_out.xml --verbosity=0 -n auto ${{ matrix.extra-args }}
+      run: pytest --junit-xml=tests_out.xml --verbosity=0 -n logical ${{ matrix.extra-args }}
 
     - name: Upload test results
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Runners are running in a VM and test workers running on all vCPUs might get better performance than bare metal threads depending on the hypervisor vCPU scheduling.