### PR TITLE
utilities: Allow Numpy warnings from numpy.exceptions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ xfail_strict = True
 
 filterwarnings =
 	error::SyntaxWarning
-	error:Creating an ndarray from ragged nested sequences \(which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes\) is deprecated.*:numpy.VisibleDeprecationWarning
+	error:Creating an ndarray from ragged nested sequences \(which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes\) is deprecated.*
 	error:Invalid escape sequence
 	error:the matrix subclass is not the recommended way to represent matrices or deal with linear algebra
 	error:Passing (type, 1) or '1type' as a synonym of type is deprecated


### PR DESCRIPTION
Numpy 1.25.0 moved warnings and errors to a submodule[0]. Moreover, they are removed from the top level namespace in later versions of Numpy[1].

Add and use exception import that either points to the new exception submodule, or the global namespace depending on whether the former is available.

[0] https://numpy.org/doc/2.1/release/1.25.0-notes.html#numpy-now-has-an-np-exceptions-namespace
[1] https://numpy.org/doc/2.1/release/2.0.0-notes.html#numpy-2-0-python-api-removals