### PR TITLE
Drop support for python 3.7

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -67,6 +67,8 @@ runs:
           echo "contourpy<1.1.0" >> env_constraints.txt
           # pillow >= 10.0.0 doesn't provide win32 wheel
           echo "pillow < 10.0.0" >> env_constraints.txt
+          # pandas >= 2.1.0 doesn't provide win32 wheel
+          echo "pandas < 2.1.0" >> env_constraints.txt
         fi
 
     - name: Install updated package

--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -69,6 +69,8 @@ runs:
           echo "pillow < 10.0.0" >> env_constraints.txt
           # pandas >= 2.1.0 doesn't provide win32 wheel
           echo "pandas < 2.1.0" >> env_constraints.txt
+          # llvmlite >= 0.42.0 doesn't provide win32 wheel
+          echo "llvmlite < 0.42.0" >> env_constraints.txt
         fi
 
     - name: Install updated package

--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -21,15 +21,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
         pnl-version: ${{ (github.event_name == 'push') && fromJSON('["head"]') || fromJSON('["head", "base"]') }}
         exclude:
           - os: macos-latest
             pnl-version: 'base'
           - os: windows-latest
-            pnl-version: 'base'
-          - python-version: '3.7'
             pnl-version: 'base'
           - python-version: '3.8'
             pnl-version: 'base'
@@ -39,14 +37,6 @@ jobs:
             pnl-version: 'base'
           - python-version: '3.12'
             pnl-version: 'base'
-
-            # Python 3.7 x64 on macos-14 (arm64) images is broken [0]
-            # and arm64 version is not available [1].
-            # Restrict python 3.7 macos runs to macos-13
-            # [0] https://github.com/actions/setup-python/issues/855
-            # [1] https://github.com/actions/setup-python/issues/856
-          - python-version: '3.7'
-            os: macos-latest
 
     outputs:
       on_master: ${{ steps.on_master.outputs.on-branch }}
@@ -80,9 +70,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        # Block python3.7.17 on macos. see:
-        # https://github.com/actions/setup-python/issues/682
-        python-version: ${{ (matrix.os == 'macos-latest' && matrix.python-version == '3.7') && '3.7.16' || matrix.python-version }}
+        python-version: ${{ matrix.python-version }}
 
     - name: Get pip cache location
       shell: bash

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.11', '3.12']
+        python-version: ['3.8', '3.11', '3.12']
         python-architecture: ['x64']
         extra-args: ['']
         os: [ubuntu, macos, windows]
@@ -51,7 +51,7 @@ jobs:
             extra-args: '--forked -m "not llvm"'
 
           # add 32-bit build on windows
-          - python-version: '3.8'
+          - python-version: '3.9'
             python-architecture: 'x86'
             os: windows
 
@@ -70,22 +70,18 @@ jobs:
             # https://github.com/ionelmc/pytest-benchmark/issues/243
             extra-args: '-m benchmark --benchmark-enable --benchmark-only --benchmark-min-rounds=2 --benchmark-max-time=0.001 --benchmark-warmup=off -n0 --dist=no'
 
-          # add python 3.7 with deps restricted to min supported version
-          - python-version: '3.7'
-            python-architecture: 'x64'
-            os: ubuntu
-            version-restrict: 'min'
-
-          # add python 3.8 build on macos since 3.7 is broken
-          # https://github.com/actions/virtual-environments/issues/4230
-          # use default python-architecture
+          # add python 3.8 with deps restricted to min supported version
+          # use default python architecture
+          # https://github.com/actions/setup-python/issues/960
           - python-version: '3.8'
             os: macos
+            version-restrict: 'min'
 
         exclude:
-          # 3.7 is broken on macos-11,
-          # https://github.com/actions/virtual-environments/issues/4230
-          - python-version: '3.7'
+          # 3.8/x64 python is broken on aarch64 macos runners
+          # https://github.com/actions/setup-python/issues/960
+          - python-version: '3.8'
+            python-architecture: 'x64'
             os: macos
 
     steps:
@@ -112,7 +108,8 @@ jobs:
       if: ${{ matrix.version-restrict == 'min' }}
       shell: bash
       run: |
-        sed -i '/^[^#]/s/>=/==/' *requirements.txt
+        # macos/bsd sed requires backup suffix argument to -i
+        sed -i=.bak -e '/^[^#]/s/>=/==/' *requirements.txt
         git config user.name "github actions"
         git config user.email "none"
         git commit -a -m "Restrict version of direct dependencies to min"

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -69,14 +69,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
         dist: [wheel, sdist]
-        exclude:
-          # 3.7 is broken on macos-11,
-          # https://github.com/actions/virtual-environments/issues/4230
-          - python-version: '3.7'
-            os: macos-latest
 
     runs-on: ${{ matrix.os }}
     needs: [create-python-dist]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pandas<2.2.4
 pillow<11.2.0
 pint<0.22.0
 protobuf<3.20.4
-rich>=10.1, <10.13
+rich>=10.2, <10.13
 scipy>=1.7.3, <1.16
 toposort<1.11
 torch>=1.10.0, <2.6.0; (platform_machine == 'AMD64' or platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
 
         # Supported Python Versions
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -66,7 +65,7 @@ setup(
     ],
 
     # Require recent python
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 
     # What does your project relate to?
     keywords='cognitive modeling',


### PR DESCRIPTION
Bump minimum rich requirement.
Restrict 32-bit job to last available wheels.
Drop Python3.7 CI jobs.
Bump minimum Python requirement to 3.8