### PR TITLE
llvm: Use new pass manager when available

### DIFF
--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -674,8 +674,8 @@ def _gen_cuda_kernel_wrapper_module(function):
         shared = ir.GlobalVariable(module, ptr.type.pointee,
                                    name=function.name + "_shared_" + name,
                                    addrspace=3)
-        shared.alignment = 128
         shared.linkage = "internal"
+        shared.align = 128
         shared_ptr = b.addrspacecast(shared, shared.type.pointee.as_pointer())
 
         char_ptr_ty = ir.IntType(8).as_pointer()
@@ -724,7 +724,7 @@ def _gen_cuda_kernel_wrapper_module(function):
         builder, args[1] = _upload_to_shared(builder, args[1], one, "state")
         builder, args[4] = _upload_to_shared(builder, args[4], one, "data")
 
-        # TODO: Investigate benefit of uplaoding dynamic RO structures to
+        # TODO: Investigate benefit of uploading dynamic RO structures to
         #       shared memory (e.g. inputs)
 
     # Check global id and exit if we're over

--- a/psyneulink/core/llvm/jit_engine.py
+++ b/psyneulink/core/llvm/jit_engine.py
@@ -8,7 +8,10 @@
 
 # ********************************************* LLVM bindings **************************************************************
 
-from llvmlite import binding
+import llvmlite
+import llvmlite.binding as binding
+import packaging.version as version
+import sys
 import time
 import warnings
 
@@ -48,6 +51,12 @@ if ptx_enabled:
 # Compiler binding
 __initialized = False
 
+# llvmlite>=0.44 introduced new pass manager, but it was broken on windows[1].
+# The new pass manager is, however, required starting llvmlite-0.45.0.[2]
+# [1] https://github.com/numba/llvmlite/issues/1078
+# [2] https://github.com/numba/llvmlite/pull/1092
+__required_version_for_new_pass_manager = '0.45.0' if sys.platform == "win32" else '0.44.0'
+__cpu_use_new_pass_manager = version.parse(llvmlite.__version__) >= version.parse(__required_version_for_new_pass_manager)
 
 def _binding_initialize():
     global __initialized
@@ -64,40 +73,62 @@ def _binding_initialize():
         __initialized = True
 
 
+def _new_pass_builder(target_machine, opt_level):
+    pto = binding.create_pipeline_tuning_options(speed_level=opt_level)
+    pto.loop_vectorization = opt_level != 0
+    pto.slp_vectorization = opt_level != 0
+
+    pass_builder = binding.create_pass_builder(target_machine, pto)
+
+    return pass_builder
+
+def _old_pass_manager(target_machine, opt_level):
+    pass_manager_builder = binding.PassManagerBuilder()
+    pass_manager_builder.loop_vectorize = opt_level != 0
+    pass_manager_builder.slp_vectorize = opt_level != 0
+    pass_manager_builder.opt_level = opt_level
+
+    # Create module pass manager and populate it with analysis and opt passes
+    pass_manager = binding.ModulePassManager()
+    target_machine.add_analysis_passes(pass_manager)
+    pass_manager_builder.populate(pass_manager)
+
+    return pass_manager
+
 def _cpu_jit_constructor():
     _binding_initialize()
 
     opt_level = int(debug_env.get('opt', 2))
 
-    # PassManagerBuilder can be shared
-    __pass_manager_builder = binding.PassManagerBuilder()
-    __pass_manager_builder.loop_vectorize = opt_level != 0
-    __pass_manager_builder.slp_vectorize = opt_level != 0
-    __pass_manager_builder.opt_level = opt_level
-
-    __cpu_features = binding.get_host_cpu_features().flatten()
-    __cpu_name = binding.get_host_cpu_name()
-
-    # Create compilation target, use default triple
-    __cpu_target = binding.Target.from_default_triple()
+    # Create compilation target, use triple from current process
     # FIXME: reloc='static' is needed to avoid crashes on win64
     # see: https://github.com/numba/llvmlite/issues/457
-    __cpu_target_machine = __cpu_target.create_target_machine(cpu=__cpu_name, features=__cpu_features, opt=opt_level, reloc='static')
+    cpu_target = binding.Target.from_triple(binding.get_process_triple())
+    cpu_target_machine = cpu_target.create_target_machine(cpu=binding.get_host_cpu_name(),
+                                                          features=binding.get_host_cpu_features().flatten(),
+                                                          opt=opt_level,
+                                                          reloc='static')
 
-    __cpu_pass_manager = binding.ModulePassManager()
-    __cpu_target_machine.add_analysis_passes(__cpu_pass_manager)
-    __pass_manager_builder.populate(__cpu_pass_manager)
+    if __cpu_use_new_pass_manager:
+        pass_manager = None
+        pass_builder = _new_pass_builder(cpu_target_machine, opt_level)
+    else:
+        pass_manager = _old_pass_manager(cpu_target_machine, opt_level)
+        pass_builder = None
 
     # And an execution engine with a builtins backing module
     builtins_module = _generate_cpu_builtins_module(LLVMBuilderContext.get_current().float_ty)
+
+    backing_mod = binding.parse_assembly(str(builtins_module))
+    backing_mod.verify()
+
     if "dump-llvm-gen" in debug_env:
         with open(builtins_module.name + '.generated.ll', 'w') as dump_file:
-            dump_file.write(str(builtins_module))
+            dump_file.write(str(backing_mod))
 
-    __backing_mod = binding.parse_assembly(str(builtins_module))
+    cpu_jit_engine = binding.create_mcjit_compiler(backing_mod, cpu_target_machine)
 
-    __cpu_jit_engine = binding.create_mcjit_compiler(__backing_mod, __cpu_target_machine)
-    return __cpu_jit_engine, __cpu_pass_manager, __cpu_target_machine
+    return cpu_jit_engine, cpu_target_machine, pass_manager, pass_builder
 
 
 def _ptx_jit_constructor():
@@ -154,10 +185,12 @@ class jit_engine:
     def __init__(self):
         self._jit_engine = None
         self._jit_pass_manager = None
-        self._target_machine = None
+        self._jit_pass_builder = None
+        self._jit_target_machine = None
         self.__mod = None
+
         # Add an extra reference to make sure it's not destroyed before
-        # instances of jit_engine
+        # all instances of jit_engine
         self.__debug_env = debug_env
 
         self.staged_modules = set()
@@ -177,7 +210,7 @@ class jit_engine:
 
     def opt_and_add_bin_module(self, module):
         start = time.perf_counter()
-        self._pass_manager.run(module)
+        self._pass_manager.run(module, self._pass_builder)
         finish = time.perf_counter()
 
         if "time_stat" in debug_env:
@@ -196,8 +229,10 @@ class jit_engine:
         self._engine.add_module(module)
         self._engine.finalize_object()
         finish = time.perf_counter()
+
         if "time_stat" in debug_env:
             print("Time to finalize LLVM module bundle '{}': {}".format(module.name, finish - start))
+
         self.__optimized_modules += 1
 
     def _remove_bin_module(self, module):
@@ -232,21 +267,42 @@ class jit_engine:
         return self._jit_engine
 
     @property
+    def _target_machine(self):
+        if self._jit_target_machine is None:
+            self._init()
+
+        return self._jit_target_machine
+
+    @property
     def _pass_manager(self):
+        # use new pass manager
+        if self._pass_builder is not None:
+            return self._pass_builder.getModulePassManager()
+
+        # use old pass manager
         if self._jit_pass_manager is None:
             self._init()
 
         return self._jit_pass_manager
 
+    @property
+    def _pass_builder(self):
+        if self._jit_pass_builder is None and self._jit_pass_manager is None:
+            self._init()
+
+        return self._jit_pass_builder
+
     def stage_compilation(self, modules):
         self.staged_modules |= modules
 
     # Unfortunately, this needs to be done for every jit_engine.
-    # Liking step in opt_and_add_bin_module invalidates 'mod_bundle',
-    # so it can't be linked mutliple times (in multiple engines).
+    # Linking step in opt_and_add_bin_module invalidates 'mod_bundle',
+    # so it can't be linked multiple times (in multiple engines).
+    # These modules are still using 'unknown-unknown-unknown' triple
     def compile_staged(self):
         # Parse generated modules and link them
         mod_bundle = binding.parse_assembly("")
+
         while self.staged_modules:
             m = self.staged_modules.pop()
 
@@ -275,9 +331,10 @@ class cpu_jit_engine(jit_engine):
     def _init(self):
         assert self._jit_engine is None
         assert self._jit_pass_manager is None
-        assert self._target_machine is None
+        assert self._jit_pass_builder is None
+        assert self._jit_target_machine is None
 
-        self._jit_engine, self._jit_pass_manager, self._target_machine = _cpu_jit_constructor()
+        self._jit_engine, self._jit_target_machine, self._jit_pass_manager, self._jit_pass_builder = _cpu_jit_constructor()
         if self._object_cache is not None:
             self._jit_engine.set_object_cache(self._object_cache)
 
@@ -353,9 +410,9 @@ class ptx_jit_engine(jit_engine):
     def _init(self):
         assert self._jit_engine is None
         assert self._jit_pass_manager is None
-        assert self._target_machine is None
+        assert self._jit_target_machine is None
 
-        self._jit_pass_manager, self._target_machine = _ptx_jit_constructor()
+        self._jit_pass_manager, self._jit_target_machine = _ptx_jit_constructor()
         self._jit_engine = ptx_jit_engine.cuda_engine(self._target_machine)
 
     def get_kernel(self, name):


### PR DESCRIPTION
The new pass manager is available in llvmlite >=0.44, and required from llvmlite >=0.45.
Fix alignment of GPU shared buffers.