### PR TITLE
Remove autograd

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,6 @@ Dependencies that are automatically installed (except those noted as optional) i
    * pillow
    * llvmlite
    * mpi4py (optional)
-   * autograd (optional)
 
 Lists of required packages for PsyNeuLink, developing PsyNeuLink, and running the PsyNeuLink tutorial are also
 stored in pip-style `requirements.txt`, `dev_requirements.txt`, and `tutorial_requirements.txt` in the source code.

--- a/Scripts/Models (Under Development)/Bustamante_Stroop_XOR_LVOC_Model_VZ.py
+++ b/Scripts/Models (Under Development)/Bustamante_Stroop_XOR_LVOC_Model_VZ.py
@@ -18,7 +18,7 @@ using a version of the `Learned Value of Control Model
 <https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1006043&rev=2>`_
 """
 
-import autograd.numpy as np
+import numpy as np
 import psyneulink as pnl
 
 # from build_stimuli_VZ import xor_dict

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -178,7 +178,6 @@ Dependencies that are automatically installed (except those noted as optional) i
    * pillow
    * llvmlite
    * mpi4py (optional)
-   * autograd (optional)
 
 Lists of required packages for PsyNeuLink, developing PsyNeuLink, and running the PsyNeuLink tutorial are also
 stored in pip-style `requirements.txt`, `dev_requirements.txt`, and `tutorial_requirements.txt` in the source code.

--- a/docs/source/index_logo_with_text.rst
+++ b/docs/source/index_logo_with_text.rst
@@ -163,7 +163,6 @@ Dependencies that are automatically installed (except those noted as optional) i
    * pillow
    * llvmlite
    * mpi4py (optional)
-   * autograd (optional)
 
 Lists of required packages for PsyNeuLink, developing PsyNeuLink, and running the PsyNeuLink tutorial are also
 stored in pip-style `requirements.txt`, `dev_requirements.txt`, and `tutorial_requirements.txt` in the source code.

--- a/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
@@ -32,17 +32,11 @@ from numbers import Number
 
 import numpy as np
 
+# Conditionally import torch
 try:
     import torch
 except ImportError:
     torch = None
-
-# Conditionally import torch, this is a bit more strict than the usual conditional import of pytorch. This is because
-# GradientOptimization needs torch.func.grad, which is not available in pytorch versions less than 2.0.0.
-try:
-    from torch.func import grad
-except ImportError:
-    grad = None
 
 from beartype import beartype
 
@@ -1261,16 +1255,17 @@ class GradientOptimization(OptimizationFunction):
             **kwargs
         )
 
-        # Differentiate objective_function using autograd.grad()
+        # Differentiate objective_function using torch.func.grad()
         if objective_function is not None and not self.gradient_function:
 
             if torch is None:
                 raise ValueError("PyTorch is not installed. Please install PyTorch to use GradientOptimization without "
                                  "specifying a gradient_function.")
 
-            if grad is None:
-                raise ValueError("PyTorch version is too old. Please upgrade PyTorch to >= 2.0 to use "
-                                 "GradientOptimization without specifying a gradient_function.")
+            if 'grad' not in dir(torch.func):
+                raise ValueError("torch.func.grad not found. PyTorch version is probably too old. Please upgrade "
+                                 "PyTorch to >= 2.0 to use GradientOptimization without specifying a "
+                                 "gradient_function.")
 
             try:
                 # Need to wrap objective_function in a lambda to pass to grad because it needs to return a torch tensor

--- a/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
@@ -951,8 +951,9 @@ class GradientOptimization(OptimizationFunction):
     which should be the derivative of the `objective_function <GradientOptimization.objective_function>`
     with respect to `variable <GradientOptimization.variable>` at its current value:
     :math:`\\frac{d(objective\\_function(variable))}{d(variable)}`.  If the **gradient_function* argument of the
-    constructor is not specified, then an attempt is made to use `Autograd's <https://github.com/HIPS/autograd>`_ `grad
-    <autograd.grad>` method to generate `gradient_function <GradientOptimization.gradient_function>`.  If that fails,
+    constructor is not specified, then an attempt is made to use PyTorch functional
+    `autograd's <https://pytorch.org/docs/stable/generated/torch.func.grad.html>`_ `grad <torch.func.grad>`
+    method to generate `gradient_function <GradientOptimization.gradient_function>`.  If that fails,
     an error occurs.  The **search_space** argument can be used to specify lower and/or upper bounds for each dimension
     of the sample; if the gradient causes a value of the sample to exceed a bound along a dimenson, the value of the
     bound is used for that dimension, unless/until the gradient shifts and causes it to return back within the bound.
@@ -972,7 +973,7 @@ class GradientOptimization(OptimizationFunction):
     gradient_function : function
         specifies function used to compute the gradient in each iteration of the `optimization process
         <GradientOptimization_Procedure>`;  if it is not specified, an attempt is made to compute it using
-        `autograd.grad <https://github.com/HIPS/autograd>`_.
+        `PyTorch autograd's <https://pytorch.org/docs/stable/generated/torch.func.grad.html>`_ `grad <torch.func.grad>`.
 
     direction : ASCENT or DESCENT : default ASCENT
         specifies the direction of gradient optimization: if *ASCENT*, movement is attempted in the positive direction

--- a/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
@@ -1262,7 +1262,7 @@ class GradientOptimization(OptimizationFunction):
                 raise ValueError("PyTorch is not installed. Please install PyTorch to use GradientOptimization without "
                                  "specifying a gradient_function.")
 
-            if 'grad' not in dir(torch.func):
+            if 'func' not in dir(torch):
                 raise ValueError("torch.func.grad not found. PyTorch version is probably too old. Please upgrade "
                                  "PyTorch to >= 2.0 to use GradientOptimization without specifying a "
                                  "gradient_function.")

--- a/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
@@ -32,12 +32,16 @@ from numbers import Number
 
 import numpy as np
 
-# Conditionally import torch
 try:
     import torch
-    from torch.func import grad
 except ImportError:
     torch = None
+
+# Conditionally import torch, this is a bit more strict than the usual conditional import of pytorch. This is because
+# GradientOptimization needs torch.func.grad, which is not available in pytorch versions less than 2.0.0.
+try:
+    from torch.func import grad
+except ImportError:
     grad = None
 
 from beartype import beartype
@@ -1265,8 +1269,8 @@ class GradientOptimization(OptimizationFunction):
                                  "specifying a gradient_function.")
 
             if grad is None:
-                raise ValueError("PyTorch version is too old. Please upgrade PyTorch to use GradientOptimization without "
-                                 "specifying a gradient_function.")
+                raise ValueError("PyTorch version is too old. Please upgrade PyTorch to >= 2.0 to use "
+                                 "GradientOptimization without specifying a gradient_function.")
 
             try:
                 # Need to wrap objective_function in a lambda to pass to grad because it needs to return a torch tensor

--- a/psyneulink/core/components/functions/nonstateful/transferfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/transferfunctions.py
@@ -722,8 +722,6 @@ class Exponential(TransferFunction):  # ----------------------------------------
         scale = self._get_current_parameter_value(SCALE, context)
         offset = self._get_current_parameter_value(OFFSET, context)
 
-        # The following doesn't work with autograd (https://github.com/HIPS/autograd/issues/416)
-        # result = scale * np.exp(rate * variable + bias) + offset
         result = scale * e**(rate * variable + bias) + offset
         return self.convert_output_type(result)
 
@@ -1022,8 +1020,6 @@ class Logistic(TransferFunction):  # -------------------------------------------
         offset = self._get_current_parameter_value(OFFSET, context)
         scale = self._get_current_parameter_value(SCALE, context)
 
-        # The following doesn't work with autograd (https://github.com/HIPS/autograd/issues/416)
-        # result = 1. / (1 + np.exp(-gain * (variable - bias) + offset))
         result = scale * (1. / (1 + e**(-gain * (variable + bias - x_0) + offset)))
 
         return self.convert_output_type(result)
@@ -1346,9 +1342,6 @@ class Tanh(TransferFunction):  # -----------------------------------------------
         offset = self._get_current_parameter_value(OFFSET, context)
         scale = self._get_current_parameter_value(SCALE, context)
 
-        # The following probably doesn't work with autograd (https://github.com/HIPS/autograd/issues/416)
-        #   (since np.exp doesn't work)
-        # result = 1. / (1 + np.tanh(-gain * (variable - bias) + offset))
         exponent = -2 * (gain * (variable + bias - x_0) + offset)
         result = scale * (1 - e**exponent)/ (1 + e**exponent)
 
@@ -2437,7 +2430,6 @@ class GaussianDistort(TransferFunction):  #-------------------------------------
         offset = self._get_current_parameter_value(OFFSET, context)
         random_state = self._get_current_parameter_value('random_state', context)
 
-        # The following doesn't work with autograd (https://github.com/HIPS/autograd/issues/416)
         result = scale * random_state.normal(variable + bias, variance) + offset
 
         return self.convert_output_type(result)
@@ -2846,7 +2838,6 @@ class Dropout(TransferFunction):  #
             result = variable
 
         else:
-            # ??Not sure whether the following works with autograd (https://github.com/HIPS/autograd/issues/416)
             p = p or self.defaults.p
             self.binomial_distort.parameters.p.set(p, context)
             result = self.binomial_distort(variable) * (1 / (1 - p))

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -625,17 +625,7 @@ def iscompatible(candidate, reference=None, **kargs):
                         else:
                             return True
                 else:
-                    if not is_number(value):
-                        try:
-                            # True for autograd ArrayBox (and maybe other types?)
-                            # if isinstance(value._value, Number):
-                            from autograd.numpy.numpy_boxes import ArrayBox
-                            if isinstance(value, ArrayBox):
-                                return True
-                        except:
-                            return False
-                    else:
-                        return True
+                    return is_number(value)
             # Test copy since may need to convert matrix to array (see above)
             if not recursively_check_elements_for_numeric(candidate.copy()):
                 return False

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -1017,15 +1017,17 @@ def convert_to_np_array(value, dimension=None):
     """
     def safe_create_np_array(value):
         with warnings.catch_warnings():
+
+            # If we have a torch tensor, allow it to pass through unchanged
+            if torch and torch.is_tensor(value):
+                return value
+
             warnings.filterwarnings('error', category=np.VisibleDeprecationWarning)
             # NOTE: this will raise a ValueError in the future.
             # See https://numpy.org/neps/nep-0034-infer-dtype-is-object.html
             try:
                 try:
-                    if torch and torch.is_tensor(value):
-                        return value
-                    else:
-                        return np.asarray(value)
+                    return np.asarray(value)
                 except np.VisibleDeprecationWarning:
                     return np.asarray(value, dtype=object)
                 except ValueError as e:

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -1049,7 +1049,8 @@ def convert_to_np_array(value, dimension=None):
             except RuntimeError as e:
 
                 # If we get a RuntimeError, it is probably because we are trying to convert a torch tensor.
-                # We can't convert to a numpy array without breaking autograd, so we need to return the original value
+                # We can't convert to a numpy array without breaking pytorch autograd, so we need to return the
+                # original value
                 if "call numpy() on Tensor" in str(e) and torch:
                     return value
                 else:

--- a/psyneulink/library/compositions/gymforagercfa.py
+++ b/psyneulink/library/compositions/gymforagercfa.py
@@ -177,7 +177,8 @@ class GymForagerCFA(RegressionCFA):
 
         .. note::
             If this method is assigned as the `objective_funtion of a `GradientOptimization` `Function`,
-            it is differentiated using `autograd <https://github.com/HIPS/autograd>`_\\.grad().
+            it is differentiated using
+            `PyTorch autograd's <https://pytorch.org/docs/stable/generated/torch.func.grad.html>`_ `grad <torch.func.grad>`.
         """
         predicted_outcome=0
 

--- a/psyneulink/library/compositions/regressioncfa.py
+++ b/psyneulink/library/compositions/regressioncfa.py
@@ -633,23 +633,23 @@ class RegressionCFA(CompositionFunctionApproximator):
             computed_terms[PV.F] = f = self.terms[PV.F.value]
 
             # Compute value of each control_signal from its variable
-            c = [None] * len(control_allocation)
+            c = np.zeros((len(control_allocation), ))
             for i, var in enumerate(control_allocation):
                 c[i] = self.control_signal_functions[i](var, context=context)
-            computed_terms[PV.C] = c = np.array(c)
+            computed_terms[PV.C] = c
 
             # Compute costs for new control_signal values
             if PV.COST in terms:
                 # computed_terms[PV.COST] = -(np.exp(0.25*c-3))
                 # computed_terms[PV.COST] = -(np.exp(0.25*c-3) + (np.exp(0.25*np.abs(c-self.control_signal_change)-3)))
-                costs = [None] * len(c)
+                costs = np.zeros((len(control_allocation),))
                 for i, val in enumerate(c):
                     # MODIFIED 11/9/18 OLD:
                     costs[i] = -(self._compute_costs[i](val, context=context))
                     # # MODIFIED 11/9/18 NEW: [JDC]
                     # costs[i] = -(self._compute_costs[i](val, ref_variables[i]))
                     # MODIFIED 11/9/18 END
-                computed_terms[PV.COST] = np.array(costs)
+                computed_terms[PV.COST] = costs
 
             # Compute terms interaction that are used
             if any(term in terms for term in [PV.FF, PV.FFC, PV.FFCC]):

--- a/psyneulink/library/compositions/regressioncfa.py
+++ b/psyneulink/library/compositions/regressioncfa.py
@@ -346,7 +346,9 @@ class RegressionCFA(CompositionFunctionApproximator):
 
         .. note::
             If this method is assigned as the `objective_funtion of a `GradientOptimization` `Function`,
-            it is differentiated using `autograd <https://github.com/HIPS/autograd>`_\\.grad().
+            it is differentiated using
+            `PyTorch autograd's <https://pytorch.org/docs/stable/generated/torch.func.grad.html>`_
+            `grad <torch.func.grad>`.
         """
 
         predicted_outcome=0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-autograd<1.7
 beartype<0.18.0
 dill<0.3.9
 fastkde>=1.0.24, <1.0.31

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -1858,7 +1858,7 @@ class TestControlMechanisms:
                           control_signals=[(pnl.SLOPE, m1), (pnl.SLOPE, m2)])
 
         import torch
-        if 'grad' in dir(torch.func):
+        if 'func' in dir(torch):
             lvoc = pnl.OptimizationControlMechanism(**ocm_kwargs)
 
             c.add_node(lvoc)

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -1853,14 +1853,13 @@ class TestControlMechanisms:
         c.add_node(m2, required_roles=pnl.NodeRole.INPUT)
         c._analyze_graph()
 
-
         ocm_kwargs = dict(agent_rep=pnl.RegressionCFA,
-                                                state_features=[m1.input_ports[0], m1.input_ports[1], m2.input_port, m2],
-                                                state_feature_function=pnl.LinearCombination(offset=10.0),
-                                                objective_mechanism=pnl.ObjectiveMechanism(
-                                                    monitor=[m1, m2]),
-                                                function=pnl.GradientOptimization(max_iterations=1),
-                                                control_signals=[(pnl.SLOPE, m1), (pnl.SLOPE, m2)])
+                          state_features=[m1.input_ports[0], m1.input_ports[1], m2.input_port, m2],
+                          state_feature_function=pnl.LinearCombination(offset=10.0),
+                          objective_mechanism=pnl.ObjectiveMechanism(
+                              monitor=[m1, m2]),
+                          function=pnl.GradientOptimization(max_iterations=1),
+                          control_signals=[(pnl.SLOPE, m1), (pnl.SLOPE, m2)])
 
         try:
             from torch.func import grad

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -1842,6 +1842,13 @@ class TestControlMechanisms:
 
     @pytest.mark.pytorch
     def test_lvoc_features_function(self):
+
+        # Skip if pytorch is not available. For some reason the pytest.mark.pytorch is not working as expected for this
+        # test, so we are checking for the availability of torch here and skipping the test if it is not available.
+        from psyneulink import torch_available
+        if not torch_available:
+            pytest.skip("Pytorch is not installed")
+
         m1 = pnl.TransferMechanism(input_ports=["InputPort A", "InputPort B"])
         m2 = pnl.TransferMechanism()
         c = pnl.Composition()

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -1840,6 +1840,7 @@ class TestControlMechanisms:
 
         assert len(lvoc.input_ports) == 5
 
+    @pytest.mark.pytorch
     def test_lvoc_features_function(self):
         m1 = pnl.TransferMechanism(input_ports=["InputPort A", "InputPort B"])
         m2 = pnl.TransferMechanism()

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -1869,7 +1869,7 @@ class TestControlMechanisms:
         # torch.func.grad.
         except ImportError:
             with pytest.raises(ValueError):
-                lvoc = pnl.OptimizationControlMechanism(**ocm_kwargs)
+                pnl.OptimizationControlMechanism(**ocm_kwargs)
 
             return
 


### PR DESCRIPTION
The replaces autograd with PyTorch `torch.func.grad` in GradientOptimization. It also removes references to it in a few other places. There is currently only one test that exercises autograd and this seems to pass using PyTorch. 