### PR TITLE
Codestyle and CI macos py3.7 docs

### DIFF
--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -48,11 +48,6 @@ jobs:
           - python-version: '3.7'
             os: macos-latest
 
-        include:
-          - python-version: '3.7'
-            os: macos-13
-            pnl-version: 'head'
-
     outputs:
       on_master: ${{ steps.on_master.outputs.on-branch }}
 

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -822,8 +822,8 @@ class DDM(ProcessingMechanism):
                  #    v[0]=self.value[self.DECISION_VARIABLE_INDEX]
                  #    v[1]=self.parameter_ports[THRESHOLD]
                  #    v[2]=self.input_ports[0].variable
-                 FUNCTION: lambda v: [float(v[2][0][0]), 0] \
-                                      if (v[1] - v[0]) < (v[1] + v[0]) \
+                 FUNCTION: lambda v: [float(v[2][0][0]), 0]
+                                      if (v[1] - v[0]) < (v[1] + v[0])
                                       else [0, float(v[2][0][1])]
                  }
             ])

--- a/tests/composition/test_learning.py
+++ b/tests/composition/test_learning.py
@@ -1893,6 +1893,7 @@ class TestBackPropLearning:
         ('runtime+pway+comp',  None,          .02,              .03,         .04,     [[0.63612349]]),
         ('learning_mech',      .01,           .02,              .03,         .04,     [[0.63458688]]),
     ]
+
     @pytest.mark.parametrize('spec_types', spec_types, ids=[x[0] for x in spec_types])
     def test_different_learning_rate_specs_for_comp(self, spec_types):
         learning_mech_learning_rate = spec_types[1]
@@ -1966,7 +1967,7 @@ class TestBackPropLearning:
         ('autodiff-pytorch', 'autodiff', pnl.ExecutionMode.PyTorch)
     ]
 
-    @ pytest.mark.pytorch
+    @pytest.mark.pytorch
     @pytest.mark.parametrize('test_vars', test_vars, ids=[x[0] for x in test_vars])
     def test_backprop_fct_with_2_inputs_to_linear_combination_product(self, test_vars):
         test_name = test_vars[0]
@@ -2028,7 +2029,7 @@ class TestBackPropLearning:
                     [[0.05066789, 0.05971998]], [[0.06846757, 0.08519742]]]
         np.testing.assert_allclose(comp.results, expected, atol=1e-8)
 
-    @ pytest.mark.pytorch
+    @pytest.mark.pytorch
     @pytest.mark.parametrize('test_vars', test_vars, ids=[x[0] for x in test_vars])
     def test_backprop_fct_with_3_inputs_to_linear_combination_product(self, test_vars):
         test_name = test_vars[0]
@@ -2223,6 +2224,7 @@ class TestBackPropLearning:
              [np.array([0.34065762, 0.40283722, 0.90991679])]]
         ),
     ]
+
     # Indices into expected_quantities
     @pytest.mark.parametrize("expected_quantities", expected_quantities,
                              # Rename L0 for test output as keyword actually = 'difference'


### PR DESCRIPTION
Drop macos python3.7 documentation ci job.
Fix codestyle errors detected by new pycodestyle