### PR TITLE
llvm: Fix processing of enum values after compilation sync

### DIFF
--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1793,13 +1793,14 @@ class TransferMechanism(ProcessingMechanism_Base):
             # return True
             return self.parameters.is_finished_flag._get(context)
 
-        assert self.parameters.value.history_min_length + 1 >= self._termination_measure_num_items_expected,\
-            "History of 'value' is not guaranteed enough entries for termination_mesasure"
+        assert self.parameters.value.history_min_length + 1 >= self._termination_measure_num_items_expected, \
+            "History of 'value' is not guaranteed enough entries for termination_measure"
+
         measure = self.termination_measure
         value = self.parameters.value._get(context)
 
         if self._termination_measure_num_items_expected==0:
-            status = self.parameters.num_executions._get(context)._get_by_time_scale(self.termination_measure)
+            status = self.parameters.num_executions._get(context)._get_by_time_scale(TimeScale(self.termination_measure))
 
         elif self._termination_measure_num_items_expected==1:
             # Squeeze to collapse 2d array with single item

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -370,7 +370,7 @@ class LLVMBuilderContext:
         # has_initializers is only used in "reset" variants
         initializers.add('has_initializers')
 
-        # 'termination_mesasure" is only used in "is_finished" variant
+        # 'termination_measure" is only used in "is_finished" variant
         used_param_ids.add('termination_measure')
         used_state_ids.add('termination_measure')
 
@@ -531,6 +531,11 @@ class LLVMBuilderContext:
             # Python 'int' is handled above as it is the default type for '0'
             return ir.IntType(t.nbytes * 8)
         elif isinstance(t, np.ndarray):
+            # 0d uint32 values were likely created from enums (above) and are
+            # observed here after compilation sync.
+            # Avoid silent promotion to float (via Python's builtin int-type)
+            if t.ndim == 0 and t.dtype == np.uint32:
+                return self.convert_python_struct_to_llvm_ir(t.reshape(1)[0])
             return self.convert_python_struct_to_llvm_ir(t.tolist())
         elif isinstance(t, np.random.RandomState):
             return pnlvm.builtins.get_mersenne_twister_state_struct(self)


### PR DESCRIPTION
Enums are represented as 0-d integer arrays and the Parameter type changes to 0-d integer array after compilation sync. Make sure the new value type can be consumed by the follow-up compiled, or Python, execution.

Closes: https://github.com/PrincetonUniversity/PsyNeuLink/issues/2984