### PR TITLE
llvm: Allow llvmlite-0.45.x and LLVM 20

### DIFF
--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -773,12 +773,11 @@ def _gen_cuda_kernel_wrapper_module(function):
 
 @functools.lru_cache(maxsize=128)
 def _convert_llvm_ir_to_ctype(t: ir.Type):
-    type_t = type(t)
 
-    if type_t is ir.VoidType:
+    if isinstance(t, ir.VoidType):
         return None
 
-    elif type_t is ir.IntType:
+    elif isinstance(t, ir.IntType):
         if t.width == 1:
             return ctypes.c_bool
         elif t.width == 8:
@@ -790,15 +789,15 @@ def _convert_llvm_ir_to_ctype(t: ir.Type):
         elif t.width == 64:
             return ctypes.c_uint64
         else:
-            assert False, "Unknown integer type: {}".format(type_t)
+            assert False, "Unknown integer type: {}".format(t)
 
-    elif type_t is ir.DoubleType:
+    elif isinstance(t, ir.DoubleType):
         return ctypes.c_double
 
-    elif type_t is ir.FloatType:
+    elif isinstance(t, ir.FloatType):
         return ctypes.c_float
 
-    elif type_t is ir.HalfType:
+    elif isinstance(t, ir.HalfType):
         # There's no half type in ctypes. Use uint16 instead.
         # User will need to do the necessary casting.
         return ctypes.c_uint16
@@ -808,11 +807,11 @@ def _convert_llvm_ir_to_ctype(t: ir.Type):
         pointee = _convert_llvm_ir_to_ctype(t.pointee)
         ret_t = ctypes.POINTER(pointee)
 
-    elif type_t is ir.ArrayType:
+    elif isinstance(t, ir.ArrayType):
         element_type = _convert_llvm_ir_to_ctype(t.element)
         ret_t = element_type * len(t)
 
-    elif type_t is ir.LiteralStructType:
+    elif isinstance(t, ir.LiteralStructType):
         global _struct_count
         uniq_name = "struct_" + str(_struct_count)
         _struct_count += 1

--- a/psyneulink/core/llvm/builtins.py
+++ b/psyneulink/core/llvm/builtins.py
@@ -2188,6 +2188,7 @@ def _setup_rand_binomial(ctx, state_ty, gen_float, prefix):
 def get_philox_state_struct(ctx):
     int64_ty = ir.IntType(64)
     int16_ty = ir.IntType(16)
+
     return ir.LiteralStructType([
         ir.ArrayType(int64_ty, 4),  # counter
         ir.ArrayType(int64_ty, 2),  # key
@@ -2195,7 +2196,12 @@ def get_philox_state_struct(ctx):
         ctx.int32_ty,  #  the other half of random 64 bit int
         int16_ty,      #  buffer pos
         int16_ty,      #  has uint buffered
-        int64_ty])     #  seed
+        int64_ty],     #  seed
+
+        # Apply 'packed' if floating point numbers use only 32b/4B. This leads
+        # to most structures having only 4B alignment that might conflict with
+        # int64 types used above.
+        packed=(ctx.float_ty == ir.FloatType()))
 
 
 def setup_philox(ctx):

--- a/psyneulink/core/llvm/jit_engine.py
+++ b/psyneulink/core/llvm/jit_engine.py
@@ -62,7 +62,11 @@ __gpu_use_new_pass_manager = version.parse(llvmlite.__version__) >= version.pars
 def _binding_initialize():
     global __initialized
     if not __initialized:
-        binding.initialize()
+        # calling binding.initalize() is not needed in later versions
+        # of llvmlite, and throws exception in >=0.45.0
+        if version.parse(llvmlite.__version__) < version.parse('0.45.0'):
+            binding.initialize()
+
         if not ptx_enabled:
             # native == currently running CPU. ASM printer includes opcode emission
             binding.initialize_native_target()

--- a/psyneulink/core/llvm/jit_engine.py
+++ b/psyneulink/core/llvm/jit_engine.py
@@ -21,24 +21,35 @@ from .debug import debug_env
 
 try:
     import pycuda
+
     # Do not continue if the version is too old
     if pycuda.VERSION[0] < 2018:
         raise UserWarning("pycuda too old (need 2018+): " + str(pycuda.VERSION))
+
     import pycuda.driver
-    # pyCUDA needs to be built against 6+ to enable Linker
-    if pycuda.driver.get_version()[0] < 6:
-        raise UserWarning("CUDA driver too old (need 6+): " + str(pycuda.driver.get_version()))
+
+    # pyCUDA needs to be built against CUDA SDK 6+ to enable Linker
+    # PTX workaround in ptx jit compiler below requires at least ISA
+    # version 6.0 which was added in CUDA 9.0 [0] and the respective
+    # driver 384.81 [1] (for runtime JIT PTX compilation)
+    # [0] https://docs.nvidia.com/cuda/archive/9.0/parallel-thread-execution/index.html
+    # [1] https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#id8
+    if pycuda.driver.get_version()[0] < 9:
+        raise UserWarning("CUDA driver too old (need 9+): " + str(pycuda.driver.get_version()))
 
     from pycuda import autoinit as pycuda_default
     import pycuda.compiler
+
     assert pycuda_default.context is not None
     pycuda_default.context.set_cache_config(pycuda.driver.func_cache.PREFER_L1)
     ptx_enabled = True
     if "cuda-check" in debug_env:
         print("PsyNeuLink: CUDA backend enabled!")
+
 except Exception as e:
     if "cuda-check" in debug_env:
         warnings.warn("Failed to enable CUDA/PTX: {}".format(e))
+
     ptx_enabled = False
 
 
@@ -158,7 +169,16 @@ def _ptx_jit_constructor():
 
     # Create compilation target, use 64bit triple
     ptx_target = binding.Target.from_triple("nvptx64-nvidia-cuda")
-    ptx_target_machine = ptx_target.create_target_machine(cpu=ptx_sm, opt=opt_level)
+
+    # llvm 20 (and possibly other versions) generates unsupported instructions
+    # for the selected ptx isa version used for older targets (sm_50, sm_60)[0]
+    # Using higher version of ptx isa works around the issue.
+    # There isn't a good way to get supported ptx versions from llvmlite, so just
+    # hardcode ptx_60 (from 'llc -mattr=help -mtriple=nvptx64-nvidia-cuda').
+    # [0] https://github.com/llvm/llvm-project/issues/171709
+    use_ptx = "+ptx60" if binding.llvm_version_info[0] == 20 else ""
+
+    ptx_target_machine = ptx_target.create_target_machine(cpu=ptx_sm, opt=opt_level, features=use_ptx)
 
     # The threshold of '64' is empirically selected on GF 3050
     extra_opts = {'size_level' : 1, 'inlining_threshold': 64}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ graph-scheduler>=1.2.1, <1.3.0
 graphviz>=0.20.0, <0.22.0
 grpcio>=1.60.0, <1.77.0
 leabra-psyneulink>=0.3.2, <0.3.3
-llvmlite>=0.40, <0.45
+llvmlite>=0.40, <0.46
 matplotlib>=3.7.0, <3.10.8
 modeci_mdf>=0.4.3, <0.5; (platform_machine == 'AMD64' or platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
 networkx>=2.6, <3.7


### PR DESCRIPTION
Use 'packed' attribute on Philox state structure when using fp32. LLVM 20 assumes different
alignment/padding than cython and numpy.

Do not call `llvmlite.binding_initialize()` when using llvmlite>=0.45. The call has been deprecated
and causes an error in llvmlite-0.45.

Use explicit ptx isa version 6.0 when generating PTX to workaround bug
https://github.com/llvm/llvm-project/issues/171709
GPUs that are only supported in newer PTX ISAs will automatically use max(6.0, required_ptx_isa_version).
This requires at least CUDA 9+ (released 2018), and driver 384.81+.

Update llvmlite dependency to <0.46.