### PR TITLE
llvm: Do not change representation of modulated parameters in binary structure

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1634,28 +1634,6 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
     def llvm_param_ids(self):
         return self._get_param_ids()
 
-    def _is_param_modulated(self, p):
-        try:
-            if p in self.owner.parameter_ports:
-                return True
-        except AttributeError:
-            pass
-        try:
-            if p in self.parameter_ports:
-                return True
-        except AttributeError:
-            pass
-        try:
-            modulated_params = (
-                getattr(self.parameters, p.sender.modulation).source
-                for p in self.owner.mod_afferents)
-            if p in modulated_params:
-                return True
-        except AttributeError:
-            pass
-
-        return False
-
     def _get_param_initializer(self, context):
         def _convert(x):
             if isinstance(x, Enum):
@@ -1663,8 +1641,10 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
             elif isinstance(x, SampleIterator):
                 if isinstance(x.generator, list):
                     return tuple(v for v in x.generator)
+
                 else:
                     return (x.start, x.step, x.num)
+
             elif isinstance(x, Component):
                 return x._get_param_initializer(context)
 
@@ -1672,18 +1652,18 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                 # This can't use tupleize and needs to recurse to handle
                 # 'search_space' list of SampleIterators
                 return tuple(_convert(i) for i in x)
+
             except TypeError:
                 return x if x is not None else tuple()
 
         def _get_values(p):
             param = p.get(context)
-            # Modulated parameters change shape to array
-            if np.ndim(param) == 0 and self._is_param_modulated(p):
-                return (param,)
-            elif p.name == 'num_trials_per_estimate': # Should always be int
+            if p.name == 'num_trials_per_estimate': # Should always be int
                 return 0 if param is None else int(param)
+
             elif p.name == 'matrix': # Flatten matrix
                 return tuple(np.asarray(param, dtype=float).ravel())
+
             return _convert(param)
 
         return tuple(map(_get_values, self._get_compilation_params()))

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2955,6 +2955,7 @@ class Mechanism_Base(Mechanism):
         if len(self.mod_afferents) > 0:
             mod_input_type_list = (ctx.get_output_struct_type(proj) for proj in self.mod_afferents)
             input_type_list.append(pnlvm.ir.LiteralStructType(mod_input_type_list))
+
         # Prefer an array type if there is no modulation.
         # This is used to keep ctypes inputs as arrays instead of structs.
         elif all(t == input_type_list[0] for t in input_type_list):
@@ -2966,48 +2967,62 @@ class Mechanism_Base(Mechanism):
                         get_output_ptr, get_input_data_ptr,
                         mech_params, mech_state, mech_input):
         group_ports = getattr(self, group)
-        ports_param, ports_state = ctx.get_param_or_state_ptr(builder, self, group, param_struct_ptr=mech_params, state_struct_ptr=mech_state, history=None)
+        ports_param, ports_state = ctx.get_param_or_state_ptr(builder,
+                                                              self,
+                                                              group,
+                                                              param_struct_ptr=mech_params,
+                                                              state_struct_ptr=mech_state,
+                                                              history=None)
 
         mod_afferents = self.mod_afferents
         for i, port in enumerate(ports):
             p_function = ctx.import_llvm_function(port)
 
-            # Find input and output locations
-            builder, p_input_data = get_input_data_ptr(builder, i)
+            port_idx = group_ports.index(port)
+            p_params = builder.gep(ports_param, [ctx.int32_ty(0), ctx.int32_ty(port_idx)])
+            p_state = builder.gep(ports_state, [ctx.int32_ty(0), ctx.int32_ty(port_idx)])
+
+            builder, p_input_data_ptr = get_input_data_ptr(builder, i)
             builder, p_output = get_output_ptr(builder, i)
 
+
+            def _maybe_add_dimension(value, expected_type, kind, allowed_ports, allowed_ports2={}):
+                if value.type == expected_type:
+                    return value
+
+                assert port in allowed_ports or port in allowed_ports2, \
+                    "Port {} {} shape mismatch, got: {} vs. expected: {}".format(port, kind, value.type, expected_type)
+
+                warnings.warn("Shape mismatch: Port {} {} shape mismatch, got: {} vs. {}".format(port,
+                                                                                                 kind,
+                                                                                                 value.type,
+                                                                                                 expected_type),
+                              category=pnlvm.PNLCompilerWarning)
+
+                type_with_extra_dimension = pnlvm.ir.ArrayType(value.type.pointee, 1).as_pointer()
+                return builder.bitcast(value, type_with_extra_dimension)
+
+
+            p_output = _maybe_add_dimension(p_output, p_function.args[3].type, "output", self._parameter_ports)
+
+            # Setup input location
             if len(port.mod_afferents) == 0:
                 # There's no modulation so the only input is data
-                if p_input_data.type == p_function.args[2].type:
-                    p_input = p_input_data
-                else:
-                    assert port in self.output_ports, \
-                        "Port {} with input shape mismatch, got: {} vs. expected: {}".format(port, p_input_data.type, p_function.args[2].type)
-
-                    # Ports always take at least 2d input. However, parsing
-                    # the function result can result in a 1d structure or a scalar.
-                    # Casting the pointer is LLVM way of adding dimensions
-                    array_1d = pnlvm.ir.ArrayType(p_input_data.type.pointee, 1)
-                    assert array_1d == p_function.args[2].type.pointee, \
-                        "{} vs. {}".format(p_function.args[2].type.pointee, p_input_data.type.pointee)
-
-                    # restrict shape matching to casting 1d values to 2d arrays
-                    # for Control/Gating signals
-                    assert len(p_function.args[2].type.pointee) == 1
-                    assert str(port).startswith("(ControlSignal") or str(port).startswith("(GatingSignal")
-                    p_input = builder.bitcast(p_input_data, p_function.args[2].type)
+                p_input = _maybe_add_dimension(p_input_data_ptr,
+                                               p_function.args[2].type,
+                                               "input",
+                                               self._parameter_ports,
+                                               self.output_ports)
 
             else:
                 # Port input structure is: (data, [modulations]),
-                p_input = builder.alloca(p_function.args[2].type.pointee,
-                                         name=group + "_port_" + str(i) + "_input")
+                p_input = builder.alloca(p_function.args[2].type.pointee, name=group + "_port_" + str(i) + "_input")
 
                 # Fill in the data.
-                # FIXME: We can potentially hit the same dimensionality issue
-                #        as above, but it's more difficult to manifest and
-                #        not even new tests that modulate output ports hit it.
-                p_data = builder.gep(p_input, [ctx.int32_ty(0), ctx.int32_ty(0)])
-                builder.store(builder.load(p_input_data), p_data)
+                p_data_ptr = builder.gep(p_input, [ctx.int32_ty(0), ctx.int32_ty(0)])
+                p_input_data_ptr = _maybe_add_dimension(p_input_data_ptr, p_data_ptr.type, "input", self._parameter_ports)
+                data = builder.load(p_input_data_ptr)
+                builder.store(data, p_data_ptr)
 
                 # Copy mod_afferent/modulated inputs
                 for idx, p_mod in enumerate(port.mod_afferents):
@@ -3018,10 +3033,6 @@ class Mechanism_Base(Mechanism):
                     mod_out_ptr = builder.gep(p_input, [ctx.int32_ty(0), ctx.int32_ty(1 + idx)])
                     afferent_val = builder.load(mod_in_ptr)
                     builder.store(afferent_val, mod_out_ptr)
-
-            port_idx = group_ports.index(port)
-            p_params = builder.gep(ports_param, [ctx.int32_ty(0), ctx.int32_ty(port_idx)])
-            p_state = builder.gep(ports_state, [ctx.int32_ty(0), ctx.int32_ty(port_idx)])
 
             builder.call(p_function, [p_params, p_state, p_input, p_output])
 

--- a/psyneulink/core/components/ports/port.py
+++ b/psyneulink/core/components/ports/port.py
@@ -2382,17 +2382,23 @@ class Port_Base(Port):
 
             # Replace base param with the modulation value
             if name is not None:
-                f_mod_param_ptr = pnlvm.helpers.get_param_ptr(builder,
-                                                              self.function,
-                                                              f_params, name)
+                f_mod_param_ptr = pnlvm.helpers.get_param_ptr(builder, self.function, f_params, name)
+
                 if f_mod_param_ptr.type != f_mod_ptr.type:
                     warnings.warn("Shape mismatch: Modulation vs. modulated parameter: {} vs. {}".format(
                                   afferent.defaults.value,
                                   getattr(self.function.parameters, name).get(None)),
-                                  pnlvm.PNLCompilerWarning)
+                                  category=pnlvm.PNLCompilerWarning)
+
+                    # The below steps can convert all the way from 2D single element
+                    # arrays, often returned by ParameterPorts, all the way down to
+                    # scalars.
+                    f_mod_ptr = pnlvm.helpers.unwrap_2d_array(builder, f_mod_ptr)
                     param_val = pnlvm.helpers.load_extract_scalar_array_one(builder, f_mod_ptr)
+
                 else:
                     param_val = builder.load(f_mod_ptr)
+
                 builder.store(param_val, f_mod_param_ptr)
 
         # OutputPort returns 1D array even for scalar functions

--- a/psyneulink/core/llvm/builder_context.py
+++ b/psyneulink/core/llvm/builder_context.py
@@ -502,11 +502,6 @@ class LLVMBuilderContext:
             elif p.name in {'seed', 'function-seed'}:
                 val = float(val)
 
-            # Modulation turns scalars into arrays
-            # TODO: should this be 2d arrays?
-            if np.ndim(val) == 0 and component._is_param_modulated(p):
-                val = [val]
-
             return self.convert_python_struct_to_llvm_ir(val)
 
         elements = map(_param_struct, component._get_compilation_params())

--- a/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/ddm.py
@@ -1257,7 +1257,8 @@ class DDM(ProcessingMechanism):
                                                             state_struct_ptr=m_state)
 
         # Find the single numeric entry in previous_value.
-        # This exists only if the 'function' is 'integrator'
+        # This exists only if the 'function' is 'integrator' (and therefore has
+        # "previous_value" parameter.
         prev_val_ptr = ctx.get_param_or_state_ptr(builder, self.function, "previous_value", state_struct_ptr=f_state)
         if prev_val_ptr is None:
             return ctx.bool_ty(1)
@@ -1271,8 +1272,13 @@ class DDM(ProcessingMechanism):
         prev_val = builder.call(llvm_fabs, [prev_val])
 
         # Get functions params and apply modulation
-        f_params, builder = self._gen_llvm_param_ports_for_obj(
-                self.function, f_base_params, ctx, builder, m_base_params, m_state, m_in)
+        f_params, builder = self._gen_llvm_param_ports_for_obj(self.function,
+                                                               f_base_params,
+                                                               ctx,
+                                                               builder,
+                                                               m_base_params,
+                                                               m_state,
+                                                               m_in)
 
         # Get threshold value
         threshold_ptr = ctx.get_param_or_state_ptr(builder,
@@ -1280,8 +1286,7 @@ class DDM(ProcessingMechanism):
                                                    THRESHOLD,
                                                    param_struct_ptr=f_params)
 
-        threshold_ptr = builder.gep(threshold_ptr, [ctx.int32_ty(0), ctx.int32_ty(0)])
-        threshold = builder.load(threshold_ptr)
+        threshold = pnlvm.helpers.load_extract_scalar_array_one(builder, threshold_ptr)
         is_prev_greater_or_equal = builder.fcmp_ordered('>=', prev_val, threshold)
 
         return is_prev_greater_or_equal


### PR DESCRIPTION
Move the workaround to the code applying modulation.
* input to parameter ports
* outputs from parameter ports
* applying modulation to Port parameters.