### PR TITLE
ci/ga: Use native python version on macos-arm64 runners

### DIFF
--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -17,7 +17,12 @@ concurrency:
 
 jobs:
   docs-build:
-    runs-on: ${{ matrix.os }}
+    # Python 3.7 x64 on macos-14 (arm64) images is broken [0]
+    # and arm64 version is not available [1].
+    # Restrict python 3.7 macos runs to macos-13
+    # [0] https://github.com/actions/setup-python/issues/855
+    # [1] https://github.com/actions/setup-python/issues/856
+    runs-on: ${{ (matrix.os == 'macos-latest' && matrix.python-version == '3.7') && 'macos-13' || matrix.os }}
     strategy:
       fail-fast: false
       # Matrix setup is a hacky way to include 'base' build in pull requests
@@ -25,7 +30,6 @@ jobs:
       # on event name and final configuration (ubuntu, python3.11).
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        python-architecture: ['x64']
         os: [ubuntu-latest, macos-latest, windows-latest]
         event:
           - ${{ github.event_name }}
@@ -81,7 +85,6 @@ jobs:
         # Block python3.7.17 on macos. see:
         # https://github.com/actions/setup-python/issues/682
         python-version: ${{ (matrix.os == 'macos-latest' && matrix.python-version == '3.7') && '3.7.16' || matrix.python-version }}
-        architecture: ${{ matrix.python-architecture }}
 
     - name: Get pip cache location
       shell: bash
@@ -95,8 +98,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.pip_cache.outputs.pip_cache_dir }}/wheels
-        key: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-${{ hashFiles('requirements.txt', 'doc_requirements.txt') }}-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-${{ hashFiles('requirements.txt', 'doc_requirements.txt') }}
+        key: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-wheels-${{ hashFiles('requirements.txt', 'doc_requirements.txt') }}-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-wheels-${{ hashFiles('requirements.txt', 'doc_requirements.txt') }}
 
     # We need to install all PNL deps since docs config imports psyneulink module
     - name: Install local, editable PNL package
@@ -126,7 +129,7 @@ jobs:
     - name: Upload Documentation
       uses: actions/upload-artifact@v4
       with:
-        name: Documentation-${{matrix.pnl-version}}-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}
+        name: Documentation-${{matrix.pnl-version}}-${{ matrix.os }}-${{ matrix.python-version }}
         retention-days: 1
         path: docs/build/html
 
@@ -172,7 +175,7 @@ jobs:
     - name: Download branch docs
       uses: actions/download-artifact@v4
       with:
-        name: Documentation-head-${{ matrix.os }}-${{ matrix.python-version }}-x64
+        name: Documentation-head-${{ matrix.os }}-${{ matrix.python-version }}
         path: _built_docs/${{ github.ref }}
       if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/docs'
 
@@ -189,7 +192,7 @@ jobs:
     - name: Download main docs
       uses: actions/download-artifact@v4
       with:
-        name: Documentation-head-${{ matrix.os }}-${{ matrix.python-version }}-x64
+        name: Documentation-head-${{ matrix.os }}-${{ matrix.python-version }}
         # This overwrites files in current directory
       if: startsWith(github.ref, 'refs/tags/') && contains(needs.*.outputs.on_master, 'master')
 

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -107,8 +107,8 @@ jobs:
 
           # add python 3.8 build on macos since 3.7 is broken
           # https://github.com/actions/virtual-environments/issues/4230
+          # use default python-architecture
           - python-version: '3.8'
-            python-architecture: 'x64'
             os: macos
 
         exclude:


### PR DESCRIPTION
macos-latest now uses macos-14 on M1 (arm64) runners.
Use native python-architecture in these jobs.