### PR TITLE
• autodiffcomposition.py

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -750,7 +750,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
     """
     Component(                 \
         default_variable=None, \
-        input_shapes=None,             \
+        input_shapes=None,     \
         params=None,           \
         name=None,             \
         prefs=None,            \
@@ -1137,6 +1137,8 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
             execution_phase=ContextFlags.IDLE,
             execution_id=None,
         )
+
+
 
         if reset_stateful_function_when is not None:
             self.reset_stateful_function_when = reset_stateful_function_when

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -731,16 +731,14 @@ class Projection_Base(Projection):
         register_category(entry=self,
                           base_class=Projection_Base,
                           name=name,
-                          registry=ProjectionRegistry,
-                          )
+                          registry=ProjectionRegistry)
 
         # Create projection's _portRegistry and ParameterPort entry
         self._portRegistry = {}
 
         register_category(entry=ParameterPort,
                           base_class=Port_Base,
-                          registry=self._portRegistry,
-                          )
+                          registry=self._portRegistry)
 
         self._instantiate_sender(sender, context=context)
 

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -1174,6 +1174,7 @@ class AutodiffComposition(Composition):
                                            f"and KL_DIV (KL divergence.")
 
     def get_targets(self, execution_mode=pnlvm.ExecutionMode.PyTorch):
+        """Return `TARGET` `Nodes <Composition_Nodes>` of the AutodiffComposition."""
         self.infer_backpropagation_learning_pathways(execution_mode=execution_mode)
         return super(AutodiffComposition, self).get_targets()
 

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -1173,6 +1173,10 @@ class AutodiffComposition(Composition):
                                            f"likelihood), POISSONNLL (Poisson negative log likelihood, "
                                            f"and KL_DIV (KL divergence.")
 
+    def get_targets(self, execution_mode=pnlvm.ExecutionMode.PyTorch):
+        self.infer_backpropagation_learning_pathways(execution_mode=execution_mode)
+        return super(AutodiffComposition, self).get_targets()
+
     def autodiff_forward(self, inputs, targets,
                          synch_with_pnl_options, retain_in_pnl_options,
                          execution_mode, scheduler, context):


### PR DESCRIPTION
This PR adds get_target() to AutodiffComposition as an override, that calls infer_backpropagation_learning_pathways() 
in order determine TARGET Nodes for the Composition to be returned.