### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -111,6 +111,18 @@ runs:
       shell: bash
       run: |
         pip install ${{ steps.dist.outputs.wheel }}[${{ inputs.features }}] -c env_constraints.txt -c broken_trans_deps.txt
+      env:
+        # Setting CXXFLAGS works around a missing include that breaks the build
+        # of onnx-1/17.0 on recent gcc/clang compilers.
+        # This should be removed once onnx wheels for Python 3.13 are available.
+        # Note that the MS Visual C equivalent option needs to start with an extra
+        # space otherwise the argument gets interpreted as a file location.
+        CXXFLAGS: ${{ startsWith(runner.os, 'windows') && ' /FI cstdint' || '-include cstdint' }}
+        # Setting TEMP works around broken onnx-1.17.0 build on windows where
+        # too long paths in default TEMP directory don't work with msbuild.
+        # This should be removed once onnx wheels for Python 3.13 are available.
+        # Note that $TEMP is only used to set pip's build location on Windows.
+        TEMP: ${{ runner.temp }}
 
     - name: Cleanup old wheels
       shell: bash

--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macos-latest, windows-latest]
         pnl-version: ${{ (github.event_name == 'push') && fromJSON('["head"]') || fromJSON('["head", "base"]') }}
         exclude:
@@ -36,6 +36,8 @@ jobs:
           - python-version: '3.10'
             pnl-version: 'base'
           - python-version: '3.12'
+            pnl-version: 'base'
+          - python-version: '3.13'
             pnl-version: 'base'
 
     outputs:

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.11', '3.12']
+        python-version: ['3.8', '3.11', '3.12', '3.13']
         python-architecture: ['x64']
         extra-args: ['']
         os: [ubuntu, macos, windows]

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macos-latest, windows-latest]
         dist: [wheel, sdist]
 

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,3 +1,5 @@
 psyneulink-sphinx-theme<1.2.8.0
 sphinx>=5, <8.2.4
 sphinx_autodoc_typehints<1.16.0
+
+standard-imghdr <3.14; python_version >= '3.13'

--- a/psyneulink/core/globals/mdf.py
+++ b/psyneulink/core/globals/mdf.py
@@ -1474,7 +1474,9 @@ def generate_script_from_mdf(model_input, outfile=None):
             for module in module_names.copy():
                 try:
                     friendly_name = module_friendly_name_mapping[module]
-                    comp_strs[i][j] = re.sub(f'{module}\\.', f'{friendly_name}.', comp_strs[i][j])
+                    # Use '\b' "beginning of word" to avoid mangling references
+                    # to psyneulink in dill pickled strings.
+                    comp_strs[i][j] = re.sub(f'\\b{module}\\.', f'{friendly_name}.', comp_strs[i][j])
                 except KeyError:
                     pass
 

--- a/psyneulink/core/scheduling/scheduler.py
+++ b/psyneulink/core/scheduling/scheduler.py
@@ -342,7 +342,7 @@ In standard mode"""
     ],
     'Scheduler': [
         (
-            r'(Arguments\n    ---------\n)',
+            r'(Arguments\n *---------\n)',
             """\\1
     composition : Composition
         specifies the `Components <Component>` to be ordered for execution, and any dependencies among them,

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 
     # Require recent python

--- a/tests/mdf/test_mdf.py
+++ b/tests/mdf/test_mdf.py
@@ -431,8 +431,12 @@ def test_mdf_pnl_results_equivalence_individual_functions(mech_type, function, r
 @pytest.mark.parametrize('fmt', ['json', 'yml'])
 def test_generate_script_from_mdf(filename, composition_name, fmt, tmp_path):
     orig_file = read_defined_model_script(filename)
-    exec(orig_file)
-    serialized = eval(f'pnl.get_mdf_serialized({composition_name}, fmt="{fmt}")')
+
+    _locals = {}
+    _globals = {}
+    exec(orig_file, _globals, _locals)
+    serialized = eval(f'pnl.get_mdf_serialized({composition_name}, fmt="{fmt}")', _globals, _locals)
+
 
     mdf_file, mdf_fname, _ = get_mdf_output_file(filename, tmp_path, fmt)
     mdf_file.write_text(serialized)


### PR DESCRIPTION
Adapt test.
Advertise support for Python 3.13.
Add CI workarounds to build onnx-1.17.0.
Enable Python 3.13 CI jobs.