### PR TITLE
requirements: Update scipy requirements from <1.12 to >=1.7.3, < 1.15.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ pillow<10.5.0
 pint<0.22.0
 protobuf<3.20.4
 rich>=10.1, <10.13
-scipy>=1.7.3, <1.12
+scipy>=1.7.3, <1.14
 toposort<1.11
 torch>=1.10.0, <2.4.0; (platform_machine == 'AMD64' or platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ pillow<10.5.0
 pint<0.22.0
 protobuf<3.20.4
 rich>=10.1, <10.13
-scipy>=1.7.3, <1.14
+scipy>=1.7.3, <1.15
 toposort<1.11
 torch>=1.10.0, <2.4.0; (platform_machine == 'AMD64' or platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ pillow<10.5.0
 pint<0.22.0
 protobuf<3.20.4
 rich>=10.1, <10.13
-scipy<1.12
+scipy>=1.7.3, <1.12
 toposort<1.11
 torch>=1.10.0, <2.4.0; (platform_machine == 'AMD64' or platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'

--- a/tests/composition/test_parameterestimationcomposition.py
+++ b/tests/composition/test_parameterestimationcomposition.py
@@ -1,7 +1,10 @@
 import numpy as np
+import optuna
 import pandas as pd
 import pytest
-import optuna
+import scipy
+
+from packaging import version as pversion
 
 import psyneulink as pnl
 
@@ -125,17 +128,32 @@ def test_pec_run_input_formats(inputs_dict, error_msg):
         pec.run(inputs=inputs_dict)
 
 
+# SciPy changed their implementation of differential evolution and the way it selects
+# samples to evaluate in 1.12 [0,1], and then again in 1.14 [2,3], leading to slightly
+# different results
+#
+# [0] https://docs.scipy.org/doc/scipy/release/1.12.0-notes.html#scipy-optimize-improvements
+# [1] https://github.com/scipy/scipy/pull/18496
+# [2] https://docs.scipy.org/doc/scipy/release/1.14.0-notes.html#scipy-optimize-improvements
+# [3] https://github.com/scipy/scipy/pull/20677
+if pversion.parse(scipy.version.version) >= pversion.parse('1.14.0'):
+    expected_differential_evolution = [0.010113000942356953]
+elif pversion.parse(scipy.version.version) >= pversion.parse('1.12.0'):
+    expected_differential_evolution = [0.010074123395259815]
+else:
+    expected_differential_evolution = [0.010363518438648106]
+
 @pytest.mark.composition
 @pytest.mark.parametrize(
-    "opt_method, result",
+    "opt_method, expected_result",
     [
-        ("differential_evolution", [0.010363518438648106]),
+        ("differential_evolution", expected_differential_evolution),
         (optuna.samplers.RandomSampler(seed=0), [0.01]),
         (optuna.samplers.CmaEsSampler(seed=0), [0.01]),
     ],
-    ids=["differential_evolultion", "optuna_random_sampler", "optuna_cmaes_sampler"],
+    ids=["differential_evolution", "optuna_random_sampler", "optuna_cmaes_sampler"],
 )
-def test_parameter_optimization_ddm(func_mode, opt_method, result):
+def test_parameter_optimization_ddm(func_mode, opt_method, expected_result):
     """Test parameter optimization of a DDM in integrator mode"""
 
     if func_mode == "Python":
@@ -210,11 +228,9 @@ def test_parameter_optimization_ddm(func_mode, opt_method, result):
     trial_inputs[0] = np.abs(trial_inputs[0])
     trial_inputs[-1] = np.abs(trial_inputs[-1])
 
-    inputs_dict = {decision: trial_inputs}
+    pec.run(inputs={comp: trial_inputs})
 
-    ret = pec.run(inputs={comp: trial_inputs})
-
-    np.testing.assert_allclose(pec.optimized_parameter_values, result)
+    np.testing.assert_allclose(pec.optimized_parameter_values, expected_result)
 
 
 # func_mode is a hacky wa to get properly marked; Python, LLVM, and CUDA


### PR DESCRIPTION
Set the minimum SciPy version to the last version that supports Python 3.7.
Adjust expected results in the differential evolution test based on SciPy version.
Increase upper bound from <1.12 to <1.15.
