### PR TITLE
requirements: Bump fastkde to 2.x

### DIFF
--- a/psyneulink/core/components/functions/nonstateful/fitfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/fitfunctions.py
@@ -189,7 +189,11 @@ def simulation_likelihood(
                 continue
 
             # Do KDE
-            fKDE = fastKDE.fastKDE(dsub, doSaveMarginals=False)
+            try:
+                fKDE = fastKDE.fastKDE(dsub, do_save_marginals=False)
+            except TypeError:
+                fKDE = fastKDE.fastKDE(dsub, doSaveMarginals=False)
+
             pdf = fKDE.pdf
             axes = fKDE.axes
 

--- a/psyneulink/core/components/functions/nonstateful/fitfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/fitfunctions.py
@@ -189,10 +189,7 @@ def simulation_likelihood(
                 continue
 
             # Do KDE
-            try:
-                fKDE = fastKDE.fastKDE(dsub, do_save_marginals=False)
-            except TypeError:
-                fKDE = fastKDE.fastKDE(dsub, doSaveMarginals=False)
+            fKDE = fastKDE.fastKDE(dsub, do_save_marginals=False)
 
             pdf = fKDE.pdf
             axes = fKDE.axes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beartype<0.20.0
 dill<0.3.10
-fastkde>=1.0.24, <1.0.31
+fastkde>=1.0.24, <2.0.2
 graph-scheduler>=1.2.1, <1.3.0
 graphviz<0.21.0
 grpcio<1.68.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beartype<0.20.0
 dill<0.3.10
-fastkde>=1.0.24, <2.0.2
+fastkde>=2.0.0, <2.0.2
 graph-scheduler>=1.2.1, <1.3.0
 graphviz<0.21.0
 grpcio<1.68.0


### PR DESCRIPTION
fastkde 2.x uses underscores in keyword params rather than camelCase.
versions 2.0.0 and 2.0.1 are available for all covered python versions (3.7-3.12)