### PR TITLE
ci: release workflow minor corrections

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -128,7 +128,7 @@ jobs:
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:
-        name: test-results-${{ matrix.os }}-${{ matrix.python-version }}
+        name: test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.dist }}
         path: tests_out.xml
         retention-days: 30
       if: success() || failure()

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -72,6 +72,11 @@ jobs:
         python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12]
         os: [ubuntu-latest, macos-latest, windows-latest]
         dist: [wheel, sdist]
+        exclude:
+          # 3.7 is broken on macos-11,
+          # https://github.com/actions/virtual-environments/issues/4230
+          - python-version: '3.7'
+            os: macos-latest
 
     runs-on: ${{ matrix.os }}
     needs: [create-python-dist]


### PR DESCRIPTION
- exclude unavailable macos-11 on py3.7 
- add matrix.dist to test result artifact to avoid duplication