### PR TITLE
ga: Move wheel/sdist creation to install-pnl action

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -5,6 +5,13 @@ inputs:
     description: 'PsyNeuLink features to install'
     required: true
     default: ''
+outputs:
+  wheel:
+    description: 'Returns path to the built .whl package'
+    value: ${{ steps.dist.outputs.wheel }}
+  sdist:
+    description: 'Returns path to the built .sdist package'
+    value: ${{ steps.dist.outputs.sdist }}
 
 runs:
   using: "composite"
@@ -83,12 +90,21 @@ runs:
           echo "new_package=''" >> $GITHUB_OUTPUT
         fi
 
+    - name: Build dist
+      id: dist
+      shell: bash
+      run: |
+        pip install setuptools wheel
+        python setup.py sdist bdist_wheel
+        echo "wheel=$(ls dist/*.whl)" | tee -a "$GITHUB_OUTPUT"
+        echo "sdist=$(ls dist/*.sdist)" | tee -a "$GITHUB_OUTPUT"
+
     - name: Python dependencies
       shell: bash
       run: |
-        pip install -e .[${{ inputs.features }}] -c env_constraints.txt -c broken_trans_deps.txt
+        pip install ${{ steps.dist.outputs.wheel }}[${{ inputs.features }}] -c env_constraints.txt -c broken_trans_deps.txt
 
-    - name: "Cleanup old wheels"
+    - name: Cleanup old wheels
       shell: bash
       run: |
         pip cache info

--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -100,7 +100,7 @@ jobs:
         restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-wheels-${{ hashFiles('requirements.txt', 'doc_requirements.txt') }}
 
     # We need to install all PNL deps since docs config imports psyneulink module
-    - name: Install local, editable PNL package
+    - name: Install PNL package
       uses: ./.github/actions/install-pnl
       with:
         features: 'doc'

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -132,8 +132,9 @@ jobs:
         key: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-${{ hashFiles('requirements.txt', 'dev_requirements.txt') }}-${{ github.sha }}
         restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-${{ hashFiles('requirements.txt', 'dev_requirements.txt') }}
 
-    - name: Install local, editable PNL package
+    - name: Install PNL package
       uses: ./.github/actions/install-pnl
+      id: install
       with:
         features: 'dev'
 
@@ -185,15 +186,10 @@ jobs:
           echo "::warning::Not uploading to coveralls.io, token not available!"
         fi
 
-    - name: Build dist
-      run: |
-        pip install setuptools wheel
-        python setup.py sdist bdist_wheel
-
     - name: Upload dist packages
       uses: actions/upload-artifact@v4
       if: matrix.version-restrict == ''
       with:
         name: dist-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}
-        path: dist/
+        path: ${{ steps.install.outputs.wheel }} ${{ steps.install.outputs.sdist }}
         retention-days: 2


### PR DESCRIPTION
Use wheel package to install psyneulink instead of using editable install.
Provide paths in install-pnl action outputs.
Use install-pnl outputs to upload the hwheel/sdist.