### PR TITLE
llvm:  Add basic support for aggregated OutputPort variables

### DIFF
--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2894,18 +2894,22 @@ class Mechanism_Base(Mechanism):
 
     def _canonicalize_port_variable_specification(self, variable_spec):
         """
-        Convert variable spec to canonical form of [(param_name1, indices1), (param_name2, indices2), ...]
+        Convert variable spec to canonical form of [(spec1, indices1), (spec2, indices2), ...]
 
         Returns None if the spec could not be parsed.
         """
 
         # There are several specification formats;
-        # 1.) Parameter name or a KEYWORD that translates to a Parameter name
+        # 1.) Special. passed through without change
+        if variable_spec is None or is_numeric(variable_spec) or isinstance(variable_spec, MechParamsDict):
+            return [(variable_spec, [])]
+
+        # 2.) Parameter name or a KEYWORD that translates to a Parameter name
         translated_spec = output_port_spec_to_parameter_name.get(variable_spec, variable_spec)
         if isinstance(translated_spec, str):
             return [(translated_spec, [])]
 
-        # 2.) A tuple of parameter name with indices.
+        # 3.) A tuple of parameter name with indices.
         #     The indices might be callable (e.g. to make the index match a corresponding input port),
         #     or Numpy numerals
         translated_name = output_port_spec_to_parameter_name.get(variable_spec[0], variable_spec[0])

--- a/tests/ports/test_output_ports.py
+++ b/tests/ports/test_output_ports.py
@@ -8,25 +8,27 @@ class TestOutputPorts:
     @pytest.mark.mechanism
     def test_output_port_variable_spec(self, mech_mode):
         # Test specification of OutputPort's variable
-        mech = pnl.ProcessingMechanism(default_variable=[[1.],[2.],[3.]],
+        mech = pnl.ProcessingMechanism(default_variable=[[1.], [2.], [3.]],
                                        name='MyMech',
                                        output_ports=[
                                            pnl.OutputPort(name='z', variable=(pnl.OWNER_VALUE, 2)),
                                            pnl.OutputPort(name='y', variable=(pnl.OWNER_VALUE, 1)),
                                            pnl.OutputPort(name='x', variable=(pnl.OWNER_VALUE, 0)),
                                            pnl.OutputPort(name='all', variable=(pnl.OWNER_VALUE)),
+                                           pnl.OutputPort(name='xy', variable=[(pnl.OWNER_VALUE, 0), (pnl.OWNER_VALUE, 1)]),
                                            pnl.OutputPort(name='execution count', variable=(pnl.OWNER_EXECUTION_COUNT))
                                        ])
-        expected = [[3.],[2.],[1.],[[1.],[2.],[3.]], [0]]
+        expected = [[3.], [2.], [1.], [[1.], [2.], [3.]], [[1.], [2.]], [0]]
         for i, e in zip(mech.output_values, expected):
             assert np.array_equal(i, e)
+
         EX = pytest.helpers.get_mech_execution(mech, mech_mode)
 
-        EX([[1.],[2.],[3.]])
-        EX([[1.],[2.],[3.]])
-        EX([[1.],[2.],[3.]])
-        res = EX([[1.],[2.],[3.]])
-        expected = [[3.],[2.],[1.],[[1.],[2.],[3.]], [4]]
+        EX([[1.], [2.], [3.]])
+        EX([[1.], [2.], [3.]])
+        EX([[1.], [2.], [3.]])
+        res = EX([[1.], [2.], [3.]])
+        expected = [[3.], [2.], [1.],[[1.], [2.], [3.]], [[1.], [2.]], [4]]
         for i, e in zip(res, expected):
             assert np.array_equal(i, e)
 
@@ -61,8 +63,10 @@ class TestOutputPorts:
         C.add_node(node=mech)
         C.termination_processing[pnl.TimeScale.TRIAL] = pnl.AtPass(2)
         outs = C.run(inputs={mech: var}, num_trials=2, execution_mode=comp_mode)
+
         # outs is entire mechanism value, expected is output port value
         np.testing.assert_allclose(outs[0], expected1)
+
         outs = C.run(inputs={mech: var}, num_trials=2, execution_mode=comp_mode)
         np.testing.assert_allclose(outs[0], expected2)
 


### PR DESCRIPTION
Add shared variable spec canonicalization function for both Python and compiled execution.
Create on-stack structure to store aggregated arguments.
Add and update tests.