### PR TITLE
llvm: AutoassociativeProjection is a PNL param of the Mechanism

### DIFF
--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -13052,12 +13052,21 @@ _
 
     @property
     def _inner_projections(self):
-        # PNL considers afferent projections to input_CIM to be part
-        # of the nested composition. Filter them out.
+        # Filter out projections not used in compiled variant of this composition:
+        # * afferent projections to input_CIM and parameter_CIM.
+        #   These are included in node wrapper of the nested composition node,
+        #   and included in outer composition
+        # * efferent projections from output_CIM.
+        #   Same as above, they are considered part of the outer composition,
+        #   and are executed in node wrappers of the receiving nodes
+        # * Autoassociative projections (RTM, LCA)
+        #   These are executed as part of their respective mechanism and are
+        #   included in the compiled structures of their respective mechanisms.
         return (p for p in self.projections
-                  if p.receiver.owner is not self.input_CIM and
-                     p.receiver.owner is not self.parameter_CIM and
-                     p.sender.owner is not self.output_CIM)
+                if p.receiver.owner is not self.input_CIM and
+                   p.receiver.owner is not self.parameter_CIM and
+                   p.sender.owner is not self.output_CIM and
+                   p.sender.owner is not p.receiver.owner)
 
     def _get_param_ids(self):
         return ["nodes", "projections"] + super()._get_param_ids()

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -169,8 +169,7 @@ class Execution:
                 # "old_val" is a helper storage in compiled RecurrentTransferMechanism
                 # to workaround the fact that compiled projections do no pull values
                 # from their source output ports
-                # recurrent projection of RTM is not a PNL parameter.
-                if attribute in {"old_val", "recurrent_projection"}:
+                if attribute == "old_val":
                     continue
 
                 # Handle PNL parameters


### PR DESCRIPTION
Remove explicit inclusion of the recurrent projection in the compiled structures.
Filter out Autoassociative projections from the list of composition projections.