### PR TITLE
Update execution flow in ParameterEstimationComposition.run method

### DIFF
--- a/psyneulink/core/compositions/parameterestimationcomposition.py
+++ b/psyneulink/core/compositions/parameterestimationcomposition.py
@@ -960,8 +960,21 @@ class ParameterEstimationComposition(Composition):
             num_trials_per_estimate, context=context
         )
 
-        # Run the composition as normal
-        results = super(ParameterEstimationComposition, self).run(*args, context=context, **kwargs)
+        # Run the composition as normal, if we are in Python execution mode
+        if self.controller.parameters.comp_execution_mode.get(context) == 'Python':
+            results = super(ParameterEstimationComposition, self).run(*args, context=context, **kwargs)
+
+        # Otherwise, we are in LLVM mode, so we need to set the execution phase to PROCESSING and call the
+        # controller's execute method directly. This is a performance workaround to avoid the overhead of the
+        # of running Composition.run() after the controller has been executed in LLVM mode, because then the
+        # run() method is executed in Python mode, unecessarily slowing down the overall execution since the
+        # controller has already done all the work in LLVM mode.
+        else:
+            context.execution_phase = ContextFlags.PROCESSING
+            self.controller.execute(context=context)
+            context.remove_flag(ContextFlags.PROCESSING)
+
+            results = self.parameters.results._get(context)
 
         # IMPLEMENTATION NOTE: has not executed OCM after first call
         if hasattr(self.controller, "optimal_control_allocation"):


### PR DESCRIPTION
This pull request improves the execution logic in the `ParameterEstimationComposition` class to better handle different execution modes, optimizing performance when running in LLVM mode. The main change is that the composition now detects whether it should run in Python or LLVM mode and adjusts its execution strategy accordingly, avoiding unnecessary overhead in LLVM mode.

Execution mode-specific logic:

* In the `run` method of `ParameterEstimationComposition`, added a conditional to check the controller's `comp_execution_mode`. If in Python mode, it runs as before; if in LLVM mode, it sets the execution phase to `PROCESSING`, directly calls the controller's `execute` method, and retrieves results without incurring the overhead of the standard `run()` method. This improves performance for LLVM execution.
* When in controller execution mode is LLVM, `ParemeterEstimationComposition.run` now only actually executes the controller.
The old approach involved executing the entire composition with controller execution happening first. The optimization happens entirely inside the controller execution but then after completing the composition itself would run in Python mode, leading to hangs after optimization.