### PR TITLE
Registries: Use '_pnl_internal_' prefix for Components created during module load

### DIFF
--- a/psyneulink/__init__.py
+++ b/psyneulink/__init__.py
@@ -99,6 +99,8 @@ for reg in primary_registries:
 
     process_registry_object_instances(reg, func)
 
+core.globals.registry._register_auto_name_prefix = ""
+
 def System(*args, **kwars):
     show_warning_sys_and_proc_warning()
 

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -576,7 +576,7 @@ from psyneulink.core.globals.parameters import (
 from psyneulink.core.globals.preferences.basepreferenceset import BasePreferenceSet, VERBOSE_PREF
 from psyneulink.core.globals.preferences.preferenceset import \
     PreferenceLevel, PreferenceSet, _assign_prefs
-from psyneulink.core.globals.registry import register_category, _get_auto_name_prefix
+from psyneulink.core.globals.registry import register_category, _get_auto_name_prefix, _PNL_INHERENT_PREFIX
 from psyneulink.core.globals.sampleiterator import SampleIterator
 from psyneulink.core.globals.utilities import (
     ContentAddressableList,
@@ -1375,6 +1375,12 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
         # 'import psyneulink' call
         newone._is_pnl_inherent = False
 
+        # Remove internal prefix from name if an internal instance is the
+        # source of the copy
+        # FIXME: Use str.removeprefix in Python 3.9+
+        if newone.name.startswith(_PNL_INHERENT_PREFIX):
+            newone.name = newone.name[len(_PNL_INHERENT_PREFIX):]
+
         return newone
 
     # ------------------------------------------------------------------------------------------------------------------
@@ -1386,7 +1392,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
         if p.read_only and p.getter is not None:
             return False
 
-        # Shared and aliased parameters are for user conveniecne and not compiled.
+        # Shared and aliased parameters are for user convenience and not compiled.
         if isinstance(p, (ParameterAlias, SharedParameter)):
             return False
 
@@ -1638,6 +1644,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
         def _convert(x):
             if isinstance(x, Enum):
                 return x.value
+
             elif isinstance(x, SampleIterator):
                 if isinstance(x.generator, list):
                     return tuple(v for v in x.generator)
@@ -1668,12 +1675,14 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
 
         return tuple(map(_get_values, self._get_compilation_params()))
 
-    def _gen_llvm_function_reset(self, ctx, builder, *_, tags):
+    def _gen_llvm_function_reset(self, ctx:pnlvm.LLVMBuilderContext, builder:pnlvm.ir.IRBuilder, *_, tags:frozenset):
         assert "reset" in tags
         return builder
 
-    def _gen_llvm_function(self, *, ctx:pnlvm.LLVMBuilderContext,
-                                    extra_args=[], tags:frozenset):
+    def _gen_llvm_function(self, *, ctx:pnlvm.LLVMBuilderContext, extra_args=[], tags:frozenset):
+        assert not self.is_pnl_inherent, "Can't compile internal Component: {}".format(self.name)
+        assert not self.name.startswith(_PNL_INHERENT_PREFIX), "Can't compile internal Component: {}".format(self.name)
+
         args = [ctx.get_param_struct_type(self).as_pointer(),
                 ctx.get_state_struct_type(self).as_pointer(),
                 ctx.get_input_struct_type(self).as_pointer(),
@@ -1686,11 +1695,11 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                 p.attributes.add('noalias')
 
         if "reset" in tags:
-            builder = self._gen_llvm_function_reset(ctx, builder, params, state,
-                                                    arg_in, arg_out, tags=tags)
+            builder = self._gen_llvm_function_reset(ctx, builder, params, state, arg_in, arg_out, tags=tags)
+
         else:
-            builder = self._gen_llvm_function_body(ctx, builder, params, state,
-                                                   arg_in, arg_out, tags=tags)
+            builder = self._gen_llvm_function_body(ctx, builder, params, state, arg_in, arg_out, tags=tags)
+
         builder.ret_void()
         return builder.function
 

--- a/psyneulink/core/globals/registry.py
+++ b/psyneulink/core/globals/registry.py
@@ -68,8 +68,12 @@ class RegistryError(Exception):
         return repr(self.error_value)
 
 
-_register_auto_name_prefix = ""
+_PNL_INHERENT_PREFIX = "__pnl_inherent_"
+_register_auto_name_prefix = _PNL_INHERENT_PREFIX
 
+# Use indirection to retrieve the current prefix.
+# Importing _register_auto_name_prefix variable directly would keep the value
+# it had at import time.
 def _get_auto_name_prefix():
     return _register_auto_name_prefix
 


### PR DESCRIPTION
Assert that internal Components are not compiled.