### PR TITLE
mdf: Flush file contents when using temporary files

### DIFF
--- a/psyneulink/core/globals/mdf.py
+++ b/psyneulink/core/globals/mdf.py
@@ -1434,6 +1434,10 @@ def generate_script_from_mdf(model_input, outfile=None):
             # delete=False because of problems with reading file on windows
             with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
                 f.write(model_input)
+
+                # Make sure the contents are resident in FS before re-opening
+                # the file by name
+                f.flush()
                 model = load_mdf(f.name)
 
     imports_str = ''


### PR DESCRIPTION
Otherwise the written contents might not be visible to mdf parser.

Fixes `tests/mdf/test_mdf.py::test_generate_script_from_mdf[yml-model_basic.py-comp]` test failure on Python 3.14