### PR TITLE
llvm; Refactor ExecutionMode handling

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -71,8 +71,7 @@ def pytest_runtest_setup(item):
 def pytest_generate_tests(metafunc):
     mech_and_func_modes = ['Python',
                            pytest.param('LLVM', marks=pytest.mark.llvm),
-                           pytest.param('PTX', marks=[pytest.mark.llvm,
-                                                      pytest.mark.cuda])
+                           pytest.param('PTX', marks=[pytest.mark.llvm, pytest.mark.cuda])
                           ]
 
     if "func_mode" in metafunc.fixturenames:
@@ -81,9 +80,9 @@ def pytest_generate_tests(metafunc):
     if "mech_mode" in metafunc.fixturenames:
         metafunc.parametrize("mech_mode", mech_and_func_modes)
 
-    if "comp_mode_no_llvm" in metafunc.fixturenames:
+    if "comp_mode_no_per_node" in metafunc.fixturenames:
         modes = [m for m in get_comp_execution_modes()
-                 if m.values[0] is not pnlvm.ExecutionMode.LLVM]
+                 if m.values[0] is not pnlvm.ExecutionMode._LLVMPerNode]
         metafunc.parametrize("comp_mode", modes)
 
     elif "comp_mode" in metafunc.fixturenames:
@@ -151,7 +150,7 @@ def pytest_runtest_teardown(item):
     pnlvm.cleanup("llvm" in item.keywords and not skip_cleanup_check)
 
 @pytest.fixture
-def comp_mode_no_llvm():
+def comp_mode_no_per_node():
     # dummy fixture to allow 'comp_mode' filtering
     pass
 
@@ -187,7 +186,7 @@ def llvm_current_fp_precision():
 @pytest.helpers.register
 def get_comp_execution_modes():
     return [pytest.param(pnlvm.ExecutionMode.Python),
-            pytest.param(pnlvm.ExecutionMode.LLVM, marks=pytest.mark.llvm),
+            pytest.param(pnlvm.ExecutionMode._LLVMPerNode, marks=pytest.mark.llvm),
             pytest.param(pnlvm.ExecutionMode._LLVMExec, marks=pytest.mark.llvm),
             pytest.param(pnlvm.ExecutionMode.LLVMRun, marks=pytest.mark.llvm),
             pytest.param(pnlvm.ExecutionMode.PTXRun, marks=[pytest.mark.llvm,  pytest.mark.cuda])

--- a/conftest.py
+++ b/conftest.py
@@ -188,7 +188,7 @@ def llvm_current_fp_precision():
 def get_comp_execution_modes():
     return [pytest.param(pnlvm.ExecutionMode.Python),
             pytest.param(pnlvm.ExecutionMode.LLVM, marks=pytest.mark.llvm),
-            pytest.param(pnlvm.ExecutionMode.LLVMExec, marks=pytest.mark.llvm),
+            pytest.param(pnlvm.ExecutionMode._LLVMExec, marks=pytest.mark.llvm),
             pytest.param(pnlvm.ExecutionMode.LLVMRun, marks=pytest.mark.llvm),
             pytest.param(pnlvm.ExecutionMode.PTXRun, marks=[pytest.mark.llvm,  pytest.mark.cuda])
            ]

--- a/docs/source/Compilation.rst
+++ b/docs/source/Compilation.rst
@@ -34,7 +34,7 @@ Compiled form of a model can be invoked by passing one of the following values t
 
   * `ExecutionMode.Python`: Normal python execution
   * `ExecutionMode.LLVM`: Compile and execute individual nodes. The scheduling loop still runs in Python. If any of the nodes fails to compile, an error is raised. *NOTE:* Schedules that require access to node data will not work correctly.
-  * `ExecutionMode.LLVMExec`: Execution of `Composition.exec` is replaced by a compiled equivalent. If the `Composition` fails to compile, an error is raised.
+  * `ExecutionMode._LLVMExec`: Execution of `Composition.exec` is replaced by a compiled equivalent. If the `Composition` fails to compile, an error is raised.
   * `ExecutionMode.LLVMRun`: Execution of `Composition.run` is replaced by a compiled equivalent. If the `Composition` fails to compile, an error is raised.
   * `ExecutionMode.Auto`: This option attempts all three above mentioned granularities, and gracefully falls back to lower granularity. Warnings are raised in place of errors. This is the recommended way to invoke compiled execution as the final fallback is the Python baseline.
 

--- a/docs/source/Compilation.rst
+++ b/docs/source/Compilation.rst
@@ -33,7 +33,7 @@ Use
 Compiled form of a model can be invoked by passing one of the following values to the `bin_execute` parameter of `Composition.run`, or `Composition.exec`:
 
   * `ExecutionMode.Python`: Normal python execution
-  * `ExecutionMode.LLVM`: Compile and execute individual nodes. The scheduling loop still runs in Python. If any of the nodes fails to compile, an error is raised. *NOTE:* Schedules that require access to node data will not work correctly.
+  * `ExecutionMode._LLVMPerNode`: Compile and execute individual nodes. The scheduling loop still runs in Python. If any of the nodes fails to compile, an error is raised. *NOTE:* Schedules that require access to node data will not work correctly.
   * `ExecutionMode._LLVMExec`: Execution of `Composition.exec` is replaced by a compiled equivalent. If the `Composition` fails to compile, an error is raised.
   * `ExecutionMode.LLVMRun`: Execution of `Composition.run` is replaced by a compiled equivalent. If the `Composition` fails to compile, an error is raised.
   * `ExecutionMode.Auto`: This option attempts all three above mentioned granularities, and gracefully falls back to lower granularity. Warnings are raised in place of errors. This is the recommended way to invoke compiled execution as the final fallback is the Python baseline.

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -2067,14 +2067,15 @@ in order of their power, are:
       the compiled binary is semantically equivalent to the execution of the `run <Composition.run>` method
       using the Python interpreter;
 
-    * `ExecutionMode.LLVMExec` -- compile and run each `TRIAL <TimeScale.TRIAL>`, using the Python interpreter
+    * `ExecutionMode._LLVMExec` -- compile and run each `TRIAL <TimeScale.TRIAL>`, using the Python interpreter
       to iterate over them; if successful, the compiled binary for each `TRIAL <TimeScale.TRIAL>` is semantically
       equivalent the execution of the `execute <Composition.execute>` method using the Python interpreter;
+      This mode does not support Trial scope scheduling rules and should not be used outside of development or testing.
 
     * `ExecutionMode.LLVM` -- compile and run `Node <Composition_Nodes>` of the `Composition` and their `Projections
       <Projection>`, using the Python interpreter to call the Composition's `scheduler <Composition.scheduler>`,
       execute each Node and iterate over `TRIAL <TimeScale.TRIAL>`\\s; note that, in this mode, scheduling
-      `Conditions <Condition>` that rely on Node `Parameters` is not supported;
+      `Conditions <Condition>` that rely on Node `Parameters` are not supported;
 
     * `ExecutionMode.Python` (same as *False*; the default) -- use the Python interpreter to execute the `Composition`.
 

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -11432,7 +11432,7 @@ _
                     _comp_ex = pnlvm.CompExecution.get(self, context, additional_tags=comp_ex_tags)
                     if execution_mode & pnlvm.ExecutionMode.LLVM:
                         results += _comp_ex.run(inputs, num_trials, num_inputs_sets)
-                    elif execution_mode & pnlvm.ExecutionMode.PTX:
+                    elif execution_mode & pnlvm.ExecutionMode._PTX:
                         results += _comp_ex.cuda_run(inputs, num_trials, num_inputs_sets)
                     else:
                         assert False, "Unknown execution mode: {}".format(execution_mode)

--- a/psyneulink/core/llvm/__init__.py
+++ b/psyneulink/core/llvm/__init__.py
@@ -49,7 +49,7 @@ class ExecutionMode(enum.Flag):
     LLVM
       compile and run Composition `Nodes <Composition_Nodes>` and `Projections <Projection>` individually.
 
-    LLVMExec
+    _LLVMExec
       compile and run each `TRIAL <TimeScale.TRIAL>` individually.
 
     LLVMRun
@@ -84,7 +84,7 @@ class ExecutionMode(enum.Flag):
 
     Auto = _Fallback | _Run | _Exec | LLVM
     LLVMRun = LLVM | _Run
-    LLVMExec = LLVM | _Exec
+    _LLVMExec = LLVM | _Exec
     PTXRun = _PTX | _Run
     COMPILED = ~ (Python | PyTorch)
 

--- a/psyneulink/core/llvm/__init__.py
+++ b/psyneulink/core/llvm/__init__.py
@@ -74,21 +74,41 @@ class ExecutionMode(enum.Flag):
       compile and run multiple `TRIAL <TimeScale.TRIAL>`\\s using CUDA for GPU.
    """
 
-    Python   = 0
-    PyTorch = enum.auto()
-    LLVM     = enum.auto()
+    Python    = 0
+    PyTorch   = enum.auto()
+    _LLVM     = enum.auto()
     _PTX      = enum.auto()
     _PerNode  = enum.auto()
     _Exec     = enum.auto()
     _Run      = enum.auto()
     _Fallback = enum.auto()
 
-    Auto = _Fallback | _Run | _Exec | LLVM
-    LLVMRun = LLVM | _Run
-    _LLVMExec = LLVM | _Exec
-    _LLVMPerNode = LLVM | _PerNode
+    Auto = _Fallback | _Run | _Exec | _LLVM
     PTXRun = _PTX | _Run
-    COMPILED = ~ (Python | PyTorch)
+    LLVMRun = _LLVM | _Run
+    _LLVMExec = _LLVM | _Exec
+    _LLVMPerNode = _LLVM | _PerNode
+
+    def is_cpu_compiled(self):
+        is_cpu_compiled = self & self._LLVM
+
+        # assert that only on of CPU and GPU compiled modes is enabled
+        if is_cpu_compiled:
+            assert not self & self._PTX
+
+        return is_cpu_compiled
+
+    def is_gpu_compiled(self):
+        is_gpu_compiled = self & self._PTX
+
+        # assert that only on of CPU and GPU compiled modes is enabled
+        if is_gpu_compiled:
+            assert not self & self._LLVM
+
+        return is_gpu_compiled
+
+    def is_compiled(self):
+        return self.is_cpu_compiled() or self.is_gpu_compiled()
 
 
 _binary_generation = 0

--- a/psyneulink/core/llvm/__init__.py
+++ b/psyneulink/core/llvm/__init__.py
@@ -77,7 +77,7 @@ class ExecutionMode(enum.Flag):
     Python   = 0
     PyTorch = enum.auto()
     LLVM     = enum.auto()
-    PTX      = enum.auto()
+    _PTX      = enum.auto()
     _Run      = enum.auto()
     _Exec     = enum.auto()
     _Fallback = enum.auto()
@@ -85,7 +85,7 @@ class ExecutionMode(enum.Flag):
     Auto = _Fallback | _Run | _Exec | LLVM
     LLVMRun = LLVM | _Run
     LLVMExec = LLVM | _Exec
-    PTXRun = PTX | _Run
+    PTXRun = _PTX | _Run
     COMPILED = ~ (Python | PyTorch)
 
 

--- a/psyneulink/core/llvm/__init__.py
+++ b/psyneulink/core/llvm/__init__.py
@@ -78,13 +78,15 @@ class ExecutionMode(enum.Flag):
     PyTorch = enum.auto()
     LLVM     = enum.auto()
     _PTX      = enum.auto()
-    _Run      = enum.auto()
+    _PerNode  = enum.auto()
     _Exec     = enum.auto()
+    _Run      = enum.auto()
     _Fallback = enum.auto()
 
     Auto = _Fallback | _Run | _Exec | LLVM
     LLVMRun = LLVM | _Run
     _LLVMExec = LLVM | _Exec
+    _LLVMPerNode = LLVM | _PerNode
     PTXRun = _PTX | _Run
     COMPILED = ~ (Python | PyTorch)
 

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -949,7 +949,7 @@ class AutodiffComposition(Composition):
                     if node not in self.get_nodes_by_role(NodeRole.TARGET)
                     for pathway in _get_pytorch_backprop_pathway(node)]
 
-        if execution_mode == pnlvm.ExecutionMode.PyTorch:
+        if execution_mode is pnlvm.ExecutionMode.PyTorch:
             # For PyTorch mode, only need to construct dummy TARGET Nodes, to allow targets to be:
             #  - specified in the same way as for other execution_modes
             #  - trial-by-trial values kept aligned with inputs in batch / minibatch construction
@@ -1073,7 +1073,7 @@ class AutodiffComposition(Composition):
           before the next time it calls run(), in a call to backward() by do_gradient_optimization()
           in _batch_inputs() or _batch_function_inputs(),
         """
-        assert execution_mode == pnlvm.ExecutionMode.PyTorch
+        assert execution_mode is pnlvm.ExecutionMode.PyTorch
         pytorch_rep = self.parameters.pytorch_representation._get(context)
 
         # --------- Do forward computation on current inputs -------------------------------------------------

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -184,7 +184,7 @@ AutoDiffCompositions in learning. Although it is best suited for use with `super
        during execution (see `AutodiffComposition_Nested_Modulation` below), which is not supported by PyTorch.
 
     .. warning::
-      * Specifying `ExecutionMode.LLVM` or `ExecutionMode.PyTorch` in the learn() method of a standard
+      * Specifying `ExecutionMode.LLVMRun` or `ExecutionMode.PyTorch` in the learn() method of a standard
         `Composition` causes an error.
 
 COMMENT:
@@ -204,7 +204,7 @@ the constructor (see `AutodiffComposition <AutodiffComposition_Class_Reference>`
 `Compilation Modes <Composition_Compiled_Modes>` for more information about executing a Composition in compiled mode.
 
     .. note::
-       Specifying `ExecutionMode.LLVMRUn` in either the `learn <Composition.learn>` and `run <Composition.run>`
+       Specifying `ExecutionMode.LLVMRun` in either the `learn <Composition.learn>` and `run <Composition.run>`
        methods of an AutodiffComposition causes it to (attempt to) use compiled execution in both cases; this is
        because LLVM compilation supports the use of modulation in PsyNeuLink models (as compared to `PyTorch mode
        <AutodiffComposition_PyTorch>`; see `note <AutodiffComposition_PyTorch_Note>` below).

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -238,10 +238,12 @@ class CompositionRunner():
         Outputs from the final execution
         """
 
-        if not (execution_mode & ExecutionMode.COMPILED):
-            self._is_llvm_mode = False
-        else:
+        if execution_mode.is_compiled():
+            assert execution_mode.is_cpu_compiled()
             self._is_llvm_mode = True
+
+        else:
+            self._is_llvm_mode = False
 
         if execution_mode is ExecutionMode.Python and learning_rate is not None:
             # User learning_rate specified in call to learn, so use that by passing it in runtime_params,

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -359,7 +359,7 @@ class CompositionRunner():
                                   **kwargs)
             skip_initialization = True
 
-            if execution_mode == ExecutionMode.PyTorch:
+            if execution_mode is ExecutionMode.PyTorch:
                 pytorch_rep = (self._composition.parameters.pytorch_representation._get(context).
                                copy_weights_to_psyneulink(context))
                 if pytorch_rep and synch_with_pnl_options[MATRIX_WEIGHTS] == MINIBATCH:
@@ -372,7 +372,7 @@ class CompositionRunner():
             self._composition.parameters.results.get(context)[-1 * num_epoch_results:], context)
         # return result of last *trial* (as usual for a call to run)
 
-        if execution_mode == ExecutionMode.PyTorch and synch_with_pnl_options[MATRIX_WEIGHTS] == EPOCH:
+        if execution_mode is ExecutionMode.PyTorch and synch_with_pnl_options[MATRIX_WEIGHTS] == EPOCH:
             # Copy weights at end of learning run
             pytorch_rep.copy_weights_to_psyneulink(context)
 

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -2907,12 +2907,13 @@ class TestMiscTrainingFunctionality:
 
         # fp32 results are different due to rounding
         if pytest.helpers.llvm_current_fp_precision() == 'fp32' and \
-           autodiff_mode != pnl.ExecutionMode.PyTorch and \
+           autodiff_mode is not pnl.ExecutionMode.PyTorch and \
            optimizer_type == 'sgd' and \
            learning_rate == 10:
             expected = [[[0.9918830394744873]], [[0.9982172846794128]], [[0.9978305697441101]], [[0.9994590878486633]]]
+
         # FIXME: LLVM version is broken with learning rate == 1.5
-        if learning_rate != 1.5 or autodiff_mode == pnl.ExecutionMode.PyTorch:
+        if learning_rate != 1.5 or autodiff_mode is pnl.ExecutionMode.PyTorch:
             np.testing.assert_allclose(results, expected)
 
 

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -3764,7 +3764,7 @@ class TestRun:
         np.testing.assert_allclose(np.array([[75.]]), output)
 
     @pytest.mark.parametrize("mode", [pnl.ExecutionMode.Python,
-                                      pytest.param(pnl.ExecutionMode.LLVM, marks=pytest.mark.llvm),
+                                      pytest.param(pnl.ExecutionMode._LLVMPerNode, marks=pytest.mark.llvm),
                                       pytest.param(pnl.ExecutionMode._LLVMExec, marks=pytest.mark.llvm),
                                      ])
     def test_execute_composition(self, mode):
@@ -3864,7 +3864,7 @@ class TestRun:
                 and "that is in deferred init" in str(error_text.value))
 
     @pytest.mark.parametrize("mode", [pnl.ExecutionMode.Python,
-                                      pytest.param(pnl.ExecutionMode.LLVM, marks=pytest.mark.llvm),
+                                      pytest.param(pnl.ExecutionMode._LLVMPerNode, marks=pytest.mark.llvm),
                                       pytest.param(pnl.ExecutionMode._LLVMExec, marks=pytest.mark.llvm),
                                      ])
     def test_execute_no_inputs(self, mode):
@@ -4423,8 +4423,8 @@ class TestRun:
         self._check_comp_ex(comp, None, comp_mode, struct_name, is_not=True)
         self._check_comp_ex(comp, orig_comp_ex, comp_mode, struct_name, is_not=True)
 
-    @pytest.mark.usefixtures("comp_mode_no_llvm")
-    @pytest.mark.parametrize("comp_mode2", [m for m in pytest.helpers.get_comp_execution_modes() if m.values[0] is not pnl.ExecutionMode.LLVM])
+    @pytest.mark.usefixtures("comp_mode_no_per_node")
+    @pytest.mark.parametrize("comp_mode2", [m for m in pytest.helpers.get_comp_execution_modes() if m.values[0] is not pnl.ExecutionMode._LLVMPerNode])
     def test_execution_after_cleanup_enum_param(self, comp_mode, comp_mode2):
         """
         This test checks that compiled sync works for Parameters with Enum values.
@@ -6607,7 +6607,7 @@ class TestProperties:
 
     @pytest.mark.composition
     @pytest.mark.parametrize("mode", [pnl.ExecutionMode.Auto, pnl.ExecutionMode.Python,
-                                      pytest.param(pnl.ExecutionMode.LLVM, marks=[_fallback_xfail, pytest.mark.llvm]),
+                                      pytest.param(pnl.ExecutionMode._LLVMPerNode, marks=[_fallback_xfail, pytest.mark.llvm]),
                                       pytest.param(pnl.ExecutionMode._LLVMExec, marks=[_fallback_xfail, pytest.mark.llvm]),
                                       pytest.param(pnl.ExecutionMode.LLVMRun, marks=[_fallback_xfail, pytest.mark.llvm]),
                                       pytest.param(pnl.ExecutionMode.PTXRun, marks=[_fallback_xfail, pytest.mark.llvm, pytest.mark.cuda]),

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -4274,7 +4274,7 @@ class TestRun:
             comp.run()
 
     def _check_comp_ex(self, comp, comparison, comp_mode, struct_name, context=None, is_not=False):
-        if comp_mode == pnl.ExecutionMode.Python:
+        if comp_mode is pnl.ExecutionMode.Python:
             return
 
         if context is None:

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -3765,7 +3765,7 @@ class TestRun:
 
     @pytest.mark.parametrize("mode", [pnl.ExecutionMode.Python,
                                       pytest.param(pnl.ExecutionMode.LLVM, marks=pytest.mark.llvm),
-                                      pytest.param(pnl.ExecutionMode.LLVMExec, marks=pytest.mark.llvm),
+                                      pytest.param(pnl.ExecutionMode._LLVMExec, marks=pytest.mark.llvm),
                                      ])
     def test_execute_composition(self, mode):
         comp = Composition()
@@ -3865,7 +3865,7 @@ class TestRun:
 
     @pytest.mark.parametrize("mode", [pnl.ExecutionMode.Python,
                                       pytest.param(pnl.ExecutionMode.LLVM, marks=pytest.mark.llvm),
-                                      pytest.param(pnl.ExecutionMode.LLVMExec, marks=pytest.mark.llvm),
+                                      pytest.param(pnl.ExecutionMode._LLVMExec, marks=pytest.mark.llvm),
                                      ])
     def test_execute_no_inputs(self, mode):
         m_inner = ProcessingMechanism(input_shapes=2)
@@ -6608,7 +6608,7 @@ class TestProperties:
     @pytest.mark.composition
     @pytest.mark.parametrize("mode", [pnl.ExecutionMode.Auto, pnl.ExecutionMode.Python,
                                       pytest.param(pnl.ExecutionMode.LLVM, marks=[_fallback_xfail, pytest.mark.llvm]),
-                                      pytest.param(pnl.ExecutionMode.LLVMExec, marks=[_fallback_xfail, pytest.mark.llvm]),
+                                      pytest.param(pnl.ExecutionMode._LLVMExec, marks=[_fallback_xfail, pytest.mark.llvm]),
                                       pytest.param(pnl.ExecutionMode.LLVMRun, marks=[_fallback_xfail, pytest.mark.llvm]),
                                       pytest.param(pnl.ExecutionMode.PTXRun, marks=[_fallback_xfail, pytest.mark.llvm, pytest.mark.cuda]),
                                      ])

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -2469,7 +2469,7 @@ class TestControlMechanisms:
 
         ret = comp.run(inputs={mech: [2]}, num_trials=1, execution_mode=comp_mode)
         np.testing.assert_allclose(ret, expected)
-        if comp_mode == pnl.ExecutionMode.Python:
+        if comp_mode is pnl.ExecutionMode.Python:
             np.testing.assert_allclose(comp.controller.function.saved_values.flatten(), exp_values)
 
     @pytest.mark.benchmark
@@ -2531,7 +2531,7 @@ class TestControlMechanisms:
         benchmark(comp.run, inputs={ctl_mech:seeds, mech:5.0}, num_trials=len(seeds) * 2, execution_mode=comp_mode)
 
         # Python uses fp64 irrespective of the pytest precision setting
-        precision = 'fp64' if comp_mode == pnl.ExecutionMode.Python else pytest.helpers.llvm_current_fp_precision()
+        precision = 'fp64' if comp_mode is pnl.ExecutionMode.Python else pytest.helpers.llvm_current_fp_precision()
         if prng == 'Default':
             np.testing.assert_allclose(np.squeeze(comp.results[:len(seeds) * 2]), [[100, 21], [100, 23], [100, 20]] * 2)
         elif prng == 'Philox' and precision == 'fp64':
@@ -2644,7 +2644,7 @@ class TestControlMechanisms:
         benchmark(comp.run, inputs={ctl_mech:seeds, mech:0.1}, num_trials=len(seeds) * 2, execution_mode=comp_mode)
 
         # Python uses fp64 irrespective of the pytest precision setting
-        precision = 'fp64' if comp_mode == pnl.ExecutionMode.Python else pytest.helpers.llvm_current_fp_precision()
+        precision = 'fp64' if comp_mode is pnl.ExecutionMode.Python else pytest.helpers.llvm_current_fp_precision()
         if prng == 'Default':
             np.testing.assert_allclose(np.squeeze(comp.results[:len(seeds) * 2]), [[-1, 3.99948962], [1, 3.99948962], [-1, 3.99948962]] * 2)
         elif prng == 'Philox' and precision == 'fp64':
@@ -3359,7 +3359,7 @@ class TestModelBasedOptimizationControlMechanisms_Execution:
         results, saved_values = benchmark(comp_run, inputs, mode)
 
         np.testing.assert_array_equal(results, result)
-        if mode == pnl.ExecutionMode.Python:
+        if mode is pnl.ExecutionMode.Python:
             np.testing.assert_array_equal(saved_values.flatten(), [0.75, 1.5, 2.25])
 
     def test_model_based_ocm_with_buffer(self):

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -2507,9 +2507,9 @@ class TestControlMechanisms:
     @pytest.mark.benchmark
     @pytest.mark.control
     @pytest.mark.composition
-    # 'LLVM' mode is not supported, because synchronization of compiler and
+    # '_LLVMPerNode' mode is not supported, because synchronization of compiler and
     # python values during execution is not implemented.
-    @pytest.mark.usefixtures("comp_mode_no_llvm")
+    @pytest.mark.usefixtures("comp_mode_no_per_node")
     @pytest.mark.parametrize('prng', ['Default', 'Philox'])
     def test_modulation_of_random_state_DDM(self, comp_mode, benchmark, prng):
         # set explicit seed to make sure modulation is different
@@ -2622,9 +2622,9 @@ class TestControlMechanisms:
     @pytest.mark.benchmark
     @pytest.mark.control
     @pytest.mark.composition
-    # 'LLVM' mode is not supported, because synchronization of compiler and
+    # '_LLVMPerNode' mode is not supported, because synchronization of compiler and
     # python values during execution is not implemented.
-    @pytest.mark.usefixtures("comp_mode_no_llvm")
+    @pytest.mark.usefixtures("comp_mode_no_per_node")
     @pytest.mark.parametrize('prng', ['Default', 'Philox'])
     def test_modulation_of_random_state_DDM_Analytical(self, comp_mode, benchmark, prng):
         # set explicit seed to make sure modulation is different

--- a/tests/composition/test_learning.py
+++ b/tests/composition/test_learning.py
@@ -510,7 +510,7 @@ class TestLearningPathwayMethods:
 
     # Use explicit parametrize instead of the autodiff_mode fixture to avoid
     # applying marks. This test doesn't execute pytorch or compiled mode
-    @pytest.mark.parametrize('execution_mode', [pnl.ExecutionMode.LLVM, pnl.ExecutionMode.PyTorch])
+    @pytest.mark.parametrize('execution_mode', [pnl.ExecutionMode.LLVMRun, pnl.ExecutionMode.PyTorch])
     def test_execution_mode_pytorch_and_LLVM_errors(self, execution_mode):
         A = TransferMechanism(name="learning-process-mech-A")
         B = TransferMechanism(name="learning-process-mech-B")

--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -693,9 +693,9 @@ def test_DDM_threshold_modulation_integrator(comp_mode):
                             (100.0, 100.0, [[100.0], [76.0]]),
                         ])
 # 3/5/2021 - DDM' default behaviour now requires resetting stateful
-# functions after each trial. This is not supported in LLVM execution mode.
+# functions after each trial. This is not supported in _LLVMPerNode execution mode.
 # See: https://github.com/PrincetonUniversity/PsyNeuLink/issues/1935
-@pytest.mark.usefixtures("comp_mode_no_llvm")
+@pytest.mark.usefixtures("comp_mode_no_per_node")
 def test_ddm_is_finished(comp_mode, noise, threshold, expected_results):
 
     comp = Composition()
@@ -711,11 +711,11 @@ def test_ddm_is_finished(comp_mode, noise, threshold, expected_results):
 @pytest.mark.parametrize("until_finished", ["until_finished", "not_until_finished"])
 @pytest.mark.parametrize("threshold_mod", ["threshold_modulated", "threshold_not_modulated"])
 # 3/5/2021 - DDM' default behaviour now requires resetting stateful
-# functions after each trial. This is not supported in LLVM execution mode.
+# functions after each trial. This is not supported in _LLVMPerNode execution mode.
 # See: https://github.com/PrincetonUniversity/PsyNeuLink/issues/1935
 # Moreover, evaluating scheduler conditions in Python is not supported
 # for compiled execution
-@pytest.mark.usefixtures("comp_mode_no_llvm")
+@pytest.mark.usefixtures("comp_mode_no_per_node")
 def test_ddm_is_finished_with_dependency(comp_mode, until_finished, threshold_mod):
 
     comp = Composition()
@@ -801,9 +801,9 @@ def test_sequence_of_DDM_mechs_in_Composition_Pathway():
 @pytest.mark.composition
 @pytest.mark.ddm_mechanism
 # 3/5/2021 - DDM' default behaviour now requires resetting stateful
-# functions after each trial. This is not supported in LLVM execution mode.
+# functions after each trial. This is not supported in _LLVMPerNode execution mode.
 # See: https://github.com/PrincetonUniversity/PsyNeuLink/issues/1935
-@pytest.mark.usefixtures("comp_mode_no_llvm")
+@pytest.mark.usefixtures("comp_mode_no_per_node")
 def test_DDMMechanism_LCA_equivalent(comp_mode):
 
     ddm = DDM(default_variable=[0],

--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -1233,9 +1233,9 @@ class TestStatefulness:
           [np.array([0.5]), np.array([0.9375])],
           [np.array([0.5]), np.array([0.96875])]]),
         ], ids=lambda x: str(x) if isinstance(x, pnl.Condition) else "")
-    # 'LLVM' mode is not supported, because synchronization of compiler and
+    # '_LLVMPerNode' mode is not supported, because synchronization of compiler and
     # python values during execution is not implemented.
-    @pytest.mark.usefixtures("comp_mode_no_llvm")
+    @pytest.mark.usefixtures("comp_mode_no_per_node")
     def test_reset_stateful_function_when_composition(self, comp_mode, cond0, cond1, expected):
         I1 = pnl.IntegratorMechanism()
         I2 = pnl.IntegratorMechanism()

--- a/tests/mechanisms/test_mechanisms.py
+++ b/tests/mechanisms/test_mechanisms.py
@@ -289,7 +289,7 @@ class TestResetValues:
         np.testing.assert_allclose(original_output, [np.array([[0.5]]), np.array([[0.75]])])
         np.testing.assert_allclose(output_after_reinitialization, [np.array([[0.875]]), np.array([[0.9375]])])
 
-    @pytest.mark.usefixtures("comp_mode_no_llvm")
+    @pytest.mark.usefixtures("comp_mode_no_per_node")
     def test_reset_integrator_function(self, comp_mode):
         """This test checks that the Mechanism.integrator_function is reset when the mechanism is"""
 

--- a/tests/mechanisms/test_recurrent_transfer_mechanism.py
+++ b/tests/mechanisms/test_recurrent_transfer_mechanism.py
@@ -1179,8 +1179,8 @@ class TestCustomCombinationFunction:
     @pytest.mark.composition
     @pytest.mark.integrator_mechanism
     @pytest.mark.parametrize('until_finished, expected', [
-        (True, [[[[0.96875]]], [[[0.9990234375]]]]), # The 5th and the 10th iteration
-        (False, [[[[0.5]]], [[[0.75]]]]), # The first and the second iteration
+        (True, [[[0.96875]], [[0.9990234375]]]), # The 5th and the 10th iteration
+        (False, [[[0.5]], [[0.75]]]), # The first and the second iteration
     ], ids=['until_finished', 'oneshot'])
     # 'LLVM' mode is not supported, because synchronization of compiler and
     # python values during execution is not implemented.
@@ -1197,10 +1197,9 @@ class TestCustomCombinationFunction:
         results = C.run(inputs={I1: [[1.0]]}, num_trials=1, execution_mode=comp_mode)
         if comp_mode is pnl.ExecutionMode.Python:
             assert I1.parameters.is_finished_flag.get(C) is until_finished
+
         results2 = C.run(inputs={I1: [[1.0]]}, num_trials=1, execution_mode=comp_mode)
-        if comp_mode is not pnl.ExecutionMode.LLVM:
-            results = [results]
-            results2 = [results2]
+
         np.testing.assert_allclose(expected[0], results)
         np.testing.assert_allclose(expected[1], results2)
 

--- a/tests/mechanisms/test_recurrent_transfer_mechanism.py
+++ b/tests/mechanisms/test_recurrent_transfer_mechanism.py
@@ -1110,9 +1110,9 @@ class TestCustomCombinationFunction:
           [np.array([0.5]), np.array([0.9375])],
           [np.array([0.5]), np.array([0.96875])]]),
         ], ids=lambda x: str(x) if isinstance(x, pnl.Condition) else "")
-    # 'LLVM' mode is not supported, because synchronization of compiler and
+    # '_LLVMPerNode' mode is not supported, because synchronization of compiler and
     # python values during execution is not implemented.
-    @pytest.mark.usefixtures("comp_mode_no_llvm")
+    @pytest.mark.usefixtures("comp_mode_no_per_node")
     def test_reset_stateful_function_when_composition(self, comp_mode, cond0, cond1, expected):
         I1 = pnl.RecurrentTransferMechanism(integrator_mode=True,
                                             integration_rate=0.5)
@@ -1145,9 +1145,9 @@ class TestCustomCombinationFunction:
                              ids=["initializers1", "NO initializers1"])
     @pytest.mark.parametrize('has_initializers1', [True, False],
                              ids=["initializers2", "NO initializers2"])
-    # 'LLVM' mode is not supported, because synchronization of compiler and
+    # '_LLVMPerNode' mode is not supported, because synchronization of compiler and
     # python values during execution is not implemented.
-    @pytest.mark.usefixtures("comp_mode_no_llvm")
+    @pytest.mark.usefixtures("comp_mode_no_per_node")
     def test_reset_stateful_function_when_has_initializers_composition(self, comp_mode, cond0, cond1, expected,
                                            has_initializers1, has_initializers2):
         I1 = pnl.RecurrentTransferMechanism(integrator_mode=True,
@@ -1182,9 +1182,9 @@ class TestCustomCombinationFunction:
         (True, [[[0.96875]], [[0.9990234375]]]), # The 5th and the 10th iteration
         (False, [[[0.5]], [[0.75]]]), # The first and the second iteration
     ], ids=['until_finished', 'oneshot'])
-    # 'LLVM' mode is not supported, because synchronization of compiler and
+    # '_LLVMPerNode' mode is not supported, because synchronization of compiler and
     # python values during execution is not implemented.
-    @pytest.mark.usefixtures("comp_mode_no_llvm")
+    @pytest.mark.usefixtures("comp_mode_no_per_node")
     def test_max_executions_before_finished(self, comp_mode, until_finished, expected):
         I1 = pnl.RecurrentTransferMechanism(integrator_mode=True,
                                             integration_rate=0.5,

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -1650,9 +1650,9 @@ class TestOnResumeIntegratorMode:
 
     @pytest.mark.transfer_mechanism
     @pytest.mark.benchmark(group="TransferMechanism")
-    # 'LLVM' mode is not supported, because synchronization of compiler and
+    # '_LLVMPerNode' mode is not supported, because synchronization of compiler and
     # python values during execution is not implemented.
-    @pytest.mark.usefixtures("comp_mode_no_llvm")
+    @pytest.mark.usefixtures("comp_mode_no_per_node")
     def test_termination_measures(self, comp_mode):
         stim_input = ProcessingMechanism(input_shapes=2, name='Stim Input')
         stim_percept = TransferMechanism(name='Stimulus', input_shapes=2, function=Logistic)

--- a/tests/models/test_greedy_agent.py
+++ b/tests/models/test_greedy_agent.py
@@ -214,7 +214,7 @@ def test_predator_prey(benchmark, mode, ocm_mode, prng, samples, fp_type):
             # np.testing.assert_allclose(run_results, [[0.9705216285127504, -0.1343332460369043]])
             np.testing.assert_allclose(run_results, [[0.9705216285127504, -0.1343332460369043]], atol=1e-6, rtol=1e-6)
         elif prng == 'Philox':
-            if mode == pnl.ExecutionMode.Python or pytest.helpers.llvm_current_fp_precision() == 'fp64':
+            if mode is pnl.ExecutionMode.Python or pytest.helpers.llvm_current_fp_precision() == 'fp64':
                 # np.testing.assert_allclose(run_results[0], [[-0.16882940384606543, -0.07280074899749223]])
                 np.testing.assert_allclose(run_results, [[-0.16882940384606543, -0.07280074899749223]])
             elif pytest.helpers.llvm_current_fp_precision() == 'fp32':
@@ -225,7 +225,7 @@ def test_predator_prey(benchmark, mode, ocm_mode, prng, samples, fp_type):
         else:
             assert False, "Unknown PRNG!"
 
-        if mode == pnl.ExecutionMode.Python and not benchmark.enabled:
+        if mode is pnl.ExecutionMode.Python and not benchmark.enabled:
             # FIXME: The results are 'close' for both Philox and MT,
             #        because they're dominated by costs
             # FIX: Requires 1e-5 tolerance

--- a/tests/models/test_greedy_agent.py
+++ b/tests/models/test_greedy_agent.py
@@ -101,10 +101,9 @@ def test_simplified_greedy_agent_random(benchmark, comp_mode):
 @pytest.mark.parametrize('prng', ['Default', 'Philox'])
 @pytest.mark.parametrize('fp_type', [pnl.core.llvm.ir.DoubleType, pnl.core.llvm.ir.FloatType])
 def test_predator_prey(benchmark, mode, ocm_mode, prng, samples, fp_type):
-    if len(samples) > 10 and mode not in {pnl.ExecutionMode.LLVM,
-                                          pnl.ExecutionMode.LLVMExec,
-                                          pnl.ExecutionMode.LLVMRun} and \
-       ocm_mode not in {'LLVM', 'PTX'}:
+
+    # Skip large test instances that are not CPU compiled, or executed in parallel.
+    if len(samples) > 10 and not (mode & pnl.ExecutionMode.LLVM) and ocm_mode not in {'LLVM', 'PTX'}:
         pytest.skip("This test takes too long")
 
     # Instantiate LLVMBuilderContext using the preferred fp type

--- a/tests/models/test_greedy_agent.py
+++ b/tests/models/test_greedy_agent.py
@@ -103,7 +103,7 @@ def test_simplified_greedy_agent_random(benchmark, comp_mode):
 def test_predator_prey(benchmark, mode, ocm_mode, prng, samples, fp_type):
 
     # Skip large test instances that are not CPU compiled, or executed in parallel.
-    if len(samples) > 10 and not (mode & pnl.ExecutionMode.LLVM) and ocm_mode not in {'LLVM', 'PTX'}:
+    if len(samples) > 10 and not mode.is_compiled() and ocm_mode not in {'LLVM', 'PTX'}:
         pytest.skip("This test takes too long")
 
     # Instantiate LLVMBuilderContext using the preferred fp type

--- a/tests/ports/test_output_ports.py
+++ b/tests/ports/test_output_ports.py
@@ -44,7 +44,7 @@ class TestOutputPorts:
                               (("num_executions", pnl.TimeScale.PASS), [1], [1]),
                               (("num_executions", pnl.TimeScale.TIME_STEP), [1], [1]),
                              ], ids=lambda x: str(x) if len(x) != 1 else '')
-    @pytest.mark.usefixtures("comp_mode_no_llvm")
+    @pytest.mark.usefixtures("comp_mode_no_per_node")
     def tests_output_port_variable_spec_composition(self, comp_mode, spec, expected1, expected2):
         if (len(spec) == 2) and (spec[1] == pnl.TimeScale.RUN) and \
            ((comp_mode & pnl.ExecutionMode._Exec) == pnl.ExecutionMode._Exec):

--- a/tests/ports/test_output_ports.py
+++ b/tests/ports/test_output_ports.py
@@ -46,8 +46,7 @@ class TestOutputPorts:
                              ], ids=lambda x: str(x) if len(x) != 1 else '')
     @pytest.mark.usefixtures("comp_mode_no_per_node")
     def tests_output_port_variable_spec_composition(self, comp_mode, spec, expected1, expected2):
-        if (len(spec) == 2) and (spec[1] == pnl.TimeScale.RUN) and \
-           ((comp_mode & pnl.ExecutionMode._Exec) == pnl.ExecutionMode._Exec):
+        if (len(spec) == 2) and (spec[1] == pnl.TimeScale.RUN) and (comp_mode & pnl.ExecutionMode._Exec):
             pytest.skip("{} is not supported in {}".format(spec[1], comp_mode))
 
         # Test specification of OutputPort's variable

--- a/tests/scheduling/test_condition.py
+++ b/tests/scheduling/test_condition.py
@@ -728,7 +728,7 @@ class TestCondition:
         ]
     )
     @pytest.mark.parametrize('threshold', [10, 10.0])
-    @pytest.mark.usefixtures("comp_mode_no_llvm")
+    @pytest.mark.usefixtures("comp_mode_no_per_node")
     def test_Threshold_parameters(
         self, parameter, indices, default_variable, integration_rate, expected_results, threshold, comp_mode
     ):
@@ -761,7 +761,7 @@ class TestCondition:
             ('!=', -1, 0, [[[-1]]]),
         ]
     )
-    @pytest.mark.usefixtures("comp_mode_no_llvm") # Per-node mode doesn't support Parameter access in conditions
+    @pytest.mark.usefixtures("comp_mode_no_per_node") # Per-node mode doesn't support Parameter access in conditions
     def test_Threshold_comparators(
         self, comparator, increment, threshold, expected_results, comp_mode
     ):
@@ -794,7 +794,7 @@ class TestCondition:
             ('!=', -1, -1, 0, 1, [[[-3]]]),
         ]
     )
-    @pytest.mark.usefixtures("comp_mode_no_llvm") # Per-node mode doesn't support Parameter access in conditions
+    @pytest.mark.usefixtures("comp_mode_no_per_node") # Per-node mode doesn't support Parameter access in conditions
     def test_Threshold_tolerances(
         self, comparator, increment, threshold, atol, rtol, expected_results, comp_mode
     ):

--- a/tests/scheduling/test_condition.py
+++ b/tests/scheduling/test_condition.py
@@ -761,12 +761,10 @@ class TestCondition:
             ('!=', -1, 0, [[[-1]]]),
         ]
     )
+    @pytest.mark.usefixtures("comp_mode_no_llvm") # Per-node mode doesn't support Parameter access in conditions
     def test_Threshold_comparators(
         self, comparator, increment, threshold, expected_results, comp_mode
     ):
-        if comp_mode is pnl.ExecutionMode.LLVM:
-            pytest.skip('ExecutionMode.LLVM does not support Parameter access in conditions')
-
         A = TransferMechanism(
             integrator_mode=True,
             integrator_function=pnl.AccumulatorIntegrator(rate=1, increment=increment),
@@ -796,11 +794,10 @@ class TestCondition:
             ('!=', -1, -1, 0, 1, [[[-3]]]),
         ]
     )
+    @pytest.mark.usefixtures("comp_mode_no_llvm") # Per-node mode doesn't support Parameter access in conditions
     def test_Threshold_tolerances(
         self, comparator, increment, threshold, atol, rtol, expected_results, comp_mode
     ):
-        if comp_mode is pnl.ExecutionMode.LLVM:
-            pytest.skip('ExecutionMode.LLVM does not support Parameter access in conditions')
 
         A = TransferMechanism(
             integrator_mode=True,

--- a/tests/scheduling/test_scheduler.py
+++ b/tests/scheduling/test_scheduler.py
@@ -1544,9 +1544,9 @@ class TestFeedback:
                               (TimeScale.TRIAL, [[1.5], [0.4375]]),
                               (TimeScale.RUN, [[1.5], [0.4375]])],
                               ids=lambda x: x if isinstance(x, TimeScale) else "")
-    # 'LLVM' mode is not supported, because synchronization of compiler and
+    # '_LLVMPerNode' mode is not supported, because synchronization of compiler and
     # python values during execution is not implemented.
-    @pytest.mark.usefixtures("comp_mode_no_llvm")
+    @pytest.mark.usefixtures("comp_mode_no_per_node")
     def test_time_termination_measures(self, comp_mode, timescale, expected):
         in_one_pass = timescale in {TimeScale.TIME_STEP, TimeScale.PASS}
         attention = pnl.TransferMechanism(name='Attention',


### PR DESCRIPTION
Make most compiled modes private for test/development use only.
Introduce a new _LLVMPerNode execution mode.
Do not fall back to per-node mode in automatic fallback.
Use ExecutionMode helper methods rather than COMPILED mask to determine compiled mode.