### PR TITLE
Component: faster copying

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1270,7 +1270,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                 and isinstance(self, memo[SHARED_COMPONENT_TYPES])
             ):
                 return self
-        elif 'no_shared' not in memo or not memo['no_shared']:
+        else:
             memo[SHARED_COMPONENT_TYPES] = (Component,)
 
         fun = get_deepcopy_with_shared(self._deepcopy_shared_keys)

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1275,6 +1275,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
 
         fun = get_deepcopy_with_shared(self._deepcopy_shared_keys)
         newone = fun(self, memo)
+        memo[id(self)] = newone
 
         if newone.parameters is not newone.class_parameters:
             # may be in DEFERRED INIT, so parameters/defaults belongs to class

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1089,7 +1089,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
     #                      insuring that assignment by one instance will not affect the value of others.
     name = None
 
-    _deepcopy_shared_keys = frozenset([])
+    _deepcopy_shared_keys = frozenset(['owner'])
 
     @check_user_specified
     def __init__(self,

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -669,15 +669,17 @@ class Function_Base(Function):
 
     def __deepcopy__(self, memo):
         new = super().__deepcopy__(memo)
-        # ensure copy does not have identical name
-        register_category(new, Function_Base, new.name, FunctionRegistry)
-        if "random_state" in new.parameters:
-            # HACK: Make sure any copies are re-seeded to avoid dependent RNG.
-            # functions with "random_state" param must have "seed" parameter
-            for ctx in new.parameters.seed.values:
-                new.parameters.seed.set(
-                    DEFAULT_SEED, ctx, skip_log=True, skip_history=True
-                )
+
+        if self is not new:
+            # ensure copy does not have identical name
+            register_category(new, Function_Base, new.name, FunctionRegistry)
+            if "random_state" in new.parameters:
+                # HACK: Make sure any copies are re-seeded to avoid dependent RNG.
+                # functions with "random_state" param must have "seed" parameter
+                for ctx in new.parameters.seed.values:
+                    new.parameters.seed.set(
+                        DEFAULT_SEED, ctx, skip_log=True, skip_history=True
+                    )
 
         return new
 

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -633,7 +633,7 @@ from psyneulink.core.globals.keywords import \
     MAPPING_PROJECTION, MECHANISM_VALUE, NAME, OUTPUT_PORT, OUTPUT_PORTS, OUTPUT_PORT_PARAMS, \
     OWNER_VALUE, PARAMS, PARAMS_DICT, PROJECTION, PROJECTIONS, RECEIVER, REFERENCE_VALUE, STANDARD_OUTPUT_PORTS, PORT, \
     VALUE, VARIABLE, \
-    output_port_spec_to_parameter_name, INPUT_PORT_VARIABLES
+    output_port_spec_to_parameter_name, INPUT_PORT_VARIABLES, SHARED_COMPONENT_TYPES
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.context import Context
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
@@ -1427,7 +1427,7 @@ def _instantiate_output_ports(owner, output_ports=None, context=None):
                             if isinstance(std_output_port[FUNCTION], Function):
                                 # we should not reuse standard_output_port Function
                                 # instances across multiple ports
-                                std_output_port[FUNCTION] = copy.deepcopy(std_output_port[FUNCTION], memo={'no_shared': True})
+                                std_output_port[FUNCTION] = copy.deepcopy(std_output_port[FUNCTION], memo={SHARED_COMPONENT_TYPES: None})
                         except KeyError:
                             pass
 

--- a/psyneulink/core/globals/keywords.py
+++ b/psyneulink/core/globals/keywords.py
@@ -121,7 +121,7 @@ __all__ = [
     'TRIAL', 'TRIALS_DIM',
     'UNCHANGED', 'UNIFORM_DIST_FUNCTION', 'USER_DEFINED_FUNCTION', 'USER_DEFINED_FUNCTION_TYPE',
     'VALUES', 'VALIDATE', 'VALIDATION', 'VALUE', 'VALUE_ASSIGNMENT', 'VALUE_FUNCTION', 'VARIABLE', 'VARIANCE',
-    'VECTOR', 'WALD_DIST_FUNCTION', 'WEIGHT', 'WEIGHTS', 'X_0', 'ZEROS_MATRIX'
+    'VECTOR', 'WALD_DIST_FUNCTION', 'WEIGHT', 'WEIGHTS', 'X_0', 'ZEROS_MATRIX', 'SHARED_COMPONENT_TYPES',
 ]
 
 # **********************************************************************************************************************
@@ -1092,3 +1092,5 @@ MODEL_SPEC_ID_MDF_VARIABLE = 'variable0'
 MODEL_SPEC_ID_SHAPE = 'shape'
 
 MODEL_SPEC_ID_INPUT_PORT_COMBINATION_FUNCTION = 'input_combination_function'
+
+SHARED_COMPONENT_TYPES = 'shared_component_types'

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -320,11 +320,11 @@ import toposort
 
 from psyneulink.core.globals.context import Context, ContextError, ContextFlags, _get_time, handle_external_context
 from psyneulink.core.globals.context import time as time_object
+from psyneulink.core.globals.keywords import SHARED_COMPONENT_TYPES
 from psyneulink.core.globals.log import LogCondition, LogEntry, LogError
 from psyneulink.core.globals.utilities import (
     call_with_pruned_args,
     convert_all_elements_to_np_array,
-    copy_iterable_with_shared,
     create_union_set,
     get_alias_property_getter,
     get_alias_property_setter,
@@ -403,27 +403,31 @@ def copy_parameter_value(value, shared_types=None, memo=None):
 
         e.g. in spec attribute or Parameter `Mechanism.input_ports`
     """
-    from psyneulink.core.components.component import Component, ComponentsMeta
+    if memo is None:
+        memo = {}
 
-    if shared_types is None:
-        shared_types = (Component, ComponentsMeta, types.MethodType, types.ModuleType)
-    else:
-        shared_types = tuple(shared_types)
+    if SHARED_COMPONENT_TYPES not in memo:
+        from psyneulink.core.components.component import Component, ComponentsMeta
+        if shared_types is None:
+            shared_types = (Component, ComponentsMeta)
+        else:
+            shared_types = tuple(shared_types)
+        memo[SHARED_COMPONENT_TYPES] = shared_types
+
+    # trying to deepcopy a bound method of a Component will deepcopy the
+    # Component, but we treat these situations like references.
+    # ex: GridSearch.search_function = GridSearch._traverse_grid
+    method_owner = getattr(value, '__self__', None)
+    if method_owner:
+        memo[id(method_owner)] = method_owner
 
     try:
-        return copy_iterable_with_shared(
-            value,
-            shared_types=shared_types,
-            memo=memo
-        )
-    except TypeError:
-        # this will attempt to copy the current object if it
-        # is referenced in a parameter, such as
-        # ComparatorMechanism, which does this for input_ports
-        if not isinstance(value, shared_types):
-            return copy.deepcopy(value, memo)
-        else:
+        return copy.deepcopy(value, memo)
+    except TypeError as e:
+        if 'pickle' in str(e):
             return value
+        else:
+            raise
 
 
 def get_init_signature_default_value(obj, parameter):

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -824,22 +824,17 @@ def multi_getattr(obj, attr, default = None):
 
 
 # based off the answer here https://stackoverflow.com/a/15774013/3131666
-def get_deepcopy_with_shared(shared_keys=frozenset(), shared_types=()):
+def get_deepcopy_with_shared(shared_keys=frozenset()):
     """
         Arguments
         ---------
             shared_keys
                 an Iterable containing strings that should be shallow copied
 
-            shared_types
-                an Iterable containing types that when objects of that type are encountered
-                will be shallow copied
-
         Returns
         -------
             a __deepcopy__ function
     """
-    shared_types = tuple(shared_types)
     shared_keys = frozenset(shared_keys)
 
     def __deepcopy__(self, memo):
@@ -855,13 +850,10 @@ def get_deepcopy_with_shared(shared_keys=frozenset(), shared_types=()):
 
         for k in ordered_dict_keys:
             v = self.__dict__[k]
-            if k in shared_keys or isinstance(v, shared_types):
+            if k in shared_keys:
                 res_val = v
             else:
-                try:
-                    res_val = copy_iterable_with_shared(v, shared_types, memo)
-                except TypeError:
-                    res_val = copy.deepcopy(v, memo)
+                res_val = copy.deepcopy(v, memo)
             setattr(result, k, res_val)
         return result
 

--- a/psyneulink/library/compositions/pytorchwrappers.py
+++ b/psyneulink/library/compositions/pytorchwrappers.py
@@ -13,7 +13,6 @@ import graph_scheduler
 import torch
 import torch.nn as nn
 
-from psyneulink.core.components.component import Component, ComponentsMeta
 from psyneulink.core.components.functions.nonstateful.combinationfunctions import LinearCombination, PRODUCT, SUM
 from psyneulink.core.compositions.composition import NodeRole, CompositionInterfaceMechanism
 from psyneulink.library.compositions.pytorchllvmhelper import *
@@ -238,7 +237,7 @@ class PytorchCompositionWrapper(torch.nn.Module):
 
         self._regenerate_paramlist()
 
-    __deepcopy__ = get_deepcopy_with_shared(shared_types=(Component, ComponentsMeta))
+    __deepcopy__ = get_deepcopy_with_shared()
 
     def _regenerate_paramlist(self):
         """Add Projection matrices to Pytorch Module's parameter list"""


### PR DESCRIPTION
During deepcopy of `Component`s, we still shallow copy most attributes that are `Component`s to treat them like pointers instead of objects.

Only do instance checks within `Component.__deepcopy__`, because this reduces time checking the type of non-Component objects (which we do not need to hybrid copy), will work outside of calls to `copy_parameter_value`, and avoids the need to manually construct hybrid copies of (possibly nested) iterables.