### PR TITLE
llvm: Create numpy structures of all params/state before syncing to Parameters

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -694,11 +694,11 @@ def make_parameter_property(param):
     return property(getter).setter(setter)
 
 
-def _has_initializers_setter(value, owning_component=None, context=None):
+def _has_initializers_setter(value, owning_component=None, context=None, *, compilation_sync=False):
     """
     Assign has_initializers status to Component and any of its owners up the hierarchy.
     """
-    if value:
+    if value and not compilation_sync:
         # only update owner's attribute if setting to True, because there may be
         # other children that have initializers
         try:

--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -888,8 +888,8 @@ class TransferError(MechanismError):
     pass
 
 
-def _integrator_mode_setter(value, owning_component=None, context=None):
-    if value:
+def _integrator_mode_setter(value, owning_component=None, context=None, *, compilation_sync=False):
+    if value and not compilation_sync:
         if not owning_component.parameters.integrator_mode._get(context):
             # when first creating parameters, integrator_function is not
             # instantiated yet
@@ -908,7 +908,8 @@ def _integrator_mode_setter(value, owning_component=None, context=None):
                 elif owning_component.on_resume_integrator_mode == RESET:
                     owning_component.reset(force=True, context=context)
 
-    owning_component.parameters.has_initializers._set(value, context)
+    if not compilation_sync:
+        owning_component.parameters.has_initializers._set(value, context)
 
     return value
 

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -8,7 +8,6 @@
 
 # ********************************************* Binary Execution Wrappers **************************************************************
 
-from collections import Counter
 import concurrent.futures
 import copy
 import ctypes
@@ -239,24 +238,6 @@ class CUDAExecution(Execution):
         self._gpu_buffers = {}
         for b in buffers:
             self._gpu_buffers["_" + b] = None
-        self._uploaded_bytes = Counter()
-        self._downloaded_bytes = Counter()
-
-    def __del__(self):
-        if "stat" in self._debug_env:
-            try:
-                name = self._bin_func.name
-            except AttributeError:
-                name = self._composition.name
-
-            for k, v in self._uploaded_bytes.items():
-                print("{} CUDA uploaded `{}': {}".format(name, k, _pretty_size(v)))
-            if len(self._uploaded_bytes) > 1:
-                print("{} CUDA uploaded `total': {}".format(name, _pretty_size(sum(self._uploaded_bytes.values()))))
-            for k, v in self._downloaded_bytes.items():
-                print("{} CUDA downloaded `{}': {}".format(name, k, _pretty_size(v)))
-            if len(self._downloaded_bytes) > 1:
-                print("{} CUDA downloaded `total': {}".format(name, _pretty_size(sum(self._downloaded_bytes.values()))))
 
     @property
     def _bin_func_multirun(self):
@@ -305,7 +286,6 @@ class CUDAExecution(Execution):
         # Create input argument
         new_var = np.asfarray(variable, dtype=self._vi_dty)
         data_in = jit_engine.pycuda.driver.In(new_var)
-        self._uploaded_bytes['input'] += new_var.nbytes
 
         self._bin_func.cuda_call(self._cuda_param_struct,
                                  self._cuda_state_struct,

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -350,10 +350,10 @@ class FuncExecution(CUDAExecution):
                                          self._ct_vo,
                                          self._ct_len)
         else:
-            self._bin_func(ctypes.byref(self._param_struct[0]),
-                           ctypes.byref(self._state_struct[0]),
+            self._bin_func(self._param_struct[0],
+                           self._state_struct[0],
                            ct_vi,
-                           ctypes.byref(self._ct_vo))
+                           self._ct_vo)
 
         return _convert_ctype_to_python(self._ct_vo)
 
@@ -820,7 +820,7 @@ class CompExecution(CUDAExecution):
 
             # Create input and result typed casts once, they are the same
             # for every submitted job.
-            input_param = ctypes.cast(ctypes.byref(ct_inputs), self.__bin_func.c_func.argtypes[5])
+            input_param = ctypes.cast(ct_inputs, self.__bin_func.c_func.argtypes[5])
             results_param = ctypes.cast(ct_results, self.__bin_func.c_func.argtypes[4])
 
             # There are 7 arguments to evaluate_alloc_range:

--- a/tests/mechanisms/test_recurrent_transfer_mechanism.py
+++ b/tests/mechanisms/test_recurrent_transfer_mechanism.py
@@ -1135,6 +1135,8 @@ class TestCustomCombinationFunction:
         C.run(inputs={I1: [[1.0]], I2: [[1.0]]}, num_trials=7, execution_mode=comp_mode)
 
         np.testing.assert_allclose(exp, C.results)
+        assert I1.has_initializers == has_initializers1
+        assert I2.has_initializers == has_initializers2
 
     @pytest.mark.composition
     @pytest.mark.integrator_mechanism


### PR DESCRIPTION
Disable special setter logic when syncing compiled parameters.
Cache both ctype instance and numpy instance for compiled execution.
Switch CUDA execution to use numpy variants of compiled structures.