### PR TITLE
llvm: Return initialized values as output from "reset" function execution variants.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -207,15 +207,15 @@ def cuda_param(val):
     return pytest.param(val, marks=[pytest.mark.llvm, pytest.mark.cuda])
 
 @pytest.helpers.register
-def get_func_execution(func, func_mode):
+def get_func_execution(func, func_mode, *, tags:frozenset=frozenset(), member='function'):
     if func_mode == 'LLVM':
-        return pnlvm.execution.FuncExecution(func).execute
+        return pnlvm.execution.FuncExecution(func, tags=tags).execute
 
     elif func_mode == 'PTX':
-        return pnlvm.execution.FuncExecution(func).cuda_execute
+        return pnlvm.execution.FuncExecution(func, tags=tags).cuda_execute
 
     elif func_mode == 'Python':
-        return func.function
+        return getattr(func, member)
     else:
         assert False, "Unknown function mode: {}".format(func_mode)
 

--- a/conftest.py
+++ b/conftest.py
@@ -220,16 +220,16 @@ def get_func_execution(func, func_mode, *, tags:frozenset=frozenset(), member='f
         assert False, "Unknown function mode: {}".format(func_mode)
 
 @pytest.helpers.register
-def get_mech_execution(mech, mech_mode):
+def get_mech_execution(mech, mech_mode, *, tags:frozenset=frozenset(), member='execute'):
     if mech_mode == 'LLVM':
-        return pnlvm.execution.MechExecution(mech).execute
+        return pnlvm.execution.MechExecution(mech, tags=tags).execute
 
     elif mech_mode == 'PTX':
-        return pnlvm.execution.MechExecution(mech).cuda_execute
+        return pnlvm.execution.MechExecution(mech, tags=tags).cuda_execute
 
     elif mech_mode == 'Python':
         def mech_wrapper(x):
-            mech.execute(x)
+            getattr(mech, member)(x)
             return mech.output_values
 
         return mech_wrapper

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3251,23 +3251,23 @@ class Mechanism_Base(Mechanism):
         on top of the variants supported by Component.
         """
 
-        # Call parent "_gen_llvm_function", this should result in calling
-        # "_gen_llvm_function_body" below
-        if "is_finished" not in tags:
-            return super()._gen_llvm_function(extra_args=extra_args, ctx=ctx, tags=tags)
+        if "is_finished" in tags:
 
-        # Keep all 4 standard arguments to ease invocation
-        args = [ctx.get_param_struct_type(self).as_pointer(),
-                ctx.get_state_struct_type(self).as_pointer(),
-                ctx.get_input_struct_type(self).as_pointer(),
-                ctx.get_output_struct_type(self).as_pointer()]
+            # Keep all 4 standard arguments to ease invocation
+            args = [ctx.get_param_struct_type(self).as_pointer(),
+                    ctx.get_state_struct_type(self).as_pointer(),
+                    ctx.get_input_struct_type(self).as_pointer(),
+                    ctx.get_output_struct_type(self).as_pointer()]
 
-        builder = ctx.create_llvm_function(args, self, return_type=ctx.bool_ty,
-                                           tags=tags)
-        params, state, inputs = builder.function.args[:3]
-        finished = self._gen_llvm_is_finished_cond(ctx, builder, params, state, inputs)
-        builder.ret(finished)
-        return builder.function
+            builder = ctx.create_llvm_function(args, self, return_type=ctx.bool_ty, tags=tags)
+            params, state, inputs = builder.function.args[:3]
+            finished = self._gen_llvm_is_finished_cond(ctx, builder, params, state, inputs)
+            builder.ret(finished)
+            return builder.function
+
+        # Call parent "_gen_llvm_function". This handles standard variants like
+        # no tags, or the "reset" tag.
+        return super()._gen_llvm_function(extra_args=extra_args, ctx=ctx, tags=tags)
 
     def _gen_llvm_function_body(self, ctx, builder, base_params, state, arg_in, arg_out, *, tags:frozenset):
         """

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3241,6 +3241,9 @@ class Mechanism_Base(Mechanism):
 
             builder.call(reinit_func, [reinit_params, reinit_state, reinit_in, reinit_out])
 
+        # update output ports after getting the reinitialized value
+        builder = self._gen_llvm_output_ports(ctx, builder, reinit_out, m_base_params, m_state, m_arg_in, m_arg_out)
+
         return builder
 
     def _gen_llvm_function(self, *, extra_args=[], ctx:pnlvm.LLVMBuilderContext, tags:frozenset):

--- a/tests/functions/test_integrator.py
+++ b/tests/functions/test_integrator.py
@@ -165,9 +165,9 @@ def DriftOnASphereFun(init, value, iterations, noise, **kwargs):
 
     else:
         if "initializer" not in kwargs:
-            return [ 0.23690849,  0.00140115,  0.0020072,  -0.00128063,
-                    -0.00096267, -0.01620475, -0.02644836,  0.46090672,
-                     0.82875571, -0.31584261, -0.00132534]
+            return [ 0.23690849474294814, 0.0014011543771184686, 0.0020071969614023914, -0.0012806262650772564,
+                    -0.0009626666466757963, -0.016204753263919822, -0.026448355473615546, 0.4609067174067295,
+                     0.828755706263852, -0.3158426068946889, -0.0013253357638719173]
 
         else:
             return [-3.72900858e-03, -3.38148799e-04, -6.43154678e-04,  4.36274120e-05,
@@ -226,7 +226,9 @@ def test_execute(func, func_mode, variable, noise, params, benchmark):
     res = benchmark(ex, variable)
 
     expected = func_res(f.initializer, variable, 3, noise, **params)
-    np.testing.assert_allclose(res, expected, rtol=1e-5, atol=1e-8)
+
+    tolerance = {} if pytest.helpers.llvm_current_fp_precision() == 'fp64' else {'rtol':1e-5, 'atol':1e-8}
+    np.testing.assert_allclose(res, expected, **tolerance)
 
 
 def test_integrator_function_no_default_variable_and_params_len_more_than_1():

--- a/tests/mechanisms/test_ddm_mechanism.py
+++ b/tests/mechanisms/test_ddm_mechanism.py
@@ -617,6 +617,28 @@ def test_WhenFinished_DDM_Analytical():
     c.is_satisfied()
 
 
+@pytest.mark.mechanism
+@pytest.mark.parametrize("initializer_param", [{}, {pnl.INITIALIZER: 5.0}], ids=["default_initializer", "custom_initializer"])
+@pytest.mark.parametrize("non_decision_time_param", [{}, {pnl.NON_DECISION_TIME: 13.0}], ids=["default_non_decision_time", "custom_non_decision_time"])
+def test_DDM_reset(mech_mode, initializer_param, non_decision_time_param):
+    D = pnl.DDM(function=pnl.DriftDiffusionIntegrator(**initializer_param, **non_decision_time_param))
+
+    ex = pytest.helpers.get_mech_execution(D, mech_mode)
+
+    initializer_value = initializer_param.get(pnl.INITIALIZER, 0)
+    non_decision_time_value = non_decision_time_param.get(pnl.NON_DECISION_TIME, 0)
+
+    ex([1])
+    ex([2])
+    result = ex([3])
+    np.testing.assert_array_equal(result, [[100], [102 - initializer_value + non_decision_time_value]])
+
+    reset_ex = pytest.helpers.get_mech_execution(D, mech_mode, tags=frozenset({"reset"}), member="reset")
+
+    reset_result = reset_ex(None if mech_mode == "Python" else [0])
+    np.testing.assert_array_equal(reset_result, [[initializer_value], [non_decision_time_value]])
+
+
 @pytest.mark.composition
 @pytest.mark.ddm_mechanism
 @pytest.mark.mechanism


### PR DESCRIPTION
Return the value of "previous_value" Parameter in Function "reset" variant for Functions that don't have other Parameters with initializers.
Return the values of "previous_value" and "previous_time" in DriftDiffusionIntegrator "reset" variant".
Update output ports in Mechanism "reset" execution variants, using the value returned from the Function's "reset" variant.

Update tests to allow the selection of execution variants for Mechanisms and Functions.
Add reproducer from https://github.com/PrincetonUniversity/PsyNeuLink/issues/3142 as a regression test.

Closes: https://github.com/PrincetonUniversity/PsyNeuLink/issues/3142