### PR TITLE
RecurrentTransferMechanism: fix Stability standard output port creation

### DIFF
--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -975,18 +975,18 @@ class RecurrentTransferMechanism(TransferMechanism):
             self.configure_learning(context=context)
 
         if ENERGY_OUTPUT_PORT_NAME in self.output_ports.names:
-            energy = Stability(self.defaults.variable[0],
+            energy = Stability(self.defaults.variable,
                                metric=ENERGY,
                                transfer_fct=self.function,
-                               matrix=self.recurrent_projection._parameter_ports[MATRIX])
+                               matrix=matrix)
             self.output_ports[ENERGY_OUTPUT_PORT_NAME]._calculate = energy.function
 
         if ENTROPY_OUTPUT_PORT_NAME in self.output_ports.names:
             if self.function.bounds == (0,1) or self.clip == (0,1):
-                entropy = Stability(self.defaults.variable[0],
+                entropy = Stability(self.defaults.variable,
                                     metric=ENTROPY,
                                     transfer_fct=self.function,
-                                    matrix=self.recurrent_projection._parameter_ports[MATRIX])
+                                    matrix=matrix)
                 self.output_ports[ENTROPY_OUTPUT_PORT_NAME]._calculate = entropy.function
             else:
                 del self.output_ports[ENTROPY_OUTPUT_PORT_NAME]

--- a/tests/mechanisms/test_lca.py
+++ b/tests/mechanisms/test_lca.py
@@ -10,6 +10,11 @@ from psyneulink.core.components.mechanisms.processing.processingmechanism import
 from psyneulink.core.scheduling.condition import Never, WhenFinished
 from psyneulink.library.components.mechanisms.processing.transfer.lcamechanism import \
     LCAMechanism, MAX_VS_AVG, MAX_VS_NEXT, CONVERGENCE
+from psyneulink.library.components.mechanisms.processing.transfer.recurrenttransfermechanism import (
+    ENERGY_OUTPUT_PORT_NAME,
+    ENTROPY_OUTPUT_PORT_NAME,
+)
+
 
 class TestLCA:
 
@@ -270,6 +275,22 @@ class TestLCA:
         comp1.add_node(lca)
         result1 = comp1.run(inputs={lca:[1, -1]}, execution_mode=comp_mode)
         np.testing.assert_allclose(result1, [[0.52497918747894, 0.47502081252106]])
+
+    def test_lca_standard_output_ports(self):
+        lca = pnl.LCAMechanism(
+            input_shapes=3,
+            output_ports=[pnl.RESULT, pnl.ENERGY, pnl.ENTROPY]
+        )
+        assert len(lca.output_ports) == 3
+        assert lca.output_ports[1].name == pnl.ENERGY == ENERGY_OUTPUT_PORT_NAME
+        assert lca.output_ports[2].name == pnl.ENTROPY == ENTROPY_OUTPUT_PORT_NAME
+
+        # TODO: uncomment or replace these checks when the relevant
+        # output ports are implemented
+        # for ip in lca.output_ports[1:]:
+        #     assert isinstance(ip.function, pnl.Stability)
+        #     assert ip.function.defaults.variable.shape == lca.defaults.variable.shape
+        #     assert ip.function.defaults.matrix == lca.recurrent_projection.defaults.matrix
 
 
 class TestLCAReset:


### PR DESCRIPTION
- fix shape incompatibility between lower-dimension Stability variable and its transfer_fct with variable matching the owning RecurrentTransferMechanism
- fix assignment of ParameterPort to Stability matrix rather than a matrix/array

problem was masked by inconsistency of ENERGY_OUTPUT_PORT_NAME and ENERGY keywords, which stopped the related standard output port code from being used