### PR TITLE
llvm: Control debug output via PNL_LLVM_DEBUG env var

### DIFF
--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -46,10 +46,10 @@ def module_count():
 
 
 _BUILTIN_PREFIX = "__pnl_builtin_"
-_builtin_intrinsics = frozenset(('pow', 'log', 'exp', 'tanh', 'coth', 'csch',
-                                 'sin', 'cos',
+_builtin_intrinsics = frozenset(('pow', 'log', 'exp', 'tanh', 'coth', 'csch', 'sin', 'cos',
                                  'is_close_float', 'is_close_double',
-                                 'mt_rand_init', 'philox_rand_init'))
+                                 'mt_rand_init', 'philox_rand_init',
+                                 'get_printf_address'))
 
 
 class _node_assembly():

--- a/psyneulink/core/llvm/debug.py
+++ b/psyneulink/core/llvm/debug.py
@@ -20,7 +20,7 @@ Increased debug output:
  * "stat" -- prints code generation and compilation statistics
  * "time_stat" -- print compilation and code generation times
  * "comp_node_debug" -- print intermediate results after execution composition node wrapper.
- * "print_values" -- Enabled printfs in llvm code (from ctx printf helper)
+ * "printf_tags" -- Enabledprintfs in compiled caode with the specififed tags
 
 Compilation modifiers:
  * "const_data" -- hardcode initial output values into generated code,

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -9,12 +9,9 @@
 # ********************************************* PNL LLVM helpers **************************************************************
 
 from contextlib import contextmanager
-from ctypes import util
 import warnings
-import sys
 
 from llvmlite import ir
-import llvmlite.binding as llvm
 
 
 from .debug import debug_env
@@ -401,55 +398,52 @@ def call_elementwise_operation(ctx, builder, x, operation, output_ptr):
     for (inp_ptr, out_ptr) in recursive_iterate_arrays(ctx, builder, x, output_ptr):
         builder.store(operation(ctx, builder, builder.load(inp_ptr)), out_ptr)
 
-def printf(builder, fmt, *args, override_debug=False):
+def printf(ctx, builder, fmt, *args, override_debug=False):
     if "print_values" not in debug_env and not override_debug:
         return
 
-    #FIXME: Fix builtin printf and use that instead of this
-    libc_name = "msvcrt" if sys.platform == "win32" else "c"
-    libc = util.find_library(libc_name)
-    assert libc is not None, "Standard libc library not found"
-
-    llvm.load_library_permanently(libc)
-    # Address will be none if the symbol is not found
-    printf_address = llvm.address_of_symbol("printf")
-    assert printf_address is not None, "'printf' symbol not found in {}".format(libc)
-
-    # Direct pointer constants don't work
-    printf_ty = ir.FunctionType(ir.IntType(32), [ir.IntType(8).as_pointer()], var_arg=True)
-    printf = builder.inttoptr(ir.IntType(64)(printf_address), printf_ty.as_pointer())
-    ir_module = builder.function.module
-    fmt += "\0"
-
+    # Set up the formatting string as global symbol
     int8 = ir.IntType(8)
-    fmt_data = bytearray(fmt.encode("utf8"))
+    fmt_data = bytearray((fmt + "\0").encode("utf8"))
     fmt_ty = ir.ArrayType(int8, len(fmt_data))
-    global_fmt = ir.GlobalVariable(ir_module, fmt_ty,
+
+    ir_module = builder.function.module
+    global_fmt = ir.GlobalVariable(ir_module,
+                                   fmt_ty,
                                    name="printf_fmt_" + str(len(ir_module.globals)))
     global_fmt.linkage = "internal"
     global_fmt.global_constant = True
     global_fmt.initializer = fmt_ty(fmt_data)
 
-    fmt_ptr = builder.gep(global_fmt, [ir.IntType(32)(0), ir.IntType(32)(0)])
-    conv_args = [builder.fpext(a, ir.DoubleType()) if is_floating_point(a) else a for a in args]
-    builder.call(printf, [fmt_ptr] + conv_args)
+    printf_ty = ir.FunctionType(ir.IntType(32), [ir.IntType(8).as_pointer()], var_arg=True)
+    get_printf_addr_f = ctx.get_builtin("get_printf_address", [])
+    printf_address = builder.call(get_printf_addr_f, [])
+
+    printf_is_not_null = builder.icmp_unsigned("!=", printf_address, printf_address.type(0))
+    with builder.if_then(printf_is_not_null, likely=True):
+        printf_f = builder.inttoptr(printf_address, printf_ty.as_pointer())
+
+        fmt_ptr = builder.gep(global_fmt, [ir.IntType(32)(0), ir.IntType(32)(0)])
+        conv_args = [builder.fpext(a, ir.DoubleType()) if is_floating_point(a) else a for a in args]
+        builder.call(printf_f, [fmt_ptr] + conv_args)
 
 
-def printf_float_array(builder, array, prefix="", suffix="\n", override_debug=False):
-    printf(builder, prefix, override_debug=override_debug)
+def printf_float_array(ctx, builder, array, prefix="", suffix="\n", override_debug=False):
+    printf(ctx, builder, prefix, override_debug=override_debug)
 
     with array_ptr_loop(builder, array, "print_array_loop") as (b1, i):
-        printf(b1, "%lf ", b1.load(b1.gep(array, [i.type(0), i])), override_debug=override_debug)
+        printf(ctx, b1, "%lf ", b1.load(b1.gep(array, [i.type(0), i])), override_debug=override_debug)
 
-    printf(builder, suffix, override_debug=override_debug)
+    printf(ctx, builder, suffix, override_debug=override_debug)
 
 
-def printf_float_matrix(builder, matrix, prefix="", suffix="\n", override_debug=False):
-    printf(builder, prefix, override_debug=override_debug)
+def printf_float_matrix(ctx, builder, matrix, prefix="", suffix="\n", override_debug=False):
+    printf(ctx, builder, prefix, override_debug=override_debug)
     with array_ptr_loop(builder, matrix, "print_row_loop") as (b1, i):
         row = b1.gep(matrix, [i.type(0), i])
-        printf_float_array(b1, row, suffix="\n", override_debug=override_debug)
-    printf(builder, suffix, override_debug=override_debug)
+        printf_float_array(ctx, b1, row, suffix="\n", override_debug=override_debug)
+
+    printf(ctx, builder, suffix, override_debug=override_debug)
 
 
 class ConditionGenerator:

--- a/psyneulink/core/llvm/jit_engine.py
+++ b/psyneulink/core/llvm/jit_engine.py
@@ -280,12 +280,14 @@ class cpu_jit_engine(jit_engine):
             self._jit_engine.set_object_cache(self._object_cache)
 
 
+# FIXME: Get device side printf pointer
 _ptx_builtin_source = """
 __device__ {type} __pnl_builtin_sin({type} a) {{ return sin(a); }}
 __device__ {type} __pnl_builtin_cos({type} a) {{ return cos(a); }}
 __device__ {type} __pnl_builtin_log({type} a) {{ return log(a); }}
 __device__ {type} __pnl_builtin_exp({type} a) {{ return exp(a); }}
 __device__ {type} __pnl_builtin_pow({type} a, {type} b) {{ return pow(a, b); }}
+__device__ int64_t __pnl_builtin_get_printf_address() {{ return 0; }}
 """
 
 

--- a/psyneulink/library/compositions/compiledoptimizer.py
+++ b/psyneulink/library/compositions/compiledoptimizer.py
@@ -106,8 +106,8 @@ class AdamOptimizer(Optimizer):
         t = builder.gep(optim_struct, [zero, ctx.int32_ty(self._T_NUM)])
 
         # get methods needed
-        pow = ctx.import_llvm_function("__pnl_builtin_pow")
-        sqrt = ctx.get_builtin("sqrt", [ctx.float_ty])
+        pow_f = ctx.import_llvm_function("__pnl_builtin_pow")
+        sqrt_f = ctx.get_builtin("sqrt", [ctx.float_ty])
 
         lr = ctx.float_ty(self.lr)
         eps = ctx.float_ty(self.eps)
@@ -120,13 +120,12 @@ class AdamOptimizer(Optimizer):
         builder.store(builder.fadd(builder.load(t), one_float), t)
         t_val = builder.load(t)
         # 1.5) calculate values to be used later (based on incremented t)
-        b1_pow = builder.call(pow, [b1, t_val])
-        b2_pow = builder.call(pow, [b2, t_val])
+        b1_pow = builder.call(pow_f, [b1, t_val])
+        b2_pow = builder.call(pow_f, [b2, t_val])
         one_minus_b1_pow = builder.fsub(one_float, b1_pow)
         one_minus_b2_pow = builder.fsub(one_float, b2_pow)
 
-        pnlvm.helpers.printf(
-                builder, f"%f b1_pow_sub %f\nb2 pow sub %f\n",t_val, one_minus_b1_pow, one_minus_b2_pow)
+        pnlvm.helpers.printf(ctx, builder, f"%f b1_pow_sub %f\nb2 pow sub %f\n",t_val, one_minus_b1_pow, one_minus_b2_pow)
 
         # 2) update first moments
         for idx, proj in enumerate(self._pytorch_model.projection_wrappers):
@@ -144,7 +143,11 @@ class AdamOptimizer(Optimizer):
             # m_t = m_t + (1-b1)*g_t
             gen_inject_mat_add(ctx, builder, m_t_ptr, tmp_val, m_t_ptr)
 
-            pnlvm.helpers.printf_float_matrix(builder, m_t_ptr, prefix=f"mt val: {proj.sender._mechanism} -> {proj.receiver._mechanism}\n", override_debug=False)
+            pnlvm.helpers.printf_float_matrix(ctx,
+                                              builder,
+                                              m_t_ptr,
+                                              prefix=f"mt val: {proj.sender._mechanism} -> {proj.receiver._mechanism}\n",
+                                              override_debug=False)
         # 3) update second moments
         for idx, proj in enumerate(self._pytorch_model.projection_wrappers):
             proj_idx_ir = ctx.int32_ty(idx)
@@ -180,24 +183,28 @@ class AdamOptimizer(Optimizer):
             delta_w_ptr = builder.gep(
                 delta_w, [zero, proj_idx_ir])
 
-            pnlvm.helpers.printf_float_matrix(builder, delta_w_ptr, prefix=f"grad val: {proj.sender._mechanism} -> {proj.receiver._mechanism}\n", override_debug=False)
+            pnlvm.helpers.printf_float_matrix(ctx,
+                                              builder,
+                                              delta_w_ptr,
+                                              prefix=f"grad val: {proj.sender._mechanism} -> {proj.receiver._mechanism}\n",
+                                              override_debug=False)
 
             # this is messy - #TODO - cleanup this
             weights_llvmlite = proj._extract_llvm_matrix(ctx, builder, state, params)
             dim_x, dim_y = proj.matrix.shape
 
             weight_row = None
-            pnlvm.helpers.printf(builder, "biascorr2 %.20f\n", one_minus_b2_pow, override_debug=False)
+            pnlvm.helpers.printf(ctx, builder, "biascorr2 %.20f\n", one_minus_b2_pow, override_debug=False)
             with pnlvm.helpers.for_loop_zero_inc(builder, ctx.int32_ty(dim_x), "optimizer_w_upd_outer") as (b1, weight_row):
                 weight_column = None
                 with pnlvm.helpers.for_loop_zero_inc(b1, ctx.int32_ty(dim_y), "optimizer_w_upd_inner") as (b2, weight_column):
                     # sqrt(v_t) + eps
                     v_t_value = b2.load(b2.gep(v_t_ptr, [zero, weight_row, weight_column]))
-                    value = b2.call(sqrt, [v_t_value])
-                    denom = b2.call(sqrt, [one_minus_b2_pow])
+                    value = b2.call(sqrt_f, [v_t_value])
+                    denom = b2.call(sqrt_f, [one_minus_b2_pow])
                     value = b2.fdiv(value, denom)
                     value = b2.fadd(value, eps)
-                    pnlvm.helpers.printf(builder, "val %.20f\n", value, override_debug=False)
+                    pnlvm.helpers.printf(ctx, builder, "val %.20f\n", value, override_debug=False)
                     # alpha_t * m_t
                     m_t_value = b2.load(b2.gep(
                         m_t_ptr, [zero, weight_row, weight_column]))
@@ -213,9 +220,9 @@ class AdamOptimizer(Optimizer):
                     value = b2.fadd(b2.load(old_weight_ptr), value)
                     b2.store(value, old_weight_ptr)
 
-                pnlvm.helpers.printf(b1, "\n", override_debug=False)
+                pnlvm.helpers.printf(ctx, b1, "\n", override_debug=False)
 
-        pnlvm.helpers.printf(builder, f"\t\t\tOPTIM DONE UPDATE\n",override_debug=False)
+        pnlvm.helpers.printf(ctx, builder, f"\t\t\tOPTIM DONE UPDATE\n",override_debug=False)
 
         builder.ret_void()
 

--- a/tests/llvm/test_debug_composition.py
+++ b/tests/llvm/test_debug_composition.py
@@ -26,7 +26,7 @@ def preserve_env():
 
 
 debug_options = ["const_input=[[[7]]]", "const_input", "const_params", "const_data", "const_state",
-                 "stat", "time_stat", "unaligned_copy"]
+                 "stat", "time_stat", "unaligned_copy", "printf_tags={'always'}"]
 options_combinations = (";".join(c) for c in pytest.helpers.power_set(debug_options))
 
 @pytest.mark.composition
@@ -62,7 +62,6 @@ def test_debug_comp(mode, debug_env):
 
     if "const_state" in debug_env:
         expected2 = expected1
-
 
     np.testing.assert_allclose(expected1, output1[0][0])
     np.testing.assert_allclose(expected2, output2[0][0])

--- a/tests/llvm/test_helpers.py
+++ b/tests/llvm/test_helpers.py
@@ -224,7 +224,7 @@ def test_helper_printf(capfd, ir_argtype, format_spec, values_to_check):
         block = function.append_basic_block(name="entry")
         builder = ir.IRBuilder(block)
 
-        pnlvm.helpers.printf(ctx, builder, format_str, *ir_values_to_check, override_debug=True)
+        pnlvm.helpers.printf(ctx, builder, format_str, *ir_values_to_check, tags={"always"})
         builder.ret_void()
 
     bin_f = pnlvm.LLVMBinaryFunction.get(custom_name)

--- a/tests/llvm/test_helpers.py
+++ b/tests/llvm/test_helpers.py
@@ -224,7 +224,7 @@ def test_helper_printf(capfd, ir_argtype, format_spec, values_to_check):
         block = function.append_basic_block(name="entry")
         builder = ir.IRBuilder(block)
 
-        pnlvm.helpers.printf(builder, format_str, *ir_values_to_check, override_debug=True)
+        pnlvm.helpers.printf(ctx, builder, format_str, *ir_values_to_check, override_debug=True)
         builder.ret_void()
 
     bin_f = pnlvm.LLVMBinaryFunction.get(custom_name)


### PR DESCRIPTION
Use per jit-engine printf pointer to not crash printf calls on GPU.
Replace 'overrride_debug' with tags and allow dynamic control via PNL_LLVM_DEBUG env var.