### PR TITLE
tests/AutodiffComposition: Explicitly copy tensors to CPU before converting to numpy

### DIFF
--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -3883,8 +3883,8 @@ def test_training_xor_with_batching(batch_size, batched_results):
     model = nn.Sequential(linear1, sigmoid, linear2, sigmoid).to(device) # MLP model
 
     # Copy the initial weights and biases. Make sure to copy the data, not just the reference.
-    weights1 = linear1.weight.detach().numpy().copy()
-    weights2 = linear2.weight.detach().numpy().copy()
+    weights1 = linear1.weight.detach().cpu().numpy().copy()
+    weights2 = linear2.weight.detach().cpu().numpy().copy()
     # bias1 = linear1.bias.detach().numpy().copy() if linear1.bias is not None else None
     # bias2 = linear2.bias.detach().numpy().copy() if linear2.bias is not None else None
 
@@ -3913,7 +3913,7 @@ def test_training_xor_with_batching(batch_size, batched_results):
             torch_losses.append(loss.item())
             torch_results.append(pred)
 
-    torch_results = torch.stack(torch_results).detach().numpy()
+    torch_results = torch.stack(torch_results).detach().cpu().numpy()
 
     autodiff_mode = pnl.ExecutionMode.PyTorch
 


### PR DESCRIPTION
Fixes: `TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first. When the test_training_xor_with_batching test is run on a CUDA enabled machine.`

Fixes: beebd2a968fbeebc45e93d9785460a1c1860686a
	("Add support for batching to AutoDiffCompostion in PyTorch mode. (#3204)")