### PR TITLE
ci: fix call to wmic (removed by default in windows-server-2025)

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -168,7 +168,10 @@ jobs:
         case "$RUNNER_OS" in
           Linux*) lscpu; lsmem;;
           macOS*) sysctl -a | grep '^hw' ;;
-          Windows*) wmic cpu get description,currentclockspeed,NumberOfCores,NumberOfEnabledCore,NumberOfLogicalProcessors; wmic memorychip get capacity,speed,status,manufacturer ;;
+          Windows*)
+            powershell -c "Get-CimInstance -ClassName Win32_Processor | Select-Object Description,CurrentClockSpeed,NumberOfCores,NumberOfEnabledCore,NumberOfLogicalProcessors"
+            powershell -c "Get-CimInstance -ClassName Win32_PhysicalMemory | Select-Object Capacity,Speed,Status,Manufacturer"
+            ;;
         esac
 
     # Windows runners use MS Edge as the default pdf viewer.


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows-server/get-started/removed-deprecated-features-windows-server?tabs=ws25