### PR TITLE
llvm, node_wrapper: Allow modulatory projections for "is_finished" wrapper

### DIFF
--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -633,12 +633,10 @@ def gen_node_wrapper(ctx, composition, node, *, tags:frozenset):
         # and the entire call should be optimized out.
         node_in = builder.alloca(node_function.args[2].type.pointee,
                                  name="mechanism_node_input")
-        incoming_projections = node.mod_afferents if "reset" in tags else node.afferents
-
-    # Checking if node is finished doesn't need projections
-    # FIXME: Can the values used in the check be modulated?
-    if "is_finished" in tags:
-        incoming_projections = []
+        if {"reset", "is_finished"}.intersection(tags):
+            incoming_projections = node.mod_afferents
+        else:
+            incoming_projections = node.afferents
 
     if "reset" in tags:
         proj_func_tags = func_tags.difference({"reset"}).union({"passthrough"})

--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -710,10 +710,10 @@ def test_DDM_threshold_modulation_integrator(comp_mode):
 
 @pytest.mark.composition
 @pytest.mark.parametrize(["noise", "threshold", "expected_results"],[
-                            (1.0, 0.0, (0.0, 1.0)),
-                            (1.5, 2, (-2.0, 1.0)),
-                            (10.0, 10.0, (10.0, 29.0)),
-                            (100.0, 100.0, (100.0, 76.0)),
+                            (1.0, 0.0, [[0.0], [1.0]]),
+                            (1.5, 2, [[-2.0], [1.0]]),
+                            (10.0, 10.0, [[10.0], [29.0]]),
+                            (100.0, 100.0, [[100.0], [76.0]]),
                         ])
 def test_ddm_is_finished(comp_mode, noise, threshold, expected_results):
 
@@ -732,8 +732,7 @@ def test_ddm_is_finished(comp_mode, noise, threshold, expected_results):
 
     results = comp.run([0], execution_mode=comp_mode)
 
-    results = [x for x in np.array(results).flatten()] #HACK: The result is an object dtype in Python comp_mode for some reason?
-    np.testing.assert_allclose(results, np.array(expected_results).flatten())
+    np.testing.assert_array_equal(results, expected_results)
 
 
 def test_sequence_of_DDM_mechs_in_Composition_Pathway():


### PR DESCRIPTION
Otherwise the evaluation of "is_finished" is different in the mechanism
execution, and evaluation of scheduling conditions.

Closes: https://github.com/PrincetonUniversity/PsyNeuLink/issues/2931

Signed-off-by: Jan Vesely <jan.vesely@rutgers.edu>