### PR TITLE
maint: update setup and build config, and release workflow

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -44,6 +44,10 @@ jobs:
         path: dist/
         retention-days: 1
 
+    - name: Validate dist files
+      shell: bash
+      run: twine check --strict dist/*
+
     - name: Upload dist files to test PyPI
       shell: bash
       run: |
@@ -145,6 +149,10 @@ jobs:
       with:
         name: Python-dist-files
         path: dist/
+
+    - name: Validate dist files
+      shell: bash
+      run: twine check --strict dist/*
 
     - name: Upload dist files to PyPI
       shell: bash

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Upload Python dist files
       uses: actions/upload-artifact@v4
       with:
-        name: Python-dist-files
+        name: psyneulink-${{ github.ref_name }}-dist
         path: dist/
         retention-days: 30
 
@@ -83,7 +83,7 @@ jobs:
     - name: Download dist files
       uses: actions/download-artifact@v4
       with:
-        name: Python-dist-files
+        name: psyneulink-${{ github.ref_name }}-dist
         path: dist/
 
     - name: Set up Python ${{ matrix.python-version }}
@@ -146,7 +146,7 @@ jobs:
     - name: Download dist files
       uses: actions/download-artifact@v4
       with:
-        name: Python-dist-files
+        name: psyneulink-${{ github.ref_name }}-dist
         path: dist/
 
     - name: Install setup dependencies
@@ -185,7 +185,7 @@ jobs:
     - name: Download dist files
       uses: actions/download-artifact@v4
       with:
-        name: Python-dist-files
+        name: psyneulink-${{ github.ref_name }}-dist
         path: dist/
 
     - name: Upload dist files to release

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -25,14 +25,16 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install setup dependencies
+      shell: bash
+      run: pip install build twine
+
     - name: Create Python Dist files
       id: create_dist
       shell: bash
       run: |
         # We don't care about the python version used.
-        pip install setuptools wheel
-        python setup.py sdist
-        python setup.py bdist_wheel
+        python -m build -v
         cd dist
         echo "sdist=$(ls *.tar.gz)" >> $GITHUB_OUTPUT
         echo "wheel=$(ls *.whl)" >> $GITHUB_OUTPUT
@@ -51,9 +53,6 @@ jobs:
     - name: Upload dist files to test PyPI
       shell: bash
       run: |
-        # Include implicit dependency on setuptools{,-rust} and preinstall wheel
-        pip install setuptools setuptools-rust wheel
-        pip install twine
         # This expects TWINE_USERNAME, TWINE_PASSWORD, and TWINE_REPOSITORY_URL
         # environment variables
         # It's not possible to condition steps on env or secrets,
@@ -150,6 +149,10 @@ jobs:
         name: Python-dist-files
         path: dist/
 
+    - name: Install setup dependencies
+      shell: bash
+      run: pip install twine
+
     - name: Validate dist files
       shell: bash
       run: twine check --strict dist/*
@@ -157,9 +160,6 @@ jobs:
     - name: Upload dist files to PyPI
       shell: bash
       run: |
-        # Include implicit dependency on setuptools{,-rust} and preinstall wheel
-        pip3 install --user setuptools setuptools-rust wheel
-        pip3 install --user twine
         # This expects TWINE_USERNAME, TWINE_PASSWORD, and TWINE_REPOSITORY_URL
         # environment variables
         # It's not possible to condition steps on env or secrets,

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         name: Python-dist-files
         path: dist/
-        retention-days: 1
+        retention-days: 30
 
     - name: Validate dist files
       shell: bash

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -193,5 +193,9 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        previous_release=$(gh --repo ${{ github.repository }} release list | head -n 1 | awk '{print $1}')
+        previous_release=$(gh --repo ${{ github.repository }} release list -L 1 | cut -f1)
+        if [[ -z "$previous_release" ]]; then
+          echo "No previous release found"
+          exit 1
+        fi
         gh --repo ${{ github.repository }} release create --generate-notes --notes-start-tag "$previous_release" ${{ github.ref_name }} dist/*

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -194,4 +194,4 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         previous_release=$(gh --repo ${{ github.repository }} release list | head -n 1 | awk '{print $1}')
-        gh --repo ${{ github.repository }} release create --generate-notes --notes-start-tag "$previous_release" ${{ github.ref }} dist/*
+        gh --repo ${{ github.repository }} release create --generate-notes --notes-start-tag "$previous_release" ${{ github.ref_name }} dist/*

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -121,7 +121,7 @@ jobs:
     - name: Run tests
       shell: bash
       # run only tests/. We don't care about codestyle/docstyle at this point
-      timeout-minutes: 80
+      timeout-minutes: 180
       run: |
         # remove sources to prevent conflict with the isntalled package
         rm -r -f psyneulink/ docs/ bin/ Matlab/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,5 @@ recursive-include tests *.py
 recursive-include tutorial *.ipynb
 include versioneer.py
 include psyneulink/_version.py
+
+include psyneulink/library/models/results/*.json

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,13 @@
-.. image:: https://badge.fury.io/py/psyneulink.svg
+.. |pypi-badge| image:: https://badge.fury.io/py/psyneulink.svg
     :target: https://badge.fury.io/py/psyneulink
-.. image:: https://github.com/PrincetonUniversity/PsyNeuLink/workflows/PsyNeuLink%20CI/badge.svg?branch=master
+
+.. |build-badge| image:: https://github.com/PrincetonUniversity/PsyNeuLink/workflows/PsyNeuLink%20CI/badge.svg?branch=master
     :target: https://github.com/PrincetonUniversity/PsyNeuLink/actions
-.. image:: https://mybinder.org/badge.svg
+
+.. |binder-badge| image:: https://mybinder.org/badge.svg
     :target: https://mybinder.org/v2/gh/PrincetonUniversity/PsyNeuLink/master
+
+|pypi-badge| |build-badge| |binder-badge|
 
 .. *****************************************************************************************
 .. ****** NOTE:  UPDATES TO THIS PAGE SHOULD ALSO BE MADE TO docs/source.index.rst *********
@@ -46,7 +50,7 @@ It is:
 
  ..
 
- - *computationally general* -- it can be used to implement, seamlessly integrate, and simulate interactions among
+ - *computationally general* -- it can be used to implement, seamlessly integrate, and simulate interactions among
    disparate components that vary in their granularity of representation and function (from individual neurons or
    neural populations to functional subsystems and abstract cognitive functions) and at any time scale of execution.
 

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ it is presently less well suited to efforts involving massively large computatio
 
 Other packages currently better suited to such applications are:
 `Emergent <https://grey.colorado.edu/emergent/index.php/Main_Page>`_ for biologically-inspired neural network models
-`Pytorch <https://pytorch.org>`_ and `TensorFlow <https://www.tensorflow.org>`_ (for deep learning models);
+`Pytorch <pytorch_>`_ and `TensorFlow <https://www.tensorflow.org>`_ (for deep learning models);
 `HDDM <http://ski.clps.brown.edu/hddm_docs/>`_ (for Drift Diffusion Models);
 `ACT-R <http://act-r.psy.cmu.edu>`_ (for production system models);
 `Genesis <http://www.genesis-sim.org>`_,
@@ -106,7 +106,7 @@ That said, priorities for ongoing development of PsyNeuLink are:
     i) acceleration, using just-in-time compilation methods and parallelization
        (see `Compilation`, and `Vesely et al., 2022 <http://www.cs.yale.edu/homes/abhishek/jvesely-cgo22.pdf>`_);
     ii) enhancement of the API to facilitate wrapping modules from other packages for integration into the PsyNeuLink
-        environment (examples currently exist for `Pytorch <https://pytorch.org>`_ ) and translating into a standard
+        environment (examples currently exist for `Pytorch <pytorch_>`_) and translating into a standard
         `Model Description Format (MDF) <https://github.com/ModECI/MDF>`_;
     iii) integration of tools for parameter estimation, model comparison and data fitting
          (see `ParameterEstimationComposition`); and
@@ -258,3 +258,5 @@ License
     Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
     on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and limitations under the License.
+
+.. _pytorch: https://pytorch.org

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -114,7 +114,7 @@ it is presently less well suited to efforts involving massively large computatio
 
 Other packages currently better suited to such applications are:
 `Emergent <https://grey.colorado.edu/emergent/index.php/Main_Page>`_ for biologically-inspired neural network models
-`Pytorch <https://pytorch.org>`_ and `TensorFlow <https://www.tensorflow.org>`_ (for deep learning models);
+`Pytorch <pytorch_>`_ and `TensorFlow <https://www.tensorflow.org>`_ (for deep learning models);
 `HDDM <http://ski.clps.brown.edu/hddm_docs/>`_ (for Drift Diffusion Models);
 `ACT-R <http://act-r.psy.cmu.edu>`_ (for production system models);
 `Genesis <http://www.genesis-sim.org>`_,
@@ -131,7 +131,7 @@ That said, priorities for ongoing development of PsyNeuLink are:
     i) acceleration, using just-in-time compilation methods and parallelization
        (see `Compilation`, and `Vesely et al., 2022 <http://www.cs.yale.edu/homes/abhishek/jvesely-cgo22.pdf>`_);
     ii) enhancement of the API to facilitate wrapping modules from other packages for integration into the PsyNeuLink
-        environment (examples currently exist for `Pytorch <https://pytorch.org>`_ ) and translating into a standard
+        environment (examples currently exist for `Pytorch <pytorch_>`_) and translating into a standard
         `Model Description Format (MDF) <https://github.com/ModECI/MDF>`_;
     iii) integration of tools for parameter estimation, model comparison and data fitting
          (see `ParameterEstimationComposition`); and
@@ -317,3 +317,5 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+
+.. _pytorch: https://pytorch.org

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -69,7 +69,7 @@ It is:
 
  ..
 
- - *computationally general* -- it can be used to implement, seamlessly integrate, and simulate interactions among
+ - *computationally general* -- it can be used to implement, seamlessly integrate, and simulate interactions among
    disparate components that vary in their granularity of representation and function (from individual neurons or
    neural populations to functional subsystems and abstract cognitive functions) and at any time scale of execution.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [bdist_wheel]
-python-tag = py3
+python_tag = py3
 
 [metadata]
-license_file = LICENSE.txt
+license_files = [LICENSE.txt]
 
 [tool:pytest]
 addopts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools", "versioneer"]
+build-backend = "setuptools.build_meta"
+
 [bdist_wheel]
 python_tag = py3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -125,3 +125,10 @@ versionfile_source = psyneulink/_version.py
 versionfile_build = psyneulink/_version.py
 tag_prefix = v
 parentdir_prefix = psyneulink-
+
+[options]
+include_package_data = True
+packages = find_namespace:
+
+[options.packages.find]
+include = psyneulink*

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
 
     description='A block modeling system for cognitive neuroscience',
     long_description=long_description,
+    long_description_content_type='text/x-rst',
 
     # Github address.
     url='https://github.com/PrincetonUniversity/PsyNeuLink',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import versioneer
 
 # Always prefer setuptools over distutils
-from setuptools import find_packages, setup
+from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
@@ -70,10 +70,6 @@ setup(
 
     # What does your project relate to?
     keywords='cognitive modeling',
-
-    # You can just specify the packages manually here if your project is
-    # simple. Or you can use find_packages().
-    packages=find_packages(),
 
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip's


### PR DESCRIPTION
- use pypa/build instead of setup.py to build
- correct deprecated/old setup.cfg settings
- run `twine check --strict` on distfiles before uploading
- fix problems uploading to github releases in test-release workflow 