### PR TITLE
ci: split windows x86 job

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -68,9 +68,21 @@ jobs:
             extra-args: '--forked -m "not llvm"'
 
           # add 32-bit build on windows
+          # split by marks to reduce peak memory
           - python-version: '3.8'
             python-architecture: 'x86'
             os: windows
+            extra-args: '-m llvm'
+
+          - python-version: '3.8'
+            python-architecture: 'x86'
+            os: windows
+            extra-args: '-m "not llvm and composition"'
+
+          - python-version: '3.8'
+            python-architecture: 'x86'
+            os: windows
+            extra-args: '-m "not llvm and not composition"'
 
           # fp32 run on linux python 3.10
           - python-version: '3.10'
@@ -181,10 +193,16 @@ jobs:
       timeout-minutes: 180
       run: pytest --junit-xml=tests_out.xml --verbosity=0 -n logical ${{ matrix.extra-args }}
 
+    # double quotes are disallowed in artifact names
+    - name: Get valid filename string from extra-args
+      id: extra_args_fname
+      run: echo extra_args="$(echo ${{ matrix.extra-args }} | tr -d '\"')" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:
-        name: test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}-${{ matrix.version-restrict }}
+        name: test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}-${{ matrix.version-restrict }}-${{ steps.extra_args_fname.outputs.extra_args }}
         path: tests_out.xml
         retention-days: 5
       if: (success() || failure()) && ! contains(matrix.extra-args, 'forked')
@@ -214,3 +232,4 @@ jobs:
         name: dist-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}
         path: dist/
         retention-days: 2
+        overwrite: true


### PR DESCRIPTION
Windows x86 ci runs can fail because the container runs out of memory
during testing. This is caused by memory leaks in psyneulink and limited
available memory on the containers. As a workaround, running the full
set of tests over multiple jobs reduces peak memory usage.

Three jobs replace the original Windows x86 build, running pytest with:
1. -m llvm
2. -m "not llvm and composition"
3. -m "not llvm and not composition"

Jobs with the same OS, python version, and architecture overwrite
uploaded dist packages.
