### PR TITLE
llvm/cuda: Synchronize CPU and GPU buffers

### DIFF
--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -298,7 +298,10 @@ class CUDAExecution(Execution):
     def __get_cuda_buffer(self, struct_name):
         private_attr_name = "_buffer_cuda" + struct_name
         private_attr = getattr(self, private_attr_name)
-        if private_attr is None:
+
+        # Param struct needs to be reuploaded every time because the values
+        # might have changed.
+        if private_attr is None or struct_name == "_param_struct":
             # Set private attribute to a new buffer
             private_attr = self.upload_ctype(getattr(self, struct_name), struct_name)
             setattr(self, private_attr_name, private_attr)

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -661,11 +661,10 @@ class CompExecution(CUDAExecution):
                                       self._cuda_conditions,
                                       threads=len(self._execution_contexts))
 
-        # Copy the data struct from the device
-        self._data_struct = self.download_ctype(self._cuda_data_struct, type(self._data_struct), '_data_struct')
+        # Copy the data structs from the device
+        self.download_to(self._data_struct, self._cuda_data_struct, 'data')
 
     # Methods used to accelerate "Run"
-
     def _get_run_input_struct(self, inputs, num_input_sets, arg=3):
         # Callers that override input arg, should ensure that _bin_func is not None
         bin_f = self._bin_run_func if arg == 3 else self._bin_func
@@ -780,6 +779,7 @@ class CompExecution(CUDAExecution):
                                      threads=len(self._execution_contexts))
 
         # Copy the data struct from the device
+        self.download_to(self._data_struct, self._cuda_data_struct, 'data')
         ct_out = self.download_ctype(data_out, output_type, 'result')
         if len(self._execution_contexts) > 1:
             return _convert_ctype_to_python(ct_out)


### PR DESCRIPTION
The values in CPU buffers can change via updates to Python Parameters. GPU buffers thus have to be updated/recreated on every launch.
Similarly, Python Parameters can access the most recent value, so modified buffers have to be downloaded after kernel execution.

Fixes PTXExec and PTXRun failures in the new `test_multiple_runs_with_parameter_change*` tests.