### PR TITLE
Revert "ci/ga: Fallback to macos-14 for python-3.13 (#3341)"

### DIFF
--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -19,7 +19,6 @@ concurrency:
 
 jobs:
   docs-build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -29,22 +28,10 @@ jobs:
         pnl-version: ['head']
         include:
           # include base version for push events. In other events it includes
-          # an already matrix configuration which is ignored.
-          # DOCS_PYTHON_VERSION and DOCS_OS
+          # an existing matrix configuration which is ignored.
           - python-version: '3.11'
             os: 'ubuntu-latest'
             pnl-version: ${{ (github.event_name == 'push') && 'head' || 'base' }}
-
-          # Use macos-14 instead of macos-latest for python 3.13.
-          # Newer image includes newer clang/llvm which fails to compile
-          # onnx-1.17.0, which doesn't provide python 3.13 wheels.
-          - python-version: '3.13'
-            os: macos-14
-            pnl-version: 'head'
-
-        exclude:
-          - python-version: '3.13'
-            os: macos-latest
 
     outputs:
       on_master: ${{ steps.on_master.outputs.on-branch }}

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -23,16 +23,13 @@ concurrency:
 jobs:
   # The main test job
   build:
-    # Use macos-14 instead of macos-latest for python 3.13.
-    # Newer image includes newer clang/llvm which fails to compile
-    # onnx-1.17.0, which doesn't provide python 3.13 wheels.
     # Explanation of the expression below:
     # line 1: Check if the job environment is listed in repository-scale "SELF_HOSTED" variable
     # line 2: "true" branch. Construct tag array to match one of the self hosted runners. All tags need to match.
     # line 3: "else" branch. Construct GA image description. Generally the {windows,macos,ubuntu}-latest.
     runs-on: ${{ (contains(vars.SELF_HOSTED, format(';{0}_{1}_{2}_{3};', matrix.os, matrix.python-version, matrix.python-architecture, matrix.extra-args))
                 && fromJSON(format('[ "self-hosted","{0}", "X64", "enabled" ]', matrix.os == 'ubuntu' && 'Linux' || matrix.os)))
-                || ((matrix.os == 'macos' && matrix.python-version == '3.13') && 'macos-14' || format('{0}-latest', matrix.os)) }}
+                || format('{0}-latest', matrix.os) }}
     env:
       # Keep DESCRIPTION in sync with the above
       DESCRIPTION: ${{ format(';{0}_{1}_{2}_{3};', matrix.os, matrix.python-version, matrix.python-architecture, matrix.extra-args) }}


### PR DESCRIPTION
This reverts commit bf914fd3d355c49a2e7f441df3f8b151c312c790.
modeci_mdf-0.4.13 no longer pins the onnx version.
The workaround is no longer necessary.