### PR TITLE
mdf: Encode numpy functions the same as Python functions

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -4011,7 +4011,12 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                     value = None
                 else:
                     value = value.__qualname__
-            elif isinstance(value, types.FunctionType):
+
+            # numpy functions are no longer "FunctionType" since numpy
+            # moved dispatch implementation from Python to C in
+            # https://github.com/numpy/numpy/commit/60a858a372b14b73547baacf4a472eccfade1073
+            # Use np.sum as a representative of these functions
+            elif isinstance(value, (types.FunctionType, type(np.sum))):
                 if functions_as_dill:
                     value = base64.encodebytes(dill.dumps(value)).decode('utf-8')
                 elif '.' in value.__qualname__:


### PR DESCRIPTION
Numpy functions like np.sum are no longer of type FunctionType since Numpy moved dispatcher implementation to C in 1.25 [0,1]

Add "type(np.sum)" in addition to types.FunctionType to  use the same path for Nnumpy functions in numpy 1.25.

[0] https://github.com/numpy/numpy/commit/60a858a372b14b73547baacf4a472eccfade1073
[1] https://github.com/numpy/numpy/issues/24019

Closes: https://github.com/PrincetonUniversity/PsyNeuLink/issues/2908