### PR TITLE
Parameter: correct .set post-initialization check

### DIFF
--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -1516,7 +1516,7 @@ class Parameter(ParameterBase):
         if isinstance(value, Component):
             owner = self._owner._owner
             if value not in owner._parameter_components:
-                if not owner.is_initializing:
+                if owner.initialization_status == ContextFlags.INITIALIZED:
                     value._initialize_from_context(context)
                     owner._parameter_components.add(value)
 


### PR DESCRIPTION
Parameter.set checks for Component values assigned after its owning Component's __init__ so that the assigned Components can be shaped compatibly and set up for later context initialization.

Check for ContextFlags.INITIALIZED initialization_status instead of is_initialized, because is_initialized also considers any initialization context, not just the status of having completed Component.__init__