### PR TITLE
llvm/component: Explicitly check for numpy array functions

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1482,6 +1482,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                 # Check if the value type is valid for compilation
                 return not isinstance(val, (str, ComponentsMeta,
                                             type(max),
+                                            type(np.sum),
                                             type(_is_compilation_param),
                                             type(self._get_compilation_params)))
             return False


### PR DESCRIPTION
Numpy builtins change type in numpy-1.25+ which converted Python dispatcher function to C dispatcher in:
60a858a372b14b73547baacf4a472eccfade1073
	("ENH: Improve array function overhead by using vectorcall")

Check for np.sum type to exclude parameters of this type from compiled structures.