### PR TITLE
llvm: Store only pointee types in byref_arg_types for pointer arguments

### DIFF
--- a/psyneulink/core/llvm/__init__.py
+++ b/psyneulink/core/llvm/__init__.py
@@ -143,16 +143,18 @@ class LLVMBinaryFunction:
         # Create ctype function instance
         start = time.perf_counter()
         return_type = _convert_llvm_ir_to_ctype(f.return_value.type)
-        params = [_convert_llvm_ir_to_ctype(a.type) for a in f.args]
+        args = [_convert_llvm_ir_to_ctype(a.type) for a in f.args]
         middle = time.perf_counter()
-        self.__c_func_type = ctypes.CFUNCTYPE(return_type, *params)
+        self.__c_func_type = ctypes.CFUNCTYPE(return_type, *args)
         finish = time.perf_counter()
 
         if "time_stat" in debug_env:
             print("Time to create ctype function '{}': {} ({} to create types)".format(
                   name, finish - start, middle - start))
 
-        self.byref_arg_types = [p._type_ for p in params]
+        # '_type_' special attribute stores pointee type for pointers
+        # https://docs.python.org/3/library/ctypes.html#ctypes._Pointer._type_
+        self.byref_arg_types = [a._type_ if hasattr(a, "contents") else None for a in args]
 
     @property
     def c_func(self):

--- a/tests/llvm/test_builtins_intrinsics.py
+++ b/tests/llvm/test_builtins_intrinsics.py
@@ -32,8 +32,10 @@ y = np.random.rand()
 def test_builtin_op(benchmark, op, args, builtin, result, func_mode):
     if func_mode == 'Python':
         f = op
+
     elif func_mode == 'LLVM':
         f = pnlvm.LLVMBinaryFunction.get(builtin)
+
     elif func_mode == 'PTX':
         wrap_name = builtin + "_test_wrapper"
         with pnlvm.LLVMBuilderContext.get_current() as ctx:
@@ -47,12 +49,19 @@ def test_builtin_op(benchmark, op, args, builtin, result, func_mode):
             builder.ret_void()
 
         bin_f = pnlvm.LLVMBinaryFunction.get(wrap_name)
-        dty = np.dtype(bin_f.byref_arg_types[0])
+
+        # The result argument is a pointer, use it to derive
+        # the right argument type
+        assert bin_f.byref_arg_types[-1] is not None
+        dty = np.dtype(bin_f.byref_arg_types[-1])
+
         ptx_res = np.empty_like(result, dtype=dty)
         ptx_res_arg = pnlvm.jit_engine.pycuda.driver.Out(ptx_res)
+
         def f(*a):
             bin_f.cuda_call(*(dty.type(p) for p in a), ptx_res_arg)
             return ptx_res
+
     res = benchmark(f, *args)
 
     if pytest.helpers.llvm_current_fp_precision() == 'fp32':

--- a/tests/llvm/test_builtins_vector.py
+++ b/tests/llvm/test_builtins_vector.py
@@ -6,6 +6,7 @@ from psyneulink.core import llvm as pnlvm
 
 
 DIM_X=1500
+
 # These are just basic tests to check that vector indexing and operations
 # work correctly when compiled. The values don't matter much.
 # Might as well make them representable in fp32 for single precision testing.
@@ -13,12 +14,10 @@ u = np.random.rand(DIM_X).astype(np.float32).astype(np.float64)
 v = np.random.rand(DIM_X).astype(np.float32).astype(np.float64)
 scalar = np.random.rand()
 
-
 add_res = np.add(u, v)
 sub_res = np.subtract(u, v)
 mul_res = np.multiply(u, v)
 smul_res = np.multiply(u, scalar)
-
 
 @pytest.mark.benchmark(group="Hadamard")
 @pytest.mark.parametrize("op, v, builtin, result", [
@@ -28,18 +27,28 @@ smul_res = np.multiply(u, scalar)
                          (np.multiply, scalar, "__pnl_builtin_vec_scalar_mult", smul_res),
                          ], ids=["ADD", "SUB", "MUL", "SMUL"])
 def test_vector_op(benchmark, op, v, builtin, result, func_mode):
-    if func_mode == 'Python':
-        def ex():
-            return op(u, v)
-    elif func_mode == 'LLVM':
-        bin_f = pnlvm.LLVMBinaryFunction.get(builtin)
+
+    def _numpy_args(bin_f):
         dty = np.dtype(bin_f.byref_arg_types[0])
-        assert dty == np.dtype(bin_f.byref_arg_types[1])
+
+        # non-pointer arguments have None is the respective byref_arg_types position
+        if bin_f.byref_arg_types[1] is not None:
+            assert dty == np.dtype(bin_f.byref_arg_types[1])
         assert dty == np.dtype(bin_f.byref_arg_types[3])
 
         lu = u.astype(dty)
         lv = dty.type(v) if np.isscalar(v) else v.astype(dty)
         lres = np.empty_like(lu)
+
+        return lu, lv, lres
+
+    if func_mode == 'Python':
+        def ex():
+            return op(u, v)
+
+    elif func_mode == 'LLVM':
+        bin_f = pnlvm.LLVMBinaryFunction.get(builtin)
+        lu, lv, lres = _numpy_args(bin_f)
 
         ct_u = lu.ctypes.data_as(bin_f.c_func.argtypes[0])
         ct_v = lv if np.isscalar(lv) else lv.ctypes.data_as(bin_f.c_func.argtypes[1])
@@ -51,17 +60,12 @@ def test_vector_op(benchmark, op, v, builtin, result, func_mode):
 
     elif func_mode == 'PTX':
         bin_f = pnlvm.LLVMBinaryFunction.get(builtin)
-        dty = np.dtype(bin_f.byref_arg_types[0])
-        assert dty == np.dtype(bin_f.byref_arg_types[1])
-        assert dty == np.dtype(bin_f.byref_arg_types[3])
-
-        lu = u.astype(dty)
-        lv = dty.type(v) if np.isscalar(v) else v.astype(dty)
-        lres = np.empty_like(lu)
+        lu, lv, lres = _numpy_args(bin_f)
 
         cuda_u = pnlvm.jit_engine.pycuda.driver.In(lu)
         cuda_v = lv if np.isscalar(lv) else pnlvm.jit_engine.pycuda.driver.In(lv)
         cuda_res = pnlvm.jit_engine.pycuda.driver.Out(lres)
+
         def ex():
             bin_f.cuda_call(cuda_u, cuda_v, np.int32(DIM_X), cuda_res)
             return lres
@@ -72,30 +76,36 @@ def test_vector_op(benchmark, op, v, builtin, result, func_mode):
 
 @pytest.mark.benchmark(group="Sum")
 def test_vector_sum(benchmark, func_mode):
+
     if func_mode == 'Python':
         def ex():
             return np.sum(u)
+
     elif func_mode == 'LLVM':
         bin_f = pnlvm.LLVMBinaryFunction.get("__pnl_builtin_vec_sum")
 
         lu = u.astype(np.dtype(bin_f.byref_arg_types[0]))
-        llvm_res = np.empty(1, dtype=lu.dtype)
+        lres = np.empty(1, dtype=lu.dtype)
 
         ct_u = lu.ctypes.data_as(bin_f.c_func.argtypes[0])
-        ct_res = llvm_res.ctypes.data_as(bin_f.c_func.argtypes[2])
+        ct_res = lres.ctypes.data_as(bin_f.c_func.argtypes[2])
 
         def ex():
             bin_f(ct_u, DIM_X, ct_res)
-            return llvm_res[0]
+            return lres[0]
+
     elif func_mode == 'PTX':
         bin_f = pnlvm.LLVMBinaryFunction.get("__pnl_builtin_vec_sum")
+
         lu = u.astype(np.dtype(bin_f.byref_arg_types[0]))
-        cuda_u = pnlvm.jit_engine.pycuda.driver.In(lu)
         res = np.empty(1, dtype=lu.dtype)
+
+        cuda_u = pnlvm.jit_engine.pycuda.driver.In(lu)
         cuda_res = pnlvm.jit_engine.pycuda.driver.Out(res)
+
         def ex():
             bin_f.cuda_call(cuda_u, np.int32(DIM_X), cuda_res)
             return res[0]
 
     res = benchmark(ex)
-    np.testing.assert_allclose(res, sum(u))
+    np.testing.assert_allclose(res, np.sum(u))


### PR DESCRIPTION
'_type_' special attribute stores pointee type for pointers [0], array element type for arrays[1], but string type representation for other types.

Adjust builtin tests to not rely on byref_arg_types of non-pointer arguments. Cleanup codestyle in builtin tests.

Use np.sum() instead of sum() to keep the result in the same precision as the input array.

[0] https://docs.python.org/3/library/ctypes.html#ctypes._Pointer._type_
[1] https://docs.python.org/3/library/ctypes.html#ctypes.Array._type_