### PR TITLE
llvm/execution/cuda: Always use pycuda ArgumentHandler as cached buffer

### DIFF
--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -249,10 +249,12 @@ class CUDAExecution(Execution):
         gpu_buffer = self._gpu_buffers[struct_name]
 
         np_struct = getattr(self, struct_name)[1]
+
+        # .array is a public member of pycuda's In/Out ArgumentHandler classes
         if gpu_buffer is None or gpu_buffer.array is not np_struct:
 
-            # 0-sized structures fail to upload use a small device buffer instead
-            gpu_buffer = arg_handler(np_struct) if np_struct.nbytes > 0 else jit_engine.pycuda.driver.mem_alloc(8)
+            # 0-sized structures fail to upload use a dummy numpy array isntead
+            gpu_buffer = arg_handler(np_struct if np_struct.nbytes > 0 else np.zeros(2))
 
             self._gpu_buffers[struct_name] = gpu_buffer
 


### PR DESCRIPTION
Only the ArgumentHandler class provides the .array member that is used to check if a gpu_buffer is not stale.

Fixes: 36e52b8ceb50d69c04d8e9aa81cd2139f27f01ee
	("llvm/execution/cuda: Use numpy argument handlers to access
	compiled structures")