### PR TITLE
llvm: cleanup

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1413,13 +1413,9 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
     def _get_state_ids(self):
         return [sp.name for sp in self._get_compilation_state()]
 
-    @property
+    @functools.cached_property
     def llvm_state_ids(self):
-        ids = getattr(self, "_state_ids", None)
-        if ids is None:
-            ids = self._get_state_ids()
-            setattr(self, "_state_ids", ids)
-        return ids
+        return self._get_state_ids()
 
     def _get_state_initializer(self, context):
         def _convert(p):
@@ -1569,13 +1565,9 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
     def _get_param_ids(self):
         return [p.name for p in self._get_compilation_params()]
 
-    @property
+    @functools.cached_property
     def llvm_param_ids(self):
-        ids = getattr(self, "_param_ids", None)
-        if ids is None:
-            ids = self._get_param_ids()
-            setattr(self, "_param_ids", ids)
-        return ids
+        return self._get_param_ids()
 
     def _is_param_modulated(self, p):
         try:

--- a/psyneulink/core/components/functions/nonstateful/transformfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/transformfunctions.py
@@ -101,9 +101,11 @@ class TransformFunction(Function_Base):
         if isinstance(param_type, pnlvm.ir.LiteralStructType):
             assert len(param_type) == 0
             return ctx.float_ty(default)
+
         elif isinstance(param_type, pnlvm.ir.ArrayType):
             index = ctx.int32_ty(0) if len(param_type) == 1 else index
             param_ptr = builder.gep(param_ptr, [ctx.int32_ty(0), index])
+
         return builder.load(param_ptr)
 
     def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tags:frozenset):

--- a/psyneulink/core/llvm/builtins.py
+++ b/psyneulink/core/llvm/builtins.py
@@ -45,7 +45,7 @@ def setup_vxm(ctx):
     # zero the output array
     with helpers.for_loop_zero_inc(builder, y, "zero") as (b1, index):
         ptr = b1.gep(o, [index])
-        b1.store(ctx.float_ty(0), ptr)
+        b1.store(ptr.type.pointee(0), ptr)
 
     # Multiplication
     with helpers.for_loop_zero_inc(builder, x, "vxm_outer") as (b1, index_i):
@@ -84,7 +84,7 @@ def setup_vxm_transposed(ctx):
     # zero the output array
     with helpers.for_loop_zero_inc(builder, x, "zero") as (b1, index):
         ptr = b1.gep(o, [index])
-        b1.store(ctx.float_ty(0), ptr)
+        b1.store(ptr.type.pointee(0), ptr)
 
     # Multiplication
     with helpers.for_loop_zero_inc(builder, x, "trans_vxm_outer") as (b1, index_j):
@@ -149,7 +149,7 @@ def setup_vec_sum(ctx):
     u, x, o = builder.function.args
 
     # Sum
-    builder.store(ctx.float_ty(-0), o)
+    builder.store(o.type.pointee(-0), o)
     with helpers.for_loop_zero_inc(builder, x, "sum") as (b1, index):
         u_ptr = b1.gep(u, [index])
         u_val = b1.load(u_ptr)
@@ -828,9 +828,9 @@ def _setup_mt_rand_float(ctx, state_ty, gen_int):
     # NOTE: The combination below could be implemented using bit ops,
     # but due to floating point rounding it'd give slightly different
     # random numbers
-    val = builder.fmul(af, ctx.float_ty(67108864.0))           # Shift left 26
+    val = builder.fmul(af, af.type(67108864.0))           # Shift left 26
     val = builder.fadd(val, bf)                                # Combine
-    val = builder.fdiv(val, ctx.float_ty(9007199254740992.0))  # Scale
+    val = builder.fdiv(val, val.type(9007199254740992.0))  # Scale
 
     # The value is in interval [0, 1)
     lower_bound = builder.fcmp_ordered(">=", val, val.type(0.0))
@@ -876,14 +876,14 @@ def _setup_mt_rand_normal(ctx, state_ty, gen_float):
     # X1 is in (-1, 1)
     builder.call(gen_float, [state, tmp])
     x1 = builder.load(tmp)
-    x1 = builder.fmul(x1, ctx.float_ty(2.0))
-    x1 = builder.fsub(x1, ctx.float_ty(1.0))
+    x1 = builder.fmul(x1, x1.type(2.0))
+    x1 = builder.fsub(x1, x1.type(1.0))
 
     # x2 is in (-1, 1)
     builder.call(gen_float, [state, tmp])
     x2 = builder.load(tmp)
-    x2 = builder.fmul(x2, ctx.float_ty(2.0))
-    x2 = builder.fsub(x2, ctx.float_ty(1.0))
+    x2 = builder.fmul(x2, x2.type(2.0))
+    x2 = builder.fsub(x2, x2.type(1.0))
 
     r2 = builder.fmul(x1, x1)
     r2 = builder.fadd(r2, builder.fmul(x2, x2))

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -263,19 +263,9 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
         # Only True/False are currently supported as named constants
         # Call deprecated visit_* methods to maintain coverage
         if node.value is True or node.value is False:
-            return self.visit_NameConstant(node)
+            return self.ctx.bool_ty(node.value)
 
-        return self.visit_Num(node)
-
-    # deprecated in Python3.8+
-    def visit_NameConstant(self, node):
-        # Only True and False are supported atm
-        assert node.value is True or node.value is False
-        return self.ctx.bool_ty(node.value)
-
-    # deprecated in Python3.8+
-    def visit_Num(self, node):
-        return self.ctx.float_ty(node.n)
+        return self.ctx.float_ty(node.value)
 
     def visit_Tuple(self, node:ast.AST):
         elements = (self.visit(element) for element in node.elts)

--- a/psyneulink/library/compositions/pytorchwrappers.py
+++ b/psyneulink/library/compositions/pytorchwrappers.py
@@ -479,7 +479,7 @@ class PytorchCompositionWrapper(torch.nn.Module):
         # 3) compute errors
         loss_fn = ctx.import_llvm_function(loss)
         total_loss = builder.alloca(ctx.float_ty)
-        builder.store(ctx.float_ty(0), total_loss)
+        builder.store(total_loss.type.pointee(0), total_loss)
 
         error_dict = {}
         for exec_set in reversed(self.execution_sets):


### PR DESCRIPTION
Remove deprecated AST traversal callbacks.
Use the type of known typed operand in binary operations.
Use `functools.cached_property` instead of open coding the functionality.