### PR TITLE
tests: MDF: make DriftDiffusionIntegrator test ids same across platforms

### DIFF
--- a/tests/mdf/test_mdf.py
+++ b/tests/mdf/test_mdf.py
@@ -369,11 +369,17 @@ ddi_termination_conds = [
 # construct test data manually instead of with multiple @pytest.mark.parametrize
 # so that other functions can use more appropriate termination conds
 individual_functions_ddi_test_data = [
-    (
-        pnl.IntegratorMechanism,
-        pnl.DriftDiffusionIntegrator(rate=0.5, offset=1, non_decision_time=1, seed=0),
-        "{{A: {{'random_draw': {0} }} }}".format(get_onnx_fixed_noise_str('randomnormal', mean=0, scale=1, seed=0, shape=(1,)))
-    ) + (x,)
+    pytest.param(
+        *(
+            (
+                pnl.IntegratorMechanism,
+                pnl.DriftDiffusionIntegrator(rate=0.5, offset=1, non_decision_time=1, seed=0),
+                "{{A: {{'random_draw': {0} }} }}".format(get_onnx_fixed_noise_str('randomnormal', mean=0, scale=1, seed=0, shape=(1,)))
+            )
+            + (x,)
+        ),
+        id=f'IntegratorMechanism-DriftDiffusionIntegrator-randomnormal-{x}'
+    )
     for x in ddi_termination_conds
 ]
 individual_functions_fhn_test_data = [


### PR DESCRIPTION
different platforms get different random numbers