### PR TITLE
Fix bug in PEC mapping outcomes variables to data.

### DIFF
--- a/Scripts/Debug/stability_flexibility/stability_flexibility.py
+++ b/Scripts/Debug/stability_flexibility/stability_flexibility.py
@@ -1,8 +1,5 @@
 import psyneulink as pnl
 import numpy as np
-import random
-import pytest
-import pandas as pd
 
 
 # Define function to generate a counterbalanced trial sequence with a specified switch trial frequency

--- a/Scripts/Debug/stability_flexibility/stability_flexibility_pec_fit.py
+++ b/Scripts/Debug/stability_flexibility/stability_flexibility_pec_fit.py
@@ -16,9 +16,9 @@ set_global_seed(pnl_seed)
 trial_seq_seed = 0
 
 # High-level parameters the impact performance of the test
-num_trials = 12
+num_trials = 50
 time_step_size = 0.01
-num_estimates = 3
+num_estimates = 10000
 
 sf_params = dict(
     gain=3.0,
@@ -104,7 +104,7 @@ pec = pnl.ParameterEstimationComposition(
     num_estimates=num_estimates,
 )
 
-# pec.controller.parameters.comp_execution_mode.set("LLVM")
+pec.controller.parameters.comp_execution_mode.set("LLVM")
 pec.controller.function.parameters.save_values.set(True)
 
 print("Running the PEC")

--- a/psyneulink/core/compositions/parameterestimationcomposition.py
+++ b/psyneulink/core/compositions/parameterestimationcomposition.py
@@ -592,13 +592,17 @@ class ParameterEstimationComposition(Composition):
 
         self._outcome_variable_indices = []
         in_comp = self.nodes[0]
-        in_comp_ports = list(in_comp.output_CIM.port_map.keys())
         for outcome_var in self.outcome_variables:
             try:
                 if not isinstance(outcome_var, OutputPort):
                     outcome_var = outcome_var.output_port
 
-                self._outcome_variable_indices.append(in_comp_ports.index(outcome_var))
+                # Get the index of the outcome variable in the output ports of inner composition. To do this,
+                # we must use the inner composition's portmap to get the CIM output port that corresponds to
+                # the outcome variable
+                index = in_comp.output_ports.index(in_comp.output_CIM.port_map[outcome_var][1])
+
+                self._outcome_variable_indices.append(index)
             except ValueError:
                 raise ValueError(
                     f"Could not find outcome variable {outcome_var.full_name} in the output ports of "

--- a/psyneulink/core/compositions/parameterestimationcomposition.py
+++ b/psyneulink/core/compositions/parameterestimationcomposition.py
@@ -603,8 +603,8 @@ class ParameterEstimationComposition(Composition):
                 index = in_comp.output_ports.index(in_comp.output_CIM.port_map[outcome_var][1])
 
                 self._outcome_variable_indices.append(index)
-            except ValueError:
-                raise ValueError(
+            except KeyError:
+                raise KeyError(
                     f"Could not find outcome variable {outcome_var.full_name} in the output ports of "
                     f"the composition being fitted to data ({self.nodes[0]}). A current limitation of the "
                     f"PEC data fitting API is that any output port of composition that should be fit to "

--- a/tests/composition/test_parameterestimationcomposition.py
+++ b/tests/composition/test_parameterestimationcomposition.py
@@ -359,7 +359,7 @@ def test_pec_bad_outcome_var_spec():
         ("threshold", decision): np.linspace(0.5, 1.0, 1000),
     }
 
-    with pytest.raises(ValueError) as ex:
+    with pytest.raises(KeyError) as ex:
         pnl.ParameterEstimationComposition(
             name="pec",
             nodes=[comp],


### PR DESCRIPTION
It turns out the that PEC code was assuming the inner compositions port map dict order was always the same as the output ports list. This was non-deterministic it seems. Now we Get the index of the outcome variable in the output ports of inner composition. To do this, we must use the inner composition's portmap to get the CIM output port that corresponds to the outcome variable.