### PR TITLE
OptimizationFunction: Wrap itertools.product in a generator

### DIFF
--- a/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
@@ -641,7 +641,7 @@ class OptimizationFunction(Function_Base):
         # Run compiled mode if requested by parameter and everything is initialized
         if self.owner and self.owner.parameters.comp_execution_mode._get(context) != 'Python' and \
           ContextFlags.PROCESSING in context.flags:
-            all_samples = [s for s in itertools.product(*self.search_space)]
+            all_samples = list(itertools.product(*self.search_space))
             all_values, num_evals = self._grid_evaluate(self.owner, context, fit_evaluate)
             assert len(all_values) == num_evals
             assert len(all_samples) == num_evals
@@ -846,7 +846,7 @@ class OptimizationFunction(Function_Base):
         """Reset iterators in `search_space <GridSearch.search_space>`"""
         for s in self.search_space:
             s.reset()
-        self.parameters.grid._set(itertools.product(*[s for s in self.search_space]), context)
+        self.parameters.grid._set((s for s in itertools.product(*[s for s in self.search_space])), context)
 
     def _traverse_grid(self, variable, sample_num, context=None):
         """Get next sample from grid.

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ filterwarnings =
 	error:the matrix subclass is not the recommended way to represent matrices or deal with linear algebra
 	error:Passing (type, 1) or '1type' as a synonym of type is deprecated
 	error:A builtin ctypes object gave a PEP3118:RuntimeWarning
+	error:Pickle, copy, and deepcopy support will be removed from itertools:DeprecationWarning
 
 [pycodestyle]
 # for code explanation see https://pep8.readthedocs.io/en/latest/intro.html#error-codes


### PR DESCRIPTION
Itertools classes won't support copy or pickle starting in Python 3.14 Filter the associated DeprecationWarning.

Fixes ~5000 warnings in a full test run.