### PR TITLE
tests: Add missing 'composition' marks

### DIFF
--- a/tests/composition/test_parameterestimationcomposition.py
+++ b/tests/composition/test_parameterestimationcomposition.py
@@ -114,6 +114,7 @@ run_input_test_args = [
 ]
 
 
+@pytest.mark.composition
 @pytest.mark.parametrize("inputs_dict, error_msg", run_input_test_args)
 def test_pec_run_input_formats(inputs_dict, error_msg):
     if error_msg:
@@ -124,6 +125,7 @@ def test_pec_run_input_formats(inputs_dict, error_msg):
         pec.run(inputs=inputs_dict)
 
 
+@pytest.mark.composition
 @pytest.mark.parametrize(
     "opt_method, result",
     [
@@ -216,6 +218,7 @@ def test_parameter_optimization_ddm(func_mode, opt_method, result):
 
 
 # func_mode is a hacky wa to get properly marked; Python, LLVM, and CUDA
+@pytest.mark.composition
 def test_parameter_estimation_ddm_mle(func_mode):
     """Test parameter estimation of a DDM in integrator mode with MLE."""
 
@@ -318,6 +321,7 @@ def test_parameter_estimation_ddm_mle(func_mode):
     )
 
 
+@pytest.mark.composition
 def test_pec_bad_outcome_var_spec():
     """
     Tests that exception is raised when outcome variables specifies and output port that doesn't exist on the
@@ -389,6 +393,7 @@ def test_pec_bad_outcome_var_spec():
     assert "The number of columns in the data to fit must match" in str(ex)
 
 
+@pytest.mark.composition
 def test_pec_controller_specified():
     """Test that an exception is raised if a controller is specified for the PEC."""
     with pytest.raises(ValueError):

--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -734,6 +734,7 @@ def test_ddm_is_finished(comp_mode, noise, threshold, expected_results):
 
     np.testing.assert_array_equal(results, expected_results)
 
+@pytest.mark.composition
 @pytest.mark.parametrize("until_finished", ["until_finished", "not_until_finished"])
 @pytest.mark.parametrize("threshold_mod", ["threshold_modulated", "threshold_not_modulated"])
 def test_ddm_is_finished_with_dependency(comp_mode, until_finished, threshold_mod):


### PR DESCRIPTION
Fixes: efc07fc76e14fc62d0687a34c59c6691dc8f3b69
	("llvm, node_wrapper: Allow modulatory projections for "is_finished" wrapper")