### PR TITLE
log: correct missing entries in dictionary with time_values

### DIFF
--- a/psyneulink/core/globals/log.py
+++ b/psyneulink/core/globals/log.py
@@ -394,7 +394,7 @@ from psyneulink._typing import Optional, Union, Literal
 from psyneulink.core.globals.context import ContextFlags, _get_time, handle_external_context
 from psyneulink.core.globals.context import time as time_object
 from psyneulink.core.globals.keywords import ALL, CONTEXT, EID_SIMULATION, FUNCTION_PARAMETER_PREFIX, MODULATED_PARAMETER_PREFIX, TIME, VALUE
-from psyneulink.core.globals.utilities import AutoNumber, ContentAddressableList
+from psyneulink.core.globals.utilities import AutoNumber, ContentAddressableList, convert_to_np_array
 
 __all__ = [
     'EntriesDict', 'Log', 'LogEntry', 'LogError', 'LogCondition'
@@ -1555,10 +1555,14 @@ class Log:
                 log_dict[eid]["Index"] = np.arange(num_indicies).reshape(num_indicies, 1).tolist()
 
             for entry in entries:
-                log_dict[eid][entry] = np.array(self._assemble_entry_data(entry,
-                                                                          time_values,
-                                                                          report_all_executions,
-                                                                          eid))
+                log_dict[eid][entry] = convert_to_np_array(
+                    self._assemble_entry_data(
+                        entry,
+                        time_values,
+                        report_all_executions,
+                        eid,
+                    )
+                )
 
         return log_dict
 
@@ -1786,64 +1790,42 @@ class Log:
 
         # entry = self._dealias_owner_name(entry)
         row = []
-        time_col = iter(time_values)
         try:
-            data = self.logged_entries[entry][execution_id]
+            logged_entries = self.logged_entries[entry][execution_id]
         except KeyError:
             return [None]
 
-        time = next(time_col, None)
-        for i in range(len(self.logged_entries[entry][execution_id])):
-            # iterate through log entry tuples:
-            # check whether the next tuple's time value matches the time for which data is currently being recorded
-            # if not, check whether the current tuple's time value matches the time for which data is being recorded
-            # if so, enter tuple's Component value in the entry's list
-            # if not, enter `None` in the entry's list
-            datum = data[i]
-            if time_values:
-                # # MODIFIED 11/14/23 OLD:
-                # if i == len(data) - 1 or data[i + 1].time != time:
-                #     if datum.time != time:
-                #         row.append(None)
-                #     else:
-                #         value = None if datum.value is None else np.array(datum.value).tolist()  # else, if is time,
-                #         # append value
-                #         row.append(value)
-                #     time = next(time_col, None)  # increment time value
-                #     if time is None:  # if no more times, break
-                #         break
-                # MODIFIED 11/14/23 NEW:
-                if report_all_executions:
-                    # Report values for all executions within a given time
-                    if i == 0 or time != data[i - 1].time:
-                        # Start new execution set on first datum or if time of entry has changed
-                        execution_set = []
-                    # If the entry's time value doesn't match one of the times specified in the call, enter None
-                    if datum.time != time:
-                        execution_set.append(None)
-                    else:
-                        execution_set.append(None if datum.value is None else np.array(datum.value).tolist())
-                    if i == len(data) - 1 or data[i + 1].time != time:
-                        time = next(time_col, None)  # increment time value
-                        row.append(execution_set)
-                    if time is None:  # if no more times, break
-                        break
+        entries_by_time = {}
+        if time_values:
+            for entry_item in logged_entries:
+                tm = entry_item.time
+                if tm in entries_by_time:
+                    entries_by_time[tm].append(entry_item)
                 else:
-                    # Only report one value (execution) for each unique time
-                    if i == len(data) - 1 or data[i + 1].time != time:
-                        # Only record value if time of entry is about to change and/or for last entry
-                        if datum.time != time:
-                            # If entry's time value doesn't match one of the times specified in the call, report None
-                            row.append(None)
-                        else:
-                            # Report value of entry
-                            value = None if datum.value is None else np.array(datum.value).tolist()
-                            row.append(value)
-                        time = next(time_col, None)  # increment time value
-                        if time is None:  # if no more times, break
-                            break
-                # MODIFIED 11/14/23 END
-            else:
+                    entries_by_time[tm] = [entry_item]
+
+            for time_val in time_values:
+                # iterate through log entry tuples:
+                # check whether the next tuple's time value is requested by time_values arg
+                # if so, enter tuple's Component value in the entry's list
+                # if not, enter `None` in the entry's list
+                matching_entry = entries_by_time.get(time_val, None)
+
+                if not report_all_executions:
+                    try:
+                        matching_entry = matching_entry[-1]
+                    except TypeError:
+                        # entry is None
+                        pass
+                    except IndexError as e:
+                        # unexpected empty list
+                        raise AssertionError() from e
+
+                matching_entry = getattr(matching_entry, 'value', None)
+                matching_entry = np.asarray(matching_entry).tolist()
+                row.append(matching_entry)
+        else:
+            for datum in logged_entries:
                 if datum.value is None:
                     value = None
                 elif isinstance(datum.value, list):

--- a/tests/log/test_log.py
+++ b/tests/log/test_log.py
@@ -548,6 +548,116 @@ class TestLog:
         log_array_T2_second_run = T2.log.nparray()
         assert log_array_T2_second_run[1][1][4][1:4] == [[[1.0, 2.0]], [[3.0, 4.0]], [[5.0, 6.0]]]
 
+    @pytest.mark.parametrize("log_entries_arg", [None, "value"])
+    @pytest.mark.parametrize(
+        "method, expected",
+        [
+            (
+                "reset",
+                {
+                    "Composition-0": {
+                        "Run": [[0], [1], [2]],
+                        "Trial": [[0], [0], [0]],
+                        "Pass": [[0], [0], [0]],
+                        "Time_step": [[0], [0], [0]],
+                        "RESULT": np.array([None, list([-1.0]), None], dtype=object),
+                        "func_value": np.array([None, None, None], dtype=object),
+                        "func_variable": np.array(
+                            [None, list([[-1.0]]), None], dtype=object
+                        ),
+                        "value": np.array([[[0.1]], [[0.3]], [[0.7]]]),
+                    }
+                },
+            ),
+            (
+                "execute",
+                {
+                    "Composition-0": {
+                        "Run": [[0], [1], [2]],
+                        "Trial": [[0], [0], [0]],
+                        "Pass": [[0], [0], [0]],
+                        "Time_step": [[0], [0], [0]],
+                        "InputPort-0": np.array([None, None, None], dtype=object),
+                        "RESULT": np.array([None, list([0.0]), None], dtype=object),
+                        "func_value": np.array([None, None, None], dtype=object),
+                        "func_variable": np.array(
+                            [None, list([[0.0]]), None], dtype=object
+                        ),
+                        "integrator_function_value": np.array(
+                            [None, list([[0.0]]), None], dtype=object
+                        ),
+                        "mod_integration_rate": np.array(
+                            [None, list([0.1]), None], dtype=object
+                        ),
+                        "mod_intercept": np.array(
+                            [None, list([0.0]), None], dtype=object
+                        ),
+                        "mod_noise": np.array([None, list([0.0]), None], dtype=object),
+                        "mod_offset-function": np.array(
+                            [None, list([0.0]), None], dtype=object
+                        ),
+                        "mod_offset-integrator_function": np.array(
+                            [None, list([0.0]), None], dtype=object
+                        ),
+                        "mod_rate": np.array([None, list([0.1]), None], dtype=object),
+                        "mod_scale": np.array([None, list([1.0]), None], dtype=object),
+                        "mod_slope": np.array([None, list([1.0]), None], dtype=object),
+                        "num_executions_before_finished": np.array(
+                            [None, 0, None], dtype=object
+                        ),
+                        "value": np.array([[[0.1]], [[0.3]], [[0.7]]]),
+                        "variable": np.array(
+                            [None, list([[-1.0]]), None], dtype=object
+                        ),
+                    }
+                },
+            ),
+        ],
+    )
+    # The intent of this test is to ensure that running the logged
+    # Component outside of a Composition between Composition runs does
+    # not disrupt collection of the logged values due to the Time
+    # objects associated with the Composition's runs not being in order
+    # and adjacent, meaning for example that the log values associated
+    # with the arrowed Time are not lost:
+    # Time(run=1, trial=1, pass=1, time_step=0)
+    # Time(run=1, trial=1, pass=1, time_step=1)
+    # Time(run=None, trial=None, pass=None, time_step=None)
+    # Time(run=None, trial=None, pass=None, time_step=None)
+    # Time(run=1, trial=1, pass=1, time_step=2)  <---
+    def test_run_after_reset(self, log_entries_arg, method, expected):
+        T1 = pnl.TransferMechanism(integrator_mode=True, integrator_function=pnl.SimpleIntegrator, integration_rate=.1)
+        COMP = pnl.Composition(pathways=[T1])
+        T1.set_log_conditions('value')
+
+        COMP.run(inputs={T1: [[1.0]]})
+        # using -1 to make the value for T1."value" identical in both
+        # reset and execute cases
+        getattr(T1, method)([[-1]], context=COMP)
+        getattr(T1, method)([[0]], context=COMP)
+        # COMP.reset()
+        COMP.run(inputs={T1: [[3.0]]})
+        COMP.run(inputs={T1: [[4.0]]})
+
+        if log_entries_arg is not None:
+            expected = {
+                COMP.name: {
+                    k: v
+                    for k, v in expected[COMP.name].items()
+                    if k in {"Run", "Trial", "Pass", "Time_step", log_entries_arg}
+                }
+            }
+
+        res = T1.log.nparray_dictionary(log_entries_arg)
+        assert res.keys() == {COMP.name}
+        assert res[COMP.name].keys() == expected[COMP.name].keys()
+        for k, res_v in res[COMP.name].items():
+            exp_v = expected[COMP.name][k]
+            if None in res_v or None in exp_v:
+                assert all(res_v == exp_v)
+            else:
+                np.testing.assert_array_almost_equal(res_v, exp_v)
+
     def test_log_dictionary_with_time(self):
 
         T1 = pnl.TransferMechanism(name='log_test_T1',


### PR DESCRIPTION
Running a logged Component outside of and between Composition.run calls caused Log._assemble_entry_data to lose track of the Time objects associated with the runs, because it assumed they would be subsequent, or separated by at most one entry. This commit matches the requested time_values with their associated log entries regardless of position in the log.