### PR TITLE
patch/emcomposition/forbid_add_projection

### DIFF
--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -4358,14 +4358,14 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         if get_input_from:
             # Connect from_nodes to input_nodes
             for i in range(len(get_input_from)):
-                self.add_projection(MappingProjection(sender=from_nodes[i], receiver=input_nodes[i]))
+                self.add_projection(MappingProjection(sender=from_nodes[i], receiver=input_nodes[i]), context=context)
 
         # Outputs -----------------------------------------------------------------------------------
         if send_output_to:
             # Connect output_nodes to to_nodes
             input_nodes = composition.get_nodes_by_role(NodeRole.INPUT)
             for i in range(len(send_output_to)):
-                self.add_projection(MappingProjection(sender=output_nodes[i], receiver=to_nodes[i]))
+                self.add_projection(MappingProjection(sender=output_nodes[i], receiver=to_nodes[i]), context=context)
 
         # TRANSFER required and excluded NodeRoles for imported Nodes to self =================================
 
@@ -6355,7 +6355,10 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                   FUNCTION:projection.function,
                                   MATRIX:projection.matrix.base,
                                   LEARNABLE:projection.learnable}}
-                return self.add_projection(proj_spec, sender=projection.sender, receiver=projection.receiver)
+                return self.add_projection(proj_spec,
+                                           sender=projection.sender,
+                                           receiver=projection.receiver,
+                                           context=context)
 
         # Create Projection if it doesn't exist
         projection = projection or default_matrix
@@ -7160,7 +7163,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         return pathway, pathway_name
 
     # FIX: REFACTOR TO TAKE Pathway OBJECT AS ARGUMENT
-    def add_pathway(self, pathway):
+    def add_pathway(self, pathway, context=None):
         """Add an existing `Pathway <Composition_Pathways>` to the Composition
 
         Arguments
@@ -7188,7 +7191,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
         # then projections
         for p in projections:
-            self.add_projection(p, p.sender.owner, p.receiver.owner)
+            self.add_projection(p, p.sender.owner, p.receiver.owner, context=context)
 
         self._analyze_graph()
 
@@ -7709,7 +7712,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                     # Version that forbids *any* duplicate Projections between same sender and receiver
                     warnings.warn(f"{warning_msg} that already exists between those nodes ({duplicate.name}) "
                                   f"and so will be ignored.")
-                    proj_set.append(self.add_projection(duplicate))
+                    proj_set.append(self.add_projection(duplicate, context=context))
 
                 # PARSE PROJECTION SPECIFICATIONS AND INSTANTIATE PROJECTIONS
                 # IMPLEMENTATION NOTE:
@@ -7729,7 +7732,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                                                  sender=sender,
                                                                  receiver=receiver,
                                                                  allow_duplicates=False,
-                                                                 feedback=feedback)
+                                                                 feedback=feedback,
+                                                                 context=context)
                             else:
                                 # Default is a matrix_spec
                                 assert is_matrix(default_proj_spec), \
@@ -7739,7 +7743,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                                                                               matrix=default_proj_spec,
                                                                                               receiver=receiver),
                                                                  allow_duplicates=False,
-                                                                 feedback=feedback)
+                                                                 feedback=feedback,
+                                                                 context=context)
                             proj_set.append(projection)
 
                         except (InputPortError, ProjectionError, MappingError) as error:
@@ -7768,7 +7773,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                 proj_set.append(self.add_projection(proj,
                                                                     sender = sender_node,
                                                                     receiver = receiver_node,
-                                                                    allow_duplicates=False, feedback=feedback))
+                                                                    allow_duplicates=False,
+                                                                    feedback=feedback,
+                                                                    context=context))
                                 if default_proj_spec:
                                     # If there IS a default Projection specification, remove from node_pairs
                                     #   only the entry for the sender-receiver pair, so that the sender is assigned
@@ -7793,13 +7800,13 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                         for sender in senders:
                                             proj_set.append(self.add_projection(
                                                 projection=MappingProjection(sender=sender, receiver=proj),
-                                                allow_duplicates=False, feedback=feedback))
+                                                allow_duplicates=False, feedback=feedback, context=context))
                                     # FIX: 4/9/22 - INCLUDE TEST FOR DEFERRED_INIT WITH ONLY SENDER SPECIFIED
                                     elif isinstance(proj, OutputPort):
                                         for receiver in receivers:
                                             proj_set.append(self.add_projection(
                                                 projection=MappingProjection(sender=proj, receiver=receiver),
-                                                allow_duplicates=False, feedback=feedback))
+                                                allow_duplicates=False, feedback=feedback, context=context))
                                     # Remove from node_pairs all pairs involving the owner of the Port
                                     #   (since all Projections to or from it have been implemented)
                                     node_pairs = [pair for pair in node_pairs if (proj.owner not in pair)]
@@ -7820,7 +7827,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                                         sender=sender,
                                                         receiver=receiver,
                                                         allow_duplicates=False,
-                                                        feedback=feedback)
+                                                        feedback=feedback,
+                                                        context=context)
                                 proj_set.append(p)
                             except (InputPortError, ProjectionError, MappingError) as error:
                                 handle_misc_errors(proj, error)
@@ -8118,11 +8126,11 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                                                                  target,
                                                                                  comparator,
                                                                                  learning_mechanism)
-        self.add_projections(learning_related_projections)
+        self.add_projections(learning_related_projections, context=context)
 
         # Create Projection to learned Projection and add to Composition
         learning_projection = self._create_learning_projection(learning_mechanism, learned_projection)
-        self.add_projection(learning_projection, is_learning_projection=True, feedback=True)
+        self.add_projection(learning_projection, is_learning_projection=True, feedback=True, context=context)
 
         # FIX 5/8/20: WHY IS LEARNING_MECHANSIMS ASSIGNED A SINGLE MECHANISM?
         # Wrap up and return
@@ -8879,10 +8887,10 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                                                                  target_mechanism,
                                                                                  objective_mechanism,
                                                                                  learning_mechanism)
-        self.add_projections(learning_related_projections)
+        self.add_projections(learning_related_projections, context=context)
 
         learning_projection = self._create_learning_projection(learning_mechanism, learned_projection)
-        self.add_projection(learning_projection, is_learning_projection=True, feedback=True)
+        self.add_projection(learning_projection, is_learning_projection=True, feedback=True, context=context)
 
 
         return target_mechanism, objective_mechanism, learning_mechanism
@@ -8985,7 +8993,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             error_sources, error_projections = self._get_back_prop_error_sources(efferents,
                                                                                  learning_mechanism,
                                                                                  context)
-            self.add_projections(error_projections)
+            self.add_projections(error_projections, context=context)
             return learning_mechanism
 
         # If learning_mechanism does not yet exist:
@@ -9059,8 +9067,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         self.add_node(learning_mechanism, required_roles=NodeRole.LEARNING, context=context)
 
         # Add all the Projections to the Composition
-        self.add_projections([act_in_projection, act_out_projection] + error_projections)
-        self.add_projection(learning_projection, is_learning_projection=True, feedback=True)
+        self.add_projections([act_in_projection, act_out_projection] + error_projections, context=context)
+        self.add_projection(learning_projection, is_learning_projection=True, feedback=True, context=context)
 
         return learning_mechanism
 
@@ -9193,7 +9201,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                                                   name=ERROR_SIGNAL,
                                                                   context=context),
                                                         context=context)[0]
-                    self.add_projections(error_signal_input_port.path_afferents[0])
+                    self.add_projections(error_signal_input_port.path_afferents[0], context=context)
 
     def _get_deeply_nested_aux_projections(self, node):
         deeply_nested_projections = {}

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6201,7 +6201,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                        name=None,
                        allow_duplicates=False,
                        context=None
-                       ):
+                       )->Projection:
         """Add **projection** to the Composition.
 
         If **projection** is not specified, and one does not already exist between **sender** and **receiver**

--- a/psyneulink/library/compositions/emcomposition/emcomposition.py
+++ b/psyneulink/library/compositions/emcomposition/emcomposition.py
@@ -2784,27 +2784,13 @@ class EMComposition(AutodiffComposition):
     def add_node(self, node, required_roles=None, context=None):
         """Override if called from command line to disallow modification of EMComposition"""
         if context is None:
-            raise CompositionError(f"Nodes cannot be added to {self.name}.")
+            raise EMCompositionError(f"Nodes cannot be added to an {self.componentCategory}: ('{self.name}').")
         super().add_node(node, required_roles, context)
 
     def add_projection(self, *args, **kwargs):
         """Override if called from command line to disallow modification of EMComposition"""
-        # if CONTEXT not in kwargs or kwargs[CONTEXT] is None:
-        #     if 'projection' in kwargs:
-        #         projection = kwargs['projection']
-        #         sender = projection.sender
-        #         receiver = projection.receiver
-        #     else:
-        #         sender = kwargs['sender']
-        #         receiver = kwargs['receiver']
-        #     if isinstance(sender, OutputPort):
-        #         sender = sender.owner
-        #     if isinstance(receiver, InputPort):
-        #         receiver = receiver.owner
-        #     if not (sender in self.nodes and receiver in self.nodes):
-        #         raise CompositionError(f"Projections cannot be added to {self.name}.")
         if CONTEXT not in kwargs or kwargs[CONTEXT] is None:
-            raise CompositionError(f"Projections cannot be added to {self.name}.")
+            raise EMCompositionError(f"Projections cannot be added to an {self.componentCategory}: ('{self.name}').")
         return super().add_projection(*args, **kwargs)
 
     # *****************************************************************************************************************

--- a/psyneulink/library/compositions/emcomposition/emcomposition.py
+++ b/psyneulink/library/compositions/emcomposition/emcomposition.py
@@ -2787,23 +2787,25 @@ class EMComposition(AutodiffComposition):
             raise CompositionError(f"Nodes cannot be added to {self.name}.")
         super().add_node(node, required_roles, context)
 
-    # def add_projection(self, *args, **kwargs):
-    #     """Override if called from command line to disallow modification of EMComposition"""
-    #     # if CONTEXT not in kwargs or kwargs[CONTEXT] is None:
-    #     #     if 'projection' in kwargs:
-    #     #         projection = kwargs['projection']
-    #     #         sender = projection.sender
-    #     #         receiver = projection.receiver
-    #     #     else:
-    #     #         sender = kwargs['sender']
-    #     #         receiver = kwargs['receiver']
-    #     #     if isinstance(sender, OutputPort):
-    #     #         sender = sender.owner
-    #     #     if isinstance(receiver, InputPort):
-    #     #         receiver = receiver.owner
-    #     #     if not (sender in self.nodes and receiver in self.nodes):
-    #     #         raise CompositionError(f"Projections cannot be added to {self.name}.")
-    #     super().add_projection(*args, **kwargs)
+    def add_projection(self, *args, **kwargs):
+        """Override if called from command line to disallow modification of EMComposition"""
+        # if CONTEXT not in kwargs or kwargs[CONTEXT] is None:
+        #     if 'projection' in kwargs:
+        #         projection = kwargs['projection']
+        #         sender = projection.sender
+        #         receiver = projection.receiver
+        #     else:
+        #         sender = kwargs['sender']
+        #         receiver = kwargs['receiver']
+        #     if isinstance(sender, OutputPort):
+        #         sender = sender.owner
+        #     if isinstance(receiver, InputPort):
+        #         receiver = receiver.owner
+        #     if not (sender in self.nodes and receiver in self.nodes):
+        #         raise CompositionError(f"Projections cannot be added to {self.name}.")
+        if CONTEXT not in kwargs or kwargs[CONTEXT] is None:
+            raise CompositionError(f"Projections cannot be added to {self.name}.")
+        return super().add_projection(*args, **kwargs)
 
     # *****************************************************************************************************************
     # ***************************************** Properties  **********************************************************

--- a/psyneulink/library/compositions/grucomposition/grucomposition.py
+++ b/psyneulink/library/compositions/grucomposition/grucomposition.py
@@ -1178,11 +1178,11 @@ class GRUComposition(AutodiffComposition):
     def add_node(self, node, required_roles=None, context=None):
         """Override if called from command line to disallow modification of GRUComposition"""
         if context is None:
-            raise CompositionError(f"Nodes cannot be added to {self.name}.")
+            raise CompositionError(f"Nodes cannot be added to a {self.componentCategory}: ('{self.name}').")
         super().add_node(node, required_roles, context)
 
     def add_projection(self, *args, **kwargs):
         """Override if called from command line to disallow modification of GRUComposition"""
         if CONTEXT not in kwargs or kwargs[CONTEXT] is None:
-            raise CompositionError(f"Projections cannot be added to {self.name}.")
-        super().add_projection(*args, **kwargs)
+            raise CompositionError(f"Projections cannot be added to a {self.componentCategory}: ('{self.name}'.")
+        return super().add_projection(*args, **kwargs)

--- a/tests/composition/test_emcomposition.py
+++ b/tests/composition/test_emcomposition.py
@@ -224,6 +224,15 @@ class TestConstruction:
         elif repeat and repeat < memory_capacity:  # Multi-entry specification and repeat = number entries; remainder
             test_memory_fill(start=repeat, memory_fill=memory_fill)
 
+    def test_disallow_modification(self):
+        em = EMComposition()
+        with pytest.raises(EMCompositionError) as error_text:
+            em.add_node(pnl.ProcessingMechanism())
+        assert "Nodes cannot be added to an EMComposition: ('EM_Composition')." in str(error_text.value)
+        with pytest.raises(EMCompositionError) as error_text:
+            em.add_projection(pnl.MappingProjection())
+        assert "Projections cannot be added to an EMComposition: ('EM_Composition')." in str(error_text.value)
+
     @pytest.mark.parametrize("softmax_choice, expected",
                              [(pnl.WEIGHTED_AVG, [[0.8479525858370621, 0.1, 0.25204741416293786]]),
                               (pnl.ARG_MAX, [[1, .1, .1]]),

--- a/tests/composition/test_grucomposition.py
+++ b/tests/composition/test_grucomposition.py
@@ -99,10 +99,10 @@ class TestConstruction:
         gru = GRUComposition()
         with pytest.raises(CompositionError) as error_text:
             gru.add_node(pnl.ProcessingMechanism())
-        assert 'Nodes cannot be added to GRU Composition.' in str(error_text.value)
+        assert 'Nodes cannot be added to a GRUComposition' in str(error_text.value)
         with pytest.raises(CompositionError) as error_text:
             gru.add_projection(pnl.MappingProjection())
-        assert 'Projections cannot be added to GRU Composition.' in str(error_text.value)
+        assert 'Projections cannot be added to a GRUComposition' in str(error_text.value)
 
     def test_solo_nested(self):
         gru = pnl.GRUComposition(input_size=3, hidden_size=5, bias=True)


### PR DESCRIPTION
This PR adds an override of the Composition.add_projection() method to EMComposition, in order to prevent modification of EMComposition.