### PR TITLE
Component: determine dependent _parameter_components as needed

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1273,8 +1273,6 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
 
         self.initialization_status = ContextFlags.INITIALIZED
 
-        self._update_parameter_components(context)
-
         self.compositions = weakref.WeakSet()
 
         # Delete the _user_specified_args attribute, we don't need it anymore
@@ -4357,25 +4355,19 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
             Returns a set of Components that are values of this object's
             Parameters
         """
-        try:
-            return self.__parameter_components
-        except AttributeError:
-            self.__parameter_components = set()
-            return self.__parameter_components
-
-    @handle_external_context()
-    def _update_parameter_components(self, context=None):
         # store all Components in Parameters to be used in
         # _dependent_components for _initialize_from_context
+        res = set()
         for p in self.parameters:
-            param_value = p._get(context)
-            try:
-                param_value = param_value.__self__
-            except AttributeError:
-                pass
+            for param_value in p.values.values():
+                try:
+                    param_value = param_value.__self__
+                except AttributeError:
+                    pass
 
-            if isinstance(param_value, Component) and param_value is not self:
-                self._parameter_components.add(param_value)
+                if isinstance(param_value, Component) and param_value is not self:
+                    res.add(param_value)
+        return res
 
     @property
     def _dependent_components(self):

--- a/psyneulink/core/components/projections/pathway/mappingprojection.py
+++ b/psyneulink/core/components/projections/pathway/mappingprojection.py
@@ -522,7 +522,6 @@ class MappingProjection(PathwayProjection_Base):
             context=context
         )
         self._parameter_ports[MATRIX]._instantiate_value(context)
-        self._parameter_ports[MATRIX]._update_parameter_components(context)
 
         # # Assign ParameterPort the same Log as the MappingProjection, so that its entries are accessible to Mechanisms
         # self._parameter_ports[MATRIX].log = self.log

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -4149,8 +4149,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         #     `num_trials_per_estimate <OptimizationControlMechanism.num_trials_per_estimate>` attribute.
         self.num_trials = None
 
-        self._update_parameter_components()
-
         self.initialization_status = ContextFlags.INITIALIZED
         #FIXME: This removes `composition.parameters.values`, as it was not being
         # populated correctly in the first place. `composition.parameters.results`

--- a/psyneulink/library/compositions/regressioncfa.py
+++ b/psyneulink/library/compositions/regressioncfa.py
@@ -302,7 +302,6 @@ class RegressionCFA(CompositionFunctionApproximator):
         if isinstance(self.update_weights, type):
             self.update_weights = \
                 self.update_weights(default_variable=update_weights_default_variable)
-            self._update_parameter_components(context)
         else:
             self.update_weights.reset({DEFAULT_VARIABLE: update_weights_default_variable})
 


### PR DESCRIPTION
Storing Components at end of __init__ is enough in most cases, but other Components may be assigned to Parameters afterward, and these must also be correctly initialized on Composition.run

Removing call to _get because any Components return as a result of a Parameter getter will also be assigned to Parameter.values