### PR TITLE
TransferMechanism: fix non-default integrator_function shape mismatch

### DIFF
--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -455,11 +455,11 @@ each element.  This is shown below using the `NormalDist` function::
     >>> my_linear_tm = pnl.TransferMechanism(input_shapes=3,
     ...                                      noise=pnl.NormalDist)
     >>> my_linear_tm.execute([1.0, 1.0, 1.0])
-    array([[2.1576537 , 1.60782117, 0.75840058]])
-    >>> my_linear_tm.execute([1.0, 1.0, 1.0])
-    array([[2.20656132, 2.71995896, 0.57600537]])
-    >>> my_linear_tm.execute([1.0, 1.0, 1.0])
     array([[1.03826716, 0.56148871, 0.8394907 ]])
+    >>> my_linear_tm.execute([1.0, 1.0, 1.0])
+    array([[ 1.59335049,  0.61367634, -0.40574659]])
+    >>> my_linear_tm.execute([1.0, 1.0, 1.0])
+    array([[ 0.80580672, -1.88025475,  0.25268581]])
 
 Notice that each element was assigned a different random value for its noise, and that these also varied across
 executions.  Notice that since only a single function was specified, it could be the name of a class.  Functions
@@ -469,9 +469,9 @@ when used in a list, functions must be instances, as shown below::
     >>> my_linear_tm = pnl.TransferMechanism(input_shapes=3,
     ...                                      noise=[pnl.NormalDist(), pnl.UniformDist(), 3.0])
     >>> my_linear_tm.execute([1.0, 1.0, 1.0])
-    array([[-0.22503678,  1.36995517,  4.        ]])
+    array([[2.55612201, 1.6257203 , 4.        ]])
     >>> my_linear_tm.execute([1.0, 1.0, 1.0])
-    array([[2.08371805, 1.60392004, 4.        ]])
+    array([[2.54362708, 1.06552886, 4.        ]])
 
 Notice that since noise is a `modulable Parameter <ParameterPort_Modulable_Parameters>`, assigning it a value
 after the TransferMechanism has been constructed must be done to its base value (see `ModulatorySignal_Modulation`
@@ -481,11 +481,11 @@ Finally, `clipping <TransferMechanism.clip>` can also be used to cap the result 
 
     >>> my_linear_tm.clip = (.5, 1.2)
     >>> my_linear_tm.execute([1.0, 1.0, 1.0])
+    array([[0.5       , 1.01316799, 1.2       ]])
+    >>> my_linear_tm.execute([1.0, 1.0, 1.0])
     array([[1.2, 1.2, 1.2]])
     >>> my_linear_tm.execute([1.0, 1.0, 1.0])
-    array([[1.2       , 1.06552886, 1.2       ]])
-    >>> my_linear_tm.execute([1.0, 1.0, 1.0])
-    array([[0.5       , 1.01316799, 1.2       ]])
+    array([[0.5, 1.2, 1.2]])
 
 Note that the range specified in **clip** applies to all elements of the result if it is an array.
 
@@ -1765,9 +1765,6 @@ class TransferMechanism(ProcessingMechanism_Base):
         self.parameters.value.clear_history(context)
 
     def _parse_function_variable(self, variable, context=None):
-        if self.is_initializing:
-            return super(TransferMechanism, self)._parse_function_variable(variable=variable, context=context)
-
         integrator_mode = self.parameters.integrator_mode._get(context)
         noise = self._get_current_parameter_value(self.parameters.noise, context)
 

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -1,4 +1,5 @@
 import contextlib
+from typing import Dict, Optional
 import numpy as np
 import pytest
 import re
@@ -6,7 +7,7 @@ import re
 import psyneulink as pnl
 from psyneulink.core.components.component import ComponentError
 from psyneulink.core.components.functions.nonstateful.learningfunctions import Reinforcement
-from psyneulink.core.components.functions.stateful.integratorfunctions import AccumulatorIntegrator, AdaptiveIntegrator
+from psyneulink.core.components.functions.stateful.integratorfunctions import AccumulatorIntegrator, AdaptiveIntegrator, FitzHughNagumoIntegrator, SimpleIntegrator
 from psyneulink.core.components.functions.nonstateful.transferfunctions import Linear, Exponential, Logistic, ReLU, SoftMax
 from psyneulink.core.components.functions.nonstateful.transformfunctions import Reduce
 from psyneulink.core.components.functions.userdefinedfunction import UserDefinedFunction
@@ -153,7 +154,7 @@ class TestTransferMechanismNoise:
         )
         T.reset_stateful_function_when = Never()
         val = T.execute([0, 0, 0, 0])
-        np.testing.assert_allclose(val, [[-0.6931771, 1.00018003, 2.5496904, -0.71562799]])
+        np.testing.assert_allclose(val, [[-1.39225086, 0.66053518, 1.10887925, -0.91598930]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -169,7 +170,7 @@ class TestTransferMechanismNoise:
         )
         T.reset_stateful_function_when = Never()
         val = T.execute([0, 0, 0, 0])
-        expected = [[-1.56404341, -3.01320403, -1.22503678, 1.3093712]]
+        expected = [[-2.55352727, 1.15765370, 1.55612201, -0.60836214]]
         np.testing.assert_allclose(val, expected)
 
     @pytest.mark.mechanism
@@ -227,7 +228,7 @@ class TestDistributionFunctions:
         )
 
         val = T.execute([0, 0, 0, 0])
-        np.testing.assert_allclose(val, [[-0.6931771 ,  1.00018003,  2.5496904 , -0.71562799]])
+        np.testing.assert_allclose(val, [[-1.39225086,  0.66053518,  1.10887925, -0.91598930]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -260,7 +261,7 @@ class TestDistributionFunctions:
             integrator_mode=True,
         )
         val = T.execute([0, 0, 0, 0])
-        np.testing.assert_allclose(val, [[1.53154485, 0.36141864, 0.64740347, 0.87558564]])
+        np.testing.assert_allclose(val, [[0.96330110, 0.28835742, 2.40513020, 4.06200184]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -292,7 +293,7 @@ class TestDistributionFunctions:
             integrator_mode=True
         )
         val = T.execute([0, 0, 0, 0])
-        np.testing.assert_allclose(val, [[0.78379859, 0.30331273, 0.47659695, 0.58338204]])
+        np.testing.assert_allclose(val, [[0.61836900, 0.25050634, 0.90974626, 0.98278548]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -307,7 +308,7 @@ class TestDistributionFunctions:
             integrator_mode=True
         )
         val = T.execute([0, 0, 0, 0])
-        np.testing.assert_allclose(val, [[1.53154485, 0.36141864, 0.64740347, 0.87558564]])
+        np.testing.assert_allclose(val, [[0.96330110, 0.28835742, 2.40513020, 4.06200184]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -322,7 +323,7 @@ class TestDistributionFunctions:
             integrator_mode=True
         )
         val = T.execute([0, 0, 0, 0])
-        np.testing.assert_allclose(val, [[0.39640095, 0.45094588, 2.88271841, 0.41203028]])
+        np.testing.assert_allclose(val, [[1.35503180, 0.96989910, 0.60138801, 0.38437082]])
 
 
 class TestTransferMechanismFunctions:
@@ -1155,7 +1156,7 @@ class TestTransferMechanismMultipleInputPorts:
             default_variable=[[0.0, 0.0], [0.0, 0.0]]
         )
         val = T.execute([[1.0, 2.0], [3.0, 4.0]])
-        np.testing.assert_allclose(val, [[1.6136458, 7.00036006], [12.09938081, 7.56874402]])
+        np.testing.assert_allclose(val, [[0.21549828, 6.32107035], [9.21775851, 7.16802140]])
 
     @pytest.mark.mechanism
     @pytest.mark.transfer_mechanism
@@ -1483,6 +1484,64 @@ class TestIntegratorMode:
         T = TransferMechanism()
         T.integrator_mode = True
         T.execute(1)
+
+    _different_integrator_function_shape_parameters = [
+        # NOTE: there is a discrepancy in shape when FHNI is instantiated
+        # before vs during TransferMechanism assignment, shown here, but
+        # this isn't directly relevant to this test, which is just meant to
+        # check that the non-default shape is carried through
+        # TransferMechanism.function
+        (None, FitzHughNagumoIntegrator, None, (3, 1, 1)),
+        (None, FitzHughNagumoIntegrator, {}, (3, 1)),
+        (np.zeros(2), SimpleIntegrator, {'default_variable': np.ones(2)}, (1, 2)),
+        (np.zeros(2), None, None, (1, 2)),
+    ]
+
+    def _different_integrator_function_shape_mechanism(
+        self, tmech_variable, integrator_function, ifunc_construct_args: Optional[Dict]
+    ):
+        # if instantiated outside of test, same instance is reused across tests
+        if ifunc_construct_args is not None:
+            integrator_function = integrator_function(**ifunc_construct_args)
+
+        t = TransferMechanism(
+            default_variable=tmech_variable, integrator_function=integrator_function, integrator_mode=True
+        )
+        return t
+
+    @pytest.mark.parametrize(
+        'tmech_variable, integrator_function, ifunc_construct_args, expected_value_shape',
+        _different_integrator_function_shape_parameters,
+    )
+    def test_different_integrator_function_shape(
+        self, tmech_variable, integrator_function, ifunc_construct_args, expected_value_shape
+    ):
+        t = self._different_integrator_function_shape_mechanism(
+            tmech_variable, integrator_function, ifunc_construct_args
+        )
+        assert t.function.defaults.variable.shape == expected_value_shape
+        assert t.function.defaults.value.shape == expected_value_shape
+        assert t.defaults.value.shape == expected_value_shape
+
+    @pytest.mark.parametrize(
+        'tmech_variable, integrator_function, ifunc_construct_args',
+        [item[:-1] for item in _different_integrator_function_shape_parameters],
+    )
+    def test_different_integrator_function_shape_compilation(
+        self, tmech_variable, integrator_function, ifunc_construct_args, comp_mode
+    ):
+        if integrator_function is FitzHughNagumoIntegrator and not ifunc_construct_args:
+            pytest.xfail(
+                'FitzHughNagumoIntegrator gets different variable/value shapes depending on whether'
+                + 'it is constructed before assignment to TransferMechanism. Bug is tangential to this test',
+            )
+
+        t = self._different_integrator_function_shape_mechanism(
+            tmech_variable, integrator_function, ifunc_construct_args
+        )
+        comp = pnl.Composition([t])
+        # test for crash on LLVM shape mismatch only
+        comp.run(execution_mode=comp_mode)
 
 
 @pytest.mark.composition


### PR DESCRIPTION
TransferMechanism._parse_function_variable bypassed the integrator_function, which would fail to update the variable shape of TransferMechanism.function

This commit causes test result differences in
tests/mechanisms/test_transfer_mechanism.py::TestDistributionFunctions and
tests/documentation/test_module_docs.py::test_core_docs[psyneulink.core.components.mechanisms.processing.transfermechanism] due to additional calls to noise functions during TransferMechanism initialization causing RNG state offset. The new results can be replicated on the parent commit by manually calling the noise functions in TransferMechanism._parse_function_variable:

```
     def _parse_function_variable(self, variable, context=None):
         if self.is_initializing:
+            self._try_execute_param(self.parameters.noise._get(context), variable, context)
             return super(TransferMechanism, self)._parse_function_variable(variable=variable, context=context)
```