### PR TITLE
ci/ga: Update package version check to work with wheel dependencies

### DIFF
--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -109,7 +109,7 @@ runs:
         done
 
     - name: Check updated package
-      if: ${{ startsWith(github.head_ref, 'dependabot/pip') && matrix.pnl-version != 'base' && steps.new_package.outputs.new_package != '' }}
+      if: ${{ steps.new_package.conclusion == 'success' && steps.new_package.outputs.new_package != '' }}
       shell: bash
       run: |
         if [ $(pip list | grep -o ${{ steps.new_package.outputs.new_package }} | wc -l) != "0" ] ; then

--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -49,7 +49,7 @@ runs:
       run: python -m pip install --upgrade pip wheel
 
     - name: Install updated package
-      if: ${{ startsWith(github.head_ref, 'dependabot/pip') && matrix.pnl-version != 'base' }}
+      if: ${{ startsWith(github.head_ref, 'dependabot/pip') && matrix.pnl-version != 'base' && matrix.version-restrict == '' }}
       shell: bash
       id: new_package
       run: |

--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -65,8 +65,12 @@ runs:
           pip show "$NEW_PACKAGE" | grep 'Version' | tee new_version.deps
 
           # uninstall new package and its dependencies but skip those from previous steps
-          # the 'orig' list is not empty (includes at least pip, wheel)
-          pip uninstall -y $(pip freeze -r orig | sed '1,/## /d')
+          # the 'orig' list is not empty (includes at least pip, wheel),
+          # but it can include the checked package.
+          export INSTALLED_PACKAGES="$(pip freeze -r orig | sed '1,/## /d')"
+          if [ "$INSTALLED_PACKAGES" != "" ]; then
+            pip uninstall -y $(pip freeze -r orig | sed '1,/## /d')
+          fi
         else
           echo "new_package=''" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/install-pnl/action.yml
+++ b/.github/actions/install-pnl/action.yml
@@ -53,16 +53,18 @@ runs:
       shell: bash
       id: new_package
       run: |
-        # The branch name pattern is: "dependabot/pip/$TARGET/$PACKAGE{-gt-$MINVERSION,,}{-lt-$MAXVERSION,}{-$VERSION,}
+        # The branch name pattern is: "dependabot/pip/$TARGET/$PACKAGE{-gt-$MINVERSION,}{-lt-$MAXVERSION,}{-$VERSION,}
         # The expression below extracts just the $PACKAGE part
         export NEW_PACKAGE=$(echo '${{ github.head_ref }}' | cut -f 4 -d/ | sed 's/-gt.*//' | sed 's/-lt.*//' | sed 's/-[0-9\.]*$//' )
         if grep "$NEW_PACKAGE" *requirements.txt; then 
           echo "new_package=$NEW_PACKAGE" >> $GITHUB_OUTPUT
+
           # save a list of all installed packages (including pip, wheel; it's never empty)
           pip freeze --all > orig
           pip install "$(echo $NEW_PACKAGE | sed 's/[-_]/./g' | xargs grep *requirements.txt -h -e | head -n1)" -c broken_trans_deps.txt
           pip show "$NEW_PACKAGE" | grep 'Version' | tee new_version.deps
-          # uninstall new packages but skip those from previous steps (pywinpty, terminado on windows x86)
+
+          # uninstall new package and its dependencies but skip those from previous steps
           # the 'orig' list is not empty (includes at least pip, wheel)
           pip uninstall -y $(pip freeze -r orig | sed '1,/## /d')
         else
@@ -89,6 +91,7 @@ runs:
         # Note that the MS Visual C equivalent option needs to start with an extra
         # space otherwise the argument gets interpreted as a file location.
         CXXFLAGS: ${{ startsWith(runner.os, 'windows') && ' /FI cstdint' || '-include cstdint' }}
+
         # Setting TEMP works around broken onnx-1.17.0 build on windows where
         # too long paths in default TEMP directory don't work with msbuild.
         # This should be removed once onnx wheels for Python 3.13 are available.


### PR DESCRIPTION
Consolidate version check steps conditional.
Comment style.
Do not try to uninstall new packages that were pulled in by pip or wheel.
Do not run the package version check in min-version jobs.