### PR TITLE
deps: Fix issues and enable Numpy 2+

### DIFF
--- a/psyneulink/core/components/functions/stateful/memoryfunctions.py
+++ b/psyneulink/core/components/functions/stateful/memoryfunctions.py
@@ -393,7 +393,7 @@ def _distance_field_weights_setter(value, owning_component=None, context=None):
     # NOTE: need the following to accommodate various forms of specification (single value, None's, etc)
     #       that are resolved elsewhere
     # FIX: STANDARDIZE FORMAT FOR FIELDWEIGHTS HERE (AS LIST OF INTS) AND GET RID OF THE FOLLOWING
-    test_val = np.array([int(np.array(val).item()) if val else 0 for val in value])
+    test_val = np.array([int(np.array(val).item()) if (arr := np.array(val)).size and arr.item() else 0 for val in value])
     test_val = np.full(len(variable), test_val) if len(test_val) == 1 else test_val
     test_curr_field_weights = np.array([int(np.array(val).item()) if val else 0 for val in current_field_weights])
     test_curr_field_weights = (np.full(len(variable), test_curr_field_weights) if len(variable) == 1

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -1928,7 +1928,7 @@ def parse_string_to_psyneulink_object_string(string):
     def is_pnl_obj(string):
         try:
             # remove parens to get rid of class instantiations
-            string = re.sub(r'\(.*?\)', '', string)
+            string = re.sub(r'\(.*\)', '', string)
             attr_sequence = string.split('.')
             obj = getattr(psyneulink, attr_sequence[0])
 

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -349,7 +349,7 @@ from psyneulink.core.globals.keywords import (AUTODIFF_COMPOSITION, CPU, CUDA, E
                                               Loss, LOSSES, MATRIX_WEIGHTS, MINIBATCH, MPS, NODE_VALUES, NODE_VARIABLES,
                                               OPTIMIZATION_STEP, RESULTS, RUN, SOFT_CLAMP,
                                               TARGETS, TRAINED_OUTPUTS, TRIAL)
-from psyneulink.core.globals.utilities import is_numeric_scalar
+from psyneulink.core.globals.utilities import is_numeric_scalar, convert_to_np_array
 from psyneulink.core.scheduling.scheduler import Scheduler
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.scheduling.time import TimeScale
@@ -1170,10 +1170,7 @@ class AutodiffComposition(Composition):
             all_output_values += [output]
 
         # Turn into a numpy array, possibly ragged
-        try:
-            all_output_values = np.array(all_output_values)
-        except (ValueError, np.VisibleDeprecationWarning):
-            all_output_values = np.array(all_output_values, dtype=object)
+        all_output_values = convert_to_np_array(all_output_values)
 
         # Swap the first two dimensions (output_port, batch) to (batch, output_port)
         all_output_values = all_output_values.swapaxes(0, 1)

--- a/psyneulink/library/compositions/emcomposition.py
+++ b/psyneulink/library/compositions/emcomposition.py
@@ -2132,13 +2132,19 @@ class EMComposition(AutodiffComposition):
             if self.num_keys == 1:
                 error_msg = f"there is only one key"
                 correction_msg = ""
-            elif not all(np.all(keys_weights[i] == keys_weights[0] for i in range(len(keys_weights)))):
+
+            elif not all(np.all(keys_weight == keys_weights[0]) for keys_weight in keys_weights):
                 error_msg = f" field weights ({field_weights}) are not all equal"
                 correction_msg = (f" To use concatenation, remove `field_weights` "
-                                     f"specification or make them all the same.")
+                                  f"specification or make them all the same.")
+
             elif not normalize_memories:
                 error_msg = f" normalize_memories is False"
                 correction_msg = f" To use concatenation, set normalize_memories to True."
+
+            else:
+                assert False, "Unknown error"
+
             warnings.warn(f"The 'concatenate_queries' arg for '{name}' is True but {error_msg}; "
                           f"concatenation will be ignored.{correction_msg}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beartype<0.20.0
 dill<0.3.10
-fastkde>=2.0.0, <2.0.2
+fastkde>=2.0.0, <2.1.4
 graph-scheduler>=1.2.1, <1.3.0
 graphviz<0.21.0
 grpcio<1.71.0
@@ -9,7 +9,7 @@ llvmlite<0.45
 matplotlib>=3.7.0, <3.10.1
 modeci_mdf<0.5, >=0.4.3; (platform_machine == 'AMD64' or platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
 networkx<3.5
-numpy>=1.21.0, <1.26.5
+numpy>=1.21.0, <2.2.4
 optuna<4.3.0
 packaging<25.0
 pandas<2.2.4

--- a/tests/mdf/model_with_control.py
+++ b/tests/mdf/model_with_control.py
@@ -65,7 +65,7 @@ comp.add_controller(
             },
             {
                 pnl.PROJECTIONS: (pnl.THRESHOLD, Decision),
-                pnl.ALLOCATION_SAMPLES: np.arange(0.1, 1.01, 0.3),
+                pnl.ALLOCATION_SAMPLES: (0.1, 0.4, 0.7000000000000001, 1.0000000000000002),
             },
         ],
     )


### PR DESCRIPTION
Don't call np.all on a generator.
Use greedy regexp match to remove function/construction call arguments.
Use convert_to_np_array helper in AutodiffComposition.
Explicitly check for empty arrays when converting ContentAddressableMemory weights to integers.

Allow the latest numpy and fastkde packages.

Closes: https://github.com/PrincetonUniversity/PsyNeuLink/issues/3205