### PR TITLE
requirements: Restrict patch version on modeci_mdf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ grpcio<1.76.0
 leabra-psyneulink<0.3.3
 llvmlite<0.45
 matplotlib>=3.7.0, <3.10.7
-modeci_mdf<0.5, >=0.4.3; (platform_machine == 'AMD64' or platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
+modeci_mdf>=0.4.3, <0.4.14; (platform_machine == 'AMD64' or platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
 networkx<3.6
 numpy>=1.21.0, <2.3.4
 optuna<4.6.0


### PR DESCRIPTION
modec-mdf==0.4.14 introduced regression vs. 0.4.13

ref from https://github.com/PrincetonUniversity/PsyNeuLink/pull/3461