### PR TITLE
pec: Use Pandas is_string_dtype to check for categorical data

### DIFF
--- a/psyneulink/core/compositions/parameterestimationcomposition.py
+++ b/psyneulink/core/compositions/parameterestimationcomposition.py
@@ -669,7 +669,7 @@ class ParameterEstimationComposition(Composition):
                                      f"is dependent on.")
 
                 # If the column is string, convert to categorical
-                if self.data[col].dtype == object:
+                if pd.api.types.is_string_dtype(self.data[col].dtype):
                     self.data[col] = self.data[col].astype('category')
 
                 # If the column is not categorical, return and error


### PR DESCRIPTION
The dtype "object" is no longer used to represent strings in Pandas 3+[1].
The API function works with both the old and the new string data representation [2,3]

[1] https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#dedicated-string-data-type-by-default
[2] https://pandas.pydata.org/docs/user_guide/migration-3-strings.html#checking-the-dtype
[3] https://pandas.pydata.org/docs/reference/api/pandas.api.types.is_string_dtype.html#pandas.api.types.is_string_dtype