### PR TITLE
treewide: Qualify calls to `product`

### DIFF
--- a/Scripts/Models (Under Development)/bi-percepts.py
+++ b/Scripts/Models (Under Development)/bi-percepts.py
@@ -2,9 +2,9 @@
 bistable percepts
 """
 
+import itertools
 import numpy as np
 import psyneulink as pnl
-from itertools import product
 import matplotlib
 matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt
@@ -51,7 +51,7 @@ bp_comp = pnl.Composition()
 print('Forming connetions: ')
 # within-percept excitation
 for percept in ALL_PERCEPTS:
-    for node_i, node_j in product(node_dict[percept], node_dict[percept]):
+    for node_i, node_j in itertools.product(node_dict[percept], node_dict[percept]):
         if node_i is not node_j:
             print(f'\t{node_i} -> excite -> {node_j}')
             bp_comp.add_linear_processing_pathway(

--- a/psyneulink/core/components/functions/stateful/memoryfunctions.py
+++ b/psyneulink/core/components/functions/stateful/memoryfunctions.py
@@ -24,10 +24,10 @@ Functions that store and can return a record of their input.
 """
 
 import copy
+import itertools
 import numbers
 import warnings
 from collections import deque
-from itertools import combinations, product
 
 from psyneulink._typing import Callable, List, Literal
 
@@ -1309,7 +1309,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         field_wts_homog = np.full(len(test_var),1).tolist()
         field_wts_heterog = np.full(len(test_var),range(0,len(test_var))).tolist()
 
-        for granularity, field_weights in product(['full_entry', 'per_field'],[field_wts_homog, field_wts_heterog]):
+        for granularity, field_weights in itertools.product(['full_entry', 'per_field'],[field_wts_homog, field_wts_heterog]):
             try:
                 distance_result = self._get_distance(test_var, test_var, field_weights, granularity, context=context)
             except:
@@ -1594,7 +1594,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
             # Check for any duplicate entries in matches and, if they are not allowed, return zeros
             if (not self.duplicate_entries_allowed
                     and any(self._is_duplicate(_memory[i],_memory[j], field_weights, context)
-                            for i, j in combinations(indices_of_selected_items, 2))):
+                            for i, j in itertools.combinations(indices_of_selected_items, 2))):
                 warnings.warn(f"More than one entry matched cue ({cue}) in memory for {self.name} "
                               f"{'of ' + self.owner.name if self.owner else ''} even though "
                               f"{repr('duplicate_entries_allowed')} is False; zeros returned as retrieved item.")
@@ -1860,7 +1860,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
 
         existing_memory = self.parameters.previous_value._get(context)
         pruned_memory = copy_parameter_value(existing_memory)
-        for entry, memory in product(entries, existing_memory):
+        for entry, memory in itertools.product(entries, existing_memory):
             if (np.all(entry == memory)
                     or fields and all(entry[f] == memory[f] for f in fields)):
                 pruned_memory = np.delete(pruned_memory, pruned_memory.tolist().index(memory.tolist()), axis=0)

--- a/psyneulink/library/compositions/regressioncfa.py
+++ b/psyneulink/library/compositions/regressioncfa.py
@@ -74,13 +74,14 @@ Class Reference
 ---------------
 
 """
+
+import itertools
 import numpy as np
 from beartype import beartype
 
 from psyneulink._typing import Optional, Union
 
 from enum import Enum
-from itertools import product
 
 from psyneulink.core.components.functions.nonstateful.learningfunctions import BayesGLM
 from psyneulink.core.components.ports.modulatorysignals.controlsignal import ControlSignal
@@ -543,7 +544,7 @@ class RegressionCFA(CompositionFunctionApproximator):
                 self.terms[FC] = fc = np.tensordot(f, c, axes=0)
                 self.num[FC] = len(fc.reshape(-1))
                 self.num_elems[FC] = len(fc.reshape(-1))
-                self.labels[FC] = list(product(self.labels[F], self.labels[C]))
+                self.labels[FC] = list(itertools.product(self.labels[F], self.labels[C]))
 
             # feature-feature-control interactions
             if any(term in specified_terms for term in [PV.FFC, PV.FFCC]):
@@ -552,7 +553,7 @@ class RegressionCFA(CompositionFunctionApproximator):
                 self.terms[FFC] = ffc = np.tensordot(ff, c, axes=0)
                 self.num[FFC] = len(ffc.reshape(-1))
                 self.num_elems[FFC] = len(ffc.reshape(-1))
-                self.labels[FFC] = list(product(self.labels[FF], self.labels[C]))
+                self.labels[FFC] = list(itertools.product(self.labels[FF], self.labels[C]))
 
             # feature-control-control interactions
             if any(term in specified_terms for term in [PV.FCC, PV.FFCC]):
@@ -561,7 +562,7 @@ class RegressionCFA(CompositionFunctionApproximator):
                 self.terms[FCC] = fcc = np.tensordot(f, cc, axes=0)
                 self.num[FCC] = len(fcc.reshape(-1))
                 self.num_elems[FCC] = len(fcc.reshape(-1))
-                self.labels[FCC] = list(product(self.labels[F], self.labels[CC]))
+                self.labels[FCC] = list(itertools.product(self.labels[F], self.labels[CC]))
 
             # feature-feature-control-control interactions
             if PV.FFCC in specified_terms:
@@ -572,7 +573,7 @@ class RegressionCFA(CompositionFunctionApproximator):
                 self.terms[FFCC] = ffcc = np.tensordot(ff, cc, axes=0)
                 self.num[FFCC] = len(ffcc.reshape(-1))
                 self.num_elems[FFCC] = len(ffcc.reshape(-1))
-                self.labels[FFCC] = list(product(self.labels[FF], self.labels[CC]))
+                self.labels[FFCC] = list(itertools.product(self.labels[FF], self.labels[CC]))
 
             # Construct "flattened" vector based on specified terms, and assign indices (as slices)
             i=0

--- a/tests/functions/test_combination.py
+++ b/tests/functions/test_combination.py
@@ -229,7 +229,7 @@ def test_reduce_function(variable, operation, exponents, weights, scale, offset,
     if operation == pnl.SUM:
         expected = np.sum(tmp, axis=1) * scale + offset
     if operation == pnl.PRODUCT:
-        expected = np.product(tmp, axis=1) * scale + offset
+        expected = np.prod(tmp, axis=1) * scale + offset
 
     np.testing.assert_allclose(res, expected, rtol=1e-5, atol=1e-8)
 
@@ -267,7 +267,7 @@ def test_linear_combination_function(variable, operation, exponents, weights, sc
     if operation == pnl.SUM:
         expected = np.sum(tmp, axis=0) * scale + offset
     if operation == pnl.PRODUCT:
-        expected = np.product(tmp, axis=0) * scale + offset
+        expected = np.prod(tmp, axis=0) * scale + offset
 
     np.testing.assert_allclose(res, expected, rtol=1e-5, atol=1e-8)
 
@@ -292,7 +292,7 @@ def test_linear_combination_function_in_mechanism(operation, input, input_ports,
     if operation == pnl.SUM:
         expected = np.sum(input, axis=0) * scale + offset
     if operation == pnl.PRODUCT:
-        expected = np.product(input, axis=0) * scale + offset
+        expected = np.prod(input, axis=0) * scale + offset
 
     # expected is always 1d vs 2d return value res
     np.testing.assert_allclose(res[0], expected)

--- a/tests/functions/test_integrator.py
+++ b/tests/functions/test_integrator.py
@@ -272,7 +272,7 @@ def test_DriftOnASphere_identicalness_against_reference_implementation():
         def convert_spherical_to_angular(dim, ros):
             ct = np.zeros(dim)
             ct[0] = np.cos(ros[0])
-            prod = np.product([np.sin(ros[k]) for k in range(1, dim - 1)])
+            prod = np.prod([np.sin(ros[k]) for k in range(1, dim - 1)])
             n_prod = prod
             for j in range(dim - 2):
                 n_prod /= np.sin(ros[j + 1])

--- a/tests/models/test_bi_percepts.py
+++ b/tests/models/test_bi_percepts.py
@@ -5,11 +5,10 @@ bistable percepts
 """
 
 
-
+import itertools
 import numpy as np
 import psyneulink as pnl
 import pytest
-from itertools import product
 from psyneulink.core.compositions.report import ReportOutput
 
 
@@ -69,7 +68,7 @@ def test_necker_cube(benchmark, comp_mode, n_nodes, n_time_steps, expected):
     # MODIFIED 4/4/20 OLD:  PASSES IN PYTHON, BUT NEEDS RESULTS B BELOW
     # within-percept excitation
     for percept in ALL_PERCEPTS:
-        for node_i, node_j in product(node_dict[percept], node_dict[percept]):
+        for node_i, node_j in itertools.product(node_dict[percept], node_dict[percept]):
             if node_i is not node_j:
                 bp_comp.add_linear_processing_pathway(
                     pathway=(node_i, [excit_level], node_j))
@@ -100,7 +99,7 @@ def test_necker_cube(benchmark, comp_mode, n_nodes, n_time_steps, expected):
     # # MODIFIED 4/4/20 NEW:  [PASSES ALL TESTS, BUT NEEDS RSEULTS A BELOW]
     # # within-percept excitation
     # for percept in ALL_PERCEPTS:
-    #     for node_i, node_j in product(node_dict[percept], node_dict[percept]):
+    #     for node_i, node_j in itertools.product(node_dict[percept], node_dict[percept]):
     #         if node_i is not node_j:
     #             bp_comp.add_linear_processing_pathway(
     #                 pathway=((node_i, [pnl.NodeRole.INPUT, pnl.NodeRole.OUTPUT]), [excit_level], (node_j, [pnl.NodeRole.INPUT,


### PR DESCRIPTION
Call itertools.product with the module qualifier.
Use np.prod instead of np.product.