### PR TITLE
ci/ga: Fallback to macos-14 for python-3.13

### DIFF
--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   docs-build:
+
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -27,10 +28,13 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         pnl-version: ${{ (github.event_name == 'push') && fromJSON('["head"]') || fromJSON('["head", "base"]') }}
         exclude:
+          # Exclude base versions other than linux
           - os: macos-latest
             pnl-version: 'base'
           - os: windows-latest
             pnl-version: 'base'
+
+          # Exclude base versions other than python 3.11
           - python-version: '3.8'
             pnl-version: 'base'
           - python-version: '3.9'
@@ -41,6 +45,17 @@ jobs:
             pnl-version: 'base'
           - python-version: '3.13'
             pnl-version: 'base'
+
+          # Use macos-14 instead of macos-latest for python 3.13.
+          # Newer image includes newer clang/llvm which fails to compile
+          # onnx-1.17.0, which doesn't provide python 3.13 wheels.
+          - python-version: '3.13'
+            os: macos-latest
+
+        include:
+          - python-version: '3.13'
+            os: macos-14
+            pnl-version: 'head'
 
     outputs:
       on_master: ${{ steps.on_master.outputs.on-branch }}

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -23,9 +23,16 @@ concurrency:
 jobs:
   # The main test job
   build:
+    # Use macos-14 instead of macos-latest for python 3.13.
+    # Newer image includes newer clang/llvm which fails to compile
+    # onnx-1.17.0, which doesn't provide python 3.13 wheels.
+    # Explanation of the expression below:
+    # line 1: Check if the job environment is listed in repository-scale "SELF_HOSTED" variable
+    # line 2: "true" branch. Construct tag array to match one of the self hosted runners. All tags need to match.
+    # line 3: "else" branch. Construct GA image description. Generally the {windows,macos,ubuntu}-latest.
     runs-on: ${{ (contains(vars.SELF_HOSTED, format(';{0}_{1}_{2}_{3};', matrix.os, matrix.python-version, matrix.python-architecture, matrix.extra-args))
                 && fromJSON(format('[ "self-hosted","{0}", "X64", "enabled" ]', matrix.os == 'ubuntu' && 'Linux' || matrix.os)))
-                || format('{0}-latest', matrix.os) }}
+                || ((matrix.os == 'macos' && matrix.python-version == '3.13') && 'macos-14' || format('{0}-latest', matrix.os)) }}
     env:
       # Keep DESCRIPTION in sync with the above
       DESCRIPTION: ${{ format(';{0}_{1}_{2}_{3};', matrix.os, matrix.python-version, matrix.python-architecture, matrix.extra-args) }}


### PR DESCRIPTION
onnx-1.17.0 fails to compile bundled abseil-cpp with newer compiler:

 clang++: error: unsupported option '-msse4.1' for target 'arm64-apple-darwin24.5.0'