### PR TITLE
ci/ga: Use one line per uploaded artifacts

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -188,5 +188,7 @@ jobs:
       if: matrix.version-restrict == ''
       with:
         name: dist-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}
-        path: ${{ steps.install.outputs.wheel }} ${{ steps.install.outputs.sdist }}
+        path: |
+          ${{ steps.install.outputs.wheel }}
+          ${{ steps.install.outputs.sdist }}
         retention-days: 2


### PR DESCRIPTION
multiple paths on the same line don't work:
```
Warning: No files were found with the provided path: dist/psyneulink-0.16.0.0+61.g1025c7e4f-py3-none-any.whl dist/psyneulink-0.16.0.0+61.g1025c7e4f.tar.gz. No artifacts will be uploaded.
```