### PR TITLE
broken_trans_deps: Restrict numpy to <2 on macos x86_64

### DIFF
--- a/broken_trans_deps.txt
+++ b/broken_trans_deps.txt
@@ -2,7 +2,7 @@
 
 # onnxruntime-1.14.0 is broken on macos/x64
 # https://github.com/microsoft/onnxruntime/issues/14663
-onnxruntime != 1.14.0; platform_system=="Darwin"
+onnxruntime != 1.14.0; platform_system == 'Darwin'
 
 # ipython == 8.13.0 uses incorrect python requires and only works with 3.9+
 # https://github.com/ipython/ipython/issues/14053
@@ -37,6 +37,11 @@ beartype != 0.17.1; python_version == '3.9'
 # coverage 7.6.5 is broken
 # https://github.com/nedbat/coveragepy/issues/1891
 coverage != 7.6.5
+
+# pytorch doesn't provide wheels for macos x64 for torch-2.3.0+
+# https://pypi.org/project/torch/2.3.0/#files
+# the last avaialble version (2.2.2) doesn't work with Numpy2.0
+numpy < 2; platform_system == 'Darwin' and platform_machine == 'x86_64'
 
 # The following need at least sphinx-5 without indicating it in dependencies:
 # * sphinxcontrib-applehelp >=1.0.8,


### PR DESCRIPTION
Some packages, like torch, stopped providing macos x86_64 wheels and the last version is compiled using Numpy 1.x.
These packages don't work with Numpy 2, although Numpy 2 is available for macos x86_64.

On the other hand, binary packages built with Numpy 2+ work OK on older versions of Numpy.