### PR TITLE
showgraph: rework output directory use and defaults

### DIFF
--- a/psyneulink/_version.py
+++ b/psyneulink/_version.py
@@ -19,7 +19,6 @@ import sys
 from typing import Any, Callable, Dict, List, Optional, Tuple
 import functools
 
-root_dir = os.path.abspath(os.path.dirname(__file__))
 
 def get_keywords() -> Dict[str, str]:
     """Get the keywords needed to look up the version information."""

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -2882,6 +2882,7 @@ import types
 import numbers
 import itertools
 import logging
+import pathlib
 import sys
 import typing
 import warnings
@@ -11056,7 +11057,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
               are animated; if it is greater than the number of trials being run, only the number being run are
               animated.
 
-            * *MOVIE_DIR*: str (default=project root dir) -- specifies the directdory to be used for the movie file;
+            * *MOVIE_DIR*: str or os.PathLike (default=project root dir) -- specifies the directdory to be used for the movie file;
               by default a subdirectory of <root_dir>/show_graph_OUTPUT/GIFS is created using the `name
               <Composition.name>` of the  `Composition`, and the gif files are stored there.
 
@@ -11490,7 +11491,7 @@ _
 
             if self._animate is not False:
                 # Save list of gifs in self._animation as movie file
-                movie_path = self._animation_directory + '/' + self._movie_filename
+                movie_path = pathlib.Path(self._animation_directory, self._movie_filename)
                 self._animation[0].save(fp=movie_path,
                                         format='GIF',
                                         save_all=True,

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -11057,9 +11057,12 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
               are animated; if it is greater than the number of trials being run, only the number being run are
               animated.
 
-            * *MOVIE_DIR*: str or os.PathLike (default=project root dir) -- specifies the directdory to be used for the movie file;
-              by default a subdirectory of <root_dir>/show_graph_OUTPUT/GIFS is created using the `name
-              <Composition.name>` of the  `Composition`, and the gif files are stored there.
+            * *MOVIE_DIR*: str or os.PathLike (default=PsyNeuLink root
+              dir or current dir) -- specifies the directory to be used
+              for the movie file; by default a subdirectory of
+              <MOVIE_DIR>/pnl-show_graph-output/GIFs is created using
+              the `name <Composition.name>` of the `Composition`, and
+              the gif files are stored there.
 
             * *MOVIE_NAME*: str (default=\\ `name <Composition.name>` + 'movie') -- specifies the name to be used
               for the movie file; it is automatically appended with '.gif'.

--- a/psyneulink/core/compositions/showgraph.py
+++ b/psyneulink/core/compositions/showgraph.py
@@ -288,6 +288,10 @@ NESTING_LEVEL = 'nesting_level'
 NUM_NESTING_LEVELS = 'num_nesting_levels'
 COMP_HIERARCHY = 'comp_hierarchy' # dict specifying the enclosing composition at each level of nesting
 
+
+default_showgraph_subdir = 'show_graph output'
+
+
 class ShowGraphError(Exception):
 
     def __init__(self, error_value):
@@ -2655,7 +2659,7 @@ class ShowGraph():
         try:
             if output_fmt == 'pdf':
                 # G.format = 'svg'
-                G.view(composition.name.replace(" ", "-"), cleanup=True, directory='show_graph OUTPUT/PDFS')
+                G.view(composition.name.replace(" ", "-"), cleanup=True, directory=f'{default_showgraph_subdir}/PDFS')
 
             # Generate images for animation
             elif output_fmt == 'gif':
@@ -2814,7 +2818,7 @@ class ShowGraph():
         if isinstance(composition._animate, dict):
             # Assign directory for animation files
             from psyneulink._version import root_dir
-            default_dir = root_dir + '/../show_graph output/GIFs/' + composition.name # + " gifs"
+            default_dir = root_dir + f'/../{default_showgraph_subdir}/GIFs/' + composition.name # + " gifs"
             # try:
             #     rmtree(composition._animate_directory)
             # except:

--- a/psyneulink/core/compositions/showgraph.py
+++ b/psyneulink/core/compositions/showgraph.py
@@ -289,7 +289,7 @@ NUM_NESTING_LEVELS = 'num_nesting_levels'
 COMP_HIERARCHY = 'comp_hierarchy' # dict specifying the enclosing composition at each level of nesting
 
 
-default_showgraph_subdir = 'show_graph output'
+default_showgraph_subdir = 'pnl-show_graph-output'
 
 
 class ShowGraphError(Exception):

--- a/psyneulink/core/compositions/showgraph.py
+++ b/psyneulink/core/compositions/showgraph.py
@@ -216,6 +216,7 @@ Class Reference
 """
 
 import inspect
+import pathlib
 import warnings
 from psyneulink._typing import Union
 
@@ -2659,7 +2660,7 @@ class ShowGraph():
         try:
             if output_fmt == 'pdf':
                 # G.format = 'svg'
-                G.view(composition.name.replace(" ", "-"), cleanup=True, directory=f'{default_showgraph_subdir}/PDFS')
+                G.view(composition.name.replace(" ", "-"), cleanup=True, directory=pathlib.Path(default_showgraph_subdir, 'PDFS'))
 
             # Generate images for animation
             elif output_fmt == 'gif':
@@ -2818,7 +2819,7 @@ class ShowGraph():
         if isinstance(composition._animate, dict):
             # Assign directory for animation files
             from psyneulink._version import root_dir
-            default_dir = root_dir + f'/../{default_showgraph_subdir}/GIFs/' + composition.name # + " gifs"
+            default_dir = pathlib.Path(root_dir, '..', default_showgraph_subdir, 'GIFs', composition.name)
             # try:
             #     rmtree(composition._animate_directory)
             # except:
@@ -2850,9 +2851,14 @@ class ShowGraph():
                 raise ShowGraphError(f"{repr(SIMULATIONS)} entry of {repr('animate')} argument for "
                                        f"{repr('show_graph')} method of {composition.name} ({composition._animate_num_trials}) "
                                        f"must a boolean.")
-            if not isinstance(composition._animation_directory, str):
-                raise ShowGraphError(f"{repr(MOVIE_DIR)} entry of {repr('animate')} argument for {repr('run')} "
-                                       f"method of {composition.name} ({composition._animation_directory}) must be a string.")
+            try:
+                composition._animation_directory = pathlib.Path(composition._animation_directory)
+            except TypeError:
+                raise ShowGraphError(
+                    f"{repr(MOVIE_DIR)} entry of 'animate' argument for 'run'"
+                    f" method of {composition.name} ({composition._animation_directory})"
+                    " must be a string or os.PathLike."
+                )
             if not isinstance(composition._movie_filename, str):
                 raise ShowGraphError(f"{repr(MOVIE_NAME)} entry of {repr('animate')} argument for {repr('run')} "
                                        f"method of {composition.name} ({composition._movie_filename}) must be a string.")
@@ -2934,7 +2940,7 @@ class ShowGraph():
         G.attr(fontsize='14')
         index = repr(composition._component_animation_execution_count)
         image_filename = '-'.join([repr(run_num), repr(trial_num), index])
-        image_file = composition._animation_directory + '/' + image_filename + '.gif'
+        image_file = pathlib.Path(composition._animation_directory, image_filename + '.gif')
         G.render(filename=image_filename,
                  directory=composition._animation_directory,
                  cleanup=True,


### PR DESCRIPTION
- change subdirectory from "show_graph OUTPUT" or "show_graph output" to "pnl-show_graph-output"
- use pathlib to make directory/file names
- avoid using python site-packages dir as a default if psyneulink is installed as non-editable