### PR TITLE
llvm: Improve UDF compiler

### DIFF
--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3154,8 +3154,6 @@ class Mechanism_Base(Mechanism):
         else:
             aggregate_type = pnlvm.ir.LiteralStructType(types)
 
-        print(aggregate_type)
-
         aggregate_storage = builder.alloca(aggregate_type)
         for idx, location in enumerate(parsed):
             out_ptr = builder.gep(aggregate_storage, [ctx.int32_ty(0), ctx.int32_ty(idx)])

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -35,6 +35,7 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
             "sum": self.call_builtin_horizontal_sum,
             "len": self.call_builtin_len,
             "max": self.call_builtin_max,
+            "bool": self.call_builtin_convert_bool,
             "float": self.call_builtin_convert_float,
             "int": self.call_builtin_convert_int,
         }
@@ -548,6 +549,10 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
         if helpers.is_pointer(x):
             x_ty = x_ty.pointee
         return self.ctx.float_ty(len(x_ty))
+
+    def call_builtin_convert_bool(self, builder, x):
+        arg = builder.load(x) if helpers.is_pointer(x) else x
+        return helpers.convert_type(builder, arg, self.ctx.bool_ty)
 
     def call_builtin_convert_float(self, builder, x):
         arg = builder.load(x) if helpers.is_pointer(x) else x

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -52,8 +52,9 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
 
             return np_cmp
 
-        # setup numpy
+        # setup attributes of numpy (np) module
         numpy_handlers = {
+            # numpy functions should be consumed by a call node
             'tanh': self.call_builtin_np_tanh,
             'exp': self.call_builtin_np_exp,
             'sqrt': self.call_builtin_np_sqrt,
@@ -65,6 +66,9 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
             'greater_equal': get_np_cmp(">="),
             'max': self.call_builtin_np_max,
             'argmax': self.call_builtin_np_argmax,
+
+            # value attributes can be returned directly
+            'nan':self.ctx.float_ty(float("nan"))
         }
 
         for k, v in func_globals.items():

--- a/psyneulink/core/llvm/codegen.py
+++ b/psyneulink/core/llvm/codegen.py
@@ -377,11 +377,14 @@ class UserDefinedFunctionVisitor(ast.NodeVisitor):
         elements = list(self.visit(element) for element in node.elts)
 
         self._update_debug_metadata(self.builder, node)
-        element_values = [self.get_rval(e) for e in elements]
 
+        element_values = [self.get_rval(e) for e in elements]
         element_types = [element.type for element in element_values]
-        assert all(e_type == element_types[0] for e_type in element_types), f"Unable to convert {node} into a list! (Elements differ in type!)"
-        result = ir.ArrayType(element_types[0], len(element_types))(ir.Undefined)
+
+        if all(e_type == element_types[0] for e_type in element_types):
+            result = ir.ArrayType(element_types[0], len(element_types))(ir.Undefined)
+        else:
+            result = ir.LiteralStructType(element_types)(ir.Undefined)
 
         for i, val in enumerate(element_values):
             result = self.builder.insert_value(result, val, i)

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -284,9 +284,11 @@ def convert_type(builder, val, t):
     if is_integer(val) and is_integer(t):
         if val.type.width > t.width:
             return builder.trunc(val, t)
+
         elif val.type.width < t.width:
             # Python integers are signed
             return builder.zext(val, t)
+
         else:
             assert False, "Unknown integer conversion: {} -> {}".format(val.type, t)
 
@@ -295,12 +297,18 @@ def convert_type(builder, val, t):
         return builder.sitofp(val, t)
 
     if is_floating_point(val) and is_integer(t):
+        # Propagate constant conversions to allow constant indexing in UDFs
+        if hasattr(val, 'constant'):
+            # Calling val.fptosi directly doesn't work
+            return t(val.constant)
+
         # Python integers are signed
         return builder.fptosi(val, t)
 
     if is_floating_point(val) and is_floating_point(t):
         if isinstance(val.type, ir.HalfType) or isinstance(t, ir.DoubleType):
             return builder.fpext(val, t)
+
         elif isinstance(val.type, ir.DoubleType) or isinstance(t, ir.HalfType):
             # FIXME: Direct conversion from double to half needs a runtime
             #        function (__truncdfhf2). llvmlite MCJIT fails to provide
@@ -311,6 +319,7 @@ def convert_type(builder, val, t):
             #        see: https://github.com/numba/llvmlite/issues/834
             if isinstance(val.type, ir.DoubleType) and isinstance(t, ir.HalfType):
                 val = builder.fptrunc(val, ir.FloatType())
+
             return builder.fptrunc(val, t)
         else:
             assert False, "Unknown float conversion: {} -> {}".format(val.type, t)

--- a/psyneulink/core/llvm/helpers.py
+++ b/psyneulink/core/llvm/helpers.py
@@ -324,6 +324,10 @@ def convert_type(builder, val, t):
         else:
             assert False, "Unknown float conversion: {} -> {}".format(val.type, t)
 
+    if isinstance(val.type, ir.ArrayType) and len(val.type) == 1:
+        val = builder.extract_value(val, [0])
+        return convert_type(builder, val, t)
+
     assert False, "Unknown type conversion: {} -> {}".format(val.type, t)
 
 

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -572,6 +572,7 @@ def test_udf_in_mechanism(mech_mode, benchmark):
 @pytest.mark.parametrize("variable,shapes,expected,ports", [
     pytest.param([-1, 2, 3, 4], 4, [[7]], [{pnl.VARIABLE: [pnl.OWNER_VALUE, (pnl.OWNER_VALUE, 0, 0)], pnl.FUNCTION: lambda x: sum(x[0][0]) + x[1]}], id="aggregate_variable"),
     pytest.param([-1, 2, 3, 4], 4, [[9]], [{pnl.VARIABLE: [pnl.OWNER_VALUE, "is_finished_flag"], pnl.FUNCTION: lambda x: sum(x[0][0]) + x[1]}], id="is_finished"),
+    pytest.param([-1, 2, 4, 3], 4, [[2]], [{pnl.VARIABLE: [pnl.OWNER_VALUE, "is_finished_flag"], pnl.FUNCTION: lambda x: np.argmax(x[0]) if x[1] else np.nan}], id="decision_index"),
 ])
 def test_udf_in_output_port(variable, shapes, expected, ports, mech_mode, benchmark):
 

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -281,6 +281,10 @@ def simpleFun(variable, param1, param2):
     return variable * 2 + param2
 
 
+def castReturn(variable, param1, param2):
+    return float(int(param1)) + float(param2) + float(variable[0] + variable[1])
+
+
 def condReturn(variable, param1, param2):
     if variable[0]:
         return param1 + 0.5
@@ -294,12 +298,14 @@ def condValReturn(variable, param1, param2):
         val = param2 + 0.3
     return val
 
+
 def lambdaGen():
     return lambda var, param1, param2: var + param1 * param2
 
 
 @pytest.mark.parametrize("func,var,params,expected", [
     (simpleFun, [1, 3], {"param1":None, "param2":3}, [5, 9]),
+    (castReturn, [1, 3], {"param1":5.5, "param2":3.6}, [12.6]),
     (condReturn, [0], {"param1":1, "param2":2}, [2.3]),
     (condReturn, [1], {"param1":1, "param2":2}, [1.5]),
     (condValReturn, [0], {"param1":1, "param2":2}, [2.3]),

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -543,6 +543,7 @@ def numpy_argmax(variable):
     pytest.param(numpy_argmax, [[5.0, float('Inf'), 1.0], [3.0, 6.0, 2.0]], 1, id="NP_ARGMAX Inf in array3"),
     pytest.param(numpy_argmax, [[5.0, float('NaN'), 1.0], [3.0, 6.0, 2.0]], 1, id="NP_ARGMAX NaN in array3"),
     pytest.param(numpy_argmax, [[5.0, float('-NaN'), 1.0], [3.0, 6.0, 2.0]], 1, id="NP_ARGMAX -NaN in array3"),
+    pytest.param(lambda x: np.nan, [[5.0, float('-NaN'), 1.0], [3.0, 6.0, 2.0]], np.nan, id="NP_NAN"),
 ])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_func_numpy(function, variable, expected, func_mode, benchmark):

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -337,8 +337,12 @@ def swap(variable, param1, param2):
     return variable
 
 
-def indexLit(variable, param1, param2):
+def indexBinOp(variable, param1, param2):
     return [1,2,3,4][variable[0] + 2]
+
+
+def indexLit(variable, param1, param2):
+    return [[1,5],2,3,4][2]
 
 
 @pytest.mark.parametrize("func,var,expected", [
@@ -353,7 +357,8 @@ def indexLit(variable, param1, param2):
     (branchOnVarFloat, [float("NaN")], [1.0]),
     (branchOnVarFloat, [float("-NaN")], [1.0]),
     (swap, [-1, 3], [3, -1]),
-    (indexLit, [0], [3]),
+    (indexLit, [1,2,3,4], [3]),
+    (indexBinOp, [1], [4]),
 ])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_func_branching(func, var, expected, func_mode, benchmark):

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -3,6 +3,7 @@ import math
 import numpy as np
 import pytest
 
+import psyneulink as pnl
 from psyneulink.core.components.functions.nonstateful.transferfunctions import Linear, Logistic
 from psyneulink.core.components.functions.userdefinedfunction import UserDefinedFunction
 from psyneulink.core.components.mechanisms.processing import ProcessingMechanism
@@ -546,6 +547,20 @@ def test_udf_in_mechanism(mech_mode, benchmark):
 
     val = benchmark(e, [-1, 2, 3, 4])
     np.testing.assert_allclose(val, [[10]])
+
+@pytest.mark.benchmark(group="UDF in Mechanism")
+def test_udf_in_output_port_with_aggregate_variable(mech_mode, benchmark):
+    def myFunction(variable):
+        return sum(variable[0][0]) + variable[1]
+
+    myMech = ProcessingMechanism(input_shapes=4,
+                                 output_ports=[{pnl.VARIABLE: [pnl.OWNER_VALUE, (pnl.OWNER_VALUE, 0, 0)],
+                                                pnl.FUNCTION: myFunction}])
+
+    e = pytest.helpers.get_mech_execution(myMech, mech_mode)
+
+    val = benchmark(e, [-1, 2, 3, 4])
+    np.testing.assert_allclose(val, [[7]])
 
 
 @pytest.mark.parametrize("op,variable,expected", [ # parameter is string since compiled udf doesn't support closures as of present

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -572,6 +572,7 @@ def test_udf_in_mechanism(mech_mode, benchmark):
 @pytest.mark.benchmark(group="UDF in Mechanism")
 @pytest.mark.parametrize("variable,shapes,expected,ports", [
     pytest.param([-1, 2, 3, 4], 4, [[7]], [{pnl.VARIABLE: [pnl.OWNER_VALUE, (pnl.OWNER_VALUE, 0, 0)], pnl.FUNCTION: lambda x: sum(x[0][0]) + x[1]}], id="aggregate_variable"),
+    pytest.param([-1, 2, 3, 4], 4, [[9]], [{pnl.VARIABLE: [pnl.OWNER_VALUE, "is_finished_flag"], pnl.FUNCTION: lambda x: sum(x[0][0]) + x[1]}], id="is_finished"),
 ])
 def test_udf_in_output_port(variable, shapes, expected, ports, mech_mode, benchmark):
 

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -503,6 +503,9 @@ def numpy_shape(variable):
 def numpy_max(variable):
     return np.max(variable)
 
+def numpy_argmax(variable):
+    return np.argmax(variable)
+
 @pytest.mark.parametrize("function,variable,expected", [
     pytest.param(lambda x: np.tanh(x), [[1, 3]], [[0.76159416, 0.99505475]], id="TANH"),
     pytest.param(lambda x: np.exp(x), [[1, 3]], [[2.71828183, 20.08553692]], id="EXP"),
@@ -526,6 +529,20 @@ def numpy_max(variable):
     pytest.param(numpy_max, [[5.0, float('NaN'), 1.0], [3.0, 6.0, 2.0]], float('NaN'), id="NP_MAX NaN in array3"),
     pytest.param(numpy_max, [[5.0, float('-NaN'), 1.0], [3.0, 6.0, 2.0]], float('-NaN'), id="NP_MAX -NaN in array3"),
     pytest.param(lambda x: x.flatten(), [[1.0, 2.0], [3.0, 4.0]], [1.0, 2.0, 3.0, 4.0], id="FLATTEN"),
+    pytest.param(numpy_argmax, 5.0, 0, id="NP_ARGMAX scalar"),
+    pytest.param(numpy_argmax, [0.0, 0.0], 0, id="NP_ARGMAX 1D equal"),
+    pytest.param(numpy_argmax, [1.0, 2.0], 1, id="NP_ARGMAX 1D"),
+    pytest.param(numpy_argmax, [1.0, 2.0, float("-Inf"), float("Inf"), float("NaN")], 4, id="NP_ARGMAX 2D Inf/NaN"),
+    pytest.param(numpy_argmax, [[2.0, 1.0], [6.0, 2.0]], 2, id="NP_ARGMAX 2D"),
+    pytest.param(numpy_argmax, [[[-2.0, -1.0], [-6.0, -2.0]],[[2.0, 1.0], [6.0, 2.0]]], 6, id="NP_ARGMAX 3D"),
+    pytest.param(numpy_argmax, [[float('-Inf'), 1.0], [6.0, 2.0]], 2, id="NP_ARGMAX -Inf in array2"),
+    pytest.param(numpy_argmax, [[float('Inf'), 1.0], [6.0, 2.0]], 0, id="NP_ARGMAX Inf in array2"),
+    pytest.param(numpy_argmax, [[float('NaN'), 1.0], [6.0, 2.0]], 0, id="NP_ARGMAX NaN in array2"),
+    pytest.param(numpy_argmax, [[float('-NaN'), 1.0], [6.0, 2.0]], 0, id="NP_ARGMAX NaN in array2"),
+    pytest.param(numpy_argmax, [[5.0, float('-Inf'), 1.0], [3.0, 6.0, 2.0]], 4, id="NP_ARGMAX -Inf in array3"),
+    pytest.param(numpy_argmax, [[5.0, float('Inf'), 1.0], [3.0, 6.0, 2.0]], 1, id="NP_ARGMAX Inf in array3"),
+    pytest.param(numpy_argmax, [[5.0, float('NaN'), 1.0], [3.0, 6.0, 2.0]], 1, id="NP_ARGMAX NaN in array3"),
+    pytest.param(numpy_argmax, [[5.0, float('-NaN'), 1.0], [3.0, 6.0, 2.0]], 1, id="NP_ARGMAX -NaN in array3"),
 ])
 @pytest.mark.benchmark(group="Function UDF")
 def test_user_def_func_numpy(function, variable, expected, func_mode, benchmark):

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -343,6 +343,10 @@ def swap(variable, param1, param2):
     return variable
 
 
+def ternaryOp(variable, param1, param2):
+    return variable[0] if variable[1] else variable[2]
+
+
 def indexBinOp(variable, param1, param2):
     return [1,2,3,4][variable[0] + 2]
 
@@ -363,6 +367,8 @@ def indexLit(variable, param1, param2):
     (branchOnVarFloat, [float("NaN")], [1.0]),
     (branchOnVarFloat, [float("-NaN")], [1.0]),
     (swap, [-1, 3], [3, -1]),
+    (ternaryOp, [-1,0,1], [1]),
+    (ternaryOp, [-1,1,1], [-1]),
     (indexLit, [1,2,3,4], [3]),
     (indexBinOp, [1], [4]),
 ])

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -284,6 +284,9 @@ def simpleFun(variable, param1, param2):
 def castReturn(variable, param1, param2):
     return float(int(param1)) + float(param2) + float(variable[0] + variable[1])
 
+def singletonArrayCast(variable, param1, param2):
+    return float(variable) + float(int(param1)) + float(bool(param2))
+
 
 def condReturn(variable, param1, param2):
     if variable[0]:
@@ -305,6 +308,7 @@ def lambdaGen():
 
 @pytest.mark.parametrize("func,var,params,expected", [
     (simpleFun, [1, 3], {"param1":None, "param2":3}, [5, 9]),
+    (singletonArrayCast, [1], {"param1":5.5, "param2":3.6}, [7]),
     (castReturn, [1, 3], {"param1":5.5, "param2":3.6}, [12.6]),
     (condReturn, [0], {"param1":1, "param2":2}, [2.3]),
     (condReturn, [1], {"param1":1, "param2":2}, [1.5]),


### PR DESCRIPTION
Add UDF compiler support for explicit Python type casts (float, int, bool).
Add UDF compiler support for rugged list literals.
Add UDF compiler support for constant indices to rugged lists.
Add UDF compiler support for "IfExpression" / ternary operator. The support is limited to cases in which both branches return values of the same type.
Add UDF compiler support for 'np.argmax'.
Add UDF compiler support for 'np.nan'.