### PR TITLE
ci/ga: Use explicit no PyTorch run

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -48,35 +48,6 @@ runs:
       shell: bash
       run: python -m pip install --upgrade pip wheel
 
-    - name: Drop pytorch on x86
-      shell: bash
-      run: |
-        echo > env_constraints.txt
-        if [ $(python -c 'import struct; print(struct.calcsize("P") * 8)') == 32 ]; then
-          sed -i /torch/d requirements.txt
-          sed -i /modeci_mdf/d requirements.txt
-          # pywinpty is a transitive dependency and v1.0+ removed support for x86 wheels
-          echo "pywinpty<1" >> env_constraints.txt
-          # jupyter_server >= 2 pulls jupyter_server_terminals which depends on in pywinpty >= 2.0.3
-          echo "jupyter_server<2" >> env_constraints.txt
-          # scipy >=1.9.2 doesn't provide win32 wheel and GA doesn't have working fortran on windows
-          echo "scipy<1.9.2" >> env_constraints.txt
-          # scikit-learn >= 1.1.3 doesn't provide win32 wheel
-          echo "scikit-learn<1.1.3" >> env_constraints.txt
-          # countourpy >=1.1.0 doesn't provide win32 wheel
-          echo "contourpy<1.1.0" >> env_constraints.txt
-          # pillow >= 10.0.0 doesn't provide win32 wheel
-          echo "pillow < 10.0.0" >> env_constraints.txt
-          # pandas >= 2.1.0 doesn't provide win32 wheel
-          echo "pandas < 2.1.0" >> env_constraints.txt
-          # llvmlite >= 0.42.0 doesn't provide win32 wheel
-          echo "llvmlite < 0.42.0" >> env_constraints.txt
-          # matplotlib >=3.8.0 doesn't provide win32 wheel
-          echo "matplotlib < 3.8.0" >> env_constraints.txt
-          # fastkde >= 2.1.3 doesn't provide win32 wheel
-          echo "fastkde < 2.1.3" >> env_constraints.txt
-        fi
-
     - name: Install updated package
       if: ${{ startsWith(github.head_ref, 'dependabot/pip') && matrix.pnl-version != 'base' }}
       shell: bash
@@ -89,7 +60,7 @@ runs:
           echo "new_package=$NEW_PACKAGE" >> $GITHUB_OUTPUT
           # save a list of all installed packages (including pip, wheel; it's never empty)
           pip freeze --all > orig
-          pip install "$(echo $NEW_PACKAGE | sed 's/[-_]/./g' | xargs grep *requirements.txt -h -e | head -n1)" -c env_constraints.txt -c broken_trans_deps.txt
+          pip install "$(echo $NEW_PACKAGE | sed 's/[-_]/./g' | xargs grep *requirements.txt -h -e | head -n1)" -c broken_trans_deps.txt
           pip show "$NEW_PACKAGE" | grep 'Version' | tee new_version.deps
           # uninstall new packages but skip those from previous steps (pywinpty, terminado on windows x86)
           # the 'orig' list is not empty (includes at least pip, wheel)
@@ -110,7 +81,7 @@ runs:
     - name: Python dependencies
       shell: bash
       run: |
-        pip install ${{ steps.dist.outputs.wheel }}[${{ inputs.features }}] -c env_constraints.txt -c broken_trans_deps.txt
+        pip install ${{ steps.dist.outputs.wheel }}[${{ inputs.features }}] -c broken_trans_deps.txt
       env:
         # Setting CXXFLAGS works around a missing include that breaks the build
         # of onnx-1/17.0 on recent gcc/clang compilers.

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -41,8 +41,9 @@ jobs:
         extra-args: ['']
         os: [ubuntu, macos, windows]
         version-restrict: ['']
+        torch: ['']
         include:
-          # code-coverage build on macos python 3.9
+          # code-coverage run on macos python 3.9
           - python-version: '3.9'
             os: macos
             extra-args: '--cov=psyneulink'
@@ -67,6 +68,11 @@ jobs:
             # The latter works around a crash in pytest when collecting tests:
             # https://github.com/ionelmc/pytest-benchmark/issues/243
             extra-args: '-m benchmark --benchmark-enable --benchmark-only --benchmark-min-rounds=2 --benchmark-max-time=0.001 --benchmark-warmup=off -n0 --dist=no'
+          # run without pytorch on windows python 3.10
+          - python-version: '3.10'
+            os: windows
+            torch: 'notorch'
+
 
           # add python 3.8 with deps restricted to min supported package versions
           - python-version: '3.8'
@@ -120,6 +126,14 @@ jobs:
         path: ${{ steps.pip_cache.outputs.pip_cache_dir }}/wheels
         key: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-wheels-${{ hashFiles('requirements.txt', 'dev_requirements.txt') }}-${{ github.sha }}
         restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-wheels-${{ hashFiles('requirements.txt', 'dev_requirements.txt') }}
+
+    - name: Drop PyTorch requirement
+      if: ${{ matrix.torch == 'notorch' }}
+      shell: bash
+      run: |
+        # macos/bsd sed requires backup suffix argument to -i
+        sed -i=.bak -e '/torch/d' requirements.txt
+        sed -i=.bak -e '/modeci_mdf/d' requirements.txt
 
     - name: Install PNL package
       uses: ./.github/actions/install-pnl
@@ -188,6 +202,12 @@ jobs:
         path: tests_out.xml
         retention-days: 5
       if: (success() || failure()) && ! contains(matrix.extra-args, 'forked')
+
+    - name: Check that PyTorch wasn't transitively included
+      if: ${{ matrix.torch == 'notorch' }}
+      shell: bash
+      run: |
+        ! pip show torch
 
     - name: Upload coveralls code coverage
       if: contains(matrix.extra-args, '--cov=psyneulink')

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -27,43 +27,38 @@ jobs:
     # line 1: Check if the job environment is listed in repository-scale "SELF_HOSTED" variable
     # line 2: "true" branch. Construct tag array to match one of the self hosted runners. All tags need to match.
     # line 3: "else" branch. Construct GA image description. Generally the {windows,macos,ubuntu}-latest.
-    runs-on: ${{ (contains(vars.SELF_HOSTED, format(';{0}_{1}_{2}_{3};', matrix.os, matrix.python-version, matrix.python-architecture, matrix.extra-args))
+    runs-on: ${{ (contains(vars.SELF_HOSTED, format(';{0}_{1}_{2};', matrix.os, matrix.python-version, matrix.extra-args))
                 && fromJSON(format('[ "self-hosted","{0}", "X64", "enabled" ]', matrix.os == 'ubuntu' && 'Linux' || matrix.os)))
                 || format('{0}-latest', matrix.os) }}
     env:
       # Keep DESCRIPTION in sync with the above
-      DESCRIPTION: ${{ format(';{0}_{1}_{2}_{3};', matrix.os, matrix.python-version, matrix.python-architecture, matrix.extra-args) }}
+      DESCRIPTION: ${{ format(';{0}_{1}_{2};', matrix.os, matrix.python-version, matrix.extra-args) }}
       SELF_HOSTED: ${{ vars.SELF_HOSTED }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.11', '3.12', '3.13']
-        python-architecture: ['x64']
         extra-args: ['']
         os: [ubuntu, macos, windows]
         version-restrict: ['']
         include:
           # code-coverage build on macos python 3.9
-          # use default python architecture
           - python-version: '3.9'
             os: macos
             extra-args: '--cov=psyneulink'
 
           # --forked run of python only tests
           # Python tests are enough to test potential naming issues
-          # use default python architecture
           - python-version: '3.9'
             os: ubuntu
             extra-args: '--forked -m "not llvm"'
 
           # fp32 run on linux python 3.10
-          # use default python architecture
           - python-version: '3.10'
             os: ubuntu
             extra-args: '--fp-precision=fp32'
 
           # --benchmark-enable run on macos python 3.10
-          # use default python architecture
           - python-version: '3.10'
             os: macos
             # pytest needs both '--benchmark-only' and '-m benchmark'
@@ -73,18 +68,13 @@ jobs:
             # https://github.com/ionelmc/pytest-benchmark/issues/243
             extra-args: '-m benchmark --benchmark-enable --benchmark-only --benchmark-min-rounds=2 --benchmark-max-time=0.001 --benchmark-warmup=off -n0 --dist=no'
 
-          # add python 3.8 with deps restricted to min supported version
-          # use default python architecture
-          # https://github.com/actions/setup-python/issues/960
+          # add python 3.8 with deps restricted to min supported package versions
           - python-version: '3.8'
             os: macos
             version-restrict: 'min'
 
         exclude:
-          # 3.8/x64 python is broken on aarch64 macos runners
-          # https://github.com/actions/setup-python/issues/960
           - python-version: '3.8'
-            python-architecture: 'x64'
             os: macos
 
     steps:
@@ -105,7 +95,6 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: ${{ matrix.python-architecture }}
 
     - name: Restrict version of direct dependencies
       if: ${{ matrix.version-restrict == 'min' }}
@@ -129,8 +118,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.pip_cache.outputs.pip_cache_dir }}/wheels
-        key: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-${{ hashFiles('requirements.txt', 'dev_requirements.txt') }}-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-wheels-${{ hashFiles('requirements.txt', 'dev_requirements.txt') }}
+        key: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-wheels-${{ hashFiles('requirements.txt', 'dev_requirements.txt') }}-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-wheels-${{ hashFiles('requirements.txt', 'dev_requirements.txt') }}
 
     - name: Install PNL package
       uses: ./.github/actions/install-pnl
@@ -195,7 +184,7 @@ jobs:
     - name: Upload test results
       uses: actions/upload-artifact@v5
       with:
-        name: test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}-${{ matrix.version-restrict }}
+        name: test-results-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.version-restrict }}
         path: tests_out.xml
         retention-days: 5
       if: (success() || failure()) && ! contains(matrix.extra-args, 'forked')
@@ -217,7 +206,7 @@ jobs:
       uses: actions/upload-artifact@v5
       if: matrix.version-restrict == ''
       with:
-        name: dist-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.python-architecture }}
+        name: dist-${{ matrix.os }}-${{ matrix.python-version }}
         path: |
           ${{ steps.install.outputs.wheel }}
           ${{ steps.install.outputs.sdist }}

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -44,27 +44,26 @@ jobs:
         version-restrict: ['']
         include:
           # code-coverage build on macos python 3.9
+          # use default python architecture
           - python-version: '3.9'
             os: macos
             extra-args: '--cov=psyneulink'
 
           # --forked run of python only tests
           # Python tests are enough to test potential naming issues
+          # use default python architecture
           - python-version: '3.9'
             os: ubuntu
             extra-args: '--forked -m "not llvm"'
 
-          # add 32-bit build on windows
-          - python-version: '3.9'
-            python-architecture: 'x86'
-            os: windows
-
           # fp32 run on linux python 3.10
+          # use default python architecture
           - python-version: '3.10'
             os: ubuntu
             extra-args: '--fp-precision=fp32'
 
           # --benchmark-enable run on macos python 3.10
+          # use default python architecture
           - python-version: '3.10'
             os: macos
             # pytest needs both '--benchmark-only' and '-m benchmark'


### PR DESCRIPTION
Drop x86 (32-bit) Windows run, it's too cumbersome to maintain.
Use machine's default Python variant in all test runs.
Add test config that explicitly drops PyTorch and modeci-mdf dependencies. Check that PyTorch is not transitively installed. 