### PR TITLE
ci/ga: setup.py generates sdist packages with .tar.gz extension

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -103,7 +103,7 @@ runs:
         pip install setuptools wheel
         python setup.py sdist bdist_wheel
         echo "wheel=$(ls dist/*.whl)" | tee -a "$GITHUB_OUTPUT"
-        echo "sdist=$(ls dist/*.sdist)" | tee -a "$GITHUB_OUTPUT"
+        echo "sdist=$(ls dist/*.tar.gz)" | tee -a "$GITHUB_OUTPUT"
 
     - name: Python dependencies
       shell: bash


### PR DESCRIPTION
Fixes: 41b254d284afb1daad6a890f9c11c57799c1a1f1
	("ga: Move wheel/sdist creation to install-pnl action (#3085)")