### PR TITLE
IntegratorMechanism: correct broken size argument

### DIFF
--- a/psyneulink/core/components/mechanisms/processing/integratormechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/integratormechanism.py
@@ -271,6 +271,10 @@ class IntegratorMechanism(ProcessingMechanism_Base):
                 variable_shape[-1] = function_variable.shape[-1]
                 # self.parameters.variable.default_value = np.zeros(tuple(variable_shape))
                 variable = np.zeros(tuple(variable_shape))
+            else:
+                variable = default_variable
+        else:
+            variable = default_variable
 
             # IMPLEMENTATON NOTE:
             #    Don't worry about case in which length of function's variable is 1 and Mechanism's is > 1

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -139,19 +139,23 @@ class TestConstructorArguments:
             super().__init__(default_variable=default_variable, **kwargs)
 
     @pytest.mark.parametrize(
-        'cls_',
+        'cls_', [pnl.ProcessingMechanism, pnl.TransferMechanism, pnl.IntegratorMechanism]
+    )
+    @pytest.mark.parametrize(
+        'size, expected_variable',
         [
-            pnl.ProcessingMechanism,
-            pytest.param(
-                pnl.IntegratorMechanism,
-                marks=pytest.mark.xfail(reason='size currently unsupported at all on IntegratorMechanism')
-            )
+            (1, [[0]]),
+            (2, [[0, 0]]),
+            (3, [[0, 0, 0]]),
+            ((1, 1), [[0], [0]]),
+            ((2, 2), [[0, 0], [0, 0]]),
+            ((3, 3), [[0, 0, 0], [0, 0, 0]]),
         ]
     )
     @pytest.mark.parametrize('params_dict_entry', [NotImplemented, 'params'])
-    def test_size(self, cls_, params_dict_entry):
-        c = cls_(**nest_dictionary({'size': 5}, params_dict_entry))
-        assert len(c.defaults.variable[-1]) == 5
+    def test_size(self, cls_, params_dict_entry, size, expected_variable):
+        c = cls_(**nest_dictionary({'size': size}, params_dict_entry))
+        np.testing.assert_array_equal(c.defaults.variable, expected_variable)
 
     @pytest.mark.parametrize(
         'cls_, function_params, expected_values',


### PR DESCRIPTION
size is used only as fallback for default_variable, but IntegratorMechanism always explicitly passed up a default_variable, even if not passed in during construction