### PR TITLE
llvm: Tweaks to structure layout and codestyle

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1410,13 +1410,25 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
             if p.name == 'matrix': # Flatten matrix
                 val = tuple(np.asfarray(x).flatten())
             elif isinstance(x, np.random.RandomState):
-                # Skip first element of random state (id string)
-                val = pnlvm._tupleize((*x.get_state()[1:], x.used_seed[0]))
+                state = x.get_state(legacy=False)
+
+                # Keep the indices in sync with bultins.py:get_mersenne_twister_state_struct
+                val = pnlvm._tupleize((state['state']['key'],
+                                       state['gauss'],
+                                       state['state']['pos'],
+                                       state['has_gauss'],
+                                       x.used_seed[0]))
             elif isinstance(x, np.random.Generator):
                 state = x.bit_generator.state
-                val = pnlvm._tupleize((state['state']['counter'], state['state']['key'],
-                                       state['buffer'], state['uinteger'], state['buffer_pos'],
-                                       state['has_uint32'], x.used_seed[0]))
+
+                # Keep the indices in sync with bultins.py:get_philox_state_struct
+                val = pnlvm._tupleize((state['state']['counter'],
+                                       state['state']['key'],
+                                       state['buffer'],
+                                       state['uinteger'],
+                                       state['buffer_pos'],
+                                       state['has_uint32'],
+                                       x.used_seed[0]))
             elif isinstance(x, Time):
                 val = tuple(x._get_by_time_scale(t) for t in TimeScale)
             elif isinstance(x, Component):

--- a/psyneulink/core/llvm/builtins.py
+++ b/psyneulink/core/llvm/builtins.py
@@ -1090,10 +1090,11 @@ def _setup_philox_rand_int32(ctx, state_ty, gen_int64):
     buffered_ptr = builder.gep(state, [ctx.int32_ty(0), ctx.int32_ty(3)])
     has_buffered_ptr = builder.gep(state, [ctx.int32_ty(0), ctx.int32_ty(5)])
     has_buffered = builder.load(has_buffered_ptr)
-    with builder.if_then(has_buffered):
+    has_buffered_cond = builder.icmp_unsigned("!=", has_buffered, has_buffered.type(0))
+    with builder.if_then(has_buffered_cond):
         buffered = builder.load(buffered_ptr)
         builder.store(buffered, out)
-        builder.store(has_buffered.type(False), has_buffered_ptr)
+        builder.store(has_buffered.type(0), has_buffered_ptr)
         builder.ret_void()
 
 
@@ -1107,7 +1108,7 @@ def _setup_philox_rand_int32(ctx, state_ty, gen_int64):
     val_hi = builder.lshr(val, val.type(val.type.width // 2))
     val_hi = builder.trunc(val_hi, buffered_ptr.type.pointee)
     builder.store(val_hi, buffered_ptr)
-    builder.store(has_buffered.type(True), has_buffered_ptr)
+    builder.store(has_buffered.type(1), has_buffered_ptr)
 
     builder.ret_void()
 
@@ -2048,7 +2049,7 @@ def get_philox_state_struct(ctx):
         ir.ArrayType(int64_ty, _PHILOX_DEFAULT_BUFFER_SIZE),  #  pre-gen buffer
         ctx.int32_ty,  #  the other half of random 64 bit int
         int16_ty,      #  buffer pos
-        ctx.bool_ty,   #  has uint buffered
+        int16_ty,      #  has uint buffered
         int64_ty])     #  seed
 
 

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -873,7 +873,7 @@ def gen_composition_exec(ctx, composition, *, tags:frozenset):
 
 
         iter_ptr = builder.alloca(ctx.int32_ty, name="iter_counter")
-        builder.store(ctx.int32_ty(0), iter_ptr)
+        builder.store(iter_ptr.type.pointee(0), iter_ptr)
 
         # Start the main loop structure
         loop_condition = builder.append_basic_block(name="scheduling_loop_condition")
@@ -964,12 +964,12 @@ def gen_composition_exec(ctx, composition, *, tags:frozenset):
         builder.block.name = "update_iter_count"
         # Increment number of iterations
         iters = builder.load(iter_ptr, name="iterw")
-        iters = builder.add(iters, ctx.int32_ty(1), name="iterw_inc")
+        iters = builder.add(iters, iters.type(1), name="iterw_inc")
         builder.store(iters, iter_ptr)
 
         max_iters = len(composition.scheduler.consideration_queue)
         completed_pass = builder.icmp_unsigned("==", iters,
-                                               ctx.int32_ty(max_iters),
+                                               iters.type(max_iters),
                                                name="completed_pass")
         # Increment pass and reset time step
         with builder.if_then(completed_pass):

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -521,7 +521,7 @@ class ConditionGenerator:
         for idx in range(len(ts.type)):
             if all(v == 0 for v in count[:idx]):
                 el = builder.extract_value(ts, idx)
-                el = builder.add(el, self.ctx.int32_ty(count[idx]))
+                el = builder.add(el, el.type(count[idx]))
             else:
                 el = self.ctx.int32_ty(0)
             ts = builder.insert_value(ts, el, idx)
@@ -573,7 +573,7 @@ class ConditionGenerator:
 
         # Update number of runs
         runs = builder.extract_value(status, 0)
-        runs = builder.add(runs, self.ctx.int32_ty(1))
+        runs = builder.add(runs, runs.type(1))
         status = builder.insert_value(status, runs, 0)
 
         # Update time stamp
@@ -682,7 +682,7 @@ class ConditionGenerator:
                                                      self.ctx.int32_ty(scale)])
             num_execs = builder.load(target_num_execs_in_scale)
 
-            return builder.icmp_unsigned('<', num_execs, self.ctx.int32_ty(count))
+            return builder.icmp_unsigned('<', num_execs, num_execs.type(count))
 
         elif isinstance(condition, AtNCalls):
             target, count = condition.args
@@ -691,7 +691,7 @@ class ConditionGenerator:
                                                     [self.ctx.int32_ty(0),
                                                      self.ctx.int32_ty(scale)])
             num_execs = builder.load(target_num_execs_in_scale)
-            return builder.icmp_unsigned('==', num_execs, self.ctx.int32_ty(count))
+            return builder.icmp_unsigned('==', num_execs, num_execs.type(count))
 
         elif isinstance(condition, AfterNCalls):
             target, count = condition.args
@@ -700,7 +700,7 @@ class ConditionGenerator:
                                                     [self.ctx.int32_ty(0),
                                                      self.ctx.int32_ty(scale)])
             num_execs = builder.load(target_num_execs_in_scale)
-            return builder.icmp_unsigned('>=', num_execs, self.ctx.int32_ty(count))
+            return builder.icmp_unsigned('>=', num_execs, num_execs.type(count))
 
         elif isinstance(condition, WhenFinished):
             # The first argument is the target node


### PR DESCRIPTION
Make MT state size 8B aligned.
Make Philox state size 8B aligned.
Use derived types in operations where the expected type is known.
Codestyle.