### PR TITLE
llvm/builtins: Restrict packed attribute on Philox structure to LLVM>=20

### DIFF
--- a/psyneulink/core/llvm/builtins.py
+++ b/psyneulink/core/llvm/builtins.py
@@ -2201,7 +2201,8 @@ def get_philox_state_struct(ctx):
         # Apply 'packed' if floating point numbers use only 32b/4B. This leads
         # to most structures having only 4B alignment that might conflict with
         # int64 types used above.
-        packed=(ctx.float_ty == ir.FloatType()))
+        # The behaviour only appeared with new llvmlite-0.45 and LLVM 20.
+        packed=(ctx.float_ty == ir.FloatType() and binding.llvm_version_info[0] >= 20))
 
 
 def setup_philox(ctx):


### PR DESCRIPTION
It was not needed with older llvmlite/llvm versions and it causes issues with older Numpy/ctypes leading to alignment issues like:

AssertionError: Size mismatch (_eval_state), numpy: 1140 vs. ctypes:1168