### PR TITLE
tests: Drop unused function arguments

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -138,11 +138,12 @@ jobs:
     - name: Lint with flake8
       shell: bash
       run: |
-        pip install flake8
+        pip install flake8 flake8-unused-arguments
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --exit-zero --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 --select=U100 --unused-arguments-ignore-stub-functions --unused-arguments-ignore-lambdas --unused-arguments-ignore-nested-functions --unused-arguments-ignore-variadic-names --extend-exclude tests/functions/test_user_defined_func.py tests/
 
     - name: Print numpy info
       shell: bash

--- a/tests/composition/pec/test_stab_flex_pec_fit.py
+++ b/tests/composition/pec/test_stab_flex_pec_fit.py
@@ -95,7 +95,6 @@ def make_stab_flex(
     lca_noise=0.0,
     scale=0.2,
     ddm_time_step_size=0.01,
-    rng_seed=None,
 ):
 
     GAIN = gain

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -352,7 +352,7 @@ def test_autodiff_forward(autodiff_mode):
 
 @pytest.mark.pytorch
 @pytest.mark.composition
-def test_retain_results(autodiff_mode):
+def test_retain_results():
     """Test that results from calls to learning() are added to results list (from retained_results)"""
     inputs = [[-0.8104468, -0.40517032, 0.75040168]]
     input_mech = pnl.ProcessingMechanism(input_shapes=3)

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -7604,24 +7604,18 @@ class TestNodeRoles:
         comp = Composition(pathways=[A,(B, NodeRole.PROBE), C], name='COMP')
         assert B.output_port in comp.output_CIM.port_map
 
-    params = [  # id     allow_probes  include_probes_in_output  err_msg
-        (
-            "allow_probes_True", True, False, None
-         ),
-        (
-            "allow_probes_True", True, True, None
-         ),
-        (
-            "allow_probes_False", False, False,
-            "B found in nested Composition of OUTER COMP (MIDDLE COMP) but without required NodeRole.OUTPUT."
-         ),
-        (
-            "allow_probes_CONTROL", "CONTROL", True,
-            "B found in nested Composition of OUTER COMP (MIDDLE COMP) but without required NodeRole.OUTPUT."
-         )
+    params = [        # allow_probes  include_probes_in_output  err_msg
+        pytest.param(True, False, None, id="allow_probes_True"),
+        pytest.param(True, True, None, id="allow_probes_True"),
+        pytest.param(False, False,
+                     "B found in nested Composition of OUTER COMP (MIDDLE COMP) but without required NodeRole.OUTPUT.",
+                     id="allow_probes_False"),
+        pytest.param("CONTROL", True,
+                     "B found in nested Composition of OUTER COMP (MIDDLE COMP) but without required NodeRole.OUTPUT.",
+                     id="allow_probes_CONTROL"),
     ]
-    @pytest.mark.parametrize('id, allow_probes, include_probes_in_output, err_msg', params, ids=[x[0] for x in params])
-    def test_nested_PROBES(self, id, allow_probes, include_probes_in_output, err_msg):
+    @pytest.mark.parametrize('allow_probes, include_probes_in_output, err_msg', params)
+    def test_nested_PROBES(self, allow_probes, include_probes_in_output, err_msg):
         """Test use of allow_probes, include_probes_in_output and orphaned output from nested comp"""
 
         A = ProcessingMechanism(name='A')
@@ -7634,9 +7628,7 @@ class TestNodeRoles:
         Z = ProcessingMechanism(name='Z')
         mcomp = Composition(pathways=[[X,Y,Z],icomp], name='MIDDLE COMP')
 
-        O = ProcessingMechanism(name='O',
-                                input_ports=[B, Y]
-                                )
+        O = ProcessingMechanism(name='O', input_ports=[B, Y])
 
         if not err_msg:
             ocomp = Composition(name='OUTER COMP',

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -943,56 +943,44 @@ class TestControlSpecification:
 @pytest.mark.control
 class TestControlMechanisms:
 
-    # id, agent_rep, state_feat, mon_for_ctl, allow_probes, obj_mech err_type, error_msg
+    # agent_rep, state_feat, mon_for_ctl, allow_probes, obj_mech err_type, error_msg
     params = [
-        ("allowable1",
-         "icomp", "I", "I", True, None, None, None
-         ),
-        ("allowable2",
-         "mcomp", "Ii A", "I B", True, None, None, None
-         ),
-        ("state_features_test_internal",
-         "icomp", "B", "I", True, None, pnl.CompositionError,
-         "Attempt to shadow the input to a node (B) in a nested Composition of OUTER COMP "
-         "that is not an INPUT Node of that Composition is not currently supported."
-         ),
-        ("state_features_test_not_in_agent_rep",
-         "icomp", "A", "I", True, None, pnl.OptimizationControlMechanismError,
-        '\'OCM\' has \'state_features\' specified ([\'SHADOWED INPUT OF A[InputPort-0] FOR I[InputPort-0]\']) '
-        'that are missing from both its `agent_rep` (\'INNER COMP\') as well as \'OUTER COMP\' '
-        'and any Compositions nested within it.'
-         ),
-        ("monitor_for_control_test_not_in_agent_rep",
-         "icomp", "I", "B", True, None, pnl.OptimizationControlMechanismError,
-         "OCM has 'outcome_ouput_ports' that receive Projections from the following Components "
-         "that do not belong to its agent_rep (INNER COMP): ['B']."
-         ),
-        ("monitor_for_control_with_obj_mech_test",
-         "icomp", "I", None, True, True, pnl.OptimizationControlMechanismError,
-         "OCM has 'outcome_ouput_ports' that receive Projections from the following Components "
-         "that do not belong to its agent_rep (INNER COMP): ['B']."
-         ),
-        ("probe_error_test",
-         "mcomp", "I", "B", False, None, pnl.CompositionError,
-         "B found in nested Composition of OUTER COMP (MIDDLE COMP) but without "
-         "required NodeRole.OUTPUT. Try setting 'allow_probes' argument of OCM to 'True'."
-         ),
-        ("probe_error_obj_mech_test",
-         "mcomp", "I", None, False, True, pnl.CompositionError,
-         "B found in nested Composition of OUTER COMP (MIDDLE COMP) but without required NodeRole.OUTPUT. "
-         "Try setting 'allow_probes' argument of ObjectiveMechanism for OCM to 'True'."
-         ),
-        ("cfa_as_agent_rep_error",
-         "cfa", "dict", None, False, True, pnl.OptimizationControlMechanismError,
-         'The agent_rep specified for OCM is a CompositionFunctionApproximator, so its \'state_features\' argument '
-         'must be a list, not a dict ({(ProcessingMechanism A): (InputPort InputPort-0), '
-         '(ProcessingMechanism B): (InputPort InputPort-0)}).'
-         )
+        pytest.param("icomp", "I", "I", True, None, None, None, id="allowable1"),
+        pytest.param("mcomp", "Ii A", "I B", True, None, None, None, id="allowable2"),
+        pytest.param("icomp", "B", "I", True, None, pnl.CompositionError,
+                     "Attempt to shadow the input to a node (B) in a nested Composition of OUTER COMP "
+                     "that is not an INPUT Node of that Composition is not currently supported.",
+                     id="state_features_test_internal"),
+        pytest.param("icomp", "A", "I", True, None, pnl.OptimizationControlMechanismError,
+                     '\'OCM\' has \'state_features\' specified ([\'SHADOWED INPUT OF A[InputPort-0] FOR I[InputPort-0]\']) '
+                     'that are missing from both its `agent_rep` (\'INNER COMP\') as well as \'OUTER COMP\' '
+                     'and any Compositions nested within it.',
+                     id="state_features_test_not_in_agent_rep"),
+        pytest.param("icomp", "I", "B", True, None, pnl.OptimizationControlMechanismError,
+                     "OCM has 'outcome_ouput_ports' that receive Projections from the following Components "
+                     "that do not belong to its agent_rep (INNER COMP): ['B'].",
+                     id="monitor_for_control_test_not_in_agent_rep"),
+        pytest.param("icomp", "I", None, True, True, pnl.OptimizationControlMechanismError,
+                     "OCM has 'outcome_ouput_ports' that receive Projections from the following Components "
+                     "that do not belong to its agent_rep (INNER COMP): ['B'].",
+                     id="monitor_for_control_with_obj_mech_test"),
+        pytest.param("mcomp", "I", "B", False, None, pnl.CompositionError,
+                     "B found in nested Composition of OUTER COMP (MIDDLE COMP) but without "
+                     "required NodeRole.OUTPUT. Try setting 'allow_probes' argument of OCM to 'True'.",
+                     id="probe_error_test"),
+        pytest.param("mcomp", "I", None, False, True, pnl.CompositionError,
+                     "B found in nested Composition of OUTER COMP (MIDDLE COMP) but without required NodeRole.OUTPUT. "
+                     "Try setting 'allow_probes' argument of ObjectiveMechanism for OCM to 'True'.",
+                     id="probe_error_obj_mech_test"),
+        pytest.param("cfa", "dict", None, False, True, pnl.OptimizationControlMechanismError,
+                     'The agent_rep specified for OCM is a CompositionFunctionApproximator, so its \'state_features\' argument '
+                     'must be a list, not a dict ({(ProcessingMechanism A): (InputPort InputPort-0), '
+                     '(ProcessingMechanism B): (InputPort InputPort-0)}).',
+                     id="cfa_as_agent_rep_error"),
     ]
-    @pytest.mark.parametrize('id, agent_rep, state_features, monitor_for_control, allow_probes, '
-                             'objective_mechanism, error_type, err_msg',
-                             params, ids=[x[0] for x in params])
-    def test_args_specific_to_ocm(self, id, agent_rep, state_features, monitor_for_control,
+    @pytest.mark.parametrize('agent_rep, state_features, monitor_for_control, allow_probes, '
+                             'objective_mechanism, error_type, err_msg', params)
+    def test_args_specific_to_ocm(self, agent_rep, state_features, monitor_for_control,
                                   allow_probes, objective_mechanism, error_type,err_msg):
         """Test args specific to OptimizationControlMechanism
         NOTE: state_features and associated warning and errors tested more fully in

--- a/tests/composition/test_emcomposition.py
+++ b/tests/composition/test_emcomposition.py
@@ -842,7 +842,8 @@ class TestExecution:
     @pytest.mark.parametrize('exec_mode', [pnl.ExecutionMode.Python, pnl.ExecutionMode.PyTorch])
     @pytest.mark.parametrize('concatenate', [True, False], ids=['concatenate', 'no_concatenate'])
     @pytest.mark.parametrize('use_storage_node', [True, False], ids=['use_storage_node', 'no_storage_node'])
-    @pytest.mark.parametrize('learning', [True, False], ids=['learning', 'no_learning'])
+#    @pytest.mark.parametrize('learning', [True, False], ids=['learning', 'no_learning'])
+    @pytest.mark.parametrize('learning', [False], ids=['no_learning'])
     def test_multiple_trials_concatenation_and_storage_node(self, exec_mode, concatenate, use_storage_node, learning):
         """Test with and without learning (learning is tested only for using_storage_node and no concatenation)"""
 
@@ -855,8 +856,7 @@ class TestExecution:
                            softmax_gain=100,
                            memory_fill=(0,.001),
                            concatenate_queries=concatenate,
-                           # learn_field_weights=learning,
-                           learn_field_weights=False,
+                           learn_field_weights=learning,
                            enable_learning=True,
                            use_storage_node=use_storage_node)
 

--- a/tests/composition/test_emcomposition.py
+++ b/tests/composition/test_emcomposition.py
@@ -319,15 +319,14 @@ class TestConstruction:
                                                          learn_field_weights,
                                                          target_fields)}
     test_field_map_and_args_assignment_data = [
-        ('args', None, field_names, field_weights, learn_field_weights, target_fields),
-        ('dict-subdict', dict_subdict, None, None, None, None),
-        ('dict-tuple', dict_tuple, None, None, None, None)]
-    field_arg_names = "format, fields, field_names, field_weights, learn_field_weights, target_fields"
+        pytest.param(None, field_names, field_weights, learn_field_weights, target_fields, id='args'),
+        pytest.param(dict_subdict, None, None, None, None, id='dict-subdict'),
+        pytest.param(dict_tuple, None, None, None, None, id='dict-tuple'),
+    ]
 
-    @pytest.mark.parametrize(field_arg_names, test_field_map_and_args_assignment_data,
-                             ids=[x[0] for x in test_field_map_and_args_assignment_data])
+    @pytest.mark.parametrize("fields, field_names, field_weights, learn_field_weights, target_fields",
+                             test_field_map_and_args_assignment_data)
     def test_field_args_and_map_assignments(self,
-                                            format,
                                             fields,
                                             field_names,
                                             field_weights,

--- a/tests/composition/test_grucomposition.py
+++ b/tests/composition/test_grucomposition.py
@@ -22,7 +22,7 @@ from psyneulink.library.compositions.grucomposition.grucomposition import GRUCom
 # ---------------------
 # HOOK FOR torch.GRU module for use in debugging internal calculations
 
-def _pytorch_gru_module_values_hook(module, input, output):
+def _pytorch_gru_module_values_hook(module, input):
     import torch
     in_len = module.input_size
     hid_len = module.hidden_size

--- a/tests/functions/test_integrator.py
+++ b/tests/functions/test_integrator.py
@@ -17,8 +17,9 @@ RAND0_1 = np.random.random()
 RAND2 = np.random.rand()
 RAND3 = np.random.rand()
 
-def SimpleIntFun(init, value, iterations, noise, rate, offset, **kwargs):
+def SimpleIntFun(_init, _value, iterations, noise, **kwargs):
     assert iterations == 3
+
     if np.isscalar(noise):
         if "initializer" in kwargs:
             return [4.91845218, 4.78766907, 4.73758993, 5.04920442, 4.09842889,
@@ -44,7 +45,7 @@ def SimpleIntFun(init, value, iterations, noise, rate, offset, **kwargs):
             return [4.7398811, 4.33354877, 3.23128239, 4.14249424, 2.05951504,
                     3.8008388, 2.14580932, 4.9102284,  3.69882314, 2.91676163]
 
-def AdaptiveIntFun(init, value, iterations, noise, rate, offset, **kwargs):
+def AdaptiveIntFun(_init, _value, iterations, noise, **kwargs):
     assert iterations == 3
 
     if np.isscalar(noise):
@@ -72,7 +73,7 @@ def AdaptiveIntFun(init, value, iterations, noise, rate, offset, **kwargs):
             return [3.59649986, 3.28818534, 2.45181396, 3.14321808, 1.56270704,
                     2.88397872, 1.62818492, 3.72575501, 2.80657186, 2.2131637]
 
-def DriftIntFun(init, value, iterations, noise, **kwargs):
+def DriftIntFun(_init, _value, iterations, noise, **kwargs):
     assert iterations == 3
 
     if np.isscalar(noise):
@@ -97,7 +98,7 @@ def DriftIntFun(init, value, iterations, noise, **kwargs):
                      2.36535325, 2.3125881 , 1.94195457, 3.4923464 , 2.73809322],
                     [3., 3., 3., 3., 3., 3., 3., 3., 3., 3.])
 
-def LeakyFun(init, value, iterations, noise, **kwargs):
+def LeakyFun(_init, _value, iterations, noise, **kwargs):
     assert iterations == 3
 
     if np.isscalar(noise):
@@ -118,7 +119,7 @@ def LeakyFun(init, value, iterations, noise, **kwargs):
         else:
             return [3.12748415, 2.76778478, 2.45911505, 3.06686514, 1.6311395, 2.19281309, 1.61148745, 3.23404557, 2.81418859, 2.63042344]
 
-def AccumulatorFun(init, value, iterations, noise, **kwargs):
+def AccumulatorFun(_init, _value, iterations, noise, **kwargs):
     assert iterations == 3
 
     if np.isscalar(noise):
@@ -149,7 +150,7 @@ def AccumulatorFun(init, value, iterations, noise, **kwargs):
             return [[1.67373165, 1.42936784, 0.97944456, 1.41185147, 0.51221934,
                      1.20867833, 0.54474727, 1.62918182, 1.06390014, 0.92255587]]
 
-def DriftOnASphereFun(init, value, iterations, noise, **kwargs):
+def DriftOnASphereFun(_init, _value, iterations, noise, **kwargs):
     assert iterations == 3
 
     if np.isscalar(noise):

--- a/tests/mechanisms/test_episodic_memory.py
+++ b/tests/mechanisms/test_episodic_memory.py
@@ -59,9 +59,7 @@ def test_with_dictionary_memory(variable, func, params, expected, benchmark, mec
 # TEST WITH ContentAddressableMemory ***********************************************************************************
 # Note:  ContentAddressableMemory has not yet been compiled for use with LLVM or PTX, so those are dummy tests for now
 test_data = [
-    (
-        # name
-        "ContentAddressableMemory Default",
+    pytest.param(
         # func
         ContentAddressableMemory,
         # func_params
@@ -75,11 +73,11 @@ test_data = [
         # expected output_port names
         ['RETRIEVED_FIELD_0'],
         # expected output
-        [[0,0]]
-    ),
-    (
+        [[0,0]],
         # name
-        "ContentAddressableMemory Func Default Variable Mech Size Init",
+        id="ContentAddressableMemory Default",
+    ),
+    pytest.param(
         # func
         ContentAddressableMemory,
         # func_params
@@ -93,20 +91,21 @@ test_data = [
         # expected output_port names
         ['RETRIEVED_FIELD_0', 'RETRIEVED_FIELD_1', 'RETRIEVED_FIELD_2'],
         # expected output
-        [[0,0],[0,0],[0,0,0]]
+        [[0,0],[0,0],[0,0,0]],
+        # name
+        id="ContentAddressableMemory Func Default Variable Mech Size Init",
     ),
-    (
-        "ContentAddressableMemory Func Default Variable Mech Default Var Init",
+    pytest.param(
         ContentAddressableMemory,
         {'default_variable': [[0],[0,0],[0,0,0]]},
         {'default_variable': [[0],[0,0],[0,0,0]]},
         [[10.],[20., 30.],[40., 50., 60.]],
         ['FIELD_0_INPUT', 'FIELD_1_INPUT', 'FIELD_2_INPUT'],
         ['RETRIEVED_FIELD_0', 'RETRIEVED_FIELD_1', 'RETRIEVED_FIELD_2'],
-        [[0],[0,0],[0,0,0]]
+        [[0],[0,0],[0,0,0]],
+        id="ContentAddressableMemory Func Default Variable Mech Default Var Init",
     ),
-    (
-        "ContentAddressableMemory Func Initializer (ragged) Mech Size Init",
+    pytest.param(
         ContentAddressableMemory,
         {'initializer':np.array([[np.array([1]), np.array([2, 3]), np.array([4, 5, 6])],
                                  [list([10]), list([20, 30]), list([40, 50, 60])],
@@ -116,10 +115,10 @@ test_data = [
         ['FIELD_0_INPUT', 'FIELD_1_INPUT', 'FIELD_2_INPUT'],
         ['RETRIEVED_FIELD_0', 'RETRIEVED_FIELD_1', 'RETRIEVED_FIELD_2'],
         # [[10.],[20., 30.],[40., 50., 60.]]
-        [[1], [2,3], [4,5,6]] # <- distance = 0 to [[10.],[20., 30.],[40., 50., 60.]]
+        [[1], [2, 3], [4, 5, 6]], # <- distance = 0 to [[10.],[20., 30.],[40., 50., 60.]]
+        id="ContentAddressableMemory Func Initializer (ragged) Mech Size Init",
     ),
-    (
-        "ContentAddressableMemory Func Initializer (ragged) Mech Default Variable Init",
+    pytest.param(
         ContentAddressableMemory,
         {'initializer':np.array([[np.array([1]), np.array([2, 3]), np.array([4, 5, 6])],
                                  [[12], [20, 55], [40, 50, 60]],
@@ -128,10 +127,10 @@ test_data = [
         [[10.],[20., 30.],[40., 50., 60.]],
         ['hello', 'world', 'goodbye'],
         ['RETRIEVED_hello', 'RETRIEVED_world', 'RETRIEVED_goodbye'],
-        [[1.],[2., 3.],[4., 5., 6.]]
+        [[1.],[2., 3.],[4., 5., 6.]],
+        id="ContentAddressableMemory Func Initializer (ragged) Mech Default Variable Init",
     ),
-    (
-        "ContentAddressableMemory Func Initializer (regular 2d) Mech Size Init",
+    pytest.param(
         ContentAddressableMemory,
         {'initializer':np.array([[np.array([1,2]), np.array([3,4]), np.array([5, 6])],
                                  [[10,20], [30,40], [50,60]],
@@ -141,9 +140,9 @@ test_data = [
         ['FIELD_0_INPUT', 'FIELD_1_INPUT', 'FIELD_2_INPUT'],
         ['RETRIEVED_FIELD_0', 'RETRIEVED_FIELD_1', 'RETRIEVED_FIELD_2'],
         [[11,12], [22,23], [34, 35]],
+        id="ContentAddressableMemory Func Initializer (regular 2d) Mech Size Init",
     ),
-    (
-        "ContentAddressableMemory Func Initializer (regular 2d) Mech Default Variable Init",
+    pytest.param(
         ContentAddressableMemory,
         {'initializer':np.array([[np.array([1,2]), np.array([3,4]), np.array([5, 6])],
                                  [[10,20], [30,40], [50,60]],
@@ -156,9 +155,9 @@ test_data = [
         ['FIELD_0_INPUT', 'FIELD_1_INPUT', 'FIELD_2_INPUT'],
         ['RETRIEVED_FIELD_0', 'RETRIEVED_FIELD_1', 'RETRIEVED_FIELD_2'],
         [[10,20], [30,40], [50, 60]],
+        id="ContentAddressableMemory Func Initializer (regular 2d) Mech Default Variable Init",
     ),
-    (
-        "ContentAddressableMemory Func Mech default_variable Init",
+    pytest.param(
         ContentAddressableMemory,
         {},
         {'default_variable':[[10,20], [30,40]],
@@ -167,9 +166,9 @@ test_data = [
         ['FIRST', 'SECOND'],
         ['RETRIEVED_FIRST', 'RETRIEVED_SECOND'],
         [[0,0], [0,0]],
+        id="ContentAddressableMemory Func Mech default_variable Init",
     ),
-    (
-        "ContentAddressableMemory Func Mech Memory Init",
+    pytest.param(
         ContentAddressableMemory,
         {},
         {'memory':[[[10,20],[30,40]],
@@ -179,9 +178,9 @@ test_data = [
         ['FIRST', 'SECOND'],
         ['RETRIEVED_FIRST', 'RETRIEVED_SECOND'],
         [[10,20], [30,40]],
+        id="ContentAddressableMemory Func Mech Memory Init",
     ),
-    (
-        "ContentAddressableMemory Func Mech Memory Init Enforce Shape",
+    pytest.param(
         ContentAddressableMemory,
         {},
         {'memory':[[11,12],[22, 23]], # <- memory incorrect shape, but should be cast by function._enforce_memory_shape
@@ -190,16 +189,14 @@ test_data = [
         ['FIRST', 'SECOND'],
         ['RETRIEVED_FIRST', 'RETRIEVED_SECOND'],
         [[11,12],[22, 23]],
+        id="ContentAddressableMemory Func Mech Memory Init Enforce Shape",
     )
 ]
 
-# Allows names to be with each test_data set
-names = [td[0] for td in test_data]
-
-@pytest.mark.parametrize('name, func, func_params, mech_params, test_var,'
-                         'input_port_names, output_port_names, expected_output', test_data, ids=names)
+@pytest.mark.parametrize('func, func_params, mech_params, test_var,'
+                         'input_port_names, output_port_names, expected_output', test_data)
 @pytest.mark.llvm_not_implemented
-def test_with_contentaddressablememory(name, func, func_params, mech_params, test_var,
+def test_with_contentaddressablememory(func, func_params, mech_params, test_var,
                                        input_port_names, output_port_names, expected_output, mech_mode):
     f = func(seed=0, **func_params)
     # EpisodicMemoryMechanism(function=f, **mech_params)

--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -20,10 +20,10 @@ from psyneulink.core.scheduling.condition import Never
 
 class TestReset:
     #                        reset_default_value     modulation
-    test_args = [('default',       1,                   None),
-                 ('OVERRIDE',     None,             pnl.OVERRIDE)]
-    @pytest.mark.parametrize('test_name, reset_default, modulation', test_args, ids=[x[0] for x in test_args])
-    def test_reset_integrator_mechanism(self, test_name, reset_default, modulation):
+    test_args = [pytest.param(1,                None,           id='default'),
+                 pytest.param(None,             pnl.OVERRIDE,   id='OVERRRIDE')]
+    @pytest.mark.parametrize('reset_default, modulation', test_args)
+    def test_reset_integrator_mechanism(self, reset_default, modulation):
         input = pnl.ProcessingMechanism(name='INPUT')
         counter = IntegratorMechanism(function=SimpleIntegrator,
                                       default_variable=1,

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -1717,31 +1717,35 @@ class TestClip:
                            [[-2.0, -1.0, 2.0], [2.0, -2.0, 1.0], [1.0, 2.0, 2.0]])
 
     test_params = [
-        # test_for           clip       scale offset input   expected     warning_msg
-        ["no clip",          None,        2,     1,   1.5,  2.63514895,   None],
-        ["ok clip",        (1.0, 3.0),    2,     1,   1.5,  2.63514895,   None],
-        ["clip lower",     (1.0, 3.0),    2,    -1,   1.5,  1.0,          (r"The upper value of clip for '.*' \(3.0\) "
-                                                                           r"is above its function's upper bound \(1\), "
-                                                                           "so it will not have an effect.")],
-        ["clip upper",     (1.0, 3.0),    2,     2,   1.5,  3.0,          (r"The lower value of clip for '.*' \(1.0\) "
-                                                                           r"is below its function's lower bound \(2\), "
-                                                                           "so it will not have an effect.")],
-        ["warning lower",  (-1.0, 2.0),   2,     0,   1.5,  1.63514895,   (r"The lower value of clip for '.*' \(-1.0\) "
-                                                                           r"is below its function's lower bound \(0\), "
-                                                                           "so it will not have an effect.")],
-        ["warning upper",  (-1.0, 3.0),   2,    -1,   1.5,  0.63514895,   (r"The upper value of clip for '.*' \(3.0\) "
-                                                                           r"is above its function's upper bound \(1\), "
-                                                                           "so it will not have an effect.")],
-        ["warning both",   (1.0, 5.0),    2,     2,   1.5,  3.63514895,   (r"The lower value of clip for '.*' \(1.0\) "
-                                                                           r"is below its function's lower bound \(2\) "
-                                                                           r"and its upper value \(5.0\) is above the "
-                                                                           r"function's upper bound \(4\), so clip will "
-                                                                           "not have an effect.")],
+        #             clip       scale offset  input   expected     warning_msg
+        pytest.param(None,          2,     1,   1.5,  2.63514895,  None, id="no clip"),
+        pytest.param((1.0, 3.0),    2,     1,   1.5,  2.63514895,  None, id="ok clip"),
+        pytest.param((1.0, 3.0),    2,    -1,   1.5,  1.0,         (r"The upper value of clip for '.*' \(3.0\) "
+                                                                    r"is above its function's upper bound \(1\), "
+                                                                     "so it will not have an effect."),
+                     id="clip lower"),
+        pytest.param((1.0, 3.0),    2,     2,   1.5,  3.0,         (r"The lower value of clip for '.*' \(1.0\) "
+                                                                    r"is below its function's lower bound \(2\), "
+                                                                     "so it will not have an effect."),
+                     id="clip upper"),
+        pytest.param((-1.0, 2.0),   2,     0,   1.5,  1.63514895,   (r"The lower value of clip for '.*' \(-1.0\) "
+                                                                     r"is below its function's lower bound \(0\), "
+                                                                      "so it will not have an effect."),
+                     id="warning lower"),
+        pytest.param((-1.0, 3.0),   2,    -1,   1.5,  0.63514895,   (r"The upper value of clip for '.*' \(3.0\) "
+                                                                     r"is above its function's upper bound \(1\), "
+                                                                      "so it will not have an effect."),
+                     id="warning upper"),
+        pytest.param((1.0, 5.0),    2,     2,   1.5,  3.63514895,   (r"The lower value of clip for '.*' \(1.0\) "
+                                                                     r"is below its function's lower bound \(2\) "
+                                                                     r"and its upper value \(5.0\) is above the "
+                                                                     r"function's upper bound \(4\), so clip will "
+                                                                      "not have an effect."),
+                     id="warning both"),
         ]
-    arg_names = "test_for, clip, scale, offset, variable, expected, warning"
 
-    @pytest.mark.parametrize(arg_names, test_params, ids=[x[0] for x in test_params])
-    def test_clip_with_respect_to_fct_bounds(self, test_for, clip, scale, offset, variable, expected, warning):
+    @pytest.mark.parametrize("clip, scale, offset, variable, expected, warning", test_params)
+    def test_clip_with_respect_to_fct_bounds(self, clip, scale, offset, variable, expected, warning):
         """Test for clip that falls outside range of function"""
 
         context = pytest.warns(UserWarning, match=warning) if warning is not None else contextlib.nullcontext()

--- a/tests/misc/test_parameters.py
+++ b/tests/misc/test_parameters.py
@@ -57,8 +57,9 @@ def test_parameter_propagation(ancestor, child):
         assert param.name in child_params
 
 
+@pytest.mark.usefixtures("reset_variable")
 @pytest.mark.parametrize('ancestor, child, should_override', ancestor_child_data)
-def test_parameter_values_overriding(ancestor, child, should_override, reset_variable):
+def test_parameter_values_overriding(ancestor, child, should_override):
     original_child_variable = child.parameters.variable.default_value
 
     # ancestor updates

--- a/tests/scheduling/test_scheduler.py
+++ b/tests/scheduling/test_scheduler.py
@@ -1629,13 +1629,13 @@ class TestFeedback:
                                       pytest.param(pnl.ExecutionMode.PTXRun, marks=[pytest.mark.llvm, pytest.mark.cuda]),
                                      ])
     @pytest.mark.parametrize("condition,scale,expected_result",
-                             [(pnl.AtTrial, None, [[[1.0]], [[2.0]]]),
+                             [(pnl.AtTrial, pnl.TimeScale.RUN, [[[1.0]], [[2.0]]]),
                              ])
     def test_run_term_conditions(self, mode, condition, scale, expected_result):
         incrementing_mechanism = pnl.ProcessingMechanism(function=pnl.SimpleIntegrator)
         comp = pnl.Composition(pathways=[incrementing_mechanism])
 
-        comp.scheduler.termination_conds = {pnl.TimeScale.RUN: condition(2)}
+        comp.scheduler.termination_conds = {scale: condition(2)}
         r = comp.run(inputs=[1], num_trials=5, execution_mode=mode)
 
         np.testing.assert_allclose(r, expected_result[-1])


### PR DESCRIPTION
There were several cases of unused arguments in test functions:
* Test names in test parameters. These were converted to use pytest.param(..., id=name) instead
* A fixture with unused value was converted to 'usefixture' decorator.
* Unused autoparametrizing fixture. This would execute identical tests multiple times. The use of fixture was removed.
* Unused parametrized arguments. These would lead to multiple executions of identical tests. These were converted to reduced parametrization instead.

The primary motivation was to avoid multiple executions of identical tests in the cases of undue parametrized arguments or auto-parametrizing fixtures, the other cases were modified to allow automatic enforcement.
Automatic enforcement was added in the form of flak8 linter that checks for unused function arguments and fails the CI build if there are any unused arguments in tests.