### PR TITLE
llvm: Consolidate construction and sync of compiled structures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -205,24 +205,10 @@ def cuda_param(val):
 @pytest.helpers.register
 def get_func_execution(func, func_mode):
     if func_mode == 'LLVM':
-        ex = pnlvm.execution.FuncExecution(func)
-
-        # Calling writeback here will replace parameter values
-        # with numpy instances that share memory with the binary
-        # structure used by the compiled function
-        ex.writeback_state_to_pnl()
-
-        return ex.execute
+        return pnlvm.execution.FuncExecution(func).execute
 
     elif func_mode == 'PTX':
-        ex = pnlvm.execution.FuncExecution(func)
-
-        # Calling writeback here will replace parameter values
-        # with numpy instances that share memory with the binary
-        # structure used by the compiled function
-        ex.writeback_state_to_pnl()
-
-        return ex.cuda_execute
+        return pnlvm.execution.FuncExecution(func).cuda_execute
 
     elif func_mode == 'Python':
         return func.function
@@ -232,29 +218,16 @@ def get_func_execution(func, func_mode):
 @pytest.helpers.register
 def get_mech_execution(mech, mech_mode):
     if mech_mode == 'LLVM':
-        ex = pnlvm.execution.MechExecution(mech)
-
-        # Calling writeback here will replace parameter values
-        # with numpy instances that share memory with the binary
-        # structure used by the compiled function
-        ex.writeback_state_to_pnl()
-
-        return ex.execute
+        return pnlvm.execution.MechExecution(mech).execute
 
     elif mech_mode == 'PTX':
-        ex = pnlvm.execution.MechExecution(mech)
-
-        # Calling writeback here will replace parameter values
-        # with numpy instances that share memory with the binary
-        # structure used by the compiled function
-        ex.writeback_state_to_pnl()
-
-        return ex.cuda_execute
+        return pnlvm.execution.MechExecution(mech).cuda_execute
 
     elif mech_mode == 'Python':
         def mech_wrapper(x):
             mech.execute(x)
             return mech.output_values
+
         return mech_wrapper
     else:
         assert False, "Unknown mechanism mode: {}".format(mech_mode)

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -346,7 +346,15 @@ def _output_type_setter(value, owning_component):
     return value
 
 
-def _seed_setter(value, owning_component, context):
+def _seed_setter(value, owning_component, context, *, compilation_sync):
+    if compilation_sync:
+        # compilation sync should provide shared memory 0d array with a floating point value.
+        assert value is not None
+        assert value != DEFAULT_SEED()
+        assert value.shape == ()
+
+        return value
+
     value = try_extract_0d_array_item(value)
     if value is None or value == DEFAULT_SEED():
         value = get_global_seed()

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -1556,7 +1556,8 @@ class Parameter(ParameterBase):
         if self.setter is not None:
             kwargs = {
                 **self._default_setter_kwargs,
-                **kwargs
+                **kwargs,
+                'compilation_sync':compilation_sync,
             }
             value = call_with_pruned_args(self.setter, value, context=context, **kwargs)
 

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -143,6 +143,7 @@ class Execution:
 
         for idx, attribute in enumerate(getattr(component, ids)):
             compiled_attribute_param = getattr(params, params._fields_[idx][0])
+            compiled_attribute_param_ctype = params._fields_[idx][1]
 
             def _enumerate_recurse(elements):
                 for element_id, element in enumerate(elements):
@@ -198,13 +199,7 @@ class Execution:
                 elif condition(pnl_param):
 
                     # Replace empty structures with None
-                    try:
-                        size_of = ctypes.sizeof(compiled_attribute_param)
-                    except TypeError:
-                        # will be a 0-dim array
-                        size_of = 1
-
-                    if size_of == 0:
+                    if ctypes.sizeof(compiled_attribute_param_ctype) == 0:
                         value = None
                     else:
                         value = np.ctypeslib.as_array(compiled_attribute_param)

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -174,6 +174,14 @@ class Execution:
                 if attribute == "ring_memory":
                     continue
 
+                # TODO: Reconstruct Time class
+                if attribute == "num_executions":
+                    continue
+
+                # TODO: Add support for syncing optimizer state
+                if attribute == "optimizer":
+                    continue
+
                 # "old_val" is a helper storage in compiled RecurrentTransferMechanism
                 # to workaround the fact that compiled projections do no pull values
                 # from their source output ports

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -178,7 +178,10 @@ class Execution:
 
                 # Handle PNL parameters
                 pnl_param = getattr(component.parameters, attribute)
-                pnl_value = pnl_param.get(context=context)
+
+                # Use ._get to retrieve underlying numpy arrays
+                # (.get will extract a scalar if originally set as a scalar)
+                pnl_value = pnl_param._get(context=context)
 
                 # Recurse if the value is a PNL object with its own parameters
                 if hasattr(pnl_value, 'parameters'):
@@ -204,13 +207,9 @@ class Execution:
                             value = value[-1]
 
                         # Try to match the shape of the old value
-                        # Use ._get to retrieve underlying numpy arrays
-                        # (.get will extract a scalar if originally set
-                        # as a scalar)
-                        old_value = pnl_param._get(context)
-                        if hasattr(old_value, 'shape'):
+                        if hasattr(pnl_value, 'shape'):
                             try:
-                                value = value.reshape(old_value.shape)
+                                value = value.reshape(pnl_value.shape)
                             except ValueError:
                                 pass
 

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -113,28 +113,20 @@ class Execution:
                       _pretty_size(ctypes.sizeof(struct_ty)), ")",
                       "for", self._obj.name)
 
-
             if len(self._execution_contexts) == 1:
                 if name == '_state':
-                    self.writeback_state_to_pnl()
+                    self._copy_params_to_pnl(self._execution_contexts[0],
+                                             self._obj,
+                                             self._state_struct,
+                                             "llvm_state_ids")
+
                 elif name == '_param':
-                    self.writeback_params_to_pnl()
+                    self._copy_params_to_pnl(self._execution_contexts[0],
+                                             self._obj,
+                                             self._param_struct,
+                                             "llvm_param_ids")
 
         return struct
-
-    def writeback_state_to_pnl(self):
-
-        self._copy_params_to_pnl(self._execution_contexts[0],
-                                 self._obj,
-                                 self._state_struct,
-                                 "llvm_state_ids")
-
-    def writeback_params_to_pnl(self):
-
-        self._copy_params_to_pnl(self._execution_contexts[0],
-                                 self._obj,
-                                 self._param_struct,
-                                 "llvm_param_ids")
 
     def _copy_params_to_pnl(self, context, component, params, ids:str):
 
@@ -222,12 +214,7 @@ class Execution:
                             except ValueError:
                                 pass
 
-                    pnl_param.set(
-                        value,
-                        context=context,
-                        override=True,
-                        compilation_sync=True,
-                    )
+                    pnl_param.set(value, context=context, override=True, compilation_sync=True)
 
 
 class CUDAExecution(Execution):


### PR DESCRIPTION
Use a helper function for recursive synchronization of the compiled structures.
Use `ctypes` type instead of value in a call to `sizeof` (`sizeof` builtin types throws an exception).
Exclude Time and Optimizer custom classes from writeback.
Do not invalidate PRNG when syncing compiled seed value.
Make the synchronization methods private, drop explicit synchronization in Function and Mechanism tests.
Restrict shape changes on synchronization to known cases of 0d arrays and 'matrix' Parameters.