### PR TITLE
LCAMechanism: do not assign default termination_threshold if evals False

### DIFF
--- a/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/lcamechanism.py
@@ -568,8 +568,6 @@ class LCAMechanism(RecurrentTransferMechanism):
                                f"args of {self.__class__} can't both be specified.")
             else:
                 termination_threshold = threshold
-        else:
-            termination_threshold = termination_threshold or self.parameters.termination_threshold.default_value
 
         termination_measure = kwargs.pop(TERMINATION_MEASURE, None)
         termination_comparison_op = kwargs.pop(TERMINATION_COMPARISION_OP, None)

--- a/tests/mechanisms/test_lca.py
+++ b/tests/mechanisms/test_lca.py
@@ -271,6 +271,12 @@ class TestLCA:
         result1 = comp1.run(inputs={lca:[1, -1]}, execution_mode=comp_mode)
         np.testing.assert_allclose(result1, [[0.52497918747894, 0.47502081252106]])
 
+    @pytest.mark.lca_mechanism
+    def test_LCAMechanism_termination_threshold(self):
+        lca = LCAMechanism(termination_threshold=0)
+        assert lca.defaults.termination_threshold == 0
+        assert lca.parameters.termination_threshold in lca.parameter_ports
+
 
 class TestLCAReset:
 


### PR DESCRIPTION
Values of 0 would be replaced by the class default (_parse_threshold_args is called before full initialization).

Fixes #3264