### PR TITLE
llvm: Disambiguate seed data type

### DIFF
--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -1721,6 +1721,7 @@ class _SeededPhilox(np.random.Generator):
 
 
 _seed = np.uint32((time.time() * 1000) % 2**31)
+
 def _get_global_seed(offset=1):
     global _seed
     old_seed = _seed
@@ -1737,7 +1738,9 @@ def set_global_seed(new_seed):
         new seed to use for randomization
     """
     global _seed
-    _seed = new_seed
+
+    # Keep the same dtype as the original seed
+    _seed = _seed.dtype.type(new_seed)
 
 
 def safe_len(arr, fallback=1):

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -478,15 +478,23 @@ class LLVMBuilderContext:
             return component._get_param_struct_type(self)
 
         def _param_struct(p):
-            val = p.get(None)   # this should use defaults
+            # TODO: Types should be based on the default value rather than
+            #       the value of context 'None'
+            val = p.get(None)
+
             if hasattr(val, "_get_compilation_params") or \
                hasattr(val, "_get_param_struct_type"):
                 return self.get_param_struct_type(val)
+
             if isinstance(val, ContentAddressableList):
                 return ir.LiteralStructType(self.get_param_struct_type(x) for x in val)
-            elif p.name == 'matrix':   # Flatten matrix
+
+            # matrices are represented as flat arrays
+            elif p.name == 'matrix':
                 val = np.asarray(val, dtype=float).ravel()
-            elif p.name == 'num_trials_per_estimate':  # Should always be int
+
+            # num_trials_per_estimate should be integer
+            elif p.name == 'num_trials_per_estimate':
                 val = np.int32(0) if val is None else np.int32(val)
 
             # seeds are represented as np.uint32, but need to be converted to
@@ -510,14 +518,21 @@ class LLVMBuilderContext:
             return component._get_state_struct_type(self)
 
         def _state_struct(p):
-            val = p.get(None)   # this should use defaults
+            # TODO: Types should be based on the default value rather than
+            #       the value of context 'None'
+            val = p.get(None)
+
             if hasattr(val, "_get_compilation_state") or \
                hasattr(val, "_get_state_struct_type"):
                 return self.get_state_struct_type(val)
+
             if isinstance(val, ContentAddressableList):
                 return ir.LiteralStructType(self.get_state_struct_type(x) for x in val)
-            if p.name == 'matrix':   # Flatten matrix
+
+            # matrices are represented as flat arrays
+            if p.name == 'matrix':
                 val = np.asarray(val, dtype=float).ravel()
+
             struct = self.convert_python_struct_to_llvm_ir(val)
             return ir.ArrayType(struct, p.history_min_length + 1)
 
@@ -536,6 +551,7 @@ class LLVMBuilderContext:
         if cache is None:
             cache = weakref.WeakKeyDictionary()
             setattr(composition, '_node_assemblies', cache)
+
         return cache.setdefault(node, _node_assembly(composition, node))
 
     def convert_python_struct_to_llvm_ir(self, t):

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -488,8 +488,17 @@ class LLVMBuilderContext:
                 val = np.asarray(val, dtype=float).ravel()
             elif p.name == 'num_trials_per_estimate':  # Should always be int
                 val = np.int32(0) if val is None else np.int32(val)
-            elif np.ndim(val) == 0 and component._is_param_modulated(p):
-                val = [val]   # modulation adds array wrap
+
+            # seeds are represented as np.uint32, but need to be converted to
+            # float for compiled variant in order to support seed modulation
+            elif p.name in {'seed', 'function-seed'}:
+                val = float(val)
+
+            # Modulation turns scalars into arrays
+            # TODO: should this be 2d arrays?
+            if np.ndim(val) == 0 and component._is_param_modulated(p):
+                val = [val]
+
             return self.convert_python_struct_to_llvm_ir(val)
 
         elements = map(_param_struct, component._get_compilation_params())

--- a/tests/misc/test_user_seed.py
+++ b/tests/misc/test_user_seed.py
@@ -2,6 +2,22 @@ import subprocess
 import sys
 
 def test_user_seed():
-    seed1 = subprocess.check_output((sys.executable, "-c" ,"from psyneulink.core.globals.utilities import _get_global_seed; print(_get_global_seed())"))
-    seed2 = subprocess.check_output((sys.executable, "-c" ,"from psyneulink.core.globals.utilities import _get_global_seed; print(_get_global_seed())"))
+    """Check that different invocations use different seed at startup"""
+
+    cmd = 'from psyneulink.core.globals.utilities import _get_global_seed; print(_get_global_seed())'
+
+    seed1 = subprocess.check_output((sys.executable, "-c", cmd))
+    seed2 = subprocess.check_output((sys.executable, "-c", cmd))
+
     assert seed1 != seed2
+
+def test_seed_type():
+    """Check that updating the global seed maintains its type"""
+
+    cmd_vanilla = 'from psyneulink.core.globals.utilities import _get_global_seed; print(_get_global_seed().dtype)'
+    cmd_updated = 'from psyneulink.core.globals.utilities import _get_global_seed, set_global_seed; set_global_seed(5); print(_get_global_seed().dtype)'
+
+    seed1_dtype = subprocess.check_output((sys.executable, "-c", cmd_vanilla))
+    seed2_dtype = subprocess.check_output((sys.executable, "-c", cmd_updated))
+
+    assert seed1_dtype == seed2_dtype


### PR DESCRIPTION
The PNL global seed is initialized as np.uint32, but can be replaced by any other type by calling the `set_global_seed` function.
This creates issues during compilation as the seed needs to be represented as a float to support modulation.
Moreover, the issue manifests in a confusing way as a failed assertion that a Port other than OutputPort sees a data type mismatch between the existing and modulated value.

Add an assertion message better explaining the asserted failure.
Explicitly convert 'seed' and 'function-seed' parameter values to float when deriving compiled data types.
Convert the new seed value passed to `set_global_seed` to match the data type of the current seed (np.uint32) and add a new test to check the behaviour.
Cleanup and improve comments in the affected code paths.