### PR TITLE
Parameter: rework fallback for missing values in a Context

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -527,15 +527,39 @@ from psyneulink.core import llvm as pnlvm
 from psyneulink.core.globals.context import \
     Context, ContextError, ContextFlags, INITIALIZATION_STATUS_FLAGS, _get_time, handle_external_context
 from psyneulink.core.globals.mdf import MDFSerializable
-from psyneulink.core.globals.keywords import \
-    CONTEXT, CONTROL_PROJECTION, DEFERRED_INITIALIZATION, DETERMINISTIC, EXECUTE_UNTIL_FINISHED, \
-    FUNCTION, FUNCTION_PARAMS, INIT_FULL_EXECUTE_METHOD, INPUT_PORTS, \
-    LEARNING, LEARNING_PROJECTION, MATRIX, MAX_EXECUTIONS_BEFORE_FINISHED, \
-    MODEL_SPEC_ID_PSYNEULINK, MODEL_SPEC_ID_METADATA, \
-    MODEL_SPEC_ID_INPUT_PORTS, MODEL_SPEC_ID_OUTPUT_PORTS, \
-    MODEL_SPEC_ID_MDF_VARIABLE, \
-    MODULATORY_SPEC_KEYWORDS, NAME, OUTPUT_PORTS, OWNER, PARAMS, PREFS_ARG, \
-    RANDOM, RESET_STATEFUL_FUNCTION_WHEN, INPUT_SHAPES, VALUE, VARIABLE, SHARED_COMPONENT_TYPES
+from psyneulink.core.globals.keywords import (
+    CONTEXT,
+    CONTROL_PROJECTION,
+    DEFERRED_INITIALIZATION,
+    DETERMINISTIC,
+    EXECUTE_UNTIL_FINISHED,
+    FUNCTION,
+    FUNCTION_PARAMS,
+    INIT_FULL_EXECUTE_METHOD,
+    INPUT_PORTS,
+    LEARNING,
+    LEARNING_PROJECTION,
+    MATRIX,
+    MAX_EXECUTIONS_BEFORE_FINISHED,
+    MODEL_SPEC_ID_PSYNEULINK,
+    MODEL_SPEC_ID_METADATA,
+    MODEL_SPEC_ID_INPUT_PORTS,
+    MODEL_SPEC_ID_OUTPUT_PORTS,
+    MODEL_SPEC_ID_MDF_VARIABLE,
+    MODULATORY_SPEC_KEYWORDS,
+    NAME,
+    OUTPUT_PORTS,
+    OWNER,
+    PARAMS,
+    PREFS_ARG,
+    RANDOM,
+    RESET_STATEFUL_FUNCTION_WHEN,
+    INPUT_SHAPES,
+    VALUE,
+    VARIABLE,
+    SHARED_COMPONENT_TYPES,
+    DEFAULT,
+)
 from psyneulink.core.globals.log import LogCondition
 from psyneulink.core.globals.parameters import (
     Defaults,
@@ -1044,11 +1068,18 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                                     read_only=True,
                                     loggable=False,
                                     stateful=False,
-                                    fallback_default=True,
+                                    fallback_value=DEFAULT,
                                     pnl_internal=True)
         is_finished_flag = Parameter(True, loggable=False, stateful=True)
         execute_until_finished = Parameter(True, pnl_internal=True)
-        num_executions = Parameter(Time(), read_only=True, modulable=False, loggable=False, pnl_internal=True)
+        num_executions = Parameter(
+            Time(),
+            read_only=True,
+            modulable=False,
+            loggable=False,
+            fallback_value=DEFAULT,
+            pnl_internal=True
+        )
         num_executions_before_finished = Parameter(0, read_only=True, modulable=False, pnl_internal=True)
         max_executions_before_finished = Parameter(1000, modulable=False, pnl_internal=True)
 
@@ -2383,7 +2414,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
 
             # set default to None context to ensure it exists
             if (
-                p._get(context) is None and p.getter is None
+                p._get(context, fallback_value=None) is None and p.getter is None
                 or context.execution_id not in p.values
             ):
                 if p._user_specified:
@@ -4425,9 +4456,11 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                 self._parameter_components.add(param_value)
 
     @property
-    def _dependent_components(self):
+    def _dependent_components(self) -> Iterable['Component']:
         """
-            Returns a set of Components that will be executed if this Component is executed
+            Returns:
+                Components that must have values in a given Context for
+                this Component to execute in that Context
         """
         return list(self._parameter_components)
 

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -3314,7 +3314,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
             # Immutable, so just assign value
             self.defaults.value = value
 
-    def _update_default_variable(self, new_default_variable, context=None):
+    def _update_default_variable(self, new_default_variable, context):
         from psyneulink.core.components.shellclasses import Function
 
         new_default_variable = convert_all_elements_to_np_array(new_default_variable)

--- a/psyneulink/core/components/functions/function.py
+++ b/psyneulink/core/components/functions/function.py
@@ -166,7 +166,7 @@ from psyneulink.core.globals.keywords import (
     MODEL_SPEC_ID_MDF_VARIABLE, MatrixKeywordLiteral, ZEROS_MATRIX
 )
 from psyneulink.core.globals.mdf import _get_variable_parameter_name
-from psyneulink.core.globals.parameters import Parameter, check_user_specified, copy_parameter_value
+from psyneulink.core.globals.parameters import Parameter, ParameterNoValueError, check_user_specified, copy_parameter_value
 from psyneulink.core.globals.preferences.basepreferenceset import REPORT_OUTPUT_PREF, ValidPrefSet
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
 from psyneulink.core.globals.registry import register_category
@@ -276,7 +276,7 @@ def get_param_value_for_keyword(owner, keyword):
         # return None
         else:
             raise FunctionError(e)
-    except AttributeError:
+    except (AttributeError, ParameterNoValueError):
         # prefs is not always created when this is called, so check
         try:
             owner.prefs

--- a/psyneulink/core/components/functions/nonstateful/distributionfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/distributionfunctions.py
@@ -35,10 +35,11 @@ from psyneulink.core.components.functions.function import (
     DEFAULT_SEED, Function_Base, FunctionError,
     _random_state_getter, _seed_setter, _noise_setter
 )
-from psyneulink.core.globals.keywords import \
-    ADDITIVE_PARAM, DIST_FUNCTION_TYPE, BETA, DIST_MEAN, DIST_SHAPE, DRIFT_DIFFUSION_ANALYTICAL_FUNCTION, \
-    EXPONENTIAL_DIST_FUNCTION, GAMMA_DIST_FUNCTION, HIGH, LOW, MULTIPLICATIVE_PARAM, NOISE, NORMAL_DIST_FUNCTION, \
-    SCALE, STANDARD_DEVIATION, THRESHOLD, UNIFORM_DIST_FUNCTION, WALD_DIST_FUNCTION
+from psyneulink.core.globals.keywords import (
+    ADDITIVE_PARAM, DIST_FUNCTION_TYPE, BETA, DIST_MEAN, DIST_SHAPE, DRIFT_DIFFUSION_ANALYTICAL_FUNCTION,
+    EXPONENTIAL_DIST_FUNCTION, GAMMA_DIST_FUNCTION, HIGH, LOW, MULTIPLICATIVE_PARAM, NOISE, NORMAL_DIST_FUNCTION,
+    SCALE, STANDARD_DEVIATION, THRESHOLD, UNIFORM_DIST_FUNCTION, WALD_DIST_FUNCTION, DEFAULT,
+)
 from psyneulink.core.globals.utilities import convert_all_elements_to_np_array, convert_to_np_array, ValidParamSpecType
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
 
@@ -160,7 +161,7 @@ class NormalDist(DistributionFunction):
         mean = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
         standard_deviation = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM], mdf_name='scale')
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
 
     @check_user_specified
     @beartype
@@ -340,7 +341,7 @@ class UniformToNormalDist(DistributionFunction):
                     :type: ``float``
         """
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
         variable = Parameter(np.array([0]), read_only=True, pnl_internal=True, constructor_argument='default_variable')
         mean = Parameter(0.0, modulable=True, aliases=[ADDITIVE_PARAM])
         standard_deviation = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
@@ -465,7 +466,7 @@ class ExponentialDist(DistributionFunction):
         """
         beta = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
 
     @check_user_specified
     @beartype
@@ -592,7 +593,7 @@ class UniformDist(DistributionFunction):
         low = Parameter(0.0, modulable=True)
         high = Parameter(1.0, modulable=True)
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
 
     @check_user_specified
     @beartype
@@ -748,7 +749,7 @@ class GammaDist(DistributionFunction):
                     :type: ``float``
         """
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
         scale = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
         dist_shape = Parameter(1.0, modulable=True, aliases=[ADDITIVE_PARAM])
 
@@ -883,7 +884,7 @@ class WaldDist(DistributionFunction):
                     :type: ``float``
         """
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
         scale = Parameter(1.0, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
         mean = Parameter(1.0, modulable=True, aliases=[ADDITIVE_PARAM])
 

--- a/psyneulink/core/components/functions/nonstateful/learningfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/learningfunctions.py
@@ -41,11 +41,12 @@ from psyneulink.core.components.functions.function import (
 )
 from psyneulink.core.components.functions.nonstateful.transferfunctions import Logistic, SoftMax
 from psyneulink.core.globals.context import handle_external_context
-from psyneulink.core.globals.keywords import \
-    CONTRASTIVE_HEBBIAN_FUNCTION, EM_STORAGE_FUNCTION, TDLEARNING_FUNCTION, LEARNING_FUNCTION_TYPE, LEARNING_RATE, \
-    KOHONEN_FUNCTION, GAUSSIAN, LINEAR, EXPONENTIAL, HEBBIAN_FUNCTION, RL_FUNCTION, BACKPROPAGATION_FUNCTION, \
-    MATRIX, Loss
-from psyneulink.core.globals.parameters import Parameter, check_user_specified
+from psyneulink.core.globals.keywords import (
+    CONTRASTIVE_HEBBIAN_FUNCTION, EM_STORAGE_FUNCTION, TDLEARNING_FUNCTION, LEARNING_FUNCTION_TYPE, LEARNING_RATE,
+    KOHONEN_FUNCTION, GAUSSIAN, LINEAR, EXPONENTIAL, HEBBIAN_FUNCTION, RL_FUNCTION, BACKPROPAGATION_FUNCTION,
+    MATRIX, Loss, DEFAULT,
+)
+from psyneulink.core.globals.parameters import Parameter, ParameterNoValueError, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
 from psyneulink.core.globals.utilities import convert_all_elements_to_np_array, is_numeric, scalar_distance, convert_to_np_array, all_within_range, safe_len, is_numeric_scalar
 
@@ -349,7 +350,7 @@ class EMStorage(LearningFunction):
         storage_prob = Parameter(1.0, modulable=True)
         decay_rate = Parameter(0.0, modulable=True)
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
 
     def _validate_storage_prob(self, storage_prob):
         storage_prob = float(storage_prob)
@@ -776,7 +777,7 @@ class BayesGLM(LearningFunction):
                     :type: ``int``
         """
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
         variable = Parameter([np.array([0, 0, 0]),
                               np.array([0])],
                              read_only=True,
@@ -1705,21 +1706,21 @@ class ContrastiveHebbian(LearningFunction):  # ---------------------------------
 def _activation_input_getter(owning_component=None, context=None):
     try:
         return owning_component.parameters.variable._get(context)[LEARNING_ACTIVATION_INPUT]
-    except (AttributeError, TypeError):
+    except (AttributeError, ParameterNoValueError, TypeError):
         return None
 
 
 def _activation_output_getter(owning_component=None, context=None):
     try:
         return owning_component.parameters.variable._get(context)[LEARNING_ACTIVATION_OUTPUT]
-    except (AttributeError, TypeError):
+    except (AttributeError, ParameterNoValueError, TypeError):
         return None
 
 
 def _error_signal_getter(owning_component=None, context=None):
     try:
         return owning_component.parameters.variable._get(context)[LEARNING_ERROR_OUTPUT]
-    except (AttributeError, TypeError):
+    except (AttributeError, ParameterNoValueError, TypeError):
         return None
 
 

--- a/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
@@ -49,9 +49,10 @@ from psyneulink.core.components.functions.function import (
 )
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.defaults import MPI_IMPLEMENTATION
-from psyneulink.core.globals.keywords import \
-    BOUNDS, GRADIENT_OPTIMIZATION_FUNCTION, GRID_SEARCH_FUNCTION, GAUSSIAN_PROCESS_FUNCTION, \
-    OPTIMIZATION_FUNCTION_TYPE, OWNER, VALUE
+from psyneulink.core.globals.keywords import (
+    BOUNDS, GRADIENT_OPTIMIZATION_FUNCTION, GRID_SEARCH_FUNCTION, GAUSSIAN_PROCESS_FUNCTION,
+    OPTIMIZATION_FUNCTION_TYPE, OWNER, VALUE, DEFAULT,
+)
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.sampleiterator import SampleIterator
 from psyneulink.core.globals.utilities import call_with_pruned_args, convert_to_np_array
@@ -450,17 +451,17 @@ class OptimizationFunction(Function_Base):
         if search_termination_function is None:
             self._unspecified_args.append(SEARCH_TERMINATION_FUNCTION)
 
-        self.randomization_dimension = randomization_dimension
-        if self.search_space:
+        if search_space and randomization_dimension is not None:
             # Make randomization dimension of search_space last for standardization of treatment
-            self.search_space.append(self.search_space.pop(self.search_space.index(self.randomization_dimension)))
-            self.randomization_dimension = len(self.search_space)
+            search_space.append(search_space.pop(search_space.index(randomization_dimension)))
+            randomization_dimension = len(search_space)
 
         super().__init__(
             default_variable=default_variable,
             save_samples=save_samples,
             save_values=save_values,
             max_iterations=max_iterations,
+            randomization_dimension=randomization_dimension,
             search_space=search_space,
             objective_function=objective_function,
             aggregation_function=aggregation_function,
@@ -1607,7 +1608,7 @@ class GridSearch(OptimizationFunction):
         save_samples = Parameter(False, pnl_internal=True)
         save_values = Parameter(False, pnl_internal=True)
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
         select_randomly_from_optimal_values = Parameter(False)
 
         direction = MAXIMIZE

--- a/psyneulink/core/components/functions/nonstateful/selectionfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/selectionfunctions.py
@@ -36,14 +36,15 @@ from psyneulink.core.components.functions.function import (
     DEFAULT_SEED, Function, Function_Base, FunctionError,
     _random_state_getter, _seed_setter,
 )
-from psyneulink.core.globals.keywords import \
-    (ALL, ARG_MAX, ARG_MAX_ABS, ARG_MAX_ABS_INDICATOR, ARG_MAX_INDICATOR,
-     ARG_MIN, ARG_MIN_ABS, ARG_MIN_ABS_INDICATOR, ARG_MIN_INDICATOR,
-     DETERMINISTIC, FIRST, LAST,
-     MAX, MAX_ABS_INDICATOR, MAX_ABS_VAL, MAX_INDICATOR, MAX_VAL,
-     MIN, MIN_ABS_INDICATOR, MIN_ABS_VAL, MIN_INDICATOR, MIN_VAL,
-     MODE, ONE_HOT_FUNCTION, PREFERENCE_SET_NAME, PROB, PROB_INDICATOR,
-     RANDOM, SELECTION_FUNCTION_TYPE)
+from psyneulink.core.globals.keywords import (
+    ALL, ARG_MAX, ARG_MAX_ABS, ARG_MAX_ABS_INDICATOR, ARG_MAX_INDICATOR,
+    ARG_MIN, ARG_MIN_ABS, ARG_MIN_ABS_INDICATOR, ARG_MIN_INDICATOR,
+    DETERMINISTIC, FIRST, LAST,
+    MAX, MAX_ABS_INDICATOR, MAX_ABS_VAL, MAX_INDICATOR, MAX_VAL,
+    MIN, MIN_ABS_INDICATOR, MIN_ABS_VAL, MIN_INDICATOR, MIN_VAL,
+    MODE, ONE_HOT_FUNCTION, PREFERENCE_SET_NAME, PROB, PROB_INDICATOR,
+    RANDOM, SELECTION_FUNCTION_TYPE, DEFAULT,
+)
 
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import \
@@ -331,7 +332,7 @@ class OneHot(SelectionFunction):
         indicator = Parameter(False, stateful=False)
         tie = Parameter(ALL, stateful=False)
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
 
         def _validate_mode(self, mode):
             if mode not in mode_options:

--- a/psyneulink/core/components/functions/nonstateful/transferfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/transferfunctions.py
@@ -94,16 +94,17 @@ from psyneulink.core.components.functions.stateful.integratorfunctions import Si
 from psyneulink.core.components.shellclasses import Projection
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.utilities import is_numeric_scalar
-from psyneulink.core.globals.keywords import \
-    (ADAPTIVE, ADDITIVE_PARAM, ALL, ANGLE_FUNCTION, BIAS, BINOMIAL_DISTORT_FUNCTION,
-     DETERMINISTIC_TRANSFER_FUNCTION_TYPE, DROPOUT_FUNCTION,
-     EXPONENTIAL_FUNCTION, GAIN, GAUSSIAN_DISTORT_FUNCTION, GAUSSIAN_FUNCTION,
-     IDENTITY_FUNCTION, INTERCEPT, LEAK, LINEAR_FUNCTION, LOGISTIC_FUNCTION,
-     MAX_INDICATOR, MAX_VAL, MULTIPLICATIVE_PARAM, OFF, OFFSET, ON, OUTPUT_TYPE,
-     PER_ITEM, PROB, PRODUCT, PROB_INDICATOR, PROBABILISTIC_TRANSFER_FUNCTION_TYPE,
-     RATE, RELU_FUNCTION, SCALE, SLOPE, SOFTMAX_FUNCTION, STANDARD_DEVIATION, SUM,
-     TANH_FUNCTION, TRANSFER_FUNCTION_TYPE, TRANSFER_WITH_COSTS_FUNCTION,
-     VARIANCE, VARIABLE, X_0, PREFERENCE_SET_NAME)
+from psyneulink.core.globals.keywords import (
+    ADAPTIVE, ADDITIVE_PARAM, ALL, ANGLE_FUNCTION, BIAS, BINOMIAL_DISTORT_FUNCTION,
+    DETERMINISTIC_TRANSFER_FUNCTION_TYPE, DROPOUT_FUNCTION,
+    EXPONENTIAL_FUNCTION, GAIN, GAUSSIAN_DISTORT_FUNCTION, GAUSSIAN_FUNCTION,
+    IDENTITY_FUNCTION, INTERCEPT, LEAK, LINEAR_FUNCTION, LOGISTIC_FUNCTION,
+    MAX_INDICATOR, MAX_VAL, MULTIPLICATIVE_PARAM, OFF, OFFSET, ON, OUTPUT_TYPE,
+    PER_ITEM, PROB, PRODUCT, PROB_INDICATOR, PROBABILISTIC_TRANSFER_FUNCTION_TYPE,
+    RATE, RELU_FUNCTION, SCALE, SLOPE, SOFTMAX_FUNCTION, STANDARD_DEVIATION, SUM,
+    TANH_FUNCTION, TRANSFER_FUNCTION_TYPE, TRANSFER_WITH_COSTS_FUNCTION,
+    VARIANCE, VARIABLE, X_0, PREFERENCE_SET_NAME, DEFAULT,
+)
 from psyneulink.core.globals.parameters import \
     FunctionParameter, Parameter, get_validator_by_function, check_user_specified, copy_parameter_value
 from psyneulink.core.globals.preferences.basepreferenceset import \
@@ -2235,7 +2236,7 @@ class GaussianDistort(TransferFunction):  #-------------------------------------
         scale = Parameter(1.0, modulable=True)
         offset = Parameter(0.0, modulable=True)
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
         range = (None, None)
 
     @check_user_specified
@@ -2459,7 +2460,7 @@ class BinomialDistort(TransferFunction):  #-------------------------------------
         """
         p = Parameter(0.5, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
         range = (None, None)
 
     @check_user_specified
@@ -2680,7 +2681,7 @@ class Dropout(TransferFunction):  #
         """
         p = Parameter(0.5, modulable=True, aliases=[MULTIPLICATIVE_PARAM])
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
 
     @check_user_specified
     @beartype

--- a/psyneulink/core/components/functions/stateful/integratorfunctions.py
+++ b/psyneulink/core/components/functions/stateful/integratorfunctions.py
@@ -45,15 +45,16 @@ from psyneulink.core.components.functions.function import (DEFAULT_SEED, Functio
                                                            _seed_setter, _noise_setter)
 from psyneulink.core.components.functions.stateful.statefulfunction import StatefulFunction
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
-from psyneulink.core.globals.keywords import \
-    (ACCUMULATOR_INTEGRATOR_FUNCTION, ADAPTIVE_INTEGRATOR_FUNCTION, ADDITIVE_PARAM,
-     DECAY, DEFAULT_VARIABLE, DRIFT_DIFFUSION_INTEGRATOR_FUNCTION, DRIFT_ON_A_SPHERE_INTEGRATOR_FUNCTION,
-     DUAL_ADAPTIVE_INTEGRATOR_FUNCTION, FITZHUGHNAGUMO_INTEGRATOR_FUNCTION, FUNCTION,
-     INCREMENT, INITIALIZER, INPUT_PORTS, INTEGRATOR_FUNCTION, INTEGRATOR_FUNCTION_TYPE,
-     INTERACTIVE_ACTIVATION_INTEGRATOR_FUNCTION, LEAKY_COMPETING_INTEGRATOR_FUNCTION,
-     MODEL_SPEC_ID_MDF_VARIABLE, MULTIPLICATIVE_PARAM, NOISE, OFFSET, OPERATION, ORNSTEIN_UHLENBECK_INTEGRATOR_FUNCTION,
-     OUTPUT_PORTS, PREVIOUS_VALUE, PRODUCT,  RATE, REST, SCALE, SIMPLE_INTEGRATOR_FUNCTION, SUM, TIME_STEP_SIZE,
-     THRESHOLD, VARIABLE)
+from psyneulink.core.globals.keywords import (
+    ACCUMULATOR_INTEGRATOR_FUNCTION, ADAPTIVE_INTEGRATOR_FUNCTION, ADDITIVE_PARAM,
+    DECAY, DEFAULT_VARIABLE, DRIFT_DIFFUSION_INTEGRATOR_FUNCTION, DRIFT_ON_A_SPHERE_INTEGRATOR_FUNCTION,
+    DUAL_ADAPTIVE_INTEGRATOR_FUNCTION, FITZHUGHNAGUMO_INTEGRATOR_FUNCTION, FUNCTION,
+    INCREMENT, INITIALIZER, INPUT_PORTS, INTEGRATOR_FUNCTION, INTEGRATOR_FUNCTION_TYPE,
+    INTERACTIVE_ACTIVATION_INTEGRATOR_FUNCTION, LEAKY_COMPETING_INTEGRATOR_FUNCTION,
+    MODEL_SPEC_ID_MDF_VARIABLE, MULTIPLICATIVE_PARAM, NOISE, OFFSET, OPERATION, ORNSTEIN_UHLENBECK_INTEGRATOR_FUNCTION,
+    OUTPUT_PORTS, PREVIOUS_VALUE, PRODUCT, RATE, REST, SCALE, SIMPLE_INTEGRATOR_FUNCTION, SUM, TIME_STEP_SIZE,
+    THRESHOLD, VARIABLE, DEFAULT,
+)
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
 from psyneulink.core.globals.utilities import ValidParamSpecType, all_within_range, is_numeric_scalar, \
@@ -2411,7 +2412,7 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
         time_step_size = Parameter(1.0, modulable=True)
         previous_time = Parameter(0.0, initializer='non_decision_time')
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
         enable_output_type_conversion = Parameter(
             False,
             stateful=False,
@@ -2984,7 +2985,7 @@ class DriftOnASphereIntegrator(IntegratorFunction):  # -------------------------
         initializer = Parameter([0, 0], initalizer='variable', dependencies=dimension, stateful=True)
         angle_function = Parameter(None, stateful=False, loggable=False)
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
         enable_output_type_conversion = Parameter(
             False,
             stateful=False,
@@ -3453,7 +3454,7 @@ class OrnsteinUhlenbeckIntegrator(IntegratorFunction):  # ----------------------
         non_decision_time = Parameter(0.0, modulable=True)
         previous_time = Parameter(0.0, initializer='non_decision_time', pnl_internal=True)
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
         enable_output_type_conversion = Parameter(
             False,
             stateful=False,

--- a/psyneulink/core/components/functions/stateful/memoryfunctions.py
+++ b/psyneulink/core/components/functions/stateful/memoryfunctions.py
@@ -43,10 +43,26 @@ from psyneulink.core.components.functions.nonstateful.selectionfunctions import 
 from psyneulink.core.components.functions.nonstateful.transferfunctions import SoftMax
 from psyneulink.core.components.functions.stateful.integratorfunctions import StatefulFunction
 from psyneulink.core.globals.context import handle_external_context
-from psyneulink.core.globals.keywords import \
-    ADDITIVE_PARAM, BUFFER_FUNCTION, MEMORY_FUNCTION, COSINE, \
-    ContentAddressableMemory_FUNCTION, DictionaryMemory_FUNCTION, \
-    MIN_INDICATOR, MIN_VAL, MULTIPLICATIVE_PARAM, NEWEST, NOISE, OLDEST, OVERWRITE, RATE, RANDOM, SINGLE, WEIGHTED
+from psyneulink.core.globals.keywords import (
+    ADDITIVE_PARAM,
+    BUFFER_FUNCTION,
+    MEMORY_FUNCTION,
+    COSINE,
+    ContentAddressableMemory_FUNCTION,
+    DictionaryMemory_FUNCTION,
+    MIN_INDICATOR,
+    MIN_VAL,
+    MULTIPLICATIVE_PARAM,
+    NEWEST,
+    NOISE,
+    OLDEST,
+    OVERWRITE,
+    RATE,
+    RANDOM,
+    SINGLE,
+    WEIGHTED,
+    DEFAULT,
+)
 from psyneulink.core.globals.parameters import Parameter, check_user_specified, copy_parameter_value
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
 from psyneulink.core.globals.utilities import \
@@ -386,7 +402,7 @@ def _distance_field_weights_setter(value, owning_component=None, context=None):
         variable = owning_component.variable
     distance_function = owning_component.parameters.distance_function._get(context)
     current_field_weights = (owning_component.parameters.distance_field_weights._get(context)
-                             if owning_component.parameters.distance_field_weights._get(context) is not None
+                             if owning_component.parameters.distance_field_weights._get(context, fallback_value=None) is not None
                              else owning_component.defaults.distance_field_weights)
 
     # If assignment is same as current distance_field_weights, skip
@@ -1188,7 +1204,7 @@ class ContentAddressableMemory(MemoryFunction): # ------------------------------
         )
         max_entries = Parameter(1000)
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
         distance_function = Parameter(Distance(metric=COSINE), stateful=False, loggable=False)
         selection_function = Parameter(OneHot(mode=MIN_INDICATOR), stateful=False, loggable=False, dependencies='distance_function')
         distance = Parameter(0, stateful=True, read_only=True)
@@ -2249,7 +2265,7 @@ class DictionaryMemory(MemoryFunction):  # -------------------------------------
         )
         max_entries = Parameter(1000)
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
 
         distance_function = Parameter(Distance(metric=COSINE), stateful=False, loggable=False)
         selection_function = Parameter(OneHot(mode=MIN_INDICATOR), stateful=False, loggable=False)

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3900,7 +3900,7 @@ class Mechanism_Base(Mechanism):
                                               category=category,
                                               component=port)
 
-        self.defaults.variable = self.input_values
+        self.defaults.variable = [copy_parameter_value(ip.defaults.value) for ip in self.input_ports]
 
     def _delete_mechanism(mechanism):
         mechanism.remove_ports(mechanism.input_ports)

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -1098,7 +1098,7 @@ from psyneulink.core.components.ports.modulatorysignals.modulatorysignal import 
 from psyneulink.core.components.ports.outputport import OutputPort
 from psyneulink.core.components.ports.parameterport import ParameterPort
 from psyneulink.core.components.ports.port import \
-    REMOVE_PORTS, PORT_SPEC, _parse_port_spec, PORT_SPECIFIC_PARAMS, PROJECTION_SPECIFIC_PARAMS
+    PORT_SPEC, _parse_port_spec, PORT_SPECIFIC_PARAMS, PROJECTION_SPECIFIC_PARAMS
 from psyneulink.core.components.shellclasses import Mechanism, Projection, Port
 from psyneulink.core.globals.context import Context, ContextFlags, handle_external_context
 # TODO: remove unused keywords
@@ -3816,7 +3816,7 @@ class Mechanism_Base(Mechanism):
                 OUTPUT_PORTS: instantiated_output_ports}
 
     @beartype
-    def remove_ports(self, ports, context=REMOVE_PORTS):
+    def remove_ports(self, ports):
         """
         remove_ports(ports)
 

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -1872,7 +1872,7 @@ class Mechanism_Base(Mechanism):
         input_port_variable_was_specified = None
 
         if (
-            not isinstance(input_ports, list)
+            not isinstance(input_ports, (list, UserList))
             and not (isinstance(input_ports, np.ndarray) and input_ports.ndim > 0)
         ):
             input_ports = [input_ports]

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -1116,7 +1116,7 @@ from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.registry import register_category, remove_instance_from_registry
 from psyneulink.core.globals.utilities import \
     ContentAddressableList, append_type_to_name, convert_all_elements_to_np_array, convert_to_np_array, \
-    iscompatible, kwCompatibilityNumeric, convert_to_list, is_numeric, parse_valid_identifier
+    iscompatible, kwCompatibilityNumeric, convert_to_list, is_numeric, parse_valid_identifier, safe_len
 from psyneulink.core.scheduling.condition import Condition
 from psyneulink.core.scheduling.time import TimeScale
 
@@ -1616,6 +1616,16 @@ class Mechanism_Base(Mechanism):
             read_only=True,
             structural=True,
         )
+
+        def _parse_variable(self, variable):
+            if variable is None:
+                return None
+            # 2d empty port causes input problems.
+            # occurs for CIMs of empty Compositions, or when remove_port
+            # called on only input port
+            if safe_len(variable) == 0:
+                return np.array([])
+            return convert_to_np_array(variable, dimension=2)
 
         def _parse_input_ports(self, input_ports):
             if input_ports is None:

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -631,7 +631,7 @@ from psyneulink.core.globals.keywords import \
     MECHANISM, MULTIPLICATIVE, MODULATORY_SIGNALS, MONITOR_FOR_CONTROL, MONITOR_FOR_MODULATION, \
     OBJECTIVE_MECHANISM, OUTCOME, OWNER_VALUE, PARAMS, PORT_TYPE, PRODUCT, PROJECTION_TYPE, PROJECTIONS, \
     REFERENCE_VALUE, SEPARATE, INPUT_SHAPES, VALUE
-from psyneulink.core.globals.parameters import Parameter, check_user_specified
+from psyneulink.core.globals.parameters import Parameter, ParameterNoValueError, check_user_specified
 from psyneulink.core.globals.context import Context, ContextFlags
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
@@ -723,7 +723,7 @@ def _control_mechanism_costs_getter(owning_component=None, context=None):
         ])  # GatingSignals don't have cost fcts
         return costs
 
-    except TypeError:
+    except (ParameterNoValueError, TypeError):
         return None
 
 def _outcome_getter(owning_component=None, context=None):
@@ -731,7 +731,7 @@ def _outcome_getter(owning_component=None, context=None):
     try:
         return np.array([port.parameters.value._get(context) for port in owning_component.outcome_input_ports],
                         dytpe=object)
-    except (AttributeError, TypeError):
+    except (AttributeError, ParameterNoValueError, TypeError):
         return None
 
 def _net_outcome_getter(owning_component=None, context=None):
@@ -742,7 +742,7 @@ def _net_outcome_getter(owning_component=None, context=None):
             c.parameters.outcome._get(context),
             c.combine_costs()
         )
-    except TypeError:
+    except (ParameterNoValueError, TypeError):
         return np.array([0])
 
 def _control_allocation_getter(owning_component=None, context=None):

--- a/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/controlmechanism.py
@@ -632,7 +632,7 @@ from psyneulink.core.globals.keywords import \
     OBJECTIVE_MECHANISM, OUTCOME, OWNER_VALUE, PARAMS, PORT_TYPE, PRODUCT, PROJECTION_TYPE, PROJECTIONS, \
     REFERENCE_VALUE, SEPARATE, INPUT_SHAPES, VALUE
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
-from psyneulink.core.globals.context import Context
+from psyneulink.core.globals.context import Context, ContextFlags
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import ContentAddressableList, convert_all_elements_to_np_array, convert_to_list, convert_to_np_array
@@ -714,7 +714,10 @@ def _control_mechanism_costs_getter(owning_component=None, context=None):
     # NOTE: In cases where there is a reconfiguration_cost, that cost is not returned by this method
     try:
         costs = convert_all_elements_to_np_array([
-            c.compute_costs(c.parameters.value._get(context), context=context)
+            (
+                c.compute_costs(c.parameters.value._get(context), context=context)
+                if c.initialization_status != ContextFlags.DEFERRED_INIT else None
+            )
             for c in owning_component.control_signals
             if hasattr(c, 'compute_costs')
         ])  # GatingSignals don't have cost fcts

--- a/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/control/optimizationcontrolmechanism.py
@@ -1209,7 +1209,10 @@ def _state_feature_values_getter(owning_component=None, context=None):
               and not owning_component.composition._is_in_composition(spec)):
             # spec is not in ocm.composition
             state_feature_value = _deferred_state_feature_spec_msg(spec.full_name, owning_component.agent_rep.name)
-        elif state_input_port.parameters.value._get(context) is not None:
+        elif (
+            state_input_port.parameters.value._has_value(context)
+            and state_input_port.parameters.value._get(context) is not None
+        ):
             # if state_input_port returns a value, use that
             state_feature_value = state_input_port.parameters.value._get(context)
         else:
@@ -1228,7 +1231,7 @@ class OptimizationControlMechanismError(ControlMechanismError):
 def _control_allocation_search_space_getter(owning_component=None, context=None):
     search_space = owning_component.parameters.search_space._get(context)
     if search_space is None:
-        return [c.parameters.allocation_samples._get(context) for c in owning_component.control_signals]
+        return [c.parameters.allocation_samples._get(context, fallback_value=None) for c in owning_component.control_signals]
     else:
         return search_space
 

--- a/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
+++ b/psyneulink/core/components/mechanisms/modulatory/learning/learningmechanism.py
@@ -589,7 +589,7 @@ from psyneulink.core.globals.keywords import \
     ADDITIVE, ASSERT, ENABLED, INPUT_PORTS, \
     LEARNING, LEARNING_MECHANISM, LEARNING_PROJECTION, LEARNING_SIGNAL, LEARNING_SIGNALS, MATRIX, \
     MODULATION, NAME, OUTPUT_PORT, OWNER_VALUE, PARAMS, PROJECTIONS, REFERENCE_VALUE, SAMPLE, PORT_TYPE, VARIABLE
-from psyneulink.core.globals.parameters import FunctionParameter, Parameter, check_user_specified
+from psyneulink.core.globals.parameters import FunctionParameter, Parameter, ParameterNoValueError, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import ContentAddressableList, convert_all_elements_to_np_array, convert_to_np_array, is_numeric, ValidParamSpecType, \
@@ -699,13 +699,13 @@ class LearningMechanismError(MechanismError):
 def _learning_signal_getter(owning_component=None, context=None):
     try:
         return owning_component.parameters.value._get(context)[0]
-    except (TypeError, IndexError):
+    except (TypeError, IndexError, ParameterNoValueError):
         return None
 
 def _error_signal_getter(owning_component=None, context=None):
     try:
         return owning_component.parameters.value._get(context)[1]
-    except (TypeError, IndexError):
+    except (TypeError, IndexError, ParameterNoValueError):
         return None
 
 

--- a/psyneulink/core/components/mechanisms/processing/compositioninterfacemechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/compositioninterfacemechanism.py
@@ -214,9 +214,8 @@ class CompositionInterfaceMechanism(ProcessingMechanism_Base):
         ports = super(CompositionInterfaceMechanism, self).add_ports(ports, context=context)
         return ports
 
-    @handle_external_context()
-    def remove_ports(self, ports, context=None):
-        super(CompositionInterfaceMechanism, self).remove_ports(ports, context)
+    def remove_ports(self, ports):
+        super(CompositionInterfaceMechanism, self).remove_ports(ports)
         input_ports_marked_for_deletion = set()
         for port in self.user_added_ports[INPUT_PORTS]:
             if port not in self.input_ports:

--- a/psyneulink/core/components/ports/inputport.py
+++ b/psyneulink/core/components/ports/inputport.py
@@ -1265,7 +1265,7 @@ class InputPort(Port_Base):
 
                         # Try to get matrix for projection
                         try:
-                            sender_dim = np.array(projection_spec.port.value).ndim
+                            sender_dim = np.array(projection_spec.port.defaults.value).ndim
                         except AttributeError as e:
                             if (isinstance(projection_spec.port, type) or
                                      projection_spec.port.initialization_status == ContextFlags.DEFERRED_INIT):
@@ -1302,7 +1302,7 @@ class InputPort(Port_Base):
                                 continue
                             # If matrix has not been specified, no worries;
                             #    variable_item can be determined by value of sender
-                            sender_shape = np.array(projection_spec.port.value).shape
+                            sender_shape = np.array(projection_spec.port.defaults.value).shape
                             variable_item = np.zeros(sender_shape)
                             # If variable_item HASN'T been specified, or it is same shape as any previous ones,
                             #     use sender's value

--- a/psyneulink/core/components/ports/parameterport.py
+++ b/psyneulink/core/components/ports/parameterport.py
@@ -384,7 +384,12 @@ from psyneulink.core.globals.keywords import \
     CONTEXT, CONTROL_PROJECTION, CONTROL_SIGNAL, CONTROL_SIGNALS, FUNCTION, FUNCTION_PARAMS, \
     LEARNING_SIGNAL, LEARNING_SIGNALS, MECHANISM, NAME, PARAMETER_PORT, PARAMETER_PORT_PARAMS, PATHWAY_PROJECTION, \
     PROJECTION, PROJECTIONS, PROJECTION_TYPE, REFERENCE_VALUE, SENDER, VALUE
-from psyneulink.core.globals.parameters import ParameterAlias, SharedParameter, check_user_specified
+from psyneulink.core.globals.parameters import (
+    ParameterAlias,
+    ParameterInvalidSourceError,
+    SharedParameter,
+    check_user_specified,
+)
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities \
@@ -1034,6 +1039,8 @@ def _instantiate_parameter_ports(owner, function=None, context=None):
             except (AttributeError, FunctionError, TypeError):
                 if not isinstance(p._owner._owner, ComponentsMeta):
                     raise
+                func = None
+            except ParameterInvalidSourceError:
                 func = None
 
             if func is None:

--- a/psyneulink/core/components/ports/parameterport.py
+++ b/psyneulink/core/components/ports/parameterport.py
@@ -387,6 +387,7 @@ from psyneulink.core.globals.keywords import \
 from psyneulink.core.globals.parameters import (
     ParameterAlias,
     ParameterInvalidSourceError,
+    ParameterNoValueError,
     SharedParameter,
     check_user_specified,
 )
@@ -1040,7 +1041,7 @@ def _instantiate_parameter_ports(owner, function=None, context=None):
                 if not isinstance(p._owner._owner, ComponentsMeta):
                     raise
                 func = None
-            except ParameterInvalidSourceError:
+            except (ParameterInvalidSourceError, ParameterNoValueError):
                 func = None
 
             if func is None:
@@ -1070,7 +1071,7 @@ def _instantiate_parameter_ports(owner, function=None, context=None):
         res = obj
         for p in param_list[0:index + 1]:
             param = getattr(res.parameters, p)
-            func = param._get(context)
+            func = param._get(context, fallback_value=None)
 
             if func is None:
                 func = param.default_value

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2434,7 +2434,7 @@ class Port_Base(Port):
         try:
             return list(itertools.chain(
                 super()._dependent_components,
-                self.efferents,
+                self.all_afferents,
             ))
         except PortError:
             return list(itertools.chain(

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2431,15 +2431,12 @@ class Port_Base(Port):
 
     @property
     def _dependent_components(self):
+        res = super()._dependent_components
         try:
-            return list(itertools.chain(
-                super()._dependent_components,
-                self.all_afferents,
-            ))
-        except PortError:
-            return list(itertools.chain(
-                super()._dependent_components,
-            ))
+            res.extend(self.all_afferents)
+        except AttributeError:
+            pass
+        return res
 
 
 def _instantiate_port_list(owner,

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -837,7 +837,7 @@ PROJECTION_SPECIFIC_PARAMS = 'PROJECTION_SPECIFIC_PARAMS'
 
 STANDARD_PORT_ARGS = {PORT_TYPE, OWNER, REFERENCE_VALUE, VARIABLE, NAME, PARAMS, PREFS_ARG}
 PORT_SPEC = 'port_spec'
-REMOVE_PORTS = 'REMOVE_PORTS'
+
 
 def _is_port_class(spec):
     if inspect.isclass(spec) and issubclass(spec, Port):

--- a/psyneulink/core/components/projections/modulatory/learningprojection.py
+++ b/psyneulink/core/components/projections/modulatory/learningprojection.py
@@ -223,7 +223,7 @@ from psyneulink.core.globals.context import ContextFlags
 from psyneulink.core.globals.keywords import \
     LEARNING, LEARNING_PROJECTION, LEARNING_SIGNAL, \
     MATRIX, PARAMETER_PORT, PROJECTION_SENDER
-from psyneulink.core.globals.parameters import Parameter, check_user_specified
+from psyneulink.core.globals.parameters import SharedParameter, Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import iscompatible, ValidParamSpecType
@@ -245,15 +245,6 @@ DefaultTrainingMechanism = ObjectiveMechanism
 
 class LearningProjectionError(ProjectionError):
     pass
-
-
-def _learning_signal_getter(owning_component=None, context=None):
-    return owning_component.sender.parameters.value._get(context)
-
-
-def _learning_signal_setter(value, owning_component=None, context=None):
-    owning_component.sender.parameters.value._set(value, context)
-    return value
 
 
 class LearningProjection(ModulatoryProjection_Base):
@@ -464,10 +455,7 @@ class LearningProjection(ModulatoryProjection_Base):
                                    stateful=False, loggable=False, reference=True)
         learning_function = Parameter(BackPropagation, stateful=False, loggable=False, reference=True)
         # learning_rate = Parameter(None, modulable=True)
-        learning_signal = Parameter(None, read_only=True,
-                                    getter=_learning_signal_getter,
-                                    setter=_learning_signal_setter,
-                                    pnl_internal=True)
+        learning_signal = SharedParameter(attribute_name='sender', shared_parameter_name='value')
         learning_enabled = None
 
 

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -429,6 +429,7 @@ from psyneulink.core.globals.keywords import \
 from psyneulink.core.globals.parameters import (
     Parameter,
     ParameterInvalidSourceError,
+    ParameterNoValueError,
     check_user_specified,
     copy_parameter_value,
 )
@@ -1228,7 +1229,7 @@ class Projection_Base(Projection):
 
         if (
             simple_edge_format
-            and self.function is not None
+            and self.parameters.function.get(fallback_value=None) is not None
             and not self.function._is_identity(defaults=True)
         ):
             edge_node = ProcessingMechanism(
@@ -1278,7 +1279,7 @@ class Projection_Base(Projection):
             metadata = self._mdf_metadata
             try:
                 metadata[MODEL_SPEC_ID_METADATA]['functions'] = mdf.Function.to_dict(self.function.as_mdf_model())
-            except AttributeError:
+            except (AttributeError, ParameterNoValueError):
                 # projection is in deferred init, special handling here?
                 pass
 

--- a/psyneulink/core/components/projections/projection.py
+++ b/psyneulink/core/components/projections/projection.py
@@ -1134,7 +1134,11 @@ class Projection_Base(Projection):
     @property
     def _dependent_components(self):
         res = super()._dependent_components
-        res.extend(self.parameter_ports)
+        try:
+            res.extend(self.parameter_ports)
+        except AttributeError:
+            # when in DEFERRED_INIT, _parameter_ports doesn't exist yet
+            pass
         if isinstance(self.sender, Component):
             res.append(self.sender)
         return res

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -11060,7 +11060,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
             * *MOVIE_NAME*: str (default=\\ `name <Composition.name>` + 'movie') -- specifies the name to be used
               for the movie file; it is automatically appended with '.gif'.
-_
+
             * *SAVE_IMAGES*: bool (default=\\ `False`\\ ) -- specifies whether to save each of the images used to
               construct the animation in separate gif files, in addition to the file containing the animation.
 

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -3090,7 +3090,12 @@ from psyneulink.core.globals.keywords import \
      SAMPLE, SENDER, SHADOW_INPUTS, SOFT_CLAMP, SUM, SYNCH_WITH_PNL_OPTIONS,
      TARGET, TARGET_MECHANISM, TEXT, VARIABLE, WEIGHT, OWNER_MECH)
 from psyneulink.core.globals.log import CompositionLog, LogCondition
-from psyneulink.core.globals.parameters import Parameter, ParametersBase, check_user_specified, copy_parameter_value
+from psyneulink.core.globals.parameters import (
+    Parameter,
+    ParametersBase,
+    check_user_specified,
+    copy_parameter_value,
+)
 from psyneulink.core.globals.preferences.basepreferenceset import BasePreferenceSet
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel, _assign_prefs
 from psyneulink.core.globals.registry import register_category
@@ -11712,18 +11717,20 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         self._check_nested_target_mechs()
         context.execution_phase = execution_phase_at_entry
 
+        if minibatch_size is None:
+            minibatch_size = self.parameters.minibatch_size._get(context)
+
+        if optimizations_per_minibatch is None:
+            optimizations_per_minibatch = self.parameters.optimizations_per_minibatch._get(context)
+
         result = runner.run_learning(
             inputs=inputs,
             targets=targets,
             num_trials=num_trials,
             epochs=epochs,
             learning_rate=learning_rate,
-            minibatch_size=minibatch_size
-                            or self.parameters.minibatch_size._get(context)
-                            or self.parameters.minibatch_size.default_value,
-            optimizations_per_minibatch=optimizations_per_minibatch
-                                        or self.parameters.optimizations_per_minibatch._get(context)
-                                        or self.parameters.optimizations_per_minibatch.default_value,
+            minibatch_size=minibatch_size,
+            optimizations_per_minibatch=optimizations_per_minibatch,
             patience=patience,
             min_delta=min_delta,
             randomize_minibatches=randomize_minibatches,
@@ -13332,7 +13339,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         if from_parameter is None:
             self._compilation_data.execution.delete(context)
         else:
-            execution_dict = self._compilation_data.execution.get(context)
+            execution_dict = self._compilation_data.execution._get(context, fallback_value=None)
             if execution_dict is None:
                 return
 

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -11558,6 +11558,8 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             call_after_minibatch=None,
             context: Optional[Context] = None,
             *args,
+            base_context: Context = Context(execution_id=None),
+            skip_initialization: bool = False,
             **kwargs
     )->list:
         """
@@ -11682,6 +11684,16 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         """
         from psyneulink.library.compositions import CompositionRunner
         from psyneulink.library.compositions import AutodiffComposition
+
+        if (
+            not skip_initialization
+            and (
+                context is None
+                or ContextFlags.SIMULATION_MODE not in context.runmode
+            )
+        ):
+            self._initialize_from_context(context, base_context, override=False)
+
         runner = CompositionRunner(self)
 
         # Non-Python (i.e. PyTorch and LLVM) learning modes only supported for AutodiffComposition
@@ -11719,6 +11731,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             call_after_minibatch=call_after_minibatch,
             context=context,
             execution_mode=execution_mode,
+            skip_initialization=skip_initialization,
             *args, **kwargs)
 
         context.remove_flag(ContextFlags.LEARNING_MODE)

--- a/psyneulink/core/compositions/parameterestimationcomposition.py
+++ b/psyneulink/core/compositions/parameterestimationcomposition.py
@@ -887,12 +887,11 @@ class ParameterEstimationComposition(Composition):
         return ocm
 
     @handle_external_context()
-    def run(self, *args, **kwargs):
+    def run(self, *args, context=None, **kwargs):
         # Clear any old results from the composition
         if self.results is not None:
             self.results = []
 
-        context = kwargs.get("context", None)
         self._assign_execution_ids(context)
 
         # Before we do anything, clear any compilation structures that have been generated. This is a workaround to
@@ -962,7 +961,7 @@ class ParameterEstimationComposition(Composition):
         )
 
         # Run the composition as normal
-        results = super(ParameterEstimationComposition, self).run(*args, **kwargs)
+        results = super(ParameterEstimationComposition, self).run(*args, context=context, **kwargs)
 
         # IMPLEMENTATION NOTE: has not executed OCM after first call
         if hasattr(self.controller, "optimal_control_allocation"):

--- a/psyneulink/core/compositions/parameterestimationcomposition.py
+++ b/psyneulink/core/compositions/parameterestimationcomposition.py
@@ -889,8 +889,8 @@ class ParameterEstimationComposition(Composition):
     @handle_external_context()
     def run(self, *args, context=None, **kwargs):
         # Clear any old results from the composition
-        if self.results is not None:
-            self.results = []
+        if self.parameters.results._get(context, fallback_value=None) is not None:
+            self.parameters.results._set([], context)
 
         self._assign_execution_ids(context)
 

--- a/psyneulink/core/compositions/showgraph.py
+++ b/psyneulink/core/compositions/showgraph.py
@@ -712,9 +712,6 @@ class ShowGraph():
         """
         composition = self.composition
 
-        if context.execution_id is None:
-            context.execution_id = composition.default_execution_id
-
         # Args not specified by user but used in calls to show_graph for nested Compositions
         comp_hierarchy = kwargs.pop(COMP_HIERARCHY, {})
         enclosing_comp = kwargs.pop(ENCLOSING_COMP,None)

--- a/psyneulink/core/globals/keywords.py
+++ b/psyneulink/core/globals/keywords.py
@@ -476,7 +476,7 @@ PNL = 'psyneulink'
 
 ON = True
 OFF = False
-DEFAULT = False
+DEFAULT = 'default'
 # AUTO = True  # MODIFIED 7/14/17 CW
 ASSERT = True
 

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -835,6 +835,8 @@ def gen_composition_exec(ctx, composition, *, tags:frozenset):
             wrapper = ctx.get_node_assembly(composition, node)
             is_finished_callbacks[node] = (wrapper, args)
 
+        for node in composition.nodes:
+            node._context_for_pytorch = composition._context_for_pytorch
 
         # Resetting internal TRIAL/PASS/TIME_STEP clock for each node
         # also resets TIME_STEP counter for input_CIM and parameter_CIM
@@ -1169,8 +1171,10 @@ def gen_composition_run(ctx, composition, *, tags:frozenset):
 def gen_autodiffcomp_exec(ctx, composition, *, tags:frozenset):
     """Creates llvm bin execute for autodiffcomp"""
     assert composition.controller is None
-    composition._build_pytorch_representation(composition.default_execution_id)
-    pytorch_model = composition.parameters.pytorch_representation.get(composition.default_execution_id)
+
+    context = composition._context_for_pytorch
+    composition._build_pytorch_representation(context)
+    pytorch_model = composition.parameters.pytorch_representation.get(context)
     with _gen_composition_exec_context(ctx, composition, tags=tags) as (builder, data, params, cond_gen):
         state, _, comp_in, _, cond = builder.function.args
 

--- a/psyneulink/core/llvm/execution.py
+++ b/psyneulink/core/llvm/execution.py
@@ -307,12 +307,21 @@ class CompExecution(CUDAExecution):
 
         self.active_executions.add(self)
 
+        # storing this for pytorch_representation in
+        # gen_autodiffcomp_exec instead of changing all
+        # signatures of _comp_ex.[cuda_]run below to pass
+        # context through.
+        # TODO: consider if pytorch_representation can
+        # simply be stateful=False and manage its own
+        # contexts/Parameter values as needed
+        composition._context_for_pytorch = context
+
     def __del__(self):
         self.active_executions.discard(self)
 
     @staticmethod
     def get(composition, context:Context, additional_tags=frozenset()):
-        executions = composition._compilation_data.execution._get(context)
+        executions = composition._compilation_data.execution._get(context, fallback_value=None)
         if executions is None:
             executions = dict()
             composition._compilation_data.execution._set(executions, context)
@@ -321,6 +330,8 @@ class CompExecution(CUDAExecution):
         if execution is None:
             execution = pnlvm.CompExecution(composition, context, additional_tags=additional_tags)
             executions[additional_tags] = execution
+
+        composition._context_for_pytorch = context
 
         return execution
 

--- a/psyneulink/library/components/mechanisms/modulatory/learning/EMstoragemechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/learning/EMstoragemechanism.py
@@ -176,7 +176,7 @@ from psyneulink.core.globals.context import ContextFlags
 from psyneulink.core.globals.keywords import \
     (ADDITIVE, EM_STORAGE_MECHANISM, LEARNING, LEARNING_PROJECTION, LEARNING_SIGNALS, MULTIPLICATIVE,
      MULTIPLICATIVE_PARAM, MODULATION, NAME, OVERRIDE, OWNER_VALUE, PROJECTIONS, REFERENCE_VALUE, VARIABLE)
-from psyneulink.core.globals.parameters import Parameter, check_user_specified, FunctionParameter, copy_parameter_value
+from psyneulink.core.globals.parameters import Parameter, ParameterNoValueError, check_user_specified, FunctionParameter, copy_parameter_value
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel
 from psyneulink.core.globals.utilities import convert_all_elements_to_np_array, is_numeric, all_within_range
@@ -200,7 +200,10 @@ def _memory_matrix_getter(owning_component=None, context=None)->list:
     <Mechanism_Base.afferents>` MappingProjections to each of the `retrieved_nodes <EMComposition.retrieved_nodes>`.
     """
     if owning_component.is_initializing:
-        if owning_component.learning_signals is None or owning_component.input_ports is None:
+        try:
+            if owning_component.learning_signals is None or owning_component.input_ports is None:
+                return None
+        except ParameterNoValueError:
             return None
 
     num_fields = len(owning_component.input_ports)

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -380,9 +380,10 @@ from psyneulink.core.components.mechanisms.processing.processingmechanism import
 from psyneulink.core.components.ports.modulatorysignals.controlsignal import ControlSignal
 from psyneulink.core.components.ports.outputport import SEQUENTIAL, StandardOutputPorts
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
-from psyneulink.core.globals.keywords import \
-    ALLOCATION_SAMPLES, FUNCTION, FUNCTION_PARAMS, INPUT_PORT_VARIABLES, NAME, OWNER_VALUE, \
-    THRESHOLD, VARIABLE, PREFERENCE_SET_NAME
+from psyneulink.core.globals.keywords import (
+    ALLOCATION_SAMPLES, FUNCTION, FUNCTION_PARAMS, INPUT_PORT_VARIABLES, NAME, OWNER_VALUE,
+    THRESHOLD, VARIABLE, PREFERENCE_SET_NAME, DEFAULT,
+)
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet, REPORT_OUTPUT_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
@@ -740,7 +741,7 @@ class DDM(ProcessingMechanism):
         input_format = Parameter(SCALAR, stateful=False, loggable=False)
         initializer = np.array([[0]])
         random_state = Parameter(None, loggable=False, getter=_random_state_getter, dependencies='seed')
-        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_default=True, setter=_seed_setter)
+        seed = Parameter(DEFAULT_SEED(), modulable=True, fallback_value=DEFAULT, setter=_seed_setter)
 
         output_ports = Parameter(
             [DECISION_VARIABLE, RESPONSE_TIME],

--- a/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/episodicmemorymechanism.py
@@ -422,7 +422,12 @@ from psyneulink.core.components.mechanisms.mechanism import MechanismError
 from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism_Base
 from psyneulink.core.components.ports.inputport import InputPort
 from psyneulink.core.globals.keywords import EPISODIC_MEMORY_MECHANISM,MULTIPLICATIVE_PARAM, NAME, OWNER_VALUE, VARIABLE
-from psyneulink.core.globals.parameters import FunctionParameter, Parameter, check_user_specified
+from psyneulink.core.globals.parameters import (
+    FunctionParameter,
+    Parameter,
+    ParameterInvalidSourceError,
+    check_user_specified,
+)
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
 from psyneulink.core.globals.utilities import deprecation_warning, convert_all_elements_to_np_array
 
@@ -619,7 +624,10 @@ class EpisodicMemoryMechanism(ProcessingMechanism_Base):
 
     def _instantiate_function(self, function, function_params, context):
         """Assign memory to function if specified in Mechanism's constructor"""
-        memory = self.parameters.memory._get(context)
+        try:
+            memory = self.parameters.memory._get(context)
+        except ParameterInvalidSourceError:
+            memory = None
         if memory is not None:
             function.reset(memory)
         super()._instantiate_function(function, function_params, context)

--- a/psyneulink/library/components/mechanisms/processing/leabramechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/leabramechanism.py
@@ -107,7 +107,12 @@ from psyneulink.core.components.component import ComponentError
 from psyneulink.core.components.functions.function import Function_Base
 from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism_Base
 from psyneulink.core.globals.keywords import LEABRA_FUNCTION, LEABRA_FUNCTION_TYPE, LEABRA_MECHANISM, NETWORK, PREFERENCE_SET_NAME
-from psyneulink.core.globals.parameters import FunctionParameter, Parameter, check_user_specified
+from psyneulink.core.globals.parameters import (
+    FunctionParameter,
+    Parameter,
+    ParameterInvalidSourceError,
+    check_user_specified,
+)
 from psyneulink.core.globals.preferences.basepreferenceset import REPORT_OUTPUT_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
 from psyneulink.core.globals.utilities import convert_all_elements_to_np_array
@@ -298,7 +303,7 @@ def _training_flag_setter(value, self=None, owning_component=None, context=None)
     if value is not self._get(context):
         try:
             set_training(owning_component.parameters.network._get(context), value)
-        except AttributeError:
+        except (AttributeError, ParameterInvalidSourceError):
             # do not return None here, or training_flag will always be
             # set to None
             pass

--- a/psyneulink/library/components/mechanisms/processing/leabramechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/leabramechanism.py
@@ -300,7 +300,7 @@ class LeabraFunction(Function_Base):
 
 
 def _training_flag_setter(value, self=None, owning_component=None, context=None):
-    if value is not self._get(context):
+    if value is not self._get(context, fallback_value=None):
         try:
             set_training(owning_component.parameters.network._get(context), value)
         except (AttributeError, ParameterInvalidSourceError):

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -213,7 +213,7 @@ from psyneulink.core.globals.context import handle_external_context
 from psyneulink.core.globals.keywords import \
     (AUTO, ENERGY, ENTROPY, FUNCTION, HETERO, HOLLOW_MATRIX, INPUT_PORT,
      MATRIX, NAME, RECURRENT_TRANSFER_MECHANISM, RESULT)
-from psyneulink.core.globals.parameters import Parameter, SharedParameter, check_user_specified, copy_parameter_value
+from psyneulink.core.globals.parameters import Parameter, ParameterNoValueError, SharedParameter, check_user_specified, copy_parameter_value
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet
 from psyneulink.core.globals.registry import register_instance, remove_instance_from_registry
 from psyneulink.core.globals.socket import ConnectionInfo
@@ -256,7 +256,7 @@ def _recurrent_transfer_mechanism_matrix_getter(owning_component=None, context=N
         a = get_auto_matrix(owning_component.parameters.auto._get(context), owning_component.recurrent_size)
         c = get_hetero_matrix(owning_component.parameters.hetero._get(context), owning_component.recurrent_size)
         return a + c
-    except TypeError:
+    except (ParameterNoValueError, TypeError):
         return None
 
 

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -368,7 +368,8 @@ else:
     from psyneulink.library.compositions.pytorchwrappers import PytorchCompositionWrapper
     from psyneulink.library.compositions.pytorchshowgraph import PytorchShowGraph
 
-from psyneulink._typing import Mapping, Optional
+from psyneulink._typing import Iterable, Mapping, Optional
+from psyneulink.core.components.component import Component
 from psyneulink.core.components.mechanisms.processing.processingmechanism import ProcessingMechanism
 from psyneulink.core.components.mechanisms.processing.compositioninterfacemechanism import CompositionInterfaceMechanism
 from psyneulink.core.components.mechanisms.modulatory.modulatorymechanism import ModulatoryMechanism_Base
@@ -378,7 +379,7 @@ from psyneulink.core.components.ports.inputport import InputPort
 from psyneulink.core.compositions.composition import Composition, NodeRole, CompositionError
 from psyneulink.core.compositions.report import (ReportOutput, ReportParams, ReportProgress, ReportSimulations,
                                                  ReportDevices, EXECUTE_REPORT, LEARN_REPORT, PROGRESS_REPORT)
-from psyneulink.core.globals.context import Context, ContextFlags, handle_external_context, CONTEXT
+from psyneulink.core.globals.context import Context, ContextFlags, handle_external_context
 from psyneulink.core.globals.keywords import (AUTODIFF_COMPOSITION, EXECUTION_MODE,
                                               LEARNING_SCALE_LITERALS, LEARNING_SCALE_NAMES, LEARNING_SCALE_VALUES,
                                               Loss, LOSSES, MATRIX_WEIGHTS, MINIBATCH, NODE_VALUES, NODE_VARIABLES,
@@ -1079,14 +1080,16 @@ class AutodiffComposition(Composition):
 
     # CLEANUP: move some of what's done in the methods below to a "validate_params" type of method
     @handle_external_context()
-    def _build_pytorch_representation(self, context=None, refresh=None):
+    def _build_pytorch_representation(self, context=None, refresh=None, base_context=Context(execution_id=None)):
         """Builds a Pytorch representation of the AutodiffComposition"""
         if self.scheduler is None:
             self.scheduler = Scheduler(graph=self.graph_processing)
         if self.parameters.pytorch_representation._get(context=context) is None or refresh:
             model = self.pytorch_composition_wrapper_type(composition=self,
                                                           device=self.device,
-                                                          context=context)
+                                                          context=context,
+                                                          base_context=base_context,
+                                                          )
 
         # Set up optimizer function
         learning_rate = self._runtime_learning_rate or self.learning_rate
@@ -1436,15 +1439,16 @@ class AutodiffComposition(Composition):
               retain_torch_trained_outputs:Optional[LEARNING_SCALE_LITERALS]=NotImplemented,
               retain_torch_targets:Optional[LEARNING_SCALE_LITERALS]=NotImplemented,
               retain_torch_losses:Optional[LEARNING_SCALE_LITERALS]=NotImplemented,
-              **kwargs)->list:
+              context: Context = None,
+              base_context: Context = Context(execution_id=None),
+              skip_initialization: bool = False,
+              **kwargs
+              ) -> list:
         """Override to handle synch and retain args
         Note: defaults for synch and retain args are set to NotImplemented, so that the user can specify None if
               they want to locally override the default values for the AutodiffComposition (see docstrings for run()
               and _parse_synch_and_retain_args() for additonal details).
         """
-
-        context = kwargs[CONTEXT]
-
         execution_phase_at_entry = context.execution_phase
         context.execution_phase = ContextFlags.PREPARING
 
@@ -1479,6 +1483,7 @@ class AutodiffComposition(Composition):
                                               retain_torch_trained_outputs,
                                               retain_torch_targets,
                                               retain_torch_losses,
+                                              context=context,
                                               **kwargs))
 
         if execution_mode == pnlvm.ExecutionMode.PyTorch and not torch_available:
@@ -1490,6 +1495,9 @@ class AutodiffComposition(Composition):
                              synch_with_pnl_options=synch_with_pnl_options,
                              retain_in_pnl_options=retain_in_pnl_options,
                              execution_mode=execution_mode,
+                             context=context,
+                             base_context=base_context,
+                             skip_initialization=skip_initialization,
                              **kwargs)
 
     def _parse_synch_and_retain_args(self,
@@ -1500,6 +1508,7 @@ class AutodiffComposition(Composition):
                                      retain_torch_trained_outputs:Optional[LEARNING_SCALE_LITERALS],
                                      retain_torch_targets:Optional[LEARNING_SCALE_LITERALS],
                                      retain_torch_losses:Optional[LEARNING_SCALE_LITERALS],
+                                     context: Context = None,
                                      **kwargs
                                      )->tuple:
         # Remove args from kwargs in case called from run() (won't be there if called from learn()
@@ -1551,7 +1560,6 @@ class AutodiffComposition(Composition):
                                                f"use 'MINIBATCH' for the {arg_args} to avoid this warning.")
 
         # Package options for synching and tracking into dictionaries as arguments to learning and exec methods
-        context = kwargs[CONTEXT]
         synch_with_pnl_options = {MATRIX_WEIGHTS: synch_projection_matrices_with_torch
                                                   or self.parameters.synch_projection_matrices_with_torch._get(context),
                                   NODE_VARIABLES: synch_node_variables_with_torch
@@ -1651,7 +1659,7 @@ class AutodiffComposition(Composition):
                        content='trial_start',
                        context=context)
 
-                self._build_pytorch_representation(context)
+                self._build_pytorch_representation(context, base_context=base_context)
                 trained_output_values, all_output_values = \
                                                 self.autodiff_forward(inputs=autodiff_inputs,
                                                                       targets=autodiff_targets,
@@ -1706,6 +1714,7 @@ class AutodiffComposition(Composition):
             retain_torch_targets:Optional[LEARNING_SCALE_LITERALS]=NotImplemented,
             retain_torch_losses:Optional[LEARNING_SCALE_LITERALS]=NotImplemented,
             batched_results:bool=False,
+            context: Context = None,
             **kwargs):
         """Override to handle synch and retain args if run called directly from run() rather than learn()
         Note: defaults for synch and retain args are NotImplemented, so that the user can specify None if they want
@@ -1737,15 +1746,14 @@ class AutodiffComposition(Composition):
                                                    retain_torch_trained_outputs,
                                                    retain_torch_targets,
                                                    retain_torch_losses,
+                                                  context=context,
                                                    **kwargs))
             kwargs[SYNCH_WITH_PNL_OPTIONS] = synch_with_pnl_options
             kwargs[RETAIN_IN_PNL_OPTIONS] = retain_in_pnl_options
 
-        results = super(AutodiffComposition, self).run(*args, **kwargs)
-
+        results = super(AutodiffComposition, self).run(*args, context=context, **kwargs)
         if EXECUTION_MODE in kwargs and kwargs[EXECUTION_MODE] is pnlvm.ExecutionMode.PyTorch:
             # Synchronize specified outcomes at end of run
-            context = kwargs[CONTEXT]
             pytorch_rep = self.parameters.pytorch_representation.get(context)
             if pytorch_rep:
                 pytorch_rep.synch_with_psyneulink(kwargs[SYNCH_WITH_PNL_OPTIONS], RUN, context)
@@ -2159,3 +2167,15 @@ class AutodiffComposition(Composition):
     def show_graph(self, *args, **kwargs):
         """Override to use PytorchShowGraph if show_pytorch is True"""
         return self._show_graph.show_graph(*args, **kwargs)
+
+    @property
+    def _dependent_components(self) -> Iterable[Component]:
+        res = super()._dependent_components
+
+        # NOTE: _dependent_components should possibly be reworked to be
+        # a context-dependent method
+        for pytorch_repr in self.parameters.pytorch_representation.values.values():
+            if pytorch_repr is not None:
+                res.extend([w.projection for w in pytorch_repr.projection_wrappers])
+
+        return res

--- a/psyneulink/library/compositions/autodiffcomposition.py
+++ b/psyneulink/library/compositions/autodiffcomposition.py
@@ -380,11 +380,13 @@ from psyneulink.core.compositions.composition import Composition, NodeRole, Comp
 from psyneulink.core.compositions.report import (ReportOutput, ReportParams, ReportProgress, ReportSimulations,
                                                  ReportDevices, EXECUTE_REPORT, LEARN_REPORT, PROGRESS_REPORT)
 from psyneulink.core.globals.context import Context, ContextFlags, handle_external_context
-from psyneulink.core.globals.keywords import (AUTODIFF_COMPOSITION, EXECUTION_MODE,
-                                              LEARNING_SCALE_LITERALS, LEARNING_SCALE_NAMES, LEARNING_SCALE_VALUES,
-                                              Loss, LOSSES, MATRIX_WEIGHTS, MINIBATCH, NODE_VALUES, NODE_VARIABLES,
-                                              OPTIMIZATION_STEP, RESULTS, RUN, SOFT_CLAMP, SYNCH_WITH_PNL_OPTIONS,
-                                              RETAIN_IN_PNL_OPTIONS, TARGETS, TRAINED_OUTPUTS, TRIAL)
+from psyneulink.core.globals.keywords import (
+    AUTODIFF_COMPOSITION, EXECUTION_MODE,
+    LEARNING_SCALE_LITERALS, LEARNING_SCALE_NAMES, LEARNING_SCALE_VALUES,
+    Loss, LOSSES, MATRIX_WEIGHTS, MINIBATCH, NODE_VALUES, NODE_VARIABLES,
+    OPTIMIZATION_STEP, RESULTS, RUN, SOFT_CLAMP, SYNCH_WITH_PNL_OPTIONS,
+    RETAIN_IN_PNL_OPTIONS, TARGETS, TRAINED_OUTPUTS, TRIAL, DEFAULT,
+)
 from psyneulink.core.globals.utilities import is_numeric_scalar, convert_to_np_array
 from psyneulink.core.scheduling.scheduler import Scheduler
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
@@ -659,14 +661,14 @@ class AutodiffComposition(Composition):
     class Parameters(Composition.Parameters):
         pytorch_representation = None
         optimizer = None
-        learning_rate = Parameter(.001, fallback_default=True)
-        synch_projection_matrices_with_torch = Parameter(RUN, fallback_default=True)
-        synch_node_variables_with_torch = Parameter(None, fallback_default=True)
-        synch_node_values_with_torch = Parameter(RUN, fallback_default=True)
-        synch_results_with_torch = Parameter(RUN, fallback_default=True)
-        retain_torch_trained_outputs = Parameter(MINIBATCH, fallback_default=True)
-        retain_torch_targets = Parameter(MINIBATCH, fallback_default=True)
-        retain_torch_losses = Parameter(MINIBATCH, fallback_default=True)
+        learning_rate = Parameter(.001, fallback_value=DEFAULT)
+        synch_projection_matrices_with_torch = Parameter(RUN, fallback_value=DEFAULT)
+        synch_node_variables_with_torch = Parameter(None, fallback_value=DEFAULT)
+        synch_node_values_with_torch = Parameter(RUN, fallback_value=DEFAULT)
+        synch_results_with_torch = Parameter(RUN, fallback_value=DEFAULT)
+        retain_torch_trained_outputs = Parameter(MINIBATCH, fallback_value=DEFAULT)
+        retain_torch_targets = Parameter(MINIBATCH, fallback_value=DEFAULT)
+        retain_torch_losses = Parameter(MINIBATCH, fallback_value=DEFAULT)
         torch_trained_outputs = Parameter([], getter=_get_torch_trained_outputs)
         torch_targets = Parameter([], getter=_get_torch_targets)
         torch_losses = Parameter([], getter=_get_torch_losses)
@@ -1084,7 +1086,7 @@ class AutodiffComposition(Composition):
         """Builds a Pytorch representation of the AutodiffComposition"""
         if self.scheduler is None:
             self.scheduler = Scheduler(graph=self.graph_processing)
-        if self.parameters.pytorch_representation._get(context=context) is None or refresh:
+        if self.parameters.pytorch_representation._get(context=context, fallback_value=None) is None or refresh:
             model = self.pytorch_composition_wrapper_type(composition=self,
                                                           device=self.device,
                                                           context=context,

--- a/psyneulink/library/compositions/compositionrunner.py
+++ b/psyneulink/library/compositions/compositionrunner.py
@@ -291,6 +291,7 @@ class CompositionRunner():
                      call_after_minibatch = None,
                      context=None,
                      execution_mode:ExecutionMode = ExecutionMode.Python,
+                     skip_initialization=False,
                      **kwargs)->np.ndarray:
         """
         Runs the composition repeatedly with the specified parameters.
@@ -345,8 +346,6 @@ class CompositionRunner():
             epochs = inf_yield_val(epochs)
         elif epochs is None:
             epochs = inf_yield_val(1)
-
-        skip_initialization = False
 
         # FIX JDC 12/10/22: PUT with Report HERE, TREATING OUTER LOOP AS RUN, AND RUN AS TRIAL
 

--- a/psyneulink/library/compositions/emcomposition/emcomposition.py
+++ b/psyneulink/library/compositions/emcomposition/emcomposition.py
@@ -1692,12 +1692,15 @@ class EMComposition(AutodiffComposition):
         # Construct memory --------------------------------------------------------------------------------
 
         memory_fill = memory_fill or 0 # FIX: GET RID OF THIS ONCE IMPLEMENTED AS A Parameter
-        self._validate_memory_specs(memory_template,
-                                    memory_capacity,
-                                    memory_fill,
-                                    field_weights,
-                                    field_names,
-                                    name)
+        self._validate_memory_specs(
+            memory_template,
+            memory_capacity,
+            memory_fill,
+            field_weights,
+            field_names,
+            name,
+            learn_field_weights,
+        )
 
         memory_template, memory_capacity = self._parse_memory_template(memory_template,
                                                                        memory_capacity,
@@ -1843,7 +1846,7 @@ class EMComposition(AutodiffComposition):
     # ***********************************  Memory Construction Methods  ***********************************************
     # *****************************************************************************************************************
     #region
-    def _validate_memory_specs(self, memory_template, memory_capacity, memory_fill, field_weights, field_names, name):
+    def _validate_memory_specs(self, memory_template, memory_capacity, memory_fill, field_weights, field_names, name, learn_field_weights):
         """Validate the memory_template, field_weights, and field_names arguments
         """
 
@@ -1879,8 +1882,8 @@ class EMComposition(AutodiffComposition):
                                      f"must be a float, int or len tuple of ints and/or floats.")
 
         # If learn_field_weights is a list of bools, it must match the len of 1st dimension (axis 0) of memory_template:
-        if isinstance(self.learn_field_weights, list) and len(self.learn_field_weights) != num_fields:
-            raise EMCompositionError(f"The number of items ({len(self.learn_field_weights)}) in the "
+        if isinstance(learn_field_weights, list) and len(learn_field_weights) != num_fields:
+            raise EMCompositionError(f"The number of items ({len(learn_field_weights)}) in the "
                                      f"'learn_field_weights' arg for {name} must match the number of "
                                      f"fields in memory ({num_fields}).")
 
@@ -2724,11 +2727,28 @@ class EMComposition(AutodiffComposition):
             self.retrieved_nodes[i].path_afferents[0].parameters.matrix.set(field_memories, context)
 
     @handle_external_context()
-    def learn(self, *args, **kwargs)->list:
+    def learn(
+        self,
+        *args,
+        context: Optional[Context] = None,
+        base_context: Context = Context(execution_id=None),
+        skip_initialization: bool = False,
+        **kwargs
+    ) -> list:
         """Override to check for inappropriate use of ARG_MAX or PROBABILISTIC options for retrieval with learning"""
-        softmax_choice = self.parameters.softmax_choice.get(kwargs[CONTEXT])
+
+        if (
+            not skip_initialization
+            and (
+                context is None
+                or ContextFlags.SIMULATION_MODE not in context.runmode
+            )
+        ):
+            self._initialize_from_context(context, base_context, override=False)
+
+        softmax_choice = self.parameters.softmax_choice.get(context)
         use_gating_for_weighting = self._use_gating_for_weighting
-        enable_learning = self.parameters.enable_learning.get(kwargs[CONTEXT])
+        enable_learning = self.parameters.enable_learning.get(context)
 
         if use_gating_for_weighting and enable_learning:
             raise EMCompositionError(f"Field weights cannot be learned when 'use_gating_for_weighting' is True; "
@@ -2738,7 +2758,13 @@ class EMComposition(AutodiffComposition):
             raise EMCompositionError(f"The ARG_MAX and PROBABILISTIC options for the 'softmax_choice' arg "
                                      f"of '{self.name}' cannot be used during learning; change to WEIGHTED_AVG.")
 
-        return super().learn(*args, **kwargs)
+        return super().learn(
+            *args,
+            context=context,
+            base_context=base_context,
+            skip_initialization=skip_initialization,
+            **kwargs,
+        )
 
     def _get_execution_mode(self, execution_mode):
         """Parse execution_mode argument and return a valid execution mode for the learn() method"""

--- a/psyneulink/library/compositions/emcomposition/emcomposition.py
+++ b/psyneulink/library/compositions/emcomposition/emcomposition.py
@@ -1016,7 +1016,10 @@ def _memory_getter(owning_component=None, context=None)->list:
 
 def field_weights_setter(field_weights, owning_component=None, context=None):
     # FIX: ALLOW DICTIONARY WITH FIELD NAME AND WEIGHT
-    if owning_component.field_weights is None:
+    if (
+        not owning_component.parameters.field_weights._has_value(context)
+        or owning_component.parameters.field_weights._get(context) is None
+    ):
         return field_weights
     elif len(field_weights) != len(owning_component.field_weights):
         raise EMCompositionError(f"The number of field_weights ({len(field_weights)}) must match the number of fields "

--- a/psyneulink/library/compositions/grucomposition/pytorchGRUwrappers.py
+++ b/psyneulink/library/compositions/grucomposition/pytorchGRUwrappers.py
@@ -39,7 +39,9 @@ class PytorchGRUCompositionWrapper(PytorchCompositionWrapper):
                  outer_creator=None,
                  dtype=None,
                  subclass_components=None,
-                 context=None):
+                 context=None,
+                 base_context=Context(execution_id=None),
+                 ):
 
         self._early_init(composition, device)
 
@@ -56,7 +58,9 @@ class PytorchGRUCompositionWrapper(PytorchCompositionWrapper):
                                               _projection_wrapper_pairs,
                                               execution_sets,
                                               Context()),
-                         context=context)
+                         context=context,
+                         base_context=base_context,
+                         )
 
         # The following have to be after super(), so that they can be assigned as attributes of torch.nn.module
 
@@ -162,7 +166,9 @@ class PytorchGRUCompositionWrapper(PytorchCompositionWrapper):
                              outer_comp,
                              outer_comp_pytorch_rep,
                              access,
-                             context)->Tuple:
+                             context,
+                             base_context=Context(execution_id=None),
+                             ) -> Tuple:
         """Return PytorchProjectionWrappers for Projections to/from GRUComposition to nested Composition
         Replace GRUComposition's nodes with gru_mech and projections to and from it.
         """
@@ -180,6 +186,8 @@ class PytorchGRUCompositionWrapper(PytorchCompositionWrapper):
                                              learnable=pnl_proj.learnable)
             except DuplicateProjectionError:
                 direct_proj = self.composition.gru_mech.afferents[0]
+            else:
+                direct_proj._initialize_from_context(context, base_context)
             # Index of input_CIM.output_ports for which pnl_proj is an efferent
             sender_port_idx = pnl_proj.sender.owner.output_ports.index(pnl_proj.sender)
 
@@ -193,6 +201,8 @@ class PytorchGRUCompositionWrapper(PytorchCompositionWrapper):
                                                 learnable=pnl_proj.learnable)
             except DuplicateProjectionError:
                 direct_proj = self.composition.gru_mech.efferents[0]
+            else:
+                direct_proj._initialize_from_context(context, base_context)
             # gru_mech has only one output_port
             sender_port_idx = 0
 

--- a/psyneulink/library/compositions/pytorchwrappers.py
+++ b/psyneulink/library/compositions/pytorchwrappers.py
@@ -225,7 +225,9 @@ class PytorchCompositionWrapper(torch.nn.Module):
                  outer_creator=None,
                  dtype=None,
                  subclass_components=None,
-                 context=None):
+                 context=None,
+                 base_context=Context(execution_id=None),
+                 ):
 
         super(PytorchCompositionWrapper, self).__init__()
 
@@ -234,7 +236,7 @@ class PytorchCompositionWrapper(torch.nn.Module):
             # Instantiate standard PytorchWrappers for Mechanisms and Projections, and execution_sets used in forward()
             _node_wrapper_pairs = self._instantiate_pytorch_mechanism_wrappers(composition, device, context)
             self._construct_node_wrapper_maps(_node_wrapper_pairs)
-            _projection_wrapper_pairs = self._instantiate_pytorch_projection_wrappers(composition, device, context)
+            _projection_wrapper_pairs = self._instantiate_pytorch_projection_wrappers(composition, device, context, base_context)
             self._construct_projection_wrapper_maps(_projection_wrapper_pairs)
             self.execution_sets, execution_context = self._get_execution_sets(composition, context)
 
@@ -411,7 +413,7 @@ class PytorchCompositionWrapper(torch.nn.Module):
 
         return _node_wrapper_pairs
 
-    def _instantiate_pytorch_projection_wrappers(self, composition, device, context)->list:
+    def _instantiate_pytorch_projection_wrappers(self, composition, device, context, base_context=Context(execution_id=None)) -> list:
         """Instantiate PytorchProjectionWrappers for Projections in the Composition being wrapped
         Assign Projections for outermost Composition (including any that are nested within it at any level)
         Note: Pytorch representation is "flattened" (i.e., any nested Compositions are replaced by their Nodes)
@@ -438,7 +440,7 @@ class PytorchCompositionWrapper(torch.nn.Module):
             # Handle projection to or from a nested Composition
             elif (isinstance(sndr_mech, CompositionInterfaceMechanism) or
                   isinstance(rcvr_mech, CompositionInterfaceMechanism)):
-                pnl_proj, proj_sndr, proj_rcvr, use = self._handle_nested_comp(projection, device, context)
+                pnl_proj, proj_sndr, proj_rcvr, use = self._handle_nested_comp(projection, context, base_context)
                 # # use = [LEARNING, SYNCH, SHOW_PYTORCH]
                 # use = [LEARNING, SYNCH]
 
@@ -471,7 +473,12 @@ class PytorchCompositionWrapper(torch.nn.Module):
 
         return proj_wrappers_pairs
 
-    def _handle_nested_comp(self, projection:MappingProjection, device:str, context:Context)->tuple:
+    def _handle_nested_comp(
+        self,
+        projection: MappingProjection,
+        context: Context,
+        base_context: Context = Context(execution_id=None),
+    ) -> tuple:
         """Flatten nested Composition and assign Projections to/from it to outermost Composition
         This method is called when a Projection is to/from a CIM in a nested Composition that is not in the current
         Composition, and is needed for learning.
@@ -500,7 +507,10 @@ class PytorchCompositionWrapper(torch.nn.Module):
                                                                  self.composition,
                                                                  self,
                                                                  ENTER_NESTED,
-                                                                 context))
+                                                                 context,
+                                                                 base_context,
+                                                                 )
+            )
             if proj_sndr_wrapper is None:
                 proj_sndr_wrapper = self.nodes_map[sndr_mech]
 
@@ -537,7 +547,9 @@ class PytorchCompositionWrapper(torch.nn.Module):
                              outer_comp,
                              outer_comp_pytorch_rep,
                              access,
-                             context)->tuple:
+                             context,
+                             base_context=Context(execution_id=None),
+                             ) -> tuple:
         proj_sndr_wrapper = None
         proj_rcvr_wrapper = None
         use = [LEARNING, SYNCH]
@@ -575,6 +587,9 @@ class PytorchCompositionWrapper(torch.nn.Module):
             except DuplicateProjectionError:
                 direct_proj = [proj for proj in projection.sender.efferents
                                if proj.receiver is destination_rcvr_port][0]
+            else:
+                direct_proj._initialize_from_context(context, base_context)
+
             if direct_proj not in self.projection_wrappers:
                 proj_wrapper = PytorchProjectionWrapper(projection=direct_proj,
                                                         pnl_proj=pnl_proj,
@@ -615,6 +630,9 @@ class PytorchCompositionWrapper(torch.nn.Module):
             except DuplicateProjectionError:
                 direct_proj = [proj for proj in projection.receiver.path_afferents
                                if proj.sender is source_sndr_port][0]
+            else:
+                direct_proj._initialize_from_context(context, base_context)
+
             if direct_proj not in self.projection_wrappers:
                 proj_wrapper = PytorchProjectionWrapper(projection=direct_proj,
                                                         pnl_proj=pnl_proj,
@@ -1697,7 +1715,10 @@ class PytorchProjectionWrapper():
         self.receiver_wrapper = receiver_wrapper  # PytorchMechanismWrapper to which Projection's receiver is mapped
         self._context = context
 
-        if projection.parameters.has_initializers._get(context) and projection.parameters.value.initializer:
+        if (
+            projection.parameters.has_initializers._get(context)
+            and projection.parameters.value.initializer
+        ):
             self.default_value = projection.parameters.value.initializer.get(context)
         else:
             self.default_value = projection.defaults.value

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -2953,6 +2953,9 @@ class TestMiscTrainingFunctionality:
 
         # mini version of xor.execute just to build up pytorch representation
         xor._analyze_graph()
+        # must manually initialize because _build_pytorch_representation
+        # is an internal method
+        xor._initialize_from_context(Context(execution_id=xor.default_execution_id))
         xor._build_pytorch_representation(context=xor.default_execution_id)
         # check whether pytorch parameters are identical to projections
         np.testing.assert_allclose(hid_map.parameters.matrix.get(None),

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -4301,7 +4301,7 @@ class TestRun:
         inputs_dict = {A: [1, 1]}
         output = comp.run(inputs=inputs_dict, execution_mode=comp_mode)
         np.testing.assert_allclose([[1, 1]], output)
-        orig_comp_ex = comp._compilation_data.execution.get(comp)
+        orig_comp_ex = comp._compilation_data.execution.get(comp, fallback_value=None)
         if orig_comp_ex is not None:
             orig_comp_ex = {
                 tag: getattr(ex, struct_name)
@@ -4345,7 +4345,7 @@ class TestRun:
         inputs_dict = {A: [1, 1]}
         output = comp.run(inputs=inputs_dict, execution_mode=comp_mode)
         np.testing.assert_allclose([[0.5, 0.5]], output)
-        orig_comp_ex = comp._compilation_data.execution.get(comp)
+        orig_comp_ex = comp._compilation_data.execution.get(comp, fallback_value=None)
         if orig_comp_ex is not None:
             orig_comp_ex = {
                 tag: getattr(ex, struct_name)
@@ -4390,7 +4390,7 @@ class TestRun:
         inputs_dict = {A: [1, 1]}
         output = comp.run(inputs=inputs_dict, execution_mode=comp_mode)
         np.testing.assert_allclose([[0.5, 0.5]], output)
-        orig_comp_ex = comp._compilation_data.execution.get(comp)
+        orig_comp_ex = comp._compilation_data.execution.get(comp, fallback_value=None)
         if orig_comp_ex is not None:
             orig_comp_ex = {
                 tag: getattr(ex, struct_name)


### PR DESCRIPTION
Parameter.fallback_default is replaced with
Parameter.fallback_value, which can be overridden for a single call by a
new argument to Parameter.get: fallback_value. If the Parameter has no
value for a Context, Parameter.get behaves according to fallback_value:
- ParameterNoValueError (default) - raises a ParameterNoValueError
- pnl.DEFAULT (keyword ('default')) - returns the Parameter's
default_value
- any other value - returns that value

Throw ParameterInvalidSourceError on SharedParameter.get if source is invalid