### PR TITLE
docs: add quotation to pip install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -172,13 +172,13 @@ To run the tutorial locally, you must run python 3.5 and install additional pack
 
 ::
 
-    pip install psyneulink[tutorial]
+    pip install "psyneulink[tutorial]"
 
 or if you downloaded the source:
 
 ::
 
-    pip install .[tutorial]
+    pip install ".[tutorial]"
 
 
 To access the tutorial, make sure you fulfill the requirements mentioned above, download the tutorial notebook (/tutorial/PsyNeuLink Tutorial.ipynb), then run the terminal command

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -211,13 +211,13 @@ To run the tutorial locally, you must run python 3.6 and install additional pack
 
 ::
 
-    pip install psyneulink[tutorial]
+    pip install "psyneulink[tutorial]"
 
 or if you downloaded the source:
 
 ::
 
-    pip install .[tutorial]
+    pip install ".[tutorial]"
 
 
 To access the tutorial, make sure you fulfill the requirements


### PR DESCRIPTION
`pip install example[example]` doesn't work in all shells but `pip install "example[example]"` works consistently.