### PR TITLE
Fix softmax

### DIFF
--- a/psyneulink/core/components/functions/nonstateful/transferfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/transferfunctions.py
@@ -3162,7 +3162,8 @@ class SoftMax(TransferFunction):
             v = np.where(np.abs(v) > mask_threshold, v, -np.inf)
 
         # Make numerically stable by shifting by max value
-        v = v - np.max(v)
+        if np.any(v != -np.inf):
+            v = v - np.max(v)
 
         # Exponentiate
         v = np.exp(v)

--- a/psyneulink/core/components/functions/nonstateful/transferfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/transferfunctions.py
@@ -3487,7 +3487,7 @@ class SoftMax(TransferFunction):
                 # Apply threshold-based masking
                 if mask_threshold is not None:
                     if torch.any(_input < 0):
-                        warnings.warn(f"SoftMax function: mask_threshold is set to {mask_threshold}, "
+                        warnings.warn(f"Softmax function: mask_threshold is set to {mask_threshold}, "
                                       f"but input contains negative values. "
                                       f"Masking will be applied to the magnitude of the input.")
 

--- a/tests/composition/test_emcomposition.py
+++ b/tests/composition/test_emcomposition.py
@@ -742,11 +742,12 @@ class TestExecution:
 
         em = pnl.EMComposition(memory_template=memory_template,
                                memory_capacity=4,
-                               memory_decay_rate= 0,
-                               learn_field_weights = False,
+                               memory_decay_rate=0,
+                               learn_field_weights=False,
                                softmax_choice=softmax_choice,
                                field_weights=field_weights,
-                               field_names=['A','B','C'])
+                               field_names=['A', 'B', 'C'],
+                               )
         # Confirm initial weight assignments (that favor A)
         assert em.nodes['A [WEIGHT]'].input_port.defaults.variable == [.75]
         assert em.nodes['B [WEIGHT]'].input_port.defaults.variable == [.25]
@@ -777,9 +778,9 @@ class TestExecution:
         # Note: field_weights favors A
         if softmax_choice == pnl.MAX_VAL:
             if operation == pnl.L0:
-                expected = [[1.70381182], [0.], [3.40762364]]
+                expected = [[1.703812], [0.], [3.407624]]
             else:
-                expected = [[1.56081243, 0.0], [0.0, 1.56081243], [3.12162487, 3.12162487]]
+                expected = [[1.419423, 0.0], [0.0, 1.419423], [2.838846, 2.838846]]
         else:
             expected = memory_template[0]
         np.testing.assert_allclose(result, expected)
@@ -902,7 +903,7 @@ class TestExecution:
                            memory_capacity=50,
                            memory_decay_rate=0,
                            softmax_gain=10,
-                           softmax_threshold=.001,
+                           softmax_threshold=0.001,
                            fields = {'STATE': {pnl.FIELD_WEIGHT: None,
                                                pnl.LEARN_FIELD_WEIGHT: False,
                                                pnl.TARGET_FIELD: True},
@@ -1029,12 +1030,16 @@ class TestExecution:
                   [0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]]
 
         result = EGO.learn(inputs={'STATE':INPUTS}, learning_rate=.5, execution_mode=pnl.ExecutionMode.PyTorch)
-        expected = [[ 0.00000000e+00,  1.35476414e-03,  1.13669378e-03,  2.20434260e-03,  6.61008388e-04, 9.88672202e-01,
-                      6.52088276e-04,  1.74149507e-03,  1.09769133e-03,  2.47971436e-03,  0.00000000e+00],
-                    [ 0.00000000e+00, -6.75284069e-02, -1.28930436e-03, -2.10726610e-01, -1.41050716e-03, -5.92286989e-01,
-                     -2.75196416e-03, -2.21010605e-03, -7.14369243e-03, -2.05167374e-02,  0.00000000e+00],
-                    [ 0.00000000e+00,  1.18578255e-03,  1.29393181e-03,  1.35476414e-03,  1.13669378e-03, 2.20434260e-03,
-                      6.61008388e-04,  9.88672202e-01,  6.52088276e-04,  2.83918640e-03,  0.00000000e+00]]
+        expected = [
+            [0.00000000e+00, 1.35933540e-03, 1.13114366e-03, 2.20590015e-03,
+             1.09314885e-03, 9.87722281e-01, 1.10371450e-03, 1.72925210e-03,
+             1.17352360e-03, 2.48170027e-03, 0.00000000e+00],
+            [0.00000000e+00, -6.54396065e-02,  1.41905061e-03, -2.08500295e-01,
+             -5.03985394e-05, -5.90196484e-01, -5.33017075e-03, -2.33024404e-03,
+             -2.02730870e-02, -1.58091223e-02,  0.00000000e+00],
+            [0.00000000e+00, 1.19576382e-03, 1.28593645e-03, 1.35933540e-03,
+             1.13114366e-03, 2.20590015e-03, 1.09314885e-03, 9.87722281e-01,
+             1.10371450e-03, 2.90277570e-03, 0.00000000e+00]]
         np.testing.assert_allclose(result, expected)
 
         # Plot (for during debugging):

--- a/tests/composition/test_emcomposition.py
+++ b/tests/composition/test_emcomposition.py
@@ -225,14 +225,17 @@ class TestConstruction:
             test_memory_fill(start=repeat, memory_fill=memory_fill)
 
     @pytest.mark.parametrize("softmax_choice, expected",
-                             [(pnl.WEIGHTED_AVG, [[0.93016008, 0.1, 0.16983992]]),
+                             [(pnl.WEIGHTED_AVG, [[0.8479525858370621, 0.1, 0.25204741416293786]]),
                               (pnl.ARG_MAX, [[1, .1, .1]]),
                               (pnl.PROBABILISTIC, [[1, .1, .1]]), # NOTE: actual stochasticity not tested here
                              ])
     def test_softmax_choice(self, softmax_choice, expected):
         em = EMComposition(memory_template=[[[1,.1,.1]], [[1,.1,.1]], [[.1,.1,1]]],
                            softmax_choice=softmax_choice,
-                           enable_learning=False)
+                           enable_learning=False,
+                           softmax_threshold=None,
+                           memory_decay_rate=0,
+                           normalize_memories=False)
         result = em.run(inputs={em.query_input_nodes[0]:[[1,0,0]]})
 
         np.testing.assert_allclose(result, expected)

--- a/tests/composition/test_emcomposition.py
+++ b/tests/composition/test_emcomposition.py
@@ -778,7 +778,7 @@ class TestExecution:
         # Note: field_weights favors A
         if softmax_choice == pnl.MAX_VAL:
             if operation == pnl.L0:
-                expected = [[1.703812], [0.], [3.407624]]
+                expected = [[1.467373], [0.], [2.934746]]
             else:
                 expected = [[1.419423, 0.0], [0.0, 1.419423], [2.838846, 2.838846]]
         else:


### PR DESCRIPTION
# Overview

Fixed softmax masking for python and pytorch function. In addition, throw a warning when input contains negative numbers and the threshold is set. Adjusted tests to reflect the new functionality.

# Description

The masking now works with `-np.inf` and `float(-inf)` for numpy and pytorch respectively. This effectively makes out the inputs bellow the threshold since `exp(-inf) == 0`. Before this the implementation did not correctly mask the inputs but set them to `0`. This does not work since `exp(0) == 1`! Also, there was a bug where v was effectively squared since it was multiplied with the mask. The main difference (in addition to proper sequencing and handling of edge cases) is:

`v = v * np.where(v > mask_threshold, v, 0)` was replaced with 
 `v = np.where(np.abs(v) > mask_threshold, v, -np.inf)`
 