### PR TITLE
Mechanism: fix execute with no input causing shared default variable memory

### DIFF
--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2539,7 +2539,7 @@ class Mechanism_Base(Mechanism):
 
                     # No input was specified, so use Mechanism's default variable
                     if input is None:
-                        input = self.defaults.variable
+                        input = copy_parameter_value(self.defaults.variable)
                     #     FIX:  this input value is sent to input CIMs when compositions are nested
                     #           variable should be based on afferent projections
                     variable = self._get_variable_from_input(input, context)

--- a/tests/mechanisms/test_mechanisms.py
+++ b/tests/mechanisms/test_mechanisms.py
@@ -130,6 +130,14 @@ class TestMechanism:
         ):
             t.parameters.noise.set(pnl.NormalDist)
 
+    def test_execute_no_input_doesnt_change_default_variable(self):
+        m = pnl.ProcessingMechanism(default_variable=1)
+        assert m.defaults.variable == [[1]]
+        m.execute()
+        assert m.defaults.variable == [[1]]
+        m.execute(2)
+        assert m.defaults.variable == [[1]]
+
 
 class TestMechanismFunctionParameters:
     f = pnl.Linear()


### PR DESCRIPTION
Calling Mechanism.execute with no input uses the Mechanism's defaults.variable as input. This was passed in without creating a copy, which resulted in defaults.variable sharing memory with an InputPort.variable, which could result in silent changes to the Mechanism's defaults.variable.