### PR TITLE
Scheduler: fix false add_condition replace warning

### DIFF
--- a/psyneulink/core/scheduling/scheduler.py
+++ b/psyneulink/core/scheduling/scheduler.py
@@ -56,8 +56,6 @@ class Scheduler(graph_scheduler.Scheduler, MDFSerializable):
 
         # TODO: consider integrating something like this into graph-scheduler?
         self._user_specified_conds = graph_scheduler.ConditionSet()
-        if conditions is not None:
-            self._user_specified_conds.add_condition_set(copy.copy(conditions))
         self._user_specified_termination_conds = copy.copy(termination_conds) if termination_conds is not None else {}
 
         super().__init__(


### PR DESCRIPTION
Do not set _user_specified_conds in __init__,
because it will be set by add_condition_set
in graph_scheduler.Scheduler.__init__. This second call would result in the condition replacement warning for any conditions passed in.