### PR TITLE
tests: Drop unused imports

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,6 @@ import itertools
 import numpy as np
 import pytest
 import re
-import sys
 import types
 
 import graph_scheduler as gs

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -45,7 +45,7 @@ from psyneulink.core.scheduling.condition import EveryNCalls
 from psyneulink.core.scheduling.scheduler import Scheduler, SchedulingMode
 from psyneulink.core.scheduling.time import TimeScale
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
-from psyneulink.library.components.mechanisms.processing.objective.comparatormechanism import ComparatorMechanism
+#from psyneulink.library.components.mechanisms.processing.objective.comparatormechanism import ComparatorMechanism
 from psyneulink.library.components.mechanisms.modulatory.control.agt.lccontrolmechanism import LCControlMechanism
 from psyneulink.library.components.mechanisms.processing.transfer.recurrenttransfermechanism import \
     RecurrentTransferMechanism

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -9,8 +9,7 @@ import pytest
 
 import psyneulink as pnl
 from psyneulink.core.components.functions.nonstateful.combinationfunctions import LinearCombination
-from psyneulink.core.components.functions.nonstateful.learningfunctions import \
-    LearningFunction, Reinforcement, BackPropagation, TDLearning
+from psyneulink.core.components.functions.nonstateful.learningfunctions import Reinforcement, BackPropagation, TDLearning
 from psyneulink.core.components.functions.nonstateful.optimizationfunctions import GridSearch
 from psyneulink.core.components.functions.nonstateful.transferfunctions import \
     Linear, Logistic, INTENSITY_COST_FCT_MULTIPLICATIVE_PARAM
@@ -49,8 +48,6 @@ from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, P
 from psyneulink.library.components.mechanisms.modulatory.control.agt.lccontrolmechanism import LCControlMechanism
 from psyneulink.library.components.mechanisms.processing.transfer.recurrenttransfermechanism import \
     RecurrentTransferMechanism
-from psyneulink.library.components.mechanisms.processing.integrator.episodicmemorymechanism import \
-    EpisodicMemoryMechanism
 from psyneulink.library.compositions.emcomposition import EMComposition
 
 logger = logging.getLogger(__name__)

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -5,7 +5,6 @@ import pytest
 
 import psyneulink as pnl
 from psyneulink.core.globals.keywords import ALLOCATION_SAMPLES, CONTROL, PROJECTIONS
-from psyneulink.core.globals.log import LogCondition
 from psyneulink.core.globals.sampleiterator import SampleIterator, SampleIteratorError, SampleSpec
 from psyneulink.core.globals.utilities import _SeededPhilox
 from psyneulink.core.components.mechanisms.modulatory.control.optimizationcontrolmechanism import \

--- a/tests/composition/test_emcomposition.py
+++ b/tests/composition/test_emcomposition.py
@@ -1,21 +1,12 @@
-import logging
-import timeit as timeit
-import os
 import numpy as np
 
 import pytest
 
 import psyneulink as pnl
 
-from psyneulink.core.globals.keywords import AUTO, CONTROL, ALL, MAX_VAL, MAX_INDICATOR, PROB
+from psyneulink.core.globals.keywords import AUTO, CONTROL
 from psyneulink.core.components.mechanisms.mechanism import Mechanism
 from psyneulink.library.compositions.emcomposition import EMComposition, EMCompositionError
-
-module_seed = 0
-np.random.seed(0)
-
-logger = logging.getLogger(__name__)
-
 
 # All tests are set to run. If you need to skip certain tests,
 # see http://doc.pytest.org/en/latest/skipping.html

--- a/tests/composition/test_graph.py
+++ b/tests/composition/test_graph.py
@@ -1,9 +1,4 @@
-import numpy as np
-import pytest
-
-from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism
-from psyneulink.core.components.projections.pathway.mappingprojection import MappingProjection
-from psyneulink.core.compositions.composition import Composition, Graph, Vertex
+from psyneulink.core.compositions.composition import Graph, Vertex
 
 
 class TestGraph:

--- a/tests/composition/test_interfaces.py
+++ b/tests/composition/test_interfaces.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-import psyneulink.core.llvm as pnlvm
+import psyneulink as pnl
 
 from psyneulink.core.components.functions.nonstateful.transferfunctions import Identity, Linear
 from psyneulink.core.components.mechanisms.processing.compositioninterfacemechanism import CompositionInterfaceMechanism
@@ -179,7 +179,7 @@ class TestConnectCompositionsViaCIMS:
         # output = 180.0
         comp3.run(inputs={comp1: [[5.]]}, execution_mode=comp_mode)
         np.testing.assert_allclose(comp3.results, [[[180.0]]])
-        if comp_mode is pnlvm.ExecutionMode.Python:
+        if comp_mode is pnl.ExecutionMode.Python:
             np.testing.assert_allclose(comp1.output_port.parameters.value.get(comp3), [30.0])
             np.testing.assert_allclose(comp2.output_port.parameters.value.get(comp3), [180.0])
             np.testing.assert_allclose(comp3.output_port.parameters.value.get(comp3), [180.0])
@@ -242,7 +242,7 @@ class TestConnectCompositionsViaCIMS:
         )
 
         np.testing.assert_allclose(output, [[180.], [1800.]])
-        if comp_mode is pnlvm.ExecutionMode.Python:
+        if comp_mode is pnl.ExecutionMode.Python:
             np.testing.assert_allclose(inner_composition_1.get_output_values(outer_composition), [[30.], [300.]])
             np.testing.assert_allclose(inner_composition_2.get_output_values(outer_composition), [[180.], [1800.]])
             np.testing.assert_allclose(outer_composition.get_output_values(outer_composition), [[180.], [1800.]])
@@ -312,7 +312,7 @@ class TestConnectCompositionsViaCIMS:
         )
         np.testing.assert_allclose(output, [[36.]])
 
-        if comp_mode is pnlvm.ExecutionMode.Python:
+        if comp_mode is pnl.ExecutionMode.Python:
             np.testing.assert_allclose(A.get_output_values(outer_composition), [[1.0]])
             np.testing.assert_allclose(B.get_output_values(outer_composition), [[2.0]])
             np.testing.assert_allclose(C.get_output_values(outer_composition), [[9.0]])

--- a/tests/composition/test_learning.py
+++ b/tests/composition/test_learning.py
@@ -8,7 +8,6 @@ import pytest
 from psyneulink.core.compositions.composition import Composition, CompositionError, RunError
 from psyneulink.core.components.mechanisms.processing.transfermechanism import TransferMechanism
 from psyneulink.core.components.functions.nonstateful.learningfunctions import BackPropagation
-import psyneulink.core.llvm as pnlvm
 from psyneulink.core.globals.keywords import Loss
 # from psyneulink.library.components.mechanisms.processing.objective.comparatormechanism import SSE, MSE, L0
 
@@ -509,8 +508,9 @@ class TestLearningPathwayMethods:
                     num_trials=2)
         np.testing.assert_allclose(comp2.results, comp1.results)
 
-    @pytest.mark.parametrize('execution_mode',
-                             [pnlvm.ExecutionMode.LLVM, pnlvm.ExecutionMode.PyTorch])
+    # Use explicit parametrize instead of the autodiff_mode fixture to avoid
+    # applying marks. This test doesn't execute pytorch or compiled mode
+    @pytest.mark.parametrize('execution_mode', [pnl.ExecutionMode.LLVM, pnl.ExecutionMode.PyTorch])
     def test_execution_mode_pytorch_and_LLVM_errors(self, execution_mode):
         A = TransferMechanism(name="learning-process-mech-A")
         B = TransferMechanism(name="learning-process-mech-B")

--- a/tests/functions/test_combination.py
+++ b/tests/functions/test_combination.py
@@ -2,8 +2,6 @@ import numpy as np
 import pytest
 
 import psyneulink as pnl
-import psyneulink.core.llvm as pnlvm
-from psyneulink import ParameterError
 
 
 class TestRearrange:
@@ -210,7 +208,7 @@ def test_reduce_function(variable, operation, exponents, weights, scale, offset,
                        weights=weights,
                        scale=scale,
                        offset=offset)
-    except ParameterError as e:
+    except pnl.ParameterError as e:
         if not np.isscalar(scale) and "scale must be a scalar" in str(e):
             pytest.xfail("vector scale is not supported")
         if not np.isscalar(offset) and "vector offset is not supported" in str(e):

--- a/tests/functions/test_distance.py
+++ b/tests/functions/test_distance.py
@@ -1,5 +1,4 @@
 import numpy as np
-import psyneulink.core.llvm as pnlvm
 import psyneulink.core.components.functions as Functions
 import psyneulink.core.globals.keywords as kw
 import pytest

--- a/tests/functions/test_distribution.py
+++ b/tests/functions/test_distribution.py
@@ -4,7 +4,6 @@ import sys
 
 from packaging import version as pversion
 
-import psyneulink.core.llvm as pnlvm
 import psyneulink.core.components.functions.nonstateful.distributionfunctions as Functions
 from psyneulink.core.globals.utilities import _SeededPhilox
 

--- a/tests/functions/test_fhn_integrator.py
+++ b/tests/functions/test_fhn_integrator.py
@@ -1,5 +1,4 @@
 import numpy as np
-import psyneulink.core.llvm as pnlvm
 import psyneulink.core.components.functions.stateful.integratorfunctions
 import pytest
 

--- a/tests/functions/test_identity.py
+++ b/tests/functions/test_identity.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 import psyneulink.core.components.functions.nonstateful.transferfunctions as Functions
-import psyneulink.core.llvm as pnlvm
 
 @pytest.mark.function
 @pytest.mark.identity_function

--- a/tests/functions/test_memory.py
+++ b/tests/functions/test_memory.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 
 import psyneulink.core.components.functions.stateful.memoryfunctions as Functions
-import psyneulink.core.llvm as pnlvm
 from psyneulink import *
 from psyneulink.core.globals.utilities import _SeededPhilox, convert_all_elements_to_np_array
 

--- a/tests/functions/test_optimization.py
+++ b/tests/functions/test_optimization.py
@@ -1,5 +1,4 @@
 import numpy as np
-import psyneulink.core.llvm as pnlvm
 import psyneulink.core.components.functions.function as Function
 import psyneulink.core.components.functions.nonstateful.objectivefunctions as Functions
 import psyneulink.core.components.functions.nonstateful.optimizationfunctions as OPTFunctions

--- a/tests/functions/test_selection.py
+++ b/tests/functions/test_selection.py
@@ -3,7 +3,6 @@ import pytest
 
 import psyneulink.core.components.functions.nonstateful.selectionfunctions as Functions
 import psyneulink.core.globals.keywords as kw
-import psyneulink.core.llvm as pnlvm
 from psyneulink.core.globals.utilities import _SeededPhilox
 
 np.random.seed(0)

--- a/tests/functions/test_stability.py
+++ b/tests/functions/test_stability.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-import psyneulink.core.llvm as pnlvm
 import psyneulink.core.components.functions.function as Function
 import psyneulink.core.components.functions.nonstateful.objectivefunctions as Functions
 import psyneulink.core.globals.keywords as kw

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -9,8 +9,6 @@ from psyneulink.core.components.mechanisms.processing import ProcessingMechanism
 from psyneulink.core.components.mechanisms.processing import TransferMechanism
 from psyneulink.core.compositions.composition import Composition
 
-import psyneulink.core.llvm as pnlvm
-
 
 # default val is same shape as expected output
 # we only use param1 and param2 to avoid automatic shape changes of the variable

--- a/tests/llvm/test_builtins_matrix.py
+++ b/tests/llvm/test_builtins_matrix.py
@@ -1,4 +1,3 @@
-import ctypes
 import numpy as np
 import pytest
 

--- a/tests/llvm/test_builtins_mt_random.py
+++ b/tests/llvm/test_builtins_mt_random.py
@@ -1,4 +1,3 @@
-import ctypes
 import numpy as np
 import pytest
 import random

--- a/tests/llvm/test_builtins_philox_random.py
+++ b/tests/llvm/test_builtins_philox_random.py
@@ -1,4 +1,3 @@
-import ctypes
 import numpy as np
 import pytest
 

--- a/tests/llvm/test_builtins_vector.py
+++ b/tests/llvm/test_builtins_vector.py
@@ -1,4 +1,3 @@
-import ctypes
 import numpy as np
 import pytest
 

--- a/tests/llvm/test_compile.py
+++ b/tests/llvm/test_compile.py
@@ -1,4 +1,3 @@
-import ctypes
 import numpy as np
 import pytest
 

--- a/tests/llvm/test_custom_func.py
+++ b/tests/llvm/test_custom_func.py
@@ -1,4 +1,3 @@
-import ctypes
 import numpy as np
 import pytest
 

--- a/tests/mechanisms/test_control_mechanism.py
+++ b/tests/mechanisms/test_control_mechanism.py
@@ -4,7 +4,6 @@ import psyneulink as pnl
 import pytest
 
 import psyneulink.core.components.functions.nonstateful.transferfunctions
-import psyneulink.core.llvm as pnlvm
 
 class TestLCControlMechanism:
 

--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 import psyneulink as pnl
-import psyneulink.core.llvm as pnlvm
 
 from psyneulink.core.components.component import ComponentError
 from psyneulink.core.components.functions.nonstateful.distributionfunctions import DriftDiffusionAnalytical, NormalDist

--- a/tests/mechanisms/test_episodic_memory.py
+++ b/tests/mechanisms/test_episodic_memory.py
@@ -4,7 +4,6 @@ import pytest
 from psyneulink.core.components.functions.function import FunctionError
 from psyneulink.core.components.functions.stateful.memoryfunctions import DictionaryMemory, \
     ContentAddressableMemory
-from psyneulink.core.components.functions.nonstateful.selectionfunctions import OneHot, ARG_MIN
 from psyneulink.library.components.mechanisms.processing.integrator.episodicmemorymechanism import \
     EpisodicMemoryMechanism, EpisodicMemoryMechanismError
 

--- a/tests/mechanisms/test_episodic_memory.py
+++ b/tests/mechanisms/test_episodic_memory.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-import psyneulink.core.llvm as pnlvm
 from psyneulink.core.components.functions.function import FunctionError
 from psyneulink.core.components.functions.stateful.memoryfunctions import DictionaryMemory, \
     ContentAddressableMemory

--- a/tests/mechanisms/test_input_output_labels.py
+++ b/tests/mechanisms/test_input_output_labels.py
@@ -1,10 +1,10 @@
-import numpy as np
-import pytest
+#import numpy as np
+#import pytest
 
-from psyneulink.core.compositions.composition import Composition
-from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism
-from psyneulink.core.components.mechanisms.processing.transfermechanism import TransferMechanism
-from psyneulink.core.globals.keywords import ENABLED, INPUT_LABELS_DICT, OUTPUT_LABELS_DICT
+#from psyneulink.core.compositions.composition import Composition
+#from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism
+#from psyneulink.core.components.mechanisms.processing.transfermechanism import TransferMechanism
+#from psyneulink.core.globals.keywords import ENABLED, INPUT_LABELS_DICT, OUTPUT_LABELS_DICT
 
 # FIX 5/8/20 ELIMINATE SYSTEM [JDC] -- CONVERTED TO COMPOSITION, BUT REQUIRE REFACTORING OF LABEL HANDLING
 # class TestMechanismInputLabels:

--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 import psyneulink as pnl
-import psyneulink.core.llvm as pnlvm
 
 from psyneulink.core.compositions.composition import Composition
 from psyneulink.core.components.functions.function import FunctionError

--- a/tests/mechanisms/test_objective_mechanism.py
+++ b/tests/mechanisms/test_objective_mechanism.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-import psyneulink.core.llvm as pnlvm
 from psyneulink.core.components.mechanisms.processing.objectivemechanism import ObjectiveMechanism
 
 VECTOR_SIZE=4

--- a/tests/mechanisms/test_processing_mechanism.py
+++ b/tests/mechanisms/test_processing_mechanism.py
@@ -2,8 +2,6 @@ import numpy as np
 import pytest
 
 from psyneulink.core.components.functions.function import FunctionError
-from psyneulink.core.components.functions.nonstateful.selectionfunctions import (
-    ARG_MAX, ARG_MAX_ABS_INDICATOR, ARG_MAX_INDICATOR)
 from psyneulink.core.components.functions.nonstateful.learningfunctions import Hebbian, Reinforcement, TDLearning
 from psyneulink.core.components.functions.nonstateful.objectivefunctions import Distance
 from psyneulink.core.components.functions.nonstateful.distributionfunctions import NormalDist, ExponentialDist, \

--- a/tests/mechanisms/test_processing_mechanism.py
+++ b/tests/mechanisms/test_processing_mechanism.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from psyneulink.core import llvm as pnlvm
 from psyneulink.core.components.functions.function import FunctionError
 from psyneulink.core.components.functions.nonstateful.selectionfunctions import (
     ARG_MAX, ARG_MAX_ABS_INDICATOR, ARG_MAX_INDICATOR)

--- a/tests/mechanisms/test_recurrent_transfer_mechanism.py
+++ b/tests/mechanisms/test_recurrent_transfer_mechanism.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 import psyneulink as pnl
-import psyneulink.core.llvm as pnlvm
 
 from psyneulink.core.compositions.composition import Composition
 from psyneulink.core.components.functions.nonstateful.combinationfunctions import Reduce

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-import psyneulink.core.llvm as pnlvm
+import psyneulink as pnl
 from psyneulink.core.components.component import ComponentError
 from psyneulink.core.components.functions.nonstateful.learningfunctions import Reinforcement
 from psyneulink.core.components.functions.stateful.integratorfunctions import AccumulatorIntegrator, AdaptiveIntegrator
@@ -1745,7 +1745,7 @@ class TestOnResumeIntegratorMode:
         result = comp.run(inputs=inputs, execution_mode=comp_mode)
 
         np.testing.assert_allclose(result, [[0.43636140750487973, 0.47074475219780554]])
-        if comp_mode is pnlvm.ExecutionMode.Python:
+        if comp_mode is pnl.ExecutionMode.Python:
             assert decision.num_executions.time_step == 1
             assert decision.num_executions.pass_ == 2
             assert decision.num_executions.trial== 1

--- a/tests/models/test_greedy_agent.py
+++ b/tests/models/test_greedy_agent.py
@@ -9,7 +9,7 @@ from psyneulink.core.components.mechanisms.modulatory.control import Optimizatio
 from psyneulink.core.components.mechanisms.processing.objectivemechanism import ObjectiveMechanism
 from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism
 from psyneulink.core.components.mechanisms.processing.transfermechanism import TransferMechanism
-from psyneulink.core.components.ports.inputport import SHADOW_INPUTS
+#from psyneulink.core.components.ports.inputport import SHADOW_INPUTS
 from psyneulink.core.components.ports.modulatorysignals.controlsignal import ControlSignal
 from psyneulink.core.compositions.composition import Composition, NodeRole
 from psyneulink.core.globals.keywords import VARIANCE, NORMED_L0_SIMILARITY

--- a/tests/ports/test_output_ports.py
+++ b/tests/ports/test_output_ports.py
@@ -1,6 +1,5 @@
 import numpy as np
 import psyneulink as pnl
-import psyneulink.core.llvm as pnlvm
 import pytest
 
 


### PR DESCRIPTION
Use psyneulink.ExecutionMode instead of psyneulink.core.llvm.ExecutionMode.
Drop unused imports of psyneulink.core.llvm. This submodule should not be used outside psyneulink.
Drop unused ctypes import.
Drop other unused imports.