### PR TITLE
doc_requirements: state sphinx v4 extra dependencies

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,3 +1,8 @@
 psyneulink-sphinx-theme<1.2.6.0
 sphinx<4.2.1
 sphinx_autodoc_typehints<1.16.0
+sphinxcontrib-applehelp<1.0.5
+sphinxcontrib-devhelp<1.0.3
+sphinxcontrib-htmlhelp<2.0.2
+sphinxcontrib-qthelp<1.0.4
+sphinxcontrib-serializinghtml<1.1.6


### PR DESCRIPTION
[doc] install appears to sometimes install packages that require sphinx v5