### PR TITLE
ci/ga: Stop 'msedge' at the end of windows jobs

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -193,3 +193,15 @@ jobs:
           ${{ steps.install.outputs.wheel }}
           ${{ steps.install.outputs.sdist }}
         retention-days: 2
+
+    - name: Stop running browsers
+      shell: pwsh
+      if: ${{ matrix.os == 'windows' }}
+      run: |
+        Get-Process;
+        Write-Output 'Stopping msedge'
+        Stop-Process -Name 'msedge' -Force -PassThru
+        Write-Output 'Waiting for msedge to stop'
+        Wait-Process -Name 'msedge' -Timeout 60 -PassThru
+        Write-Output 'Remaining processes'
+        Get-Process


### PR DESCRIPTION
Test open pdf during execution, which on Windows is handled by msedge.
msedge is also a suspect that intermittently prevents Windows CI jobs.