### PR TITLE
llvm: Add support for function/integrator_function parameters in OutputPort variable spec

### DIFF
--- a/psyneulink/core/components/functions/stateful/integratorfunctions.py
+++ b/psyneulink/core/components/functions/stateful/integratorfunctions.py
@@ -26,15 +26,10 @@ Functions that integrate current value of input with previous value.
 
 """
 
+import contextlib
+import numpy as np
 import warnings
 
-import numpy as np
-from math import e
-
-try:
-    import torch
-except ImportError:
-    torch = None
 from beartype import beartype
 
 from psyneulink._typing import Callable, Mapping, Optional, Union
@@ -375,19 +370,30 @@ class IntegratorFunction(StatefulFunction):  # ---------------------------------
     def _gen_llvm_function_body(self, ctx, builder, params, state, arg_in, arg_out, *, tags: frozenset):
         # Get rid of 2d array.
         # When part of a Mechanism, the input and output are 2d arrays.
-        arg_in = pnlvm.helpers.unwrap_2d_array(builder, arg_in)
+        if arg_in.type.pointee.count == 1:
+            arg_in = pnlvm.helpers.unwrap_2d_array(builder, arg_in)
 
         # output may be 2d with multiple items (e.g. DriftDiffusionIntegrator,
         # FitzHughNagumoIntegrator)
         if arg_out.type.pointee.count == 1:
             arg_out = pnlvm.helpers.unwrap_2d_array(builder, arg_out)
 
-        with pnlvm.helpers.array_ptr_loop(builder, arg_in, "integrate") as args:
-            self._gen_llvm_integrate(*args, ctx, arg_in, arg_out, params, state)
+        with contextlib.ExitStack() as stack:
+            element = arg_in
+            indices = [ctx.int32_ty(0)]
+            b = builder
+
+            while not pnlvm.helpers.is_scalar(element):
+                b, idx = stack.enter_context(pnlvm.helpers.array_ptr_loop(b, element, "integrator_loop"))
+                indices.append(idx)
+                element = b.gep(element, [ctx.int32_ty(0), idx])
+
+            self._gen_llvm_integrate(b, indices, ctx, arg_in, arg_out, params, state)
+
 
         return builder
 
-    def _gen_llvm_load_param(self, ctx, builder, params, index, param, *, state=None):
+    def _gen_llvm_load_param(self, ctx, builder, params, indices, param, *, state=None):
         param_p = ctx.get_param_or_state_ptr(builder, self, param, param_struct_ptr=params, state_struct_ptr=state)
         if param == NOISE and isinstance(param_p, tuple):
             # This is a noise function so call it to get value
@@ -398,7 +404,7 @@ class IntegratorFunction(StatefulFunction):  # ---------------------------------
             value_p = noise_out
 
         elif isinstance(param_p.type.pointee, pnlvm.ir.ArrayType) and param_p.type.pointee.count > 1:
-            value_p = builder.gep(param_p, [ctx.int32_ty(0), index])
+            value_p = builder.gep(param_p, indices)
         else:
             value_p = param_p
         return pnlvm.helpers.load_extract_scalar_array_one(builder, value_p)
@@ -668,27 +674,29 @@ class AccumulatorIntegrator(IntegratorFunction):  # ----------------------------
 
         return self.convert_output_type(value)
 
-    def _gen_llvm_integrate(self, builder, index, ctx, vi, vo, params, state):
-        rate = self._gen_llvm_load_param(ctx, builder, params, index, RATE)
-        increment = self._gen_llvm_load_param(ctx, builder, params, index, INCREMENT)
-        noise = self._gen_llvm_load_param(ctx, builder, params, index, NOISE, state=state)
+    def _gen_llvm_integrate(self, builder, indices, ctx, vi, vo, params, state):
+        rate = self._gen_llvm_load_param(ctx, builder, params, indices, RATE)
+        increment = self._gen_llvm_load_param(ctx, builder, params, indices, INCREMENT)
+        noise = self._gen_llvm_load_param(ctx, builder, params, indices, NOISE, state=state)
 
         # Get the only state member; previous value
         prev_ptr = ctx.get_param_or_state_ptr(builder, self, PREVIOUS_VALUE, state_struct_ptr=state)
 
         # Get rid of 2d array. When part of a Mechanism the input,
         # (and output, and context) are 2d arrays.
-        prev_ptr = pnlvm.helpers.unwrap_2d_array(builder, prev_ptr)
+        if prev_ptr.type.pointee.count == 1:
+            prev_ptr = pnlvm.helpers.unwrap_2d_array(builder, prev_ptr)
+
         assert len(prev_ptr.type.pointee) == len(vi.type.pointee)
 
-        prev_ptr = builder.gep(prev_ptr, [ctx.int32_ty(0), index])
+        prev_ptr = builder.gep(prev_ptr, indices)
         prev_val = builder.load(prev_ptr)
 
         res = builder.fmul(prev_val, rate)
         res = builder.fadd(res, noise)
         res = builder.fadd(res, increment)
 
-        vo_ptr = builder.gep(vo, [ctx.int32_ty(0), index])
+        vo_ptr = builder.gep(vo, indices)
         builder.store(res, vo_ptr)
         builder.store(res, prev_ptr)
 
@@ -895,23 +903,25 @@ class SimpleIntegrator(IntegratorFunction):  # ---------------------------------
 
         return self.convert_output_type(adjusted_value)
 
-    def _gen_llvm_integrate(self, builder, index, ctx, vi, vo, params, state):
-        rate = self._gen_llvm_load_param(ctx, builder, params, index, RATE)
-        offset = self._gen_llvm_load_param(ctx, builder, params, index, OFFSET)
-        noise = self._gen_llvm_load_param(ctx, builder, params, index, NOISE, state=state)
+    def _gen_llvm_integrate(self, builder, indices, ctx, vi, vo, params, state):
+        rate = self._gen_llvm_load_param(ctx, builder, params, indices, RATE)
+        offset = self._gen_llvm_load_param(ctx, builder, params, indices, OFFSET)
+        noise = self._gen_llvm_load_param(ctx, builder, params, indices, NOISE, state=state)
 
         # Get the only state member; previous value
         prev_ptr = ctx.get_param_or_state_ptr(builder, self, PREVIOUS_VALUE, state_struct_ptr=state)
 
         # Get rid of 2d array. When part of a Mechanism the input,
         # (and output, and context) are 2d arrays.
-        prev_ptr = pnlvm.helpers.unwrap_2d_array(builder, prev_ptr)
+        if prev_ptr.type.pointee.count == 1:
+            prev_ptr = pnlvm.helpers.unwrap_2d_array(builder, prev_ptr)
+
         assert len(prev_ptr.type.pointee) == len(vi.type.pointee)
 
-        prev_ptr = builder.gep(prev_ptr, [ctx.int32_ty(0), index])
+        prev_ptr = builder.gep(prev_ptr, indices)
         prev_val = builder.load(prev_ptr)
 
-        vi_ptr = builder.gep(vi, [ctx.int32_ty(0), index])
+        vi_ptr = builder.gep(vi, indices)
         vi_val = builder.load(vi_ptr)
 
         new_val = builder.fmul(vi_val, rate)
@@ -920,7 +930,7 @@ class SimpleIntegrator(IntegratorFunction):  # ---------------------------------
         ret = builder.fadd(ret, noise)
         res = builder.fadd(ret, offset)
 
-        vo_ptr = builder.gep(vo, [ctx.int32_ty(0), index])
+        vo_ptr = builder.gep(vo, indices)
         builder.store(res, vo_ptr)
         builder.store(res, prev_ptr)
 
@@ -1160,23 +1170,25 @@ class AdaptiveIntegrator(IntegratorFunction):  # -------------------------------
         if not all_within_range(rate, 0, 1):
             raise FunctionError(rate_value_msg.format(rate, self.name))
 
-    def _gen_llvm_integrate(self, builder, index, ctx, vi, vo, params, state):
-        rate = self._gen_llvm_load_param(ctx, builder, params, index, RATE)
-        offset = self._gen_llvm_load_param(ctx, builder, params, index, OFFSET)
-        noise = self._gen_llvm_load_param(ctx, builder, params, index, NOISE, state=state)
+    def _gen_llvm_integrate(self, builder, indices, ctx, vi, vo, params, state):
+        rate = self._gen_llvm_load_param(ctx, builder, params, indices, RATE)
+        offset = self._gen_llvm_load_param(ctx, builder, params, indices, OFFSET)
+        noise = self._gen_llvm_load_param(ctx, builder, params, indices, NOISE, state=state)
 
         # Get the only state member; previous value
         prev_ptr = ctx.get_param_or_state_ptr(builder, self, PREVIOUS_VALUE, state_struct_ptr=state)
 
         # Get rid of 2d array. When part of a Mechanism the input,
         # (and output, and context) are 2d arrays.
-        prev_ptr = pnlvm.helpers.unwrap_2d_array(builder, prev_ptr)
+        if prev_ptr.type.pointee.count == 1:
+            prev_ptr = pnlvm.helpers.unwrap_2d_array(builder, prev_ptr)
+
         assert len(prev_ptr.type.pointee) == len(vi.type.pointee)
 
-        prev_ptr = builder.gep(prev_ptr, [ctx.int32_ty(0), index])
+        prev_ptr = builder.gep(prev_ptr, indices)
         prev_val = builder.load(prev_ptr)
 
-        vi_ptr = builder.gep(vi, [ctx.int32_ty(0), index])
+        vi_ptr = builder.gep(vi, indices)
         vi_val = builder.load(vi_ptr)
 
         rev_rate = builder.fsub(rate.type(1), rate)
@@ -1187,7 +1199,7 @@ class AdaptiveIntegrator(IntegratorFunction):  # -------------------------------
         ret = builder.fadd(ret, noise)
         res = builder.fadd(ret, offset)
 
-        vo_ptr = builder.gep(vo, [ctx.int32_ty(0), index])
+        vo_ptr = builder.gep(vo, indices)
         builder.store(res, vo_ptr)
         builder.store(res, prev_ptr)
 
@@ -2550,13 +2562,13 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
         self.parameters.previous_value._set(previous_value, context)
         return convert_all_elements_to_np_array([previous_value, previous_time])
 
-    def _gen_llvm_integrate(self, builder, index, ctx, vi, vo, params, state):
+    def _gen_llvm_integrate(self, builder, indices, ctx, vi, vo, params, state):
         # Get parameter pointers
-        rate = self._gen_llvm_load_param(ctx, builder, params, index, RATE)
-        noise = self._gen_llvm_load_param(ctx, builder, params, index, NOISE, state=state)
-        offset = self._gen_llvm_load_param(ctx, builder, params, index, OFFSET)
-        threshold = self._gen_llvm_load_param(ctx, builder, params, index, THRESHOLD)
-        time_step_size = self._gen_llvm_load_param(ctx, builder, params, index, TIME_STEP_SIZE)
+        rate = self._gen_llvm_load_param(ctx, builder, params, indices, RATE)
+        noise = self._gen_llvm_load_param(ctx, builder, params, indices, NOISE, state=state)
+        offset = self._gen_llvm_load_param(ctx, builder, params, indices, OFFSET)
+        threshold = self._gen_llvm_load_param(ctx, builder, params, indices, THRESHOLD)
+        time_step_size = self._gen_llvm_load_param(ctx, builder, params, indices, TIME_STEP_SIZE)
 
         random_state = ctx.get_random_state_ptr(builder, self, state, params)
         rand_val_ptr = builder.alloca(ctx.float_ty, name="random_out")
@@ -2570,10 +2582,10 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
 
         # value = previous_value + rate * variable * time_step_size \
         #       + np.sqrt(time_step_size * noise) * random_state.normal()
-        prev_val_ptr = builder.gep(prev_ptr, [ctx.int32_ty(0), index])
+        prev_val_ptr = builder.gep(prev_ptr, indices)
         prev_val = builder.load(prev_val_ptr)
 
-        val = builder.load(builder.gep(vi, [ctx.int32_ty(0), index]))
+        val = builder.load(builder.gep(vi, indices))
         val = builder.fmul(val, rate)
         val = builder.fmul(val, time_step_size)
         val = builder.fadd(val, prev_val)
@@ -2590,17 +2602,17 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
         val = pnlvm.helpers.fclamp(builder, val, neg_threshold, threshold)
 
         # Store value result
-        data_vo_ptr = builder.gep(vo, [ctx.int32_ty(0), ctx.int32_ty(0), index])
+        data_vo_ptr = builder.gep(vo, [ctx.int32_ty(0), *indices])
         builder.store(val, data_vo_ptr)
         builder.store(val, prev_val_ptr)
 
         # Update timestep
-        prev_time_ptr = builder.gep(prev_time_ptr, [ctx.int32_ty(0), index])
+        prev_time_ptr = builder.gep(prev_time_ptr, indices)
         prev_time = builder.load(prev_time_ptr)
         curr_time = builder.fadd(prev_time, time_step_size)
         builder.store(curr_time, prev_time_ptr)
 
-        time_vo_ptr = builder.gep(vo, [ctx.int32_ty(0), ctx.int32_ty(1), index])
+        time_vo_ptr = builder.gep(vo, [ctx.int32_ty(0), ctx.int32_ty(1), *indices[1:]])
         builder.store(curr_time, time_vo_ptr)
 
     def _gen_llvm_function_reset(self, ctx, builder, params, state, arg_in, arg_out, *, tags: frozenset):
@@ -3906,25 +3918,26 @@ class LeakyCompetingIntegrator(IntegratorFunction):  # -------------------------
 
         return self.convert_output_type(adjusted_value)
 
-    def _gen_llvm_integrate(self, builder, index, ctx, vi, vo, params, state):
-        rate = self._gen_llvm_load_param(ctx, builder, params, index, RATE)
-        noise = self._gen_llvm_load_param(ctx, builder, params, index, NOISE,
-                                          state=state)
-        offset = self._gen_llvm_load_param(ctx, builder, params, index, OFFSET)
-        time_step = self._gen_llvm_load_param(ctx, builder, params, index, TIME_STEP_SIZE)
+    def _gen_llvm_integrate(self, builder, indices, ctx, vi, vo, params, state):
+        rate = self._gen_llvm_load_param(ctx, builder, params, indices, RATE)
+        offset = self._gen_llvm_load_param(ctx, builder, params, indices, OFFSET)
+        time_step = self._gen_llvm_load_param(ctx, builder, params, indices, TIME_STEP_SIZE)
+        noise = self._gen_llvm_load_param(ctx, builder, params, indices, NOISE, state=state)
 
         # Get the only state member; previous value
         prev_ptr = ctx.get_param_or_state_ptr(builder, self, PREVIOUS_VALUE, state_struct_ptr=state)
 
         # Get rid of 2d array. When part of a Mechanism the input,
         # (and output, and context) are 2d arrays.
-        prev_ptr = pnlvm.helpers.unwrap_2d_array(builder, prev_ptr)
+        if prev_ptr.type.pointee.count == 1:
+            prev_ptr = pnlvm.helpers.unwrap_2d_array(builder, prev_ptr)
+
         assert len(prev_ptr.type.pointee) == len(vi.type.pointee)
 
-        prev_ptr = builder.gep(prev_ptr, [ctx.int32_ty(0), index])
+        prev_ptr = builder.gep(prev_ptr, indices)
         prev_val = builder.load(prev_ptr)
 
-        in_ptr = builder.gep(vi, [ctx.int32_ty(0), index])
+        in_ptr = builder.gep(vi, indices)
         in_val = builder.load(in_ptr)
 
         ret = builder.fmul(prev_val, rate)
@@ -3940,7 +3953,7 @@ class LeakyCompetingIntegrator(IntegratorFunction):  # -------------------------
         ret = builder.fadd(ret, mod_noise)
         ret = builder.fadd(ret, offset)
 
-        out_ptr = builder.gep(vo, [ctx.int32_ty(0), index])
+        out_ptr = builder.gep(vo, indices)
         builder.store(ret, out_ptr)
         builder.store(ret, prev_ptr)
 

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3151,6 +3151,22 @@ class Mechanism_Base(Mechanism):
                                                   param_struct_ptr=func_params,
                                                   state_struct_ptr=func_state)
 
+            elif "integrator_function" in self.llvm_param_ids and (param_name in self.integrator_function.llvm_state_ids or
+                                                                   param_name in self.integrator_function.llvm_param_ids):
+                assert "integrator_function" in self.llvm_param_ids
+
+                integrator_func_params, integrator_func_state = ctx.get_param_or_state_ptr(builder,
+                                                                                           self,
+                                                                                           "integrator_function",
+                                                                                           param_struct_ptr=mech_params,
+                                                                                           state_struct_ptr=mech_state)
+                base = ctx.get_param_or_state_ptr(builder,
+                                                  self.integrator_function,
+                                                  param_name,
+                                                  param_struct_ptr=integrator_func_params,
+                                                  state_struct_ptr=integrator_func_state)
+
+
             else:
                 assert False, "Unsupported variable spec Parameter: {}".format(param_name)
 

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3135,8 +3135,22 @@ class Mechanism_Base(Mechanism):
 
             if param_name == VALUE:
                 base = value
+
             elif param_name in self.llvm_state_ids:
                 base = ctx.get_param_or_state_ptr(builder, self, param_name, state_struct_ptr=mech_state)
+
+            elif param_name in self.function.llvm_state_ids or param_name in self.function.llvm_param_ids:
+                func_params, func_state = ctx.get_param_or_state_ptr(builder,
+                                                                     self,
+                                                                     "function",
+                                                                     param_struct_ptr=mech_params,
+                                                                     state_struct_ptr=mech_state)
+                base = ctx.get_param_or_state_ptr(builder,
+                                                  self.function,
+                                                  param_name,
+                                                  param_struct_ptr=func_params,
+                                                  state_struct_ptr=func_state)
+
             else:
                 assert False, "Unsupported variable spec Parameter: {}".format(param_name)
 

--- a/psyneulink/core/components/ports/outputport.py
+++ b/psyneulink/core/components/ports/outputport.py
@@ -739,7 +739,9 @@ def _parse_output_port_variable(variable_spec, owner, context=None, output_port_
                 }
             }
 
-        parameter = getattr(owner.parameters, attribute_name, None) or getattr(owner.function.parameters, attribute_name, None)
+        parameter = getattr(owner.parameters, attribute_name, None) or \
+                    getattr(owner.function.parameters, attribute_name, None) or \
+                    getattr(owner.integrator_function.parameters, attribute_name, None)
         if parameter is None:
             raise OutputPortError(f"Unknown Parameter ({attribute_name}) in variable spec ({variable_spec}) for "
                                   f"{output_port_name or OutputPort.__name__} of {owner.name}.")

--- a/tests/functions/test_user_defined_func.py
+++ b/tests/functions/test_user_defined_func.py
@@ -573,10 +573,11 @@ def test_udf_in_mechanism(mech_mode, benchmark):
     pytest.param([-1, 2, 3, 4], 4, [[7]], [{pnl.VARIABLE: [pnl.OWNER_VALUE, (pnl.OWNER_VALUE, 0, 0)], pnl.FUNCTION: lambda x: sum(x[0][0]) + x[1]}], id="aggregate_variable"),
     pytest.param([-1, 2, 3, 4], 4, [[9]], [{pnl.VARIABLE: [pnl.OWNER_VALUE, "is_finished_flag"], pnl.FUNCTION: lambda x: sum(x[0][0]) + x[1]}], id="is_finished"),
     pytest.param([-1, 2, 4, 3], 4, [[2]], [{pnl.VARIABLE: [pnl.OWNER_VALUE, "is_finished_flag"], pnl.FUNCTION: lambda x: np.argmax(x[0]) if x[1] else np.nan}], id="decision_index"),
+    pytest.param([-1, 2, 4, 3], 4, [[-1, 2, 4, 3]], [{pnl.VARIABLE: [pnl.PREVIOUS_VALUE, pnl.RATE], pnl.FUNCTION: lambda x: x[0][0] * x[1]}], id="function parameters"),
 ])
 def test_udf_in_output_port(variable, shapes, expected, ports, mech_mode, benchmark):
 
-    myMech = ProcessingMechanism(input_shapes=shapes, output_ports=ports)
+    myMech = pnl.ProcessingMechanism(function=pnl.SimpleIntegrator, input_shapes=shapes, output_ports=ports)
 
     e = pytest.helpers.get_mech_execution(myMech, mech_mode)
 

--- a/tests/ports/test_output_ports.py
+++ b/tests/ports/test_output_ports.py
@@ -13,10 +13,12 @@ class TestOutputPorts:
                               ((pnl.OWNER_VALUE), [[[1], [2], [3]]], [[[1], [2], [3]]]),
                               ([(pnl.OWNER_VALUE, 0), (pnl.OWNER_VALUE, 1)], [[[1], [2]]], [[[1], [2]]]),
                               ((pnl.OWNER_EXECUTION_COUNT), [[0]], [[4]]),
+                              ([(pnl.PREVIOUS_VALUE, 1, 0), pnl.RATE], [[0, 1]], [[2, 1]]), # From AdaptiveIntegrator
                               ], ids=lambda x: str(x) if len(x) != 1 else '')
     def test_output_port_variable_spec(self, spec, expected1, expected2, mech_mode):
         mech = pnl.ProcessingMechanism(default_variable=[[1.], [2.], [3.]],
                                        name='MyMech',
+                                       function=pnl.AdaptiveIntegrator,
                                        output_ports=[pnl.OutputPort(variable=spec)])
 
         np.testing.assert_allclose(mech.output_values, expected1)
@@ -43,30 +45,28 @@ class TestOutputPorts:
                               (("num_executions", pnl.TimeScale.TRIAL), [2], [2]),
                               (("num_executions", pnl.TimeScale.PASS), [1], [1]),
                               (("num_executions", pnl.TimeScale.TIME_STEP), [1], [1]),
+                              ([pnl.SLOPE, pnl.SCALE], [1, 1], [1, 1]), # From Linear function
                              ], ids=lambda x: str(x) if len(x) != 1 else '')
     @pytest.mark.usefixtures("comp_mode_no_per_node")
-    def tests_output_port_variable_spec_composition(self, comp_mode, spec, expected1, expected2):
+    def test_output_port_variable_spec_composition(self, comp_mode, spec, expected1, expected2):
+        # TimeScale.RUN is not supported in LLVMExec/PTXExec mode since the necessary
+        # counter maintenance is skipped
         if (len(spec) == 2) and (spec[1] == pnl.TimeScale.RUN) and (comp_mode & pnl.ExecutionMode._Exec):
             pytest.skip("{} is not supported in {}".format(spec[1], comp_mode))
 
-        # Test specification of OutputPort's variable
-        # OutputPort mech.output_ports['all'] has a different dimensionality than the other OutputPorts;
-        #    as a consequence, when added as a terminal node, the Composition can't construct an IDENTITY_MATRIX
-        #    from the mech's OutputPorts to the Composition's output_CIM.
-        # FIX: Remove the following line and correct assertions below once above condition is resolved
         var = [[1], [2], [3]]
-        mech = pnl.ProcessingMechanism(default_variable=var, name='MyMech',
-                                       output_ports=[pnl.OutputPort(variable=spec)])
+        mech = pnl.ProcessingMechanism(default_variable=var, name='MyMech',output_ports=[pnl.OutputPort(variable=spec)])
+
         C = pnl.Composition(name='MyComp')
         C.add_node(node=mech)
         C.termination_processing[pnl.TimeScale.TRIAL] = pnl.AtPass(2)
-        outs = C.run(inputs={mech: var}, num_trials=2, execution_mode=comp_mode)
 
         # outs is entire mechanism value, expected is output port value
-        np.testing.assert_allclose(outs[0], expected1)
+        outs = C.run(inputs={mech: var}, num_trials=2, execution_mode=comp_mode)
+        np.testing.assert_allclose(outs, [expected1])
 
         outs = C.run(inputs={mech: var}, num_trials=2, execution_mode=comp_mode)
-        np.testing.assert_allclose(outs[0], expected2)
+        np.testing.assert_allclose(outs, [expected2])
 
     def test_no_path_afferents(self):
         A = pnl.OutputPort()

--- a/tests/ports/test_output_ports.py
+++ b/tests/ports/test_output_ports.py
@@ -6,21 +6,20 @@ import pytest
 class TestOutputPorts:
 
     @pytest.mark.mechanism
-    def test_output_port_variable_spec(self, mech_mode):
-        # Test specification of OutputPort's variable
+    @pytest.mark.parametrize("spec,expected1,expected2",
+                             [((pnl.OWNER_VALUE, 2), [[3]], [[3]]),
+                              ((pnl.OWNER_VALUE, 1), [[2]], [[2]]),
+                              ((pnl.OWNER_VALUE, 0), [[1]], [[1]]),
+                              ((pnl.OWNER_VALUE), [[[1], [2], [3]]], [[[1], [2], [3]]]),
+                              ([(pnl.OWNER_VALUE, 0), (pnl.OWNER_VALUE, 1)], [[[1], [2]]], [[[1], [2]]]),
+                              ((pnl.OWNER_EXECUTION_COUNT), [[0]], [[4]]),
+                              ], ids=lambda x: str(x) if len(x) != 1 else '')
+    def test_output_port_variable_spec(self, spec, expected1, expected2, mech_mode):
         mech = pnl.ProcessingMechanism(default_variable=[[1.], [2.], [3.]],
                                        name='MyMech',
-                                       output_ports=[
-                                           pnl.OutputPort(name='z', variable=(pnl.OWNER_VALUE, 2)),
-                                           pnl.OutputPort(name='y', variable=(pnl.OWNER_VALUE, 1)),
-                                           pnl.OutputPort(name='x', variable=(pnl.OWNER_VALUE, 0)),
-                                           pnl.OutputPort(name='all', variable=(pnl.OWNER_VALUE)),
-                                           pnl.OutputPort(name='xy', variable=[(pnl.OWNER_VALUE, 0), (pnl.OWNER_VALUE, 1)]),
-                                           pnl.OutputPort(name='execution count', variable=(pnl.OWNER_EXECUTION_COUNT))
-                                       ])
-        expected = [[3.], [2.], [1.], [[1.], [2.], [3.]], [[1.], [2.]], [0]]
-        for i, e in zip(mech.output_values, expected):
-            assert np.array_equal(i, e)
+                                       output_ports=[pnl.OutputPort(variable=spec)])
+
+        np.testing.assert_allclose(mech.output_values, expected1)
 
         EX = pytest.helpers.get_mech_execution(mech, mech_mode)
 
@@ -28,9 +27,8 @@ class TestOutputPorts:
         EX([[1.], [2.], [3.]])
         EX([[1.], [2.], [3.]])
         res = EX([[1.], [2.], [3.]])
-        expected = [[3.], [2.], [1.],[[1.], [2.], [3.]], [[1.], [2.]], [4]]
-        for i, e in zip(res, expected):
-            assert np.array_equal(i, e)
+
+        np.testing.assert_allclose(res, expected2)
 
     @pytest.mark.composition
     @pytest.mark.mechanism

--- a/tests/ports/test_output_ports.py
+++ b/tests/ports/test_output_ports.py
@@ -32,6 +32,30 @@ class TestOutputPorts:
 
         np.testing.assert_allclose(res, expected2)
 
+    @pytest.mark.mechanism
+    @pytest.mark.parametrize("spec,expected1,expected2",
+                             [([(pnl.PREVIOUS_VALUE, 1, 0), pnl.RATE], [[0, 0.5]], [[1.875, 0.5]]), # From AdaptiveIntegrator
+                              ([pnl.SLOPE, pnl.SCALE], [[1, 1]], [[1, 1]]), # From Linear function
+                              ([pnl.SLOPE, pnl.RATE, (pnl.PREVIOUS_VALUE, 1, 0)], [[1, 0.5, 0]], [[1, 0.5, 1.875]]), # Both
+                              ], ids=['integrator', 'linear', 'linear+integrator'])
+    def test_output_port_variable_spec_transfer_mech(self, spec, expected1, expected2, mech_mode):
+        mech = pnl.TransferMechanism(default_variable=[[1.], [2.], [3.]],
+                                     function=pnl.Linear,
+                                     integrator_function=pnl.AdaptiveIntegrator,
+                                     integrator_mode=True,
+                                     output_ports=[pnl.OutputPort(variable=spec)])
+
+        np.testing.assert_allclose(mech.output_values, expected1)
+
+        EX = pytest.helpers.get_mech_execution(mech, mech_mode)
+
+        EX([[1.], [2.], [3.]])
+        EX([[1.], [2.], [3.]])
+        EX([[1.], [2.], [3.]])
+        res = EX([[1.], [2.], [3.]])
+
+        np.testing.assert_allclose(res, expected2)
+
     @pytest.mark.composition
     @pytest.mark.mechanism
     @pytest.mark.parametrize('spec, expected1, expected2',


### PR DESCRIPTION
Allow arbitrary dimensions for Integrator Functions.
Split OutputPort variable spec tests.
Scan function and integrator_function (if enabled) when looking for variable spec parameters.