### PR TITLE
patch/fixes_for_KADMLP

### DIFF
--- a/Scripts/Models (Under Development)/Minigrid/KADMLP.py
+++ b/Scripts/Models (Under Development)/Minigrid/KADMLP.py
@@ -1,0 +1,487 @@
+import timeit
+
+import numpy as np
+import psyneulink
+from psyneulink import *
+import KeysAndDoorsWrapper as kad
+from psyneulink import AutodiffComposition
+
+print(psyneulink.__version__)
+# NOTE: The MLP input, while a separate Node than the state input is currently just a workaround to get the input
+# to the MLP. For some reason it keeps giving me errors when I try to pass it directly.
+
+
+# Runtime Switches:
+RENDER = True
+PNL_COMPILE = False
+RUN = True
+
+# *********************************************************************************************************************
+# *********************************************** CONSTANTS ***********************************************************
+# *********************************************************************************************************************
+
+# temp
+obs_len = 8
+num_state_nodes = 8
+num_doors = 1
+num_keys = 1
+
+# *********************************************************************************************************************
+# **************************************  MECHANISMS AND COMPOSITION  *************************************************
+# *********************************************************************************************************************
+
+# Perceptual Mechanism
+state_input = ProcessingMechanism(name='STATE INPUT',
+                                  default_variable=[[0], [0], [0] * num_doors, [0] * num_keys, [0], [0], [0], [0]])
+agent_x = TransferMechanism(name="AGENT X")
+agent_y = TransferMechanism(name="AGENT Y")
+door_states = TransferMechanism(name="DOOR STATES")
+key_states = TransferMechanism(name="KEY STATES")
+holding_key = TransferMechanism(name="HOLDING KEY")
+key_color = TransferMechanism(name="KEY COLOR")
+heaven = TransferMechanism(name="HEAVEN")
+certainty = TransferMechanism(name="CERTAINTY")
+right = TransferMechanism(name="RIGHT")
+left = TransferMechanism(name="LEFT")
+up = TransferMechanism(name="UP")
+down = TransferMechanism(name="DOWN")
+open_action = TransferMechanism(name="OPEN ACTION")
+pickup = TransferMechanism(name="PICKUP")
+read = TransferMechanism(name="READ")
+output = ProcessingMechanism(name="OUTPUT", default_variable=[[0, 0, 0, 0, 0, 0, 0]])
+
+em_init_entries = []
+num_doors = 0
+num_keys = 0
+# Translation key
+empty = -1
+none = 0
+false = 0
+true = 1
+# key colors/door locked colors
+red = 1
+green = 2
+blue = 3
+# Additional door states
+closed = 4
+open = 5
+# Key state translation
+key = 1
+no_key = 0
+# heaven hell states
+h = 1
+j = 2
+t = 0
+# certainty
+certain = 1
+not_certain = 0
+
+# Build EM to this map:
+# <     dx = -1
+# >     dx = 1
+# ^     dy = -1
+# p     pickup = true
+# .     ignore
+
+# ORDER:
+# X, Y, Door states, Key states, Holding Key, Key Color, Heaven
+# DX, DY, Open, Pickup, read
+em_init_entries = [
+    # Not holding key, door closed, door closed
+    ([0], [3], [-1], [-1], [false], [none], [none], [certain],
+     [1], [0], [0], [0], [false], [false], [false]),
+    ([1], [3], [-1], [-1], [false], [none], [none], [certain],
+     [1], [0], [0], [0], [false], [false], [false]),
+    ([2], [3], [-1], [-1], [false], [none], [none], [certain],
+     [1], [0], [0], [0], [false], [false], [false]),
+    ([3], [3], [-1], [-1], [false], [none], [none], [certain],
+     [0], [0], [1], [0], [false], [false], [false]),
+    ([3], [2], [-1], [-1], [false], [none], [none], [certain],
+     [0], [0], [1], [0], [false], [false], [false]),
+    ([3], [1], [-1], [-1], [false], [none], [none], [certain],
+     [0], [1], [0], [0], [false], [false], [false]),
+    ([2], [1], [-1], [-1], [false], [none], [none], [certain],
+     [0], [1], [0], [0], [false], [false], [false]),
+    ([1], [1], [-1], [-1], [false], [none], [none], [certain],
+     [0], [1], [0], [0], [false], [false], [false]),
+    ([0], [1], [-1], [-1], [false], [none], [none], [certain],
+     [0], [0], [1], [0], [false], [false], [false]),
+]
+instruct_em = EMComposition(name="instruct_em", memory_template=em_init_entries, memory_capacity=500,
+                            memory_decay_rate=0, memory_fill=0.001,
+                            fields={"AGENT X": {FIELD_WEIGHT: 1,
+                                                LEARN_FIELD_WEIGHT: False,
+                                                TARGET_FIELD: False},
+                                    "AGENT Y": {FIELD_WEIGHT: 1,
+                                                LEARN_FIELD_WEIGHT: False,
+                                                TARGET_FIELD: False},
+                                    "DOOR STATES": {FIELD_WEIGHT: 1,
+                                                    LEARN_FIELD_WEIGHT: False,
+                                                    TARGET_FIELD: False},
+                                    "KEY STATES": {FIELD_WEIGHT: 1,
+                                                   LEARN_FIELD_WEIGHT: False,
+                                                   TARGET_FIELD: False},
+                                    "HOLDING KEY": {FIELD_WEIGHT: 1,
+                                                    LEARN_FIELD_WEIGHT: False,
+                                                    TARGET_FIELD: False},
+                                    "KEY COLOR": {FIELD_WEIGHT: 1,
+                                                  LEARN_FIELD_WEIGHT: False,
+                                                  TARGET_FIELD: False},
+                                    "HEAVEN": {FIELD_WEIGHT: 1,
+                                               LEARN_FIELD_WEIGHT: False,
+                                               TARGET_FIELD: False},
+                                    "CERTAINTY": {FIELD_WEIGHT: 1,
+                                                  LEARN_FIELD_WEIGHT: False,
+                                                  TARGET_FIELD: False},
+                                    "RIGHT": {FIELD_WEIGHT: None,
+                                           LEARN_FIELD_WEIGHT: False,
+                                           TARGET_FIELD: True},
+                                    "LEFT": {FIELD_WEIGHT: None,
+                                           LEARN_FIELD_WEIGHT: False,
+                                           TARGET_FIELD: True},
+                                    "UP": {FIELD_WEIGHT: None,
+                                           LEARN_FIELD_WEIGHT: False,
+                                           TARGET_FIELD: True},
+                                    "DOWN": {FIELD_WEIGHT: None,
+                                           LEARN_FIELD_WEIGHT: False,
+                                           TARGET_FIELD: True},
+                                    "OPEN ACTION": {FIELD_WEIGHT: None,
+                                                    LEARN_FIELD_WEIGHT: False,
+                                                    TARGET_FIELD: True},
+                                    "PICKUP": {FIELD_WEIGHT: None,
+                                               LEARN_FIELD_WEIGHT: False,
+                                               TARGET_FIELD: True},
+                                    "READ": {FIELD_WEIGHT: None,
+                                             LEARN_FIELD_WEIGHT: False,
+                                             TARGET_FIELD: True},
+                                    },
+                            softmax_choice=ARG_MAX,
+                            normalize_memories=True,
+                            enable_learning=False,
+                            softmax_gain=10.0)
+
+# Pathways from state to EM
+state_to_em_agent_x = [state_input,
+                       MappingProjection(matrix=IDENTITY_MATRIX,
+                                         sender=state_input.output_ports[0],
+                                         receiver=instruct_em.nodes["AGENT X [QUERY]"],
+                                         learnable=False),
+                       instruct_em
+                       ]
+state_to_em_agent_y = [state_input,
+                       MappingProjection(matrix=IDENTITY_MATRIX,
+                                         sender=state_input.output_ports[1],
+                                         receiver=instruct_em.nodes["AGENT Y [QUERY]"],
+                                         learnable=False),
+                       instruct_em
+                       ]
+state_to_em_door_states = [state_input,
+                           MappingProjection(matrix=IDENTITY_MATRIX,
+                                             sender=state_input.output_ports[2],
+                                             receiver=instruct_em.nodes["DOOR STATES [QUERY]"],
+                                             learnable=False),
+                           instruct_em
+                           ]
+state_to_em_key_states = [state_input,
+                          MappingProjection(matrix=IDENTITY_MATRIX,
+                                            sender=state_input.output_ports[3],
+                                            receiver=instruct_em.nodes["KEY STATES [QUERY]"],
+                                            learnable=False),
+                          instruct_em
+                          ]
+state_to_em_holding_key = [state_input,
+                           MappingProjection(matrix=IDENTITY_MATRIX,
+                                             sender=state_input.output_ports[4],
+                                             receiver=instruct_em.nodes["HOLDING KEY [QUERY]"],
+                                             learnable=False),
+                           instruct_em
+                           ]
+state_to_em_key_color = [state_input,
+                         MappingProjection(matrix=IDENTITY_MATRIX,
+                                           sender=state_input.output_ports[5],
+                                           receiver=instruct_em.nodes["KEY COLOR [QUERY]"],
+                                           learnable=False),
+                         instruct_em
+                         ]
+state_to_em_heaven = [state_input,
+                      MappingProjection(matrix=IDENTITY_MATRIX,
+                                        sender=state_input.output_ports[6],
+                                        receiver=instruct_em.nodes["HEAVEN [QUERY]"],
+                                        learnable=False),
+                      instruct_em
+                      ]
+state_to_em_certainty = [state_input,
+                         MappingProjection(matrix=IDENTITY_MATRIX,
+                                           sender=state_input.output_ports[7],
+                                           receiver=instruct_em.nodes["CERTAINTY [QUERY]"],
+                                           learnable=False),
+                         instruct_em
+                         ]
+
+# Pathways from EM to actions
+right_matrix = np.array([[1, 0, 0, 0, 0, 0, 0]])  # Maps to first position
+left_matrix = np.array([[0, 1, 0, 0, 0, 0, 0]])  # Maps to second position
+up_matrix = np.array([[0, 0, 1, 0, 0, 0, 0]])
+down_matrix = np.array([[0, 0, 0, 1, 0, 0, 0]])
+open_matrix = np.array([[0, 0, 0, 0, 1, 0, 0]])  # Maps to third position
+pickup_matrix = np.array([[0, 0, 0, 0, 0, 1, 0]])
+read_matrix = np.array([[0, 0, 0, 0, 0, 0, 1]])
+
+state_to_em_right = [state_input,
+                  MappingProjection(matrix=IDENTITY_MATRIX,
+                                    sender=state_input,
+                                    receiver=instruct_em.nodes["RIGHT [VALUE]"],
+                                    learnable=False),
+                  instruct_em,
+                  MappingProjection(matrix=right_matrix,
+                                    sender=instruct_em.nodes["RIGHT [RETRIEVED]"],
+                                    receiver=output,
+                                    learnable=False),
+                  output
+                  ]
+state_to_em_left = [state_input,
+                  MappingProjection(matrix=IDENTITY_MATRIX,
+                                    sender=state_input,
+                                    receiver=instruct_em.nodes["LEFT [VALUE]"],
+                                    learnable=False),
+                  instruct_em,
+                  MappingProjection(matrix=left_matrix,
+                                    sender=instruct_em.nodes["LEFT [RETRIEVED]"],
+                                    receiver=output,
+                                    learnable=False),
+                  output
+                  ]
+state_to_em_up = [state_input,
+                  MappingProjection(matrix=IDENTITY_MATRIX,
+                                    sender=state_input,
+                                    receiver=instruct_em.nodes["UP [VALUE]"],
+                                    learnable=False),
+                  instruct_em,
+                  MappingProjection(matrix=up_matrix,
+                                    sender=instruct_em.nodes["UP [RETRIEVED]"],
+                                    receiver=output,
+                                    learnable=False),
+                  output
+                  ]
+state_to_em_down = [state_input,
+                  MappingProjection(matrix=IDENTITY_MATRIX,
+                                    sender=state_input,
+                                    receiver=instruct_em.nodes["DOWN [VALUE]"],
+                                    learnable=False),
+                  instruct_em,
+                  MappingProjection(matrix=down_matrix,
+                                    sender=instruct_em.nodes["DOWN [RETRIEVED]"],
+                                    receiver=output,
+                                    learnable=False),
+                  output
+                  ]
+state_to_em_open = [state_input,
+                    MappingProjection(matrix=IDENTITY_MATRIX,
+                                      sender=state_input,
+                                      receiver=instruct_em.nodes["OPEN ACTION [VALUE]"],
+                                      learnable=False),
+                    instruct_em,
+                    MappingProjection(matrix=open_matrix,
+                                      sender=instruct_em.nodes["OPEN ACTION [RETRIEVED]"],
+                                      receiver=output,
+                                      learnable=False),
+                    output
+                    ]
+state_to_em_pickup = [state_input,
+                      MappingProjection(matrix=IDENTITY_MATRIX,
+                                        sender=state_input,
+                                        receiver=instruct_em.nodes["PICKUP [VALUE]"],
+                                        learnable=False),
+                      instruct_em,
+                      MappingProjection(matrix=pickup_matrix,
+                                        sender=instruct_em.nodes["PICKUP [RETRIEVED]"],
+                                        receiver=output,
+                                        learnable=False),
+                      output
+                      ]
+state_to_em_read = [state_input,
+                    MappingProjection(matrix=IDENTITY_MATRIX,
+                                      sender=state_input,
+                                      receiver=instruct_em.nodes["READ [VALUE]"],
+                                      learnable=False),
+                    instruct_em,
+                    MappingProjection(matrix=read_matrix,
+                                      sender=instruct_em.nodes["READ [RETRIEVED]"],
+                                      receiver=output,
+                                      learnable=False),
+                    output
+                    ]
+
+# There were issues with projecting the state input directly through the mlp
+# MLP input is a separate input that I send the state input through as a work around
+mlp_input = ProcessingMechanism(name='MLP INPUT', default_variable=[0] * obs_len)
+
+# MLP output mechanism with Softmax activation
+# Even with calculating the correct entropy for this it showed no learning when using the logistic function
+mlp_output = TransferMechanism(name="MLP OUTPUT",
+                               default_variable=[0, 0, 0, 0, 0, 0, 0],
+                               function=SoftMax,
+                               )
+
+
+# Create Composition
+agent_comp = AutodiffComposition([state_to_em_agent_x,
+                                  state_to_em_agent_y,
+                                  state_to_em_door_states,
+                                  state_to_em_key_states,
+                                  state_to_em_holding_key,
+                                  state_to_em_key_color,
+                                  state_to_em_heaven,
+                                  state_to_em_certainty,
+                                  state_to_em_right,
+                                  state_to_em_left,
+                                  state_to_em_up,
+                                  state_to_em_down,
+                                  state_to_em_open,
+                                  state_to_em_pickup,
+                                  state_to_em_read],
+                                 name='KEYS AND DOORS COMPOSITION')
+
+hidden_layer = TransferMechanism(name="HIDDEN",
+                                default_variable=[0] * 64,
+                                function=ReLU)
+
+# Issue: Not learning?
+# Add a hidden layer to the learning pathway
+agent_comp.add_linear_learning_pathway(
+    pathway=[mlp_input, hidden_layer, mlp_output],
+    learning_rate=0.1,
+    loss_spec=Loss.CROSS_ENTROPY,
+    learning_function=BackPropagation
+)
+
+EMoutput_output = MappingProjection(sender=output,
+                                    receiver=mlp_output,
+                                    learnable=False,
+                                    name="DEPENDENCY_PROJECTION")
+agent_comp.add_projection(EMoutput_output, output, mlp_output)
+agent_comp.scheduler.add_condition(mlp_output, AfterNodes(output))
+
+
+# *********************************************************************************************************************
+# ******************************************   RUN SIMULATION  ********************************************************
+# *********************************************************************************************************************
+
+num_trials = 20
+
+
+def calculate_entropy(probs):
+    probs = np.asarray(probs, dtype=float)
+    probs = np.clip(probs, 1e-12, 1.0)   # avoid log(0)
+    entropy = -np.sum(probs * np.log(probs))
+    max_entropy = np.log(len(probs))
+    return entropy / max_entropy
+
+def main():
+    env = kad.KeysAndDoorsEnv(grid="""
+                                    t...
+                                    ....
+                                    ###.
+                                    s...
+                                    """)
+    reward = 0
+    done = False
+    print("Running simulation...")
+    steps = 0
+    start_time = timeit.default_timer()
+    entropy_thresh = 0.5
+    agent_comp.show_graph()
+    for _ in range(num_trials):
+        observation = env.reset()
+        while True:
+            if PNL_COMPILE:
+                BIN_EXECUTE = 'LLVM'
+            else:
+                BIN_EXECUTE = 'Python'
+
+            # Format input
+            door_input = [observation[2]] if not isinstance(observation[2], list) else observation[2]
+            key_input = [observation[3]] if not isinstance(observation[3], list) else observation[3]
+
+            input_array = [[observation[0]], [observation[1]], door_input, key_input,
+                           [observation[4]], [observation[5]], [observation[6]], [observation[7]]]
+            flattened_input = np.array([observation[0], observation[1],
+                                        door_input[0], key_input[0],
+                                        observation[4], observation[5],
+                                        observation[6], observation[7]])
+
+            # Run the agent composition
+            # execution = agent_comp.execute(
+            #     inputs={state_input: input_array,
+            #             mlp_input: flattened_input},
+            #     bin_execute=BIN_EXECUTE
+            # )
+
+            # Get outputs - EM output is second to last, MLP output is last
+            # em_output_values = execution[-2]
+            # mlp_output_vals = execution[-1]
+            # entropy = calculate_entropy(mlp_output_vals)
+            # print(f"mlp output: {mlp_output_vals}")
+            # # Extract EM action values
+            # right = float(em_output_values[0])
+            # left = float(em_output_values[1])
+            # up = float(em_output_values[2])
+            # down = float(em_output_values[3])
+            # open_action = float(em_output_values[4])
+            # pickup_action = float(em_output_values[5])
+            # read_action = float(em_output_values[6])
+            # em_action = np.array((right, left, up, down, open_action, pickup_action, read_action))
+
+            # Convert MLP logits to action
+            # mlp_action = np.zeros(7)
+            # mlp_action[np.argmax(mlp_output_vals)] = 1
+            #
+            # if entropy < entropy_thresh:
+            #     print(
+            #         f"Step {steps}: Using MLP (entropy: {entropy:.3f}, mlp_action: {mlp_action}, em_action: {em_action})")
+            # else:
+            #     print(
+            #         f"Step {steps}: Using EM (entropy: {entropy:.3f}, mlp_action: {mlp_action}, em_action: {em_action})")
+
+            # train MLP with EM action every step
+            # find the actual projections
+            hidden_to_output = hidden_layer.efferents[0]
+            weights_before = hidden_to_output.matrix.base.copy()
+            agent_comp.learn(inputs={state_input: input_array,
+                                     mlp_input: flattened_input},
+                             targets={mlp_output: output,
+                                      output: None},
+                             # execution=ExecutionMode.PyTorch
+                             )
+            weights_after = hidden_to_output.matrix.base.copy()
+            weight_change = np.abs(weights_after - weights_before).sum()
+            max_gradient = np.abs(weights_after - weights_before).max()
+            print(f"Weight change (L1): {weight_change:.6f}")
+            print(f"Max gradient: {max_gradient:.6f}")
+            print(weight_change)
+            print(max_gradient)
+            emOutput = output.output_values[-1]
+            right = emOutput[0]
+            left = emOutput[1]
+            up = emOutput[2]
+            down = emOutput[3]
+            open_action = emOutput[4]
+            pickup_action = emOutput[5]
+            read_action = emOutput[6]
+            # Execute action in environment (always use EM action during training)
+            observation, reward, done = env.step(right, left, up, down, open_action, pickup_action, read_action)
+            steps += 1
+
+            if RENDER:
+                env.render()
+            if done:
+                break
+
+    stop_time = timeit.default_timer()
+    print(f'{steps / (stop_time - start_time):.1f} steps/second, {steps} total steps in '
+          f'{stop_time - start_time:.2f} seconds')
+
+
+if RUN:
+    if __name__ == "__main__":
+        main()

--- a/Scripts/Models (Under Development)/Minigrid/KADMLP.py
+++ b/Scripts/Models (Under Development)/Minigrid/KADMLP.py
@@ -451,7 +451,7 @@ def main():
                                      mlp_input: flattened_input},
                              targets={mlp_output: output.value,
                                       output: [[[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]]},
-                             # execution=ExecutionMode.PyTorch
+                             execution=ExecutionMode.PyTorch
                              )
             weights_after = hidden_to_output.matrix.base.copy()
             weight_change = np.abs(weights_after - weights_before).sum()

--- a/Scripts/Models (Under Development)/Minigrid/KADMLP.py
+++ b/Scripts/Models (Under Development)/Minigrid/KADMLP.py
@@ -390,7 +390,7 @@ def main():
     steps = 0
     start_time = timeit.default_timer()
     entropy_thresh = 0.5
-    agent_comp.show_graph()
+    # agent_comp.show_graph()
     for _ in range(num_trials):
         observation = env.reset()
         while True:

--- a/Scripts/Models (Under Development)/Minigrid/KADMLP.py
+++ b/Scripts/Models (Under Development)/Minigrid/KADMLP.py
@@ -449,8 +449,8 @@ def main():
             weights_before = hidden_to_output.matrix.base.copy()
             agent_comp.learn(inputs={state_input: input_array,
                                      mlp_input: flattened_input},
-                             targets={mlp_output: output,
-                                      output: None},
+                             targets={mlp_output: output.value,
+                                      output: [[[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]]},
                              # execution=ExecutionMode.PyTorch
                              )
             weights_after = hidden_to_output.matrix.base.copy()

--- a/Scripts/Models (Under Development)/Minigrid/KeysAndDoorsWrapper.py
+++ b/Scripts/Models (Under Development)/Minigrid/KeysAndDoorsWrapper.py
@@ -1,6 +1,6 @@
 from KeysAndDoors import KeysAndDoors
 from collections import namedtuple
-Action = namedtuple("Action", "dx dy open pickup")
+Action = namedtuple("Action", "right left up down open pickup read")
 class KeysAndDoorsEnv:
     def __init__(
         self,
@@ -8,7 +8,10 @@ class KeysAndDoorsEnv:
         discount_rate=.95,
         step_cost=-1,
         target_reward=100,
-        grid= None
+        heaven_reward=50,
+        hell_reward=-50,
+        grid= None,
+        certainty_thresh=0.9
     ):
 
         self.env = KeysAndDoors(
@@ -16,12 +19,51 @@ class KeysAndDoorsEnv:
         coherence=coherence,
         discount_rate=discount_rate,
         step_cost=step_cost,
-        target_reward=target_reward
+        target_reward=target_reward,
+        heaven_reward=heaven_reward,
+        hell_reward=hell_reward
         )
 
         self.current_state = None
         self.current_obs = None
         self.last_action = None
+        self.certainty_thresh = certainty_thresh
+
+    # Translate current observations to a format that the model can understand
+    def translate(self, old_obs):
+        door_states = []
+        for door in old_obs[3]:
+            if door == None: door_states.append(0)
+            if door == 'R': door_states.append(1)
+            if door == 'G': door_states.append(2)
+            if door == 'B': door_states.append(3)
+            if door == 'D': door_states.append(4)
+            if door == 'O': door_states.append(5)
+        key_states = []
+        for key in old_obs[4]:
+            if key == True: key_states.append(1);
+            if key == False: key_states.append(0);
+        holding_key = 0
+        if old_obs[5] == True: holding_key = 1
+        key_color = 0
+        if old_obs[6] == 'r': key_color = 1
+        if old_obs[6] == 'g': key_color = 2
+        if old_obs[6] == 'b': key_color = 3
+
+        if len(key_states) == 0:
+            key_states = -1
+        if len(door_states) == 0:
+            door_states = -1
+
+        heaven = 0
+        if old_obs[7] == 'h': heaven = 1
+        if old_obs[7] == 'j': heaven = 2
+
+        certainty = 0
+        if old_obs[8] >= self.certainty_thresh: certainty = 1
+        observation = (old_obs[0], old_obs[1], door_states, key_states, holding_key, key_color, heaven, certainty)
+        return observation
+
 
     # resets the environment and returns the first observation
     def reset(self):
@@ -29,22 +71,25 @@ class KeysAndDoorsEnv:
         self.current_state = list(self.env.initial_state_dist())[0]
 
         # Get init observation
-        self.current_obs = list(self.env.observation_dist(Action(0, 0, False, False), self.current_state))[0]
+        self.current_obs = list(self.env.observation_dist(Action(0, 0, 0, 0, False, False, False), self.current_state))[0]
 
-        return self.current_obs
+        observation = self.translate(self.current_obs)
+
+        return observation
 
     # Agent takes an action
     # Should return reward, ending_condition, and the observation
-    def step(self, dx, dy, open, pickup):
-        action = Action(dx, dy, open, pickup)
+    def step(self, right, left, up, down, open, pickup, read):
+        action = Action(right, left, up, down, open, pickup, read)
         next_state = list(self.env.next_state_dist(self.current_state, action))[0]
-        observation = list(self.env.observation_dist(Action(dx, dy, open, pickup), next_state))[0]
+        observation = list(self.env.observation_dist(Action(right, left, up, down, open, pickup, read), next_state))[0]
         self.current_obs = observation
         reward = self.env.reward(self.current_state, action, next_state)
         ending_condition = self.env.is_absorbing(next_state)
         self.current_state = next_state
         self.last_action = action
-        return observation, reward, ending_condition
+        new_observation = self.translate(observation)
+        return new_observation, reward, ending_condition
 
     def render(self):
         print(self.env.state_string(self.current_state))

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -14181,30 +14181,24 @@ def get_compositions():
 
 def get_composition_for_node(node):
     # Find first CIM to which node projects as indication of the Composition to which it belong
-    receiver = node
-    # if not receiver.efferents:
-    #     return None
-    # while not isinstance(receiver, CompositionInterfaceMechanism):
-    #     for efferent in receiver.efferents:
-    #         if not isinstance(efferent.receiver.owner, Mechanism):
-    #             # Skip if receiver is not a Mechanism
-    #             #     (e.g., could be a Projection.matrix if efferent is a LearningProjection)
-    #             continue
-    #         receiver = efferent.receiver.owner
-    # return receiver.composition
 
     def search_for_output_CIM(receiver):
+        # Recursively search over all efferents until a CIM is found (must be an output_CIM given direction of search)
         for efferent in receiver.efferents:
             receiver = efferent.receiver.owner
             if isinstance(receiver, CompositionInterfaceMechanism):
                 return receiver.composition
             elif isinstance(receiver, ModulatoryMechanism_Base):
+                # Skip if receiver is a ModulatoryMechanism since:
+                #   - won't lead to a CIM
+                #   - likely (always?) will be part of a cycle and thus an infinitely recursive loop
                 return None
             else:
                 search_for_output_CIM(receiver)
 
         return receiver
 
+    receiver = node
     comp = None
     while not comp:
         for efferent in receiver.efferents:

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -14182,29 +14182,22 @@ def get_compositions():
 def get_composition_for_node(node):
     # Find first CIM to which node projects as indication of the Composition to which it belong
 
-    def search_for_output_CIM(receiver):
-        # Recursively search over all efferents until a CIM is found (must be an output_CIM given direction of search)
-        for efferent in receiver.efferents:
+    def search_for_output_CIM(node):
+        # Recursively search over all efferents until a CIM is found (will be an output_CIM given direction of search)
+        for efferent in node.efferents:
             receiver = efferent.receiver.owner
             if isinstance(receiver, CompositionInterfaceMechanism):
                 return receiver.composition
             elif isinstance(receiver, ModulatoryMechanism_Base):
-                # Skip if receiver is a ModulatoryMechanism since:
+                # End search on this path if receiver is a ModulatoryMechanism since it:
                 #   - won't lead to a CIM
-                #   - likely (always?) will be part of a cycle and thus an infinitely recursive loop
+                #   - likely (always?) will be part of a cycle and thus lead to an infinitely recursive loop
                 return None
             else:
                 search_for_output_CIM(receiver)
-
         return receiver
 
-    receiver = node
-    comp = None
-    while not comp:
-        for efferent in receiver.efferents:
-            comp = search_for_output_CIM(receiver)
-
-    return comp
+    return search_for_output_CIM(node)
 
 
 class LearningScale(PNLStrEnum):

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -14182,17 +14182,35 @@ def get_compositions():
 def get_composition_for_node(node):
     # Find first CIM to which node projects as indication of the Composition to which it belong
     receiver = node
-    if not receiver.efferents:
-        return None
-    while not isinstance(receiver, CompositionInterfaceMechanism):
-        for efferent in receiver.efferents:
-            if not isinstance(efferent.receiver.owner, Mechanism):
-                # Skip if receiver is not a Mechanism
-                #     (e.g., could be a Projection.matrix if efferent is a LearningProjection)
-                continue
-            receiver = efferent.receiver.owner
+    # if not receiver.efferents:
+    #     return None
+    # while not isinstance(receiver, CompositionInterfaceMechanism):
+    #     for efferent in receiver.efferents:
+    #         if not isinstance(efferent.receiver.owner, Mechanism):
+    #             # Skip if receiver is not a Mechanism
+    #             #     (e.g., could be a Projection.matrix if efferent is a LearningProjection)
+    #             continue
+    #         receiver = efferent.receiver.owner
+    # return receiver.composition
 
-    return receiver.composition
+    def search_for_output_CIM(receiver):
+        for efferent in receiver.efferents:
+            receiver = efferent.receiver.owner
+            if isinstance(receiver, CompositionInterfaceMechanism):
+                return receiver.composition
+            elif isinstance(receiver, ModulatoryMechanism_Base):
+                return None
+            else:
+                search_for_output_CIM(receiver)
+
+        return receiver
+
+    comp = None
+    while not comp:
+        for efferent in receiver.efferents:
+            comp = search_for_output_CIM(receiver)
+
+    return comp
 
 
 class LearningScale(PNLStrEnum):

--- a/psyneulink/library/compositions/pytorchwrappers.py
+++ b/psyneulink/library/compositions/pytorchwrappers.py
@@ -761,20 +761,62 @@ class PytorchCompositionWrapper(torch.nn.Module):
         # Flattening for forward() and AutodiffComposition.do_gradient_optimization
 
         # Flatten nested execution sets:
-        nested_execution_sets = {}
-        for exec_set in execution_sets:
-            for node in exec_set:
-                if isinstance(node, PytorchCompositionWrapper):
-                    nested_execution_sets[node] = node.execution_sets
-        for node, exec_sets in nested_execution_sets.items():
+        # # MODIFIED 11/20/25 OLD:
+        # nested_execution_sets = {}
+        # for exec_set in execution_sets:
+        #     for node in exec_set:
+        #         if isinstance(node, PytorchCompositionWrapper):
+        #             nested_execution_sets[node] = node.execution_sets
+        # flattened_execution_sets = []
+        # for node, nested_exec_sets in nested_execution_sets.items():
+        #     index = execution_sets.index({node})
+        #     # Remove nested Composition from execution sets
+        #     execution_sets.remove({node})
+        #     # Insert nested execution sets in place of nested Composition
+        #     execution_sets[index:index] = exec_sets
+        #
+        # return execution_sets, execution_context
+        # MODIFIED 11/20/25 NEW:
             # BREADCRUMB: NEED TO ACCOMODATE POSSIBILITY THAT SET AS ITEM OF execution_sets MAY HAVE MORE THAN ONE NODE
-            index = execution_sets.index({node})
-            # Remove nested Composition from execution sets
-            execution_sets.remove({node})
-            # Insert nested execution sets in place of nested Composition
-            execution_sets[index:index] = exec_sets
+            # Get index of item in execution_sets that is a nested composition (i.e., has nested_exec_sets)
+            #  Note: need for loop, as an item in execution_sets is a set that can contain more then one node
+        flattened_execution_sets = []
+        for exec_set in execution_sets:
+            nested_comps =  [node for node in exec_set if isinstance(node, PytorchCompositionWrapper)]
 
-        return execution_sets, execution_context
+            # If none of the nodes in the exec_set are a nested composition, add exec_set as is
+            if not nested_comps:
+                flattened_execution_sets.append(exec_set)
+                continue
+
+            # If any of the nodes in the exec_set are nested compositions, interleave their executions sets
+            first_exec_set = set()
+            for node in exec_set:
+                # Create execution set from any non-cmoposition nodes and first execution set of all nested comps
+                if node not in nested_comps:
+                    # If it is not a nested_comp, simply node to execution_set
+                    first_exec_set.add(node)
+                else:
+                    # Add nodes in first execution set of each nested comp
+                    first_exec_set.add(node.executions_sets[0])
+            flattened_execution_sets.append(first_exec_set)
+
+
+            nodes_left = True
+            i = 1
+            while (nodes_left):
+                new_exec_set = set()
+                nodes_left = False
+                for node in nested_comps:
+                    if i < len(node.execution_sets):
+                        new_exec_set.add(node.execution_sets[i])
+                        nodes_left = True
+                flattened_execution_sets.extend(new_exec_set)
+                i += 1
+        # MODIFIED 11/20/25 END
+        return flattened_execution_sets, execution_context
+
+
 
     def get_all_projection_wrappers(self, start_wrapper=None)->dict:
         """Return dict of {PytorchProjectionWrapper: PytorchCompositionWrapper} in start_comp and any nested in it."""

--- a/psyneulink/library/compositions/pytorchwrappers.py
+++ b/psyneulink/library/compositions/pytorchwrappers.py
@@ -758,43 +758,20 @@ class PytorchCompositionWrapper(torch.nn.Module):
         # 3) Remove empty execution sets
         execution_sets = [x for x in execution_sets if len(x) > 0]
 
-        # Flattening for forward() and AutodiffComposition.do_gradient_optimization
-
-        # Flatten nested execution sets:
-        # # MODIFIED 11/20/25 OLD:
-        # nested_execution_sets = {}
-        # for exec_set in execution_sets:
-        #     for node in exec_set:
-        #         if isinstance(node, PytorchCompositionWrapper):
-        #             nested_execution_sets[node] = node.execution_sets
-        # flattened_execution_sets = []
-        # for node, nested_exec_sets in nested_execution_sets.items():
-        #     index = execution_sets.index({node})
-        #     # Remove nested Composition from execution sets
-        #     execution_sets.remove({node})
-        #     # Insert nested execution sets in place of nested Composition
-        #     execution_sets[index:index] = exec_sets
-        #
-        # return execution_sets, execution_context
-        # MODIFIED 11/20/25 NEW:
-            # BREADCRUMB: NEED TO ACCOMODATE POSSIBILITY THAT SET AS ITEM OF execution_sets MAY HAVE MORE THAN ONE NODE
-            # Get index of item in execution_sets that is a nested composition (i.e., has nested_exec_sets)
-            #  Note: need for loop, as an item in execution_sets is a set that can contain more then one node
+        # Flatten nested execution sets (forward() and AutodiffComposition.do_gradient_optimization)
         flattened_execution_sets = []
         for exec_set in execution_sets:
             nested_comps =  [node for node in exec_set if isinstance(node, PytorchCompositionWrapper)]
-
             # If none of the nodes in the exec_set are a nested composition, add exec_set as is
             if not nested_comps:
                 flattened_execution_sets.append(exec_set)
                 continue
-
             # If any of the nodes in the exec_set are nested compositions, interleave their executions sets
             first_exec_set = set()
             for node in exec_set:
-                # Create execution set from any non-cmoposition nodes and first execution set of all nested comps
+                # Create execution set from any non-composition nodes and first execution set of all nested comps
                 if node not in nested_comps:
-                    # If it is not a nested_comp, simply node to execution_set
+                    # If it is not a nested composition, simply add node to execution_set
                     first_exec_set.add(node)
                 else:
                     # Add nodes in first execution set of each nested comp
@@ -804,18 +781,16 @@ class PytorchCompositionWrapper(torch.nn.Module):
             nodes_left = True
             i = 1
             while (nodes_left):
+                # Get ith execution set from each nested comp and combine into new execution set
                 new_exec_set = set()
                 nodes_left = False
                 for node in nested_comps:
                     if i < len(node.execution_sets):
                         new_exec_set |= node.execution_sets[i]
                         nodes_left = True
-                flattened_execution_sets.extend(new_exec_set)
+                flattened_execution_sets.append(new_exec_set)
                 i += 1
-        # MODIFIED 11/20/25 END
         return flattened_execution_sets, execution_context
-
-
 
     def get_all_projection_wrappers(self, start_wrapper=None)->dict:
         """Return dict of {PytorchProjectionWrapper: PytorchCompositionWrapper} in start_comp and any nested in it."""

--- a/psyneulink/library/compositions/pytorchwrappers.py
+++ b/psyneulink/library/compositions/pytorchwrappers.py
@@ -798,9 +798,8 @@ class PytorchCompositionWrapper(torch.nn.Module):
                     first_exec_set.add(node)
                 else:
                     # Add nodes in first execution set of each nested comp
-                    first_exec_set.add(node.executions_sets[0])
+                    first_exec_set |= node.execution_sets[0]
             flattened_execution_sets.append(first_exec_set)
-
 
             nodes_left = True
             i = 1
@@ -809,7 +808,7 @@ class PytorchCompositionWrapper(torch.nn.Module):
                 nodes_left = False
                 for node in nested_comps:
                     if i < len(node.execution_sets):
-                        new_exec_set.add(node.execution_sets[i])
+                        new_exec_set |= node.execution_sets[i]
                         nodes_left = True
                 flattened_execution_sets.extend(new_exec_set)
                 i += 1

--- a/psyneulink/library/compositions/pytorchwrappers.py
+++ b/psyneulink/library/compositions/pytorchwrappers.py
@@ -767,6 +767,7 @@ class PytorchCompositionWrapper(torch.nn.Module):
                 if isinstance(node, PytorchCompositionWrapper):
                     nested_execution_sets[node] = node.execution_sets
         for node, exec_sets in nested_execution_sets.items():
+            # BREADCRUMB: NEED TO ACCOMODATE POSSIBLE THAT SETS AS ITEMS OF execution_sets MAY HAVE MORE THAN ONE NODE
             index = execution_sets.index({node})
             # Remove nested Composition from execution sets
             execution_sets.remove({node})

--- a/psyneulink/library/compositions/pytorchwrappers.py
+++ b/psyneulink/library/compositions/pytorchwrappers.py
@@ -761,7 +761,7 @@ class PytorchCompositionWrapper(torch.nn.Module):
         # Flatten nested execution sets (forward() and AutodiffComposition.do_gradient_optimization)
         flattened_execution_sets = []
         for exec_set in execution_sets:
-            nested_comps =  [node for node in exec_set if isinstance(node, PytorchCompositionWrapper)]
+            nested_comps = [node for node in exec_set if isinstance(node, PytorchCompositionWrapper)]
             # If none of the nodes in the exec_set are a nested composition, add exec_set as is
             if not nested_comps:
                 flattened_execution_sets.append(exec_set)

--- a/psyneulink/library/compositions/pytorchwrappers.py
+++ b/psyneulink/library/compositions/pytorchwrappers.py
@@ -767,7 +767,7 @@ class PytorchCompositionWrapper(torch.nn.Module):
                 if isinstance(node, PytorchCompositionWrapper):
                     nested_execution_sets[node] = node.execution_sets
         for node, exec_sets in nested_execution_sets.items():
-            # BREADCRUMB: NEED TO ACCOMODATE POSSIBLE THAT SETS AS ITEMS OF execution_sets MAY HAVE MORE THAN ONE NODE
+            # BREADCRUMB: NEED TO ACCOMODATE POSSIBILITY THAT SET AS ITEM OF execution_sets MAY HAVE MORE THAN ONE NODE
             index = execution_sets.index({node})
             # Remove nested Composition from execution sets
             execution_sets.remove({node})


### PR DESCRIPTION
Fix bugs elected in KADMLP script (that combines MLP and EM for learning)

• composition.py:
  - get_composition_for_node(): truncate any branch of search that leads to a ModulatoryMechanism (as that will not lead to a CIM, and is likely in a cycle that will lead to a recurrent loop)

• pytorchwrappers.py
  _get_execution_sets(): fix bug in which there is more than one node in a nested execution_set, and for which executions sets in any nested compositions need to be interleaved