### PR TITLE
ci/ga: Reassign Python versions used for special CI jobs

### DIFF
--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -43,24 +43,14 @@ jobs:
         version-restrict: ['']
         torch: ['']
         include:
-          # code-coverage run on macos python 3.9
-          - python-version: '3.9'
-            os: macos
-            extra-args: '--cov=psyneulink'
-
           # --forked run of python only tests
           # Python tests are enough to test potential naming issues
           - python-version: '3.9'
             os: ubuntu
             extra-args: '--forked -m "not llvm"'
 
-          # fp32 run on linux python 3.10
-          - python-version: '3.10'
-            os: ubuntu
-            extra-args: '--fp-precision=fp32'
-
-          # --benchmark-enable run on macos python 3.10
-          - python-version: '3.10'
+          # --benchmark-enable run on macos python 3.9
+          - python-version: '3.9'
             os: macos
             # pytest needs both '--benchmark-only' and '-m benchmark'
             # The former fails the test if benchmarks cannot be enabled
@@ -68,11 +58,21 @@ jobs:
             # The latter works around a crash in pytest when collecting tests:
             # https://github.com/ionelmc/pytest-benchmark/issues/243
             extra-args: '-m benchmark --benchmark-enable --benchmark-only --benchmark-min-rounds=2 --benchmark-max-time=0.001 --benchmark-warmup=off -n0 --dist=no'
+
+          # fp32 run on linux python 3.10
+          - python-version: '3.10'
+            os: ubuntu
+            extra-args: '--fp-precision=fp32'
+
+          # code-coverage run on macos python 3.10
+          - python-version: '3.10'
+            os: macos
+            extra-args: '--cov=psyneulink'
+
           # run without pytorch on windows python 3.10
           - python-version: '3.10'
             os: windows
             torch: 'notorch'
-
 
           # add python 3.8 with deps restricted to min supported package versions
           - python-version: '3.8'


### PR DESCRIPTION
Use Python 3.10 for the coverage job, the job takes a lot of time and 3.10 is generally faster than 3.9.

Use Python 3.9 for the benchmark job, the jobs only runs subset of tests and check if benchmarking works rather collecting timing results.