### PR TITLE
docs: Fix basic rst formatting errors

### DIFF
--- a/docs/source/Cohen_HustonModel.rst
+++ b/docs/source/Cohen_HustonModel.rst
@@ -141,7 +141,7 @@ are turned on again and the system is run either for a certain amount of trials,
 stimulus is turned on.
 
 PLEASE NOTE:
------------
+------------
 Note that this implementation is slightly different than what was originally reported. The integration rate was set to
 0.1 instead of 0.01. Noise was turned of to better understand the core processes, and not having to deal with several
 runs, averaging these runs and plotting standard errors for these averages (which depend on the noise and amount of

--- a/docs/source/ConventionsAndDefinitions.rst
+++ b/docs/source/ConventionsAndDefinitions.rst
@@ -43,7 +43,7 @@ and Compositions (combinations of Components that implement a model).
 .. _Definitions_Components:
 
 `Components <Component>`
-~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Components are objects that perform a specific function. Every Component has a:
 

--- a/docs/source/MontagueModel.rst
+++ b/docs/source/MontagueModel.rst
@@ -1,5 +1,5 @@
 Dopamine and Temporal Differences Learning (Montague, Dayan & Sejnowski, 1996)
-==================================================================
+==============================================================================
 `"A framework for mesencephalic dopamine systems based on predictive Hebbian learning." <http://www.jneurosci.org/content/jneuro/16/5/1936.full.pdf>`_
 
 Overview

--- a/docs/source/NieuwenhuisModel.rst
+++ b/docs/source/NieuwenhuisModel.rst
@@ -65,18 +65,18 @@ associated `ObjectiveMechanism`, as shown in the figure below:
 Behavioral Network Subsystem
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**INPUT LAYER**:  a `TransferMechanism` with **size**=3 (one element for the input to the T1, T2 and distractor units
-of the *DECISION LAYER*, respectively), and assigned a `Linear` function with **slope**=1.0 and **intercept**=0.0.
+**INPUT LAYER**:  a `TransferMechanism` with **size**\ =3 (one element for the input to the T1, T2 and distractor units
+of the *DECISION LAYER*, respectively), and assigned a `Linear` function with **slope**\ =1.0 and **intercept**\ =0.0.
 
-**DECISION LAYER**: an `LCAMechanism` Mechanism of **size**=3 (one element each for the T1, T2 and distractor units),
+**DECISION LAYER**: an `LCAMechanism` Mechanism of **size**\ =3 (one element each for the T1, T2 and distractor units),
 and assigned a `Logistic` Function with a slope=1.0 and intercept=0.0.  Each element has a self-excitatory connection
-with a weight specified by **self_excitation**=2.5, a **leak**=-1.0, and every element is connected to every other
-element by mutually inhibitory connections with a weight specified by **competition**=1.0.  An ordinary differential
+with a weight specified by **self_excitation**\ =2.5, a **leak**\ =-1.0, and every element is connected to every other
+element by mutually inhibitory connections with a weight specified by **competition** =1.0.  An ordinary differential
 equation describes the change in state over time, implemented in the LCAMechanism mechanism by setting
-**integrator_mode**=`True` and **time_step_size**=0.02.
+**integrator_mode** = `True` and **time_step_size**\ =0.02.
 
-**RESPONSE LAYER**: an `LCAMechanism` Mechanism of **size**=2, with one element each for the response to T1 and T2,
-respectively, **self_excitation**=2.0, **leak**=-1.0, and no mutually inhibitory weights (**competition**=0).
+**RESPONSE LAYER**: an `LCAMechanism` Mechanism of **size**\ =2, with one element each for the response to T1 and T2,
+respectively, **self_excitation**\ =2.0, **leak**\ =-1.0, and no mutually inhibitory weights (**competition**\ =0).
 
 **PROJECTIONS**:  The weights of the behavioral network are implemented as `MappingProjections <MappingProjection>`.
 The `matrix <MappingProjection.matrix>` parameter for the one from the *INPUT_LAYER* to the *DECISION_LAYER* uses a

--- a/docs/source/PCTC_model.rst
+++ b/docs/source/PCTC_model.rst
@@ -1,5 +1,5 @@
 Proactive Control & Task Control: A Stroop Model (Kalanthroff et al., 2018)
-================================================================
+===========================================================================
 `"Task Conflict and Proactive Control: A Computational Theory of the Stroop Task" <https://www.ncbi.nlm.nih.gov/m/pubmed/25257710/>`_
 
 Overview

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -113,7 +113,7 @@ with the one exception of `prefs <Component_Prefs>`.
 
   .. note::
      The size attribute serves a role similar to
-     `shape <https://numpy.org/doc/stable/reference/generated/numpy.shape.html> in Numpy`_, with the difference that
+     `shape in Numpy <https://numpy.org/doc/stable/reference/generated/numpy.shape.html>`_, with the difference that
      size permits the specification of `ragged arrays <https://en.wikipedia.org/wiki/Jagged_array>`_ -- that is, ones
      that have elements of varying lengths, such as [[1,2],[3,4,5]].
 

--- a/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
@@ -839,7 +839,7 @@ class OptimizationFunction(Function_Base):
         return outcomes, num_evals
 
     def reset_grid(self):
-        """Reset iterators in `search_space <GridSearch.search_space>"""
+        """Reset iterators in `search_space <GridSearch.search_space>`"""
         for s in self.search_space:
             s.reset()
         self.grid = itertools.product(*[s for s in self.search_space])
@@ -1680,7 +1680,7 @@ class GridSearch(OptimizationFunction):
 
     @handle_external_context(fallback_most_recent=True)
     def reset(self, search_space, context=None, **kwargs):
-        """Assign size of `search_space <GridSearch.search_space>"""
+        """Assign size of `search_space <GridSearch.search_space>`"""
         super(GridSearch, self).reset(search_space=search_space, context=context, **kwargs)
         sample_iterators = search_space
         owner_str = ''

--- a/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
@@ -173,7 +173,7 @@ class OptimizationFunction(Function_Base):
          `GradientOptimization`) so that subclasses can be used interchangeably by OptimizationControlMechanism.
 
        - Subclasses with attributes that depend on one of the OptimizationFunction's parameters should implement the
-         `reset <OptimizationFunction.reset>` method, that calls super().reset(*args) and then
+         `reset <OptimizationFunction.reset>` method, that calls ``super().reset(*args)`` and then
          reassigns the values of the dependent attributes accordingly.  If an argument is not needed for the subclass,
          `NotImplemented` should be passed as the argument's value in the call to super (i.e.,
          the OptimizationFunction's

--- a/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
@@ -168,7 +168,7 @@ class OptimizationFunction(Function_Base):
         relevant argument(s) as `NotImplemented`.
 
     .. technical_note::
-       - Constructors of subclasses should include **kwargs in their constructor method, to accommodate arguments
+       - Constructors of subclasses should include ``**kwargs`` in their constructor method, to accommodate arguments
          required by some subclasses but not others (e.g., search_space needed by `GridSearch` but not
          `GradientOptimization`) so that subclasses can be used interchangeably by OptimizationControlMechanism.
 
@@ -907,7 +907,7 @@ class GradientOptimization(OptimizationFunction):
 
     Sample variable by following gradient with respect to the value of `objective_function
     <GradientOptimization.objective_function>` it generates, and return the sample that generates either the
-    highest (**direction=*ASCENT*) or lowest (**direction=*DESCENT*) value.
+    highest (**direction** = *ASCENT*) or lowest (**direction** = *DESCENT*) value.
 
     .. _GradientOptimization_Procedure:
 

--- a/psyneulink/core/components/functions/stateful/integratorfunctions.py
+++ b/psyneulink/core/components/functions/stateful/integratorfunctions.py
@@ -3913,7 +3913,7 @@ class FitzHughNagumoIntegrator(IntegratorFunction):  # -------------------------
     .. _FitzHughNagumoIntegrator:
 
     `function <FitzHughNagumoIntegrator._function>` returns one time step of integration of the `Fitzhugh-Nagumo model
-    https://en.wikipedia.org/wiki/FitzHugh–Nagumo_model>`_ of an excitable oscillator:
+    <https://en.wikipedia.org/wiki/FitzHugh–Nagumo_model>`_ of an excitable oscillator:
 
     .. math::
             time\\_constant_v \\frac{dv}{dt} = a_v * v^3 + (1 + threshold) * b_v * v^2 + (- threshold) * c_v * v^2 +

--- a/psyneulink/core/components/functions/stateful/integratorfunctions.py
+++ b/psyneulink/core/components/functions/stateful/integratorfunctions.py
@@ -4059,7 +4059,7 @@ class FitzHughNagumoIntegrator(IntegratorFunction):  # -------------------------
             +---------------------------------------+------------------------------------------------+----------------------------------------------+------------------------------------+---------------------------------------------------------------+
             |**FitzHughNagumoIntegrator Parameter** |`threshold <FitzHughNagumoIntegrator.threshold>`|`variable <FitzHughNagumoIntegrator.variable>`|`f_v <FitzHughNagumoIntegrator.f_v>`|`time_constant_v <FitzHughNagumoIntegrator.time_constant_v>`   |
             +---------------------------------------+------------------------------------------------+----------------------------------------------+-------------------------+--------------------------------------------------------------------------+
-            |**Gilzenrat Parameter**                |a                                               |:math:`f(X_1)`                                |:math:`w_{vX_1}`                    |:math:`T_{v}`                                                  |
+            |**Gilzenrat Parameter**                |a                                               | :math:`f(X_1)`                               | :math:`w_{vX_1}`                   | :math:`T_{v}`                                                 |
             +---------------------------------------+------------------------------------------------+----------------------------------------------+------------------------------------+---------------------------------------------------------------+
 
             The following FitzHughNagumoIntegrator parameter values must be set in the equation for :math:`\\frac{dw}{dt}`:

--- a/psyneulink/core/components/functions/stateful/memoryfunctions.py
+++ b/psyneulink/core/components/functions/stateful/memoryfunctions.py
@@ -661,7 +661,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
 
     Since `memory <ContentAddressableMemory.memory>` was not intialized, the first call to the Function returns an
     array of zeros, formatted as specified in **defaul_variable**.  However, the input in the call to the Function
-    (``[[1,2]]``) is stored as an entry in `memory <EpisodicMemoryMechanism.memory>`::
+    (``[[1,2]]``) is stored as an entry in `memory <EpisodicMemoryMechanism.memory>`:
 
         >>> c.memory
         array([[[1., 2.]]])
@@ -833,7 +833,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
     noise : float, list, 2d array, or Function : default 0.0
         specifies random value(s) added to `variable <ContentAddressableMemory.variable>` before storing in
         `memory <ContentAddressableMemory.memory>`;  if a list or 2d array, it must be the same shape as `variable
-         ContentAddressableMemory.variable>` (see `noise <ContentAddressableMemory.noise>` for details).
+        ContentAddressableMemory.variable>` (see `noise <ContentAddressableMemory.noise>` for details).
 
     initializer : 3d array or list : default None
         specifies an initial set of entries for `memory <ContentAddressableMemory.memory>` (see
@@ -1028,8 +1028,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
     Returns
     -------
 
-    entry from `memory <ContentAddressableMemory.memory>` that best matches `variable
-    <ContentAddressableMemory.variable>` : 2d array
+    entry from `memory <ContentAddressableMemory.memory>` that best matches `variable <ContentAddressableMemory.variable>` : 2d array
         if no retrieval occurs, an appropriately shaped zero-valued array is returned.
 
     """
@@ -1993,7 +1992,7 @@ class DictionaryMemory(MemoryFunction):  # -------------------------------------
     .. math::
         variable[1] * rate + noise
 
-    If the number of entries exceeds `max_entries <DictionaryMemory.max_entries>, the first (oldest) item in
+    If the number of entries exceeds `max_entries <DictionaryMemory.max_entries>`, the first (oldest) item in
     memory is deleted.
 
     Arguments
@@ -2012,11 +2011,11 @@ class DictionaryMemory(MemoryFunction):  # -------------------------------------
 
     rate : float, list, or array : default 1.0
         specifies a value used to multiply key (first item of `variable <DictionaryMemory.variable>`) before
-        storing in `memory <DictionaryMemory.memory>` (see `rate <DictionaryMemory.noise> for details).
+        storing in `memory <DictionaryMemory.memory>` (see `rate <DictionaryMemory.rate>` for details).
 
     noise : float, list, array, or Function : default 0.0
         specifies a random value added to key (first item of `variable <DictionaryMemory.variable>`) before
-        storing in `memory <DictionaryMemory.memory>` (see `noise <DictionaryMemory.noise> for details).
+        storing in `memory <DictionaryMemory.memory>` (see `noise <DictionaryMemory.noise>` for details).
 
     initializer : 3d array or list : default None
         specifies an initial set of entries for `memory <DictionaryMemory.memory>`. It must be of the following

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -988,7 +988,7 @@ or its `name <Port_Base.name>` as the key, and a dictionary containing parameter
        Projections will not be executed (see `Lazy Evaluation <Component_Lazy_Updating>`), but its `function
        <Port_Base.function>` will be.
 
-     - If the `value <Port_Base.value>` of a Port is specified, *neither its `afferent Projections <Port_Projections>`
+     - If the `value <Port_Base.value>` of a Port is specified, *neither* its `afferent Projections <Port_Projections>`
        nor it `function <Port_Base.function>` will be executed.
 
      - If the `variable <Port_base.variable>` and/or `value <Port_Base.value>` is specified for *all* of the

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -258,7 +258,7 @@ COMMENT
    <Component>`, that can be created using a constructor; a *function* is an attribute that contains a callable method
    belonging to a Function, and that is executed when the Component to which the Function belongs is executed.
    Functions are used to assign, store, and apply parameter values associated with their function (see `Function
-   <Function_Overview> for a more detailed explanation).
+   <Function_Overview>` for a more detailed explanation).
 
 The parameters of a Mechanism's `function <Mechanism_Base.function>` are attributes of its `function
 <Component.function>`, and can be accessed using standard "dot" notation for that object.  For
@@ -993,7 +993,7 @@ or its `name <Port_Base.name>` as the key, and a dictionary containing parameter
 
      - If the `variable <Port_base.variable>` and/or `value <Port_Base.value>` is specified for *all* of the
        OutputPorts of a Mechanism, then it's function will not be executed, and the `value <Mechanism_Base.value>`
-       will retain its previous value (again in accord with `Lazy Evaluation <Component_Lazy_Updating>), though its
+       will retain its previous value (again in accord with `Lazy Evaluation <Component_Lazy_Updating>`), though its
        OutputPorts *will* be executed using the assigned values, and it's `execution_count <Component_Execution_Count>`
        and `num_executions <Component_Num_Executions>` attributes will be incremented (since the OutputPorts --
        Components of the Mechanism -- executed).
@@ -1012,7 +1012,7 @@ key for each type of projecction is its `componentType <Component_Type>` appende
 *MAPPING_PROJECTION_PARAMS*, *CONTROL_PROJECTION_PARAMS*, etc.).  The sub-dictionary can contain specifications that
 apply to *all* Projections of that type and/or individual Projections. If the key of an entryis the name of a parameter
 of the Projection (or its `function <Port_Base.function>`), the specified value applies to *all* Projections of that
-type. Parameters for individual Projections are specified using the Projections or its `name <Projection_Base.name>
+type. Parameters for individual Projections are specified using the Projections or its `name <Projection_Base.name>`
 as the key, and a dictionary containing parameter specifications as its value.
 
    .. note::
@@ -2358,7 +2358,7 @@ class Mechanism_Base(Mechanism):
         .. technical_note::
             Execution sequence:
 
-            * Handle initialization if `initialization_status <Compoonent.initialization_status> is
+            * Handle initialization if `initialization_status <Compoonent.initialization_status>` is
               *ContextFlags.INITIALIZING*
             * Assign any `Port-specific runtime params <_Mechanism_Runtime_Port_and_Projection_Param_Specification>`
               to corresponding `runtime_params <Mechanism_Base.runtime_params>` dict.

--- a/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/gating/gatingmechanism.py
@@ -240,7 +240,7 @@ class GatingMechanism(ControlMechanism):
         modulation=MULTIPLICATIVE)
 
     Subclass of `ModulatoryMechanism <ModulatoryMechanism>` that gates (modulates) the value(s) of one or more `Ports
-    <Port>`.  See `Mechanism <Mechanism_Class_Reference>` for additional arguments and attributes.
+    <Port>`. See `Mechanism <Mechanism_Class_Reference>` for additional arguments and attributes.
 
     COMMENT:
         Description:
@@ -284,7 +284,7 @@ class GatingMechanism(ControlMechanism):
         specifies the `InputPorts <InputPort>` and/or `OutputPorts <OutputPorts>` to be gated by the
         GatingMechanism; the number of items must equal the length of the **default_gating_allocation**
         argument; if a `Mechanism <Mechanism>` is specified, its `primary InputPort <InputPort_Primary>`
-        is used (see `GatingMechanism_GatingSignals for details).
+        is used (see `GatingMechanism_GatingSignals` for details).
 
     modulation : str : MULTIPLICATIVE
         specifies the default form of modulation used by the GatingMechanism's `GatingSignals <GatingSignal>`,

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -3703,7 +3703,7 @@ class OptimizationControlMechanism(ControlMechanism):
 
     @property
     def state_feature_sources(self):
-        """Dict with {InputPort: source} for all INPUT Nodes of agent_rep, and sources in **state_feature_specs.
+        """Dict with {InputPort: source} for all INPUT Nodes of agent_rep, and sources in **state_feature_specs**.
         Used by state_distal_sources_and_destinations_dict()
         """
         state_dict = {}

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1940,7 +1940,7 @@ class OptimizationControlMechanism(ControlMechanism):
     def _instantiate_input_ports(self, context=None):
         """Instantiate InputPorts for state_features (with state_feature_function if specified).
 
-        This instantiates the OptimizationControlMechanism's `state_input_ports;
+        This instantiates the OptimizationControlMechanism's `state_input_ports`;
              these are used to provide input to the agent_rep when its evaluate method is called
         The OptimizationControlMechanism's outcome_input_ports are instantiated by
             ControlMechanism._instantiate_input_ports in the call to super().

--- a/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
@@ -843,7 +843,7 @@ class LearningMechanism(ModulatoryMechanism_Base):
         the values of the InputPorts to which the `covariates_sources <LearningMechanism.covariates_sources>` project;
         passed to the LearningMechanism's `function <LearningMechanism.function>` as the *COVARIATES* item of its
         `variable <LearningMechanism.variable>`, and assigned as the `value <InputPort.value>` of the LearningMechanism's
-        *COVARIATES* `InputPort <LearningMechanism_Covariates>`s.
+        *COVARIATES* `InputPorts <LearningMechanism_Covariates>`.
 
     error_sources : list[ComparatorMechanism or LearningMechanism]
         the Mechanism(s) that calculate the error signal(s) provided to the

--- a/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/controlsignal.py
@@ -21,7 +21,7 @@ Contents:
       - `ControlSignal_Modulation`
       - `ControlSignal_Allocation_and_Intensity`
       - `ControlSignal_Costs`
-  * `ControlSignal_Execution`d
+  * `ControlSignal_Execution`
   * `ControlSignal_Examples`
   * `ControlSignal_Class_Reference`
 

--- a/psyneulink/core/components/ports/modulatorysignals/learningsignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/learningsignal.py
@@ -44,7 +44,7 @@ the MappingProjection(s) being learned.
 .. _LearningSignal_Creation:
 
 Creating a LearningSignal
-------------------------
+-------------------------
 
 A LearningSignal is created automatically whenever a `MappingProjection` is `specified for learning
 <LearningMechanism_Creation>` and the Projection belongs to the same `Composition <Composition>` as the

--- a/psyneulink/core/components/ports/modulatorysignals/modulatorysignal.py
+++ b/psyneulink/core/components/ports/modulatorysignals/modulatorysignal.py
@@ -36,8 +36,8 @@ A ModulatorySignal is a subclas of `OutputPort` that belongs to a `ModulatoryMec
 used to `modulate <ModulatorySignal_Modulation>` the `value <Port_Base.value>` of one or more `Ports <Port>` by way of
 one or more `ModulatoryProjctions <ModulatoryProjection>`. A ModulatorySignal modulates the value of a Port by modifying
 a  parameter of that Port's `function <Port_Base.function>`.  There are three types of ModulatorySignals, each of which
-is  associated wth a particular type of `ModulatoryMechanism <ModulatoryMechanism>` and `ModulatoryProjection
-<ModulatoryProjection>`, and modifies the value of different types of Ports, as summarized `below:
+is associated with a particular type of `ModulatoryMechanism <ModulatoryMechanism>` and `ModulatoryProjection
+<ModulatoryProjection>`, and modifies the value of different types of Ports, as summarized below:
 
 * `ControlSignal`
     takes the `allocation <ControlSignal.allocation>` assigned to it by the `function <ControlMechanism.function>`
@@ -47,8 +47,8 @@ is  associated wth a particular type of `ModulatoryMechanism <ModulatoryMechanis
     Mechanism's `InputPorts <InputPort>` or `OutputPorts <OutputPort>` (and thereby the `value <Port_Base.value>`
     of the corresponding Port).
 ..
-* `GatingSignal` takes the `allocation <GatingSignal.allocation>` assigned to it by the `function
-    <GatingMechanism.function>` of the `GatingMechanism` to which it belongs, and uses it to modulate the parameter
+* `GatingSignal` takes the `allocation <GatingSignal.allocation>` assigned to it by the
+    `function <GatingMechanism.function>` of the `GatingMechanism` to which it belongs, and uses it to modulate the parameter
     of the `function <Port_Base.function>` of an `InputPort` or `OutputPort` (and hence that Port's `value
     <Port_Base.value>`).  A GatingMechanism and GatingSignal can be thought of as implementing a form of control
     specialized for gating the input to and/or output of a Mechanism.

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -57,7 +57,7 @@ of a `MappingProjection` to the next Mechanism in the pathway, or to the Process
 if the Mechanism is a `TERMINAL` Mechanism for that Process. Other configurations can also easily be specified using
 a Mechanism's **output_ports** argument (see `OutputPort_Specification` below).  If it is created using its
 constructor, and a Mechanism is specified in the **owner** argument, it is automatically assigned to that Mechanism.
-If its **owner* is not specified, `initialization is deferred.
+If its **owner** is not specified, `initialization is deferred.
 
 .. _OutputPort_Deferred_Initialization:
 

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -57,7 +57,7 @@ of a `MappingProjection` to the next Mechanism in the pathway, or to the Process
 if the Mechanism is a `TERMINAL` Mechanism for that Process. Other configurations can also easily be specified using
 a Mechanism's **output_ports** argument (see `OutputPort_Specification` below).  If it is created using its
 constructor, and a Mechanism is specified in the **owner** argument, it is automatically assigned to that Mechanism.
-If its **owner** is not specified, `initialization is deferred.
+If its **owner** is not specified, `initialization` is deferred.
 
 .. _OutputPort_Deferred_Initialization:
 
@@ -1519,7 +1519,7 @@ class StandardOutputPorts():
               ignoring any VARIABLE entries previously specified for individual OutputPorts;
 
             * list of ints -- assigns each int to an (OWNER_VALUE, int) entry of the corresponding OutputPort in
-              `output_port_dicts, ignoring any VARIABLE entries previously specified for individual OutputPorts;
+              `output_port_dicts`, ignoring any VARIABLE entries previously specified for individual OutputPorts;
 
             * None -- assigns `None` to VARIABLE entries for all OutputPorts for which it is not already specified.
 

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -920,7 +920,7 @@ class Port_Base(Port):
     efferents : Optional[List[Projection]]
         list of outgoing Projections from the Port (i.e., for which is a `sender <Projection_Base.sender>`;
         note:  only `OutputPorts <OutputPort>`, and members of its `ModulatoryProjection <ModulatoryProjection>`
-        subclass (`LearningProjection, ControlProjection and GatingProjection) have efferents;  the list is empty for
+        subclass (`LearningProjection`, `ControlProjection` and `GatingProjection`) have efferents;  the list is empty for
         InputPorts and ParameterPorts.
 
     function : TransferFunction : default determined by type

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -329,9 +329,9 @@ type of Port, listed below (and shown in the `table <Port_Projections_Table>`):
    ============================================ ============================================================
    *Attribute*                                  *Projection Type and Port(s)*
    ============================================ ============================================================
-   `path_afferents <Port_Base.path_afferents>` `MappingProjections <MappingProjection>` to `InputPort`
-   `mod_afferents <Port_Base.mod_afferents>`   `ModulatoryProjections <ModulatoryProjection>` to any Port
-   `efferents <Port_Base.efferents>`           `MappingProjections <MappingProjection>` from `OutputPort`
+   `path_afferents <Port_Base.path_afferents>`  `MappingProjections <MappingProjection>` to `InputPort`
+   `mod_afferents <Port_Base.mod_afferents>`    `ModulatoryProjections <ModulatoryProjection>` to any Port
+   `efferents <Port_Base.efferents>`            `MappingProjections <MappingProjection>` from `OutputPort`
    ============================================ ============================================================
 
 In addition to these attributes, all of the Projections sent and received by a Port are listed in its `projections

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -8214,7 +8214,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                            learning_update: Union[bool, Literal['online', 'after']] = 'online',
                                            default_projection_matrix=None,
                                            name: Optional[str] = None):
-        """Convenience method that calls `add_linear_learning_pathway` with **learning_function**=`Reinforcement`
+        """Convenience method that calls `add_linear_learning_pathway` with **learning_function** = `Reinforcement`
 
         Arguments
         ---------
@@ -8271,7 +8271,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                 learning_update: Union[bool, Literal['online', 'after']] = 'online',
                                 default_projection_matrix=None,
                                 name: Optional[str] = None):
-        """Convenience method that calls `add_linear_learning_pathway` with **learning_function**=`TDLearning`
+        """Convenience method that calls `add_linear_learning_pathway` with **learning_function** = `TDLearning`
 
         Arguments
         ---------
@@ -8327,7 +8327,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                              learning_update: Optional[Union[bool, Literal['online', 'after']]] = 'after',
                                              default_projection_matrix=None,
                                              name: str = None):
-        """Convenience method that calls `add_linear_learning_pathway` with **learning_function**=`Backpropagation`
+        """Convenience method that calls `add_linear_learning_pathway` with **learning_function** = `Backpropagation`
 
         Arguments
         ---------
@@ -12525,7 +12525,7 @@ _
             if True, shows labels instead of values for Mechanisms that have an `input_label_dict
             <Mechanism_Base.input_labels_dict>`.  For **num_trials** = 1, a representative label is
             shown; for **num_trials** > 1, a different label is used for each trial shown, cycling
-            through the set if **num_trials** is greater than the number of labels.  If **num_trials = *FULL*,
+            through the set if **num_trials** is greater than the number of labels.  If **num_trials** = *FULL*,
             trials will be included.
 
             it is set to the number of labels in the largest list specified in any `input_label_dict

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -1098,19 +1098,19 @@ that execution only.
 .. table::
    :widths: 5 34 33 33
 
-   +--------------------+------------------------------------+--------------------------------------------------------+
-   |                    |**Composition**                     |**AutodiffComposition**                                 |
-   +--------------------+------------------------------------+--------------------------+-----------------------------+
-   |                    |*Python*                            |`AutodiffComposition_LLVM`|`AutodiffComposition_PyTorch`|
-   |                    |                                    |(*Direct Compilation*)    |                             |
-   +====================+====================================+==========================+=============================+
-   |execution_mode=     |`ExecutionMode.Python`              |`ExecutionMode.LLVMRun`   |`ExecutionMode.PyTorch       |
-   +--------------------+------------------------------------+--------------------------+-----------------------------+
-   |`learn()            |                                    |                          |                             |
-   |<Composition.learn>`|Python interpreted                  |LLVM compiled             |PyTorch compiled             |
-   |                    |                                    |                          |                             |
-   |`run()              |                                    |                          |                             |
-   |<Composition.run>`  |Python interpreted                  |LLVM compiled             |Python interpreted           |
+   +--------------------+------------------------------------+---------------------------------------------------------+
+   |                    |**Composition**                     |**AutodiffComposition**                                  |
+   +--------------------+------------------------------------+--------------------------+------------------------------+
+   |                    |*Python*                            |`AutodiffComposition_LLVM`|`AutodiffComposition_PyTorch` |
+   |                    |                                    |(*Direct Compilation*)    |                              |
+   +====================+====================================+==========================+==============================+
+   |execution_mode=     |`ExecutionMode.Python`              |`ExecutionMode.LLVMRun`   |`ExecutionMode.PyTorch        |
+   +--------------------+------------------------------------+--------------------------+------------------------------+
+   |`learn()            |                                    |                          |                              |
+   |<Composition.learn>`|Python interpreted                  |LLVM compiled             |PyTorch compiled              |
+   |                    |                                    |                          |                              |
+   |`run()              |                                    |                          |                              |
+   |<Composition.run>`  |Python interpreted                  |LLVM compiled             |Python interpreted            |
    +--------------------+------------------------------------+--------------------------+------------------------------+
    |*Speed:*            |slow                                |fastest                   |fast                          |
    +--------------------+------------------------------------+--------------------------+------------------------------+

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -135,7 +135,7 @@ The following arguments of the Composition's constructor can be used to add Comp
         values as the **projections** argument of that method.  In general, this is not neded -- default Projections
         are created for Pathways and/or Nodes added to the Composition using the methods described above; however
         it can be useful for custom configurations, including the implementation of specific Projection `matrices
-         <MappingProjection.matrix>`.
+        <MappingProjection.matrix>`.
 
    .. _Composition_Controller_Arg:
 
@@ -1000,7 +1000,7 @@ COMMENT:
 Add explanation of how learning_rate applies to Unsupervised forms of learning
 COMMENT
 The rate at which learning occurs in a `learning pathway <Composition_Learning_Pathway>` is determined by the
-`learning_rate <LearningMechanism_Learning_Rate> Parameter of the `LearningMechanism(s) <LearningMechanism>` in that
+`learning_rate <LearningMechanism_Learning_Rate>` Parameter of the `LearningMechanism(s) <LearningMechanism>` in that
 Pathway.  If it is not specified, then the `default value <Parameter_Defaults>` for the LearningMechanism's `function
 <LearningMechanism.function>` is used, which is determined by the kind of learning in that Pathway. However, the
 learning_rate can be specified in several other ways, both at construction and/or execution.  At construction, it can
@@ -1104,7 +1104,7 @@ that execution only.
    |                    |*Python*                            |`AutodiffComposition_LLVM`|`AutodiffComposition_PyTorch` |
    |                    |                                    |(*Direct Compilation*)    |                              |
    +====================+====================================+==========================+==============================+
-   |execution_mode=     |`ExecutionMode.Python`              |`ExecutionMode.LLVMRun`   |`ExecutionMode.PyTorch        |
+   |execution_mode=     |`ExecutionMode.Python`              |`ExecutionMode.LLVMRun`   |`ExecutionMode.PyTorch`       |
    +--------------------+------------------------------------+--------------------------+------------------------------+
    |`learn()            |                                    |                          |                              |
    |<Composition.learn>`|Python interpreted                  |LLVM compiled             |PyTorch compiled              |
@@ -12542,7 +12542,7 @@ _
         Returns
         -------
 
-        Either a dict formatted appropriately for assignment as the **inputs** argument of the Composition's `run()
+        Either a dict formatted appropriately for assignment as the **inputs** argument of the Composition's `run()`
         method (form = *DICT*, the default), or string showing the format required by the **inputs** argument
         <Composition.run>` (form = *TEXT*).
 

--- a/psyneulink/core/compositions/parameterestimationcomposition.py
+++ b/psyneulink/core/compositions/parameterestimationcomposition.py
@@ -141,7 +141,7 @@ requires that the **objective_function** argument be specified:
 Supported Optimizers
 --------------------
 
-- `DifferentialEvolution <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.differential_evolution.html`_
+- `DifferentialEvolution <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.differential_evolution.html>`_
 
 Structure
 ---------

--- a/psyneulink/core/compositions/parameterestimationcomposition.py
+++ b/psyneulink/core/compositions/parameterestimationcomposition.py
@@ -69,7 +69,7 @@ that describe arguments specific to each.
       <ParameterEstimationComposition.model>`, the `values <Mechanism_Base.value>` of which are used to evaluate the
       fit of the different combinations of `parameter <ParameterEstimationComposition.parameters>` values sampled. An
       important limitation of the PEC is that the `outcome_variables <ParameterEstimationComposition.outcome_variables>`
-      must be a subset of the output ports of the `model <ParameterEstimationComposition.model>`'s `terminal Mechanism.
+      must be a subset of the output ports of the `model <ParameterEstimationComposition.model>`'s terminal Mechanism.
 
     * **optimization_function** - specifies the function used to search over the combinations of `parameter
       <ParameterEstimationComposition.parameters>` values to be estimated. This must be either an instance of
@@ -266,7 +266,7 @@ class ParameterEstimationComposition(Composition):
         <ParameterEstimationComposition.model>`, the `values <Mechanism_Base.value>` of which are used to evaluate the
         fit of the different combinations of `parameter <ParameterEstimationComposition.parameters>` values sampled. An
         important limitation of the PEC is that the `outcome_variables <ParameterEstimationComposition.outcome_variables>`
-        must be a subset of the output ports of the `model <ParameterEstimationComposition.model>`'s `terminal Mechanism.
+        must be a subset of the output ports of the `model <ParameterEstimationComposition.model>`'s terminal `Mechanism`.
 
     model :
         specifies an external `Composition` for which parameters are to be `fit to data
@@ -299,7 +299,7 @@ class ParameterEstimationComposition(Composition):
     optimization_function : OptimizationFunction, function or method : default or MaximumLikelihood or GridSearch
         specifies the function used to search over the combinations of `parameter
         <ParameterEstimationComposition.parameters>` values to be estimated. This must be either an instance of
-      `PECOptimizationFunction` or a string name of one of the supported optimizers.
+        `PECOptimizationFunction` or a string name of one of the supported optimizers.
 
     num_estimates : int : default 1
         specifies the number of estimates made for a each combination of `parameter <ParameterEstimationComposition>`

--- a/psyneulink/core/compositions/pathway.py
+++ b/psyneulink/core/compositions/pathway.py
@@ -316,7 +316,7 @@ A Pathway has the following primary attributes:
   Pathway's `pathway <Pathway.pathway>` attribute.
 
 * `composition <Pathway.composition>` - contains the `Composition` that created the Pathway and to which it belongs,
-  or None if it is a ``template <Pathway_Template>` (i.e., was constructed on its own).
+  or None if it is a `template <Pathway_Template>` (i.e., was constructed on its own).
 
 * `roles <Pathway.roles>` and `Node <Composition_Nodes>` attributes - if the Pathway was created by a Composition,
   the `roles <Pathway.roles>` attribute `this lists the `PathwayRoles <PathwayRole>` assigned to it by the Composition

--- a/psyneulink/core/compositions/showgraph.py
+++ b/psyneulink/core/compositions/showgraph.py
@@ -664,7 +664,7 @@ class ShowGraph():
         -------
 
         `pdf` or Graphviz graph object :
-            determined by **output_fmt:
+            determined by **output_fmt**:
             - ``pdf`` -- PDF: (placed in current directory);
             - ``gv`` or ``jupyter`` -- Graphviz graph object;
             - ``gif`` -- gif

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -24,7 +24,7 @@ class, and are used to validate compatibility between this instance and other Ps
       ``t.defaults.noise.defaults.noise``)
 
     - class defaults are accessible by ``t.class_defaults`` or ``TransferMechanism.defaults`` (e.g.,
-    ``t.class_defaults.noise`` or `TransferMechanism.defaults.noise)
+      ``t.class_defaults.noise`` or `TransferMechanism.defaults.noise`)
 
 .. note::
     ``t.defaults.noise`` is shorthand for ``t.parameters.noise.default_value``, and they both refer to the default

--- a/psyneulink/library/components/mechanisms/modulatory/learning/autoassociativelearningmechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/learning/autoassociativelearningmechanism.py
@@ -76,9 +76,9 @@ Execution
 ---------
 
 An AutoAssociativeLearningMechanism executes in the same manner as standard `LearningMechanism`, with two exceptions:
-* 1) its execution can be enabled or disabled by setting the `learning_enabled
-  <RecurrentTransferMechanism.learning_enabled>` attribute of the `RecurrentTransferMechanism` with which it is
-  associated (identified in its `activity_source <AutoAssociativeLearningMechanism.activity_source>` attribute).
+* 1) its execution can be enabled or disabled by setting the `learning_enabled <RecurrentTransferMechanism.learning_enabled>`
+  attribute of the `RecurrentTransferMechanism` with which it is associated (identified in its
+  `activity_source <AutoAssociativeLearningMechanism.activity_source>` attribute).
 * 2) it is executed during the `execution phase <Composition_Execution>` of the Composition's execution.  Note that this is
   different from the behavior of supervised learning algorithms (such as `Reinforcement` and `BackPropagation`),
   that are executed during the `learning phase <Composition_Execution>` of a Composition's execution

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -129,7 +129,7 @@ depending on the `function <DDM.function>` that has been assigned to the DDM, as
 +                                    +----------------------------+----------------------------+
 |                                    | `DriftDiffusionAnalytical` | `DriftDiffusionIntegrator` |
 |                                    |   (`analytic               |   (`path integration)      |
-| **OutputPorts:**                  |   <DDM_Analytic_Mode>`)    |   <DDM_Integration_Mode>`) |
+| **OutputPorts:**                   |   <DDM_Analytic_Mode>`)    |   <DDM_Integration_Mode>`) |
 +------------------------------------+----------------------------+----------------------------+
 | `DECISION_VARIABLE                 |                            |                            |
 | <DDM_DECISION_VARIABLE>`           |       X                    |          X                 |

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -339,7 +339,7 @@ of different sizes).
 .. _EpisodicMemoryMechanism_Examples_Memory_Init_Function:
 
 *Initialize memory in function*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The contents of `memory <EpisodicMemoryMechanism.memory>` can also be initialized using the **initializer** argument
 in the constructor for the EpisodicMemoryMechanism's `function <EpisodicMemoryMechanism.function>`::

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -87,7 +87,7 @@ These can be specified using any of the following arguments:
     .. hint::
        Use **default_variable** rather than **memory** to specify the shape of memory but keep it empty
        until the first entry is stored; note, however, that since retrieval is executed before storage
-       (see `EpisodicMemoryMechanism_Execution ), the first execution will return an entry of zeros.
+       (see `EpisodicMemoryMechanism_Execution`), the first execution will return an entry of zeros.
 
   * **memory** -- specifies a set of entries to be stored in `memory <EpisodicMemoryMechanism.memory>`;  it is passed
     to the constructor for the EpisodicMemoryMechanism's `function <EpisodicMemoryMechanism.function>`) as its

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -634,8 +634,7 @@ class ContrastiveHebbianMechanism(RecurrentTransferMechanism):
         condition for that phase is specified as *CONVERGENCE*.  Compares the value of `current_activity
         <ContrastiveHebbianMechanism.current_activity>` with the
         previous `value <Mechanism_Base.value>`; result is
-        assigned as the value of `delta
-        <ContrastiveHebbianMechanism.delta>.
+        assigned as the value of `delta <ContrastiveHebbianMechanism.delta>`.
 
     minus_phase_termination_condition : CONVERGENCE or COUNT: default CONVERGENCE
         determines the type of condition used to terminate the `minus_phase <ContrastiveHebbian_Minus_Phase>` of

--- a/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/contrastivehebbianmechanism.py
@@ -138,7 +138,7 @@ A ContrastiveHebbianMechanism always has two, and possibly three `InputPorts <In
     * *RECURRENT:* receives the `value <Projection_Base.value>` of the Mechanism's `recurrent_projection
       <ContrastiveHebbianMechanism.recurrent_projection>`;
     ..
-    * *TARGET:* only implemented if **target_size** is specified, **separated = `True` (default), and
+    * *TARGET:* only implemented if **target_size** is specified, **separated** = `True` (default), and
       mode is not `SIMPLE_HEBBIAN <ContrastiveHebbian_SIMPLE_HEBBIAN>`;  receives the `target <Run.target>`
       specified in the `run <System.run>` method of any `Composition` to which the Mechanism belongs.
 

--- a/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/kohonenmechanism.py
@@ -144,7 +144,7 @@ class KohonenMechanism(TransferMechanism):
 
     learning_function : LearningFunction, function or method : default Kohonen(distance_function=GUASSIAN)
         specifies function used by `learning_mechanism <KohonenMechanism.learning_mechanism>` to update `matrix
-        <MappingProjection.matrix>` of `learned_projection <KohonenMechanism.learned_projection>.
+        <MappingProjection.matrix>` of `learned_projection <KohonenMechanism.learned_projection>`.
 
 
     Attributes
@@ -179,7 +179,7 @@ class KohonenMechanism(TransferMechanism):
 
     learning_function : LearningFunction, function or method
         function used by `learning_mechanism <KohonenMechanism.learning_mechanism>` to update `matrix
-        <MappingProjection.matrix>` of `learned_projection <KohonenMechanism.learned_projection>.
+        <MappingProjection.matrix>` of `learned_projection <KohonenMechanism.learned_projection>`.
 
     learning_mechanism : LearningMechanism
         created automatically if `learning is specified <KohonenMechanism_Learning>`, and used to train the

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -166,7 +166,7 @@ which provides a comparison of the different modes of execution for an AutodiffC
 *PyTorch mode*
 ~~~~~~~~~~~~~~
 
-This is the default for an AutodiffComposition, but, can be specified explicitly by setting **execution_mode =
+This is the default for an AutodiffComposition, but, can be specified explicitly by setting **execution_mode** =
 `ExecutionMode.PyTorch` in the `learn <Composition.learn>` method (see `example <BasicsAndPrimer_Rumelhart_Model>`
 in `BasicsAndPrimer`).  In this mode, the AutodiffComposition is automatically translated to a `PyTorch
 <https://pytorch.org>`_ model for learning.  This is comparable in speed to `LLVM compilation

--- a/psyneulink/library/compositions/emcomposition.py
+++ b/psyneulink/library/compositions/emcomposition.py
@@ -507,7 +507,7 @@ and `value_input_nodes <EMComposition.value_input_nodes>` attributes, respective
 .. _EMComposition_Memory:
 
 *Memory*
-~~~~~~~
+~~~~~~~~
 
 The `memory <EMComposition.memory>` attribute contains a record of the entries in the EMComposition's memory. This is
 in the form of a 2d array, in which rows (axis 0) are entries and columns (axis 1) are fields.  The number of fields
@@ -534,7 +534,7 @@ and the number of entries is determined by the `memory_capacity <EMComposition_M
 .. _EMComposition_Output:
 
 *Output*
-~~~~~~~
+~~~~~~~~
 
 The outputs corresponding to retrieved value for each field are represented as `OUTPUT <NodeRole.INPUT>` `Nodes
 <Composition_Nodes>` of the EMComposition, listed in its `retrieved_nodes <EMComposition.retrieved_nodes>` attribute.

--- a/psyneulink/library/compositions/emcomposition.py
+++ b/psyneulink/library/compositions/emcomposition.py
@@ -2110,20 +2110,20 @@ class EMComposition(AutodiffComposition):
         and from the value_input_node to the retrieved_node for values. The `function <EMStorageMechanism.function>`
         of the `EMSorageMechanism` that takes the following arguments:
 
-         - **variable* -- template for an `entry <EMComposition_Memory>` in `memory<EMComposition.memory>`;
+         - **variable** -- template for an `entry <EMComposition_Memory>` in `memory<EMComposition.memory>`;
 
-         - **fields* -- the `input_nodes <EMComposition.input_nodes>` for the corresponding `fields
+         - **fields** -- the `input_nodes <EMComposition.input_nodes>` for the corresponding `fields
            <EMComposition_Fields>` of an `entry <EMCmposition_Memory>` in `memory <EMComposition.memory>`;
 
-         - **field_types* -- a list of the same length as ``fields``, containing 1's for key fields and 0's for
+         - **field_types** -- a list of the same length as ``fields``, containing 1's for key fields and 0's for
            value fields;
 
-         - **concatenate_keys_node* -- node used to concatenate keys (if `concatenate_keys
+         - **concatenate_keys_node** -- node used to concatenate keys (if `concatenate_keys
            <EMComposition.concatenate_keys>` is `True`) or None;
 
-         - **memory_matrix* -- `memory_template <EMComposition.memory_template>`);
+         - **memory_matrix** -- `memory_template <EMComposition.memory_template>`);
 
-         - **learning_signals* -- list of ` `MappingProjection`\\s (or their ParameterPort`\\s) that store each
+         - **learning_signals** -- list of ` `MappingProjection`\\s (or their ParameterPort`\\s) that store each
            `field <EMComposition_Fields>` of `memory <EMComposition.memory>`;
 
          - **decay_rate** -- rate at which entries in the `memory_matrix <EMComposition.memory_matrix>` decay;


### PR DESCRIPTION
Fix the following warnings:
WARNING: Malformed table. (3 instances)
WARNING: Title underline too short. (13 instances)
WARNING: Inline strong start-string without end-string. (31 instances)
WARNING: Inline literal start-string without end-string. (1 instance)
WARNING: Inline emphasis start-string without end-string. (2 instances)
WARNING: Unknown target name (3 instances)
WARNING: Inline interpreted text or phrase reference start-string without end-string. (31 instances)
WARNING: Inline substitution_reference start-string without end-string. (1 instance)

The above removes 61/81 instances of `<span class="problematic">` in the generated html.