### PR TITLE
registry: add all-Component `global_registry`

### DIFF
--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -3216,7 +3216,7 @@ from psyneulink.core.components.projections.pathway.mappingprojection import \
     MappingProjection, MappingError, PROXY_FOR, ProxyProjection
 from psyneulink.core.components.projections.pathway.pathwayprojection import PathwayProjection_Base
 from psyneulink.core.components.projections.projection import \
-    Projection_Base, ProjectionError, DuplicateProjectionError, ProjectionRegistry
+    Projection_Base, ProjectionError, DuplicateProjectionError
 from psyneulink.core.components.shellclasses import Composition_Base
 from psyneulink.core.components.shellclasses import Mechanism, Projection
 from psyneulink.core.compositions.report import Report, \
@@ -3251,9 +3251,9 @@ from psyneulink.core.globals.parameters import (
 )
 from psyneulink.core.globals.preferences.basepreferenceset import BasePreferenceSet
 from psyneulink.core.globals.preferences.preferenceset import PreferenceLevel, _assign_prefs
-from psyneulink.core.globals.registry import register_category
+from psyneulink.core.globals.registry import global_registry, register_category
 from psyneulink.core.globals.utilities import (
-    ContentAddressableList, PNLStrEnum, call_with_pruned_args, convert_all_elements_to_np_array, convert_to_list, get_from_registry, is_numeric_scalar,
+    ContentAddressableList, PNLStrEnum, call_with_pruned_args, convert_all_elements_to_np_array, convert_to_list, is_numeric_scalar,
     nesting_depth, convert_to_np_array, is_numeric, is_matrix, is_matrix_keyword, parse_valid_identifier, extended_array_equal, try_extract_0d_array_item,
 )
 from psyneulink.core.scheduling.condition import Always, Condition, Never
@@ -10427,11 +10427,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
         opt_params = {}
 
         if isinstance(projection, str):
-            import psyneulink as pnl
-
             # TODO: replace this with maybe storing only projections in
             # OptParam, then allowing get by name as well
-            reg_projection = get_from_registry(projection, pnl.ProjectionRegistry)
+            reg_projection = global_registry.get_entry(projection, Projection)
             if reg_projection:
                 projection = reg_projection
 
@@ -12483,7 +12481,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             for proj_key, _ in val_items:
                 if proj_key == o_param._default_key:
                     continue
-                reg_proj = get_from_registry(proj_key, ProjectionRegistry)
+                reg_proj = global_registry.get_entry(proj_key, Projection)
                 if reg_proj:
                     proj_key = reg_proj
                 if proj_key not in all_projections:

--- a/psyneulink/core/globals/registry.py
+++ b/psyneulink/core/globals/registry.py
@@ -9,9 +9,11 @@
 # ***********************************************  Registry ************************************************************
 
 import inspect
+import itertools
 import re
-
+import weakref
 from collections import defaultdict, namedtuple
+from typing import Any, Dict, Optional, Set, Tuple, Union
 
 from psyneulink.core.globals.keywords import \
     CONTROL_PROJECTION, DDM_MECHANISM, GATING_SIGNAL, INPUT_PORT, MAPPING_PROJECTION, OUTPUT_PORT, \
@@ -22,7 +24,8 @@ from psyneulink.core.globals.keywords import \
 __all__ = [
     'RegistryError',
     'clear_registry',
-    'process_registry_object_instances'
+    'process_registry_object_instances',
+    'global_registry',
 ]
 
 # IMPLEMENTATION NOTE:
@@ -76,6 +79,221 @@ _register_auto_name_prefix = _PNL_INHERENT_PREFIX
 # it had at import time.
 def _get_auto_name_prefix():
     return _register_auto_name_prefix
+
+
+# future intent:
+#   - store multiple registries/categories as previously defined (dict for certain Component types)
+#   - integrate below register_* methods
+class Registry:
+    def __init__(self):
+        self._instances: Dict[str, weakref.WeakSet] = {}
+
+    # future: consider if should replicate exact signature of register_instance
+    def register_instance(self, entry, name: str):
+        """
+        Add **entry** with name **name** to registry
+
+        Args:
+            entry: an object instance, generally a Component, to add to the registry
+
+            name (str): the name of **entry**
+        """
+        if name not in self._instances:
+            self._instances[name] = weakref.WeakSet()
+
+        self._instances[name].add(entry)
+
+    def rename_instance_in_registry(
+        self,
+        new_name: str,
+        old_name_or_entry: Union[str, Any],
+        types: Optional[Union[type, Tuple[type]]] = None,
+    ):
+        """
+        Rename object in registry specified by **old_name_or_entry**, if it is
+        present. **old_name_or_entry** may be an object itself or its name.
+
+        Args:
+            new_name (str): the new name for the objects specified by **old_name_or_entry**
+
+            old_name_or_entry (Union[str, Any]): object to be renamed in
+                registry, specified by instance or name
+
+            types (Optional[Union[type, Tuple[type]]], optional): if specified
+                and **old_name_or_entry** is a name, only objects of type
+                **types** will be considered for removal. ignored if
+                **old_name_or_entry** is an object. **types** will be passed to
+                `isinstance`. Defaults to None.
+        """
+        try:
+            targets = self._instances[old_name_or_entry]
+        except KeyError:
+            # name isn't present, so nothing to rename.
+            # check that entry.name are correctly stored in registry?
+            if isinstance(old_name_or_entry, str):
+                return
+        else:
+            if types is not None:
+                targets = {t for t in targets if isinstance(t, types)}
+
+            try:
+                self._instances[new_name].update(targets)
+            except KeyError:
+                self._instances[new_name] = targets
+
+            self._instances[old_name_or_entry].difference_update(targets)
+            if len(self._instances[old_name_or_entry]) == 0:
+                del self._instances[old_name_or_entry]
+            return
+
+        # at this point, old_name_or_entry should not be a str.
+        # consider if this should just assume entry will be stored only once in correct name
+        old_names = set()
+        for name, objs in self._instances.items():
+            if old_name_or_entry in objs:
+                old_names.add(name)
+                objs.discard(old_name_or_entry)
+                if new_name not in self._instances:
+                    self._instances[new_name] = weakref.WeakSet()
+                self._instances[new_name].add(old_name_or_entry)
+
+        for name in old_names:
+            if len(self._instances[name]) == 0:
+                del self._instances[name]
+
+    def remove_instance_from_registry(
+        self,
+        name_or_entry: Union[str, Any],
+        types: Optional[Union[type, Tuple[type]]] = None,
+    ):
+        """
+        Remove object specified by **name_or_entry** from the registry, if it is
+        present. **name_or_entry** may be an object itself or its name. if
+        **name_or_entry** is a name, all objects with that name will be removed.
+
+        Args:
+            name_or_entry (Union[str, Any]): object to remove from registry,
+                specified by instance or name
+
+            types (Optional[Union[type, Tuple[type]]], optional): if specified
+                and **name_or_entry** is a name, only objects of type **types**
+                will be considered for removal. ignored if **old_name_or_entry**
+                is an object. **types** will be passed to `isinstance`. Defaults
+                to None.
+        """
+        try:
+            targets = self._instances[name_or_entry]
+        except KeyError:
+            # name isn't present, so nothing to remove.
+            # check that entry.name are correctly stored in registry?
+            if isinstance(name_or_entry, str):
+                return
+        else:
+            to_del = set()
+            for obj in targets:
+                if types is None or isinstance(obj, types):
+                    to_del.add(obj)
+
+            for obj in to_del:
+                self._instances[name_or_entry].discard(obj)
+            if len(self._instances[name_or_entry]) == 0:
+                del self._instances[name_or_entry]
+            return
+
+        # at this point, name_or_entry should not be a str
+        for name, objs in self._instances.items():
+            if name_or_entry in objs:
+                objs.discard(name_or_entry)
+                if len(objs) == 0:
+                    del self._instances[name]
+                return
+
+    def clear_entries(self, types: Optional[Union[type, Tuple[type]]] = None):
+        """
+        Remove registry entries.
+
+        Args:
+            types (Optional[Union[type, Tuple[type]]], optional): if not
+                specified (or None), removes all entries from the registry. if
+                specified, removes all entries of type **types**. **types** will
+                be passed to `isinstance`. Defaults to None.
+        """
+        if types is None:
+            self._instances = {}
+            return
+
+        names_to_del = set()
+        for name, objs in self._instances.items():
+            to_del = {x for x in objs if isinstance(x, types)}
+            objs.difference_update(to_del)
+            if len(objs) == 0:
+                names_to_del.add(name)
+
+        for name in names_to_del:
+            del self._instances[name]
+
+    def get_entry(
+        self,
+        name_or_types: Optional[Union[str, type, Tuple[type]]],
+        types: Optional[Union[type, Tuple[type]]] = None,
+    ) -> Union[Any, Set[Any]]:
+        """
+        Retrieve registry entries by name or type. If **name_or_types** is a
+        **types**-like argument, then it will replace **types** and ignore names.
+
+        Args:
+            name_or_types (Optional[Union[str, type, Tuple[type]]]): a name or
+                **types**-like argument. If it is a name (str), returns objects
+                matching the name. Otherwise, replaces the **types** argument
+                and behaves as if no name was passed.
+
+            types (Optional[Union[type, Tuple[type]]], optional): a type or
+                tuple of types for `isinstance`, which matches all objects in
+                registry of that type. Defaults to None.
+
+        Returns:
+            Union[Any, Set[Any]]: All objects in registry that match the name
+                and optionally type specified (**name_or_type** is a str and
+                **types** is a type or tuple of types), or just the type specified.
+                If there are no matches, return None.
+        """
+        if name_or_types is not None and not isinstance(name_or_types, str):
+            # docstring: note override of types if both specified
+            types = name_or_types
+            name_or_types = None
+
+        res = None
+        try:
+            res = self._instances[name_or_types]
+        except KeyError:
+            if isinstance(name_or_types, str):
+                return None
+
+            if types is not None:
+                res = set(itertools.chain(*self._instances.values()))
+        else:
+            assert name_or_types is not None
+
+        if types is not None:
+            try:
+                res = set(filter(lambda x: isinstance(x, types), res))
+            except TypeError:
+                # only expected to be incompatible arg 2 of isinstance
+                res = None
+
+        if res is not None:
+            if len(res) == 0:
+                res = None
+            elif len(res) == 1:
+                res = next(iter(res))
+            else:
+                res = set(res)
+
+        return res
+
+
+global_registry = Registry()
+
 
 def register_category(entry,
                       base_class,
@@ -234,6 +452,9 @@ def register_category(entry,
     else:
         raise RegistryError("Requested entry {0} not of type {1}".format(entry, base_class))
 
+    # currently, some instances are registered using this function (ex: Mechanism_Base)
+    global_registry.register_instance(entry, entry.name)
+
 
 def register_instance(entry, name, base_class, registry, sub_dict):
 
@@ -295,6 +516,9 @@ def register_instance(entry, name, base_class, registry, sub_dict):
         else:
             renamed_instance_counts[match.groups()[0]] += 1
 
+    global_registry.register_instance(entry, entry.name)
+
+
 def rename_instance_in_registry(registry, category, new_name, old_name=None, component=None):
     """Rename instance in category registry
 
@@ -351,7 +575,11 @@ def rename_instance_in_registry(registry, category, new_name, old_name=None, com
                                        instance_count,
                                        registry_entry.renamed_instance_counts,
                                        registry_entry.default)
+
+    global_registry.rename_instance_in_registry(new_name, old_name)
+
     return new_name
+
 
 def remove_instance_from_registry(registry, category, name=None, component=None):
     """Remove instance from registry category entry
@@ -405,6 +633,9 @@ def remove_instance_from_registry(registry, category, name=None, component=None)
                                        registry_entry.renamed_instance_counts,
                                        registry_entry.default)
 
+    global_registry.remove_instance_from_registry(name, registry_entry.subclass)
+
+
 def clear_registry(registry=None):
     """Clear specified registry of all entries, but leave any categories created within it intact.
 
@@ -427,6 +658,9 @@ def clear_registry(registry=None):
             for name in instance_dict:
                 remove_instance_from_registry(registry, category, name)
             registry[category].renamed_instance_counts.clear()
+
+            global_registry.clear_entries(registry[category].subclass)
+
 
 def process_registry_object_instances(registry, func):
     for category in registry:

--- a/psyneulink/core/globals/utilities.py
+++ b/psyneulink/core/globals/utilities.py
@@ -147,7 +147,6 @@ __all__ = [
     'append_type_to_name', 'AutoNumber', 'ContentAddressableList', 'convert_to_list', 'convert_to_np_array',
     'convert_all_elements_to_np_array', 'copy_iterable_with_shared', 'get_class_attributes', 'extended_array_equal', 'flatten_list',
     'get_all_explicit_arguments', 'get_modulationOperation_name', 'get_value_from_array',
-    'get_from_registry',
     'insert_list', 'is_matrix_keyword', 'all_within_range',
     'is_comparison_operator',  'iscompatible', 'is_component', 'is_distance_metric', 'is_iterable', 'is_matrix',
     'is_modulation_operation', 'is_numeric', 'is_numeric_or_none', 'is_number', 'is_same_function_spec', 'is_unit_interval',
@@ -2577,17 +2576,5 @@ def get_stacklevel_skip_file_prefixes(
             return i + 1
     return res
 
-
-def get_from_registry(obj_name: str, registry: dict):
-    for reg in registry.values():
-        try:
-            return reg.instanceDict[obj_name]
-        except KeyError:
-            # sometimes the name attr is different than the instanceDict key
-            for o in reg.instanceDict.values():
-                if o.name == obj_name:
-                    return o
-
-    return None
 
 #endregion

--- a/tests/misc/test_registry.py
+++ b/tests/misc/test_registry.py
@@ -1,0 +1,171 @@
+from typing import Any, Dict, Set, Union
+import pytest
+
+import psyneulink as pnl
+
+
+def _get_expected_instances(names: Union[None, str, Set[str]], _locals: Dict[str, Any]):
+    if names is not None:
+        if isinstance(names, set):
+            return {_locals[x] for x in names}
+        else:
+            return _locals[names]
+    return None
+
+
+class TestRegistry:
+    # registry is not properly cleared in pytest --forked mode despite
+    # clear_registry in pytest_runtest_teardown.
+    # unclear if this is a bug or expected
+    @pytest.fixture(autouse=True)
+    def _preclear_registry(self):
+        for registry in pnl.primary_registries:
+            pnl.clear_registry(registry)
+
+    @pytest.fixture(scope='function')
+    def reg_test_components(self):
+        apm = pnl.ProcessingMechanism(name='A')  # noqa: F841
+        bpm = pnl.ProcessingMechanism(name='B')  # noqa: F841
+
+        afunc = pnl.Logistic(name='A')  # noqa: F841
+
+        return apm, bpm, afunc
+
+    @pytest.mark.parametrize(
+        'name_or_types, types, expected',
+        [
+            # name only, first arg
+            ('A', None, {'apm', 'afunc'}),
+            ('B', None, 'bpm'),
+            ('C', None, None),
+            # name and types
+            ('A', pnl.ProcessingMechanism, 'apm'),
+            ('A', pnl.Logistic, 'afunc'),
+            ('A', pnl.Function, 'afunc'),
+            (None, pnl.ProcessingMechanism, {'apm', 'bpm'}),
+            ('A', pnl.Component, {'apm', 'afunc'}),
+            ('C', pnl.Component, None),
+            # type as first arg
+            (pnl.ProcessingMechanism, None, {'apm', 'bpm'}),
+            (pnl.ProcessingMechanism, pnl.Projection, {'apm', 'bpm'}),
+            (pnl.Projection, None, None),
+            (pnl.Projection, pnl.ProcessingMechanism, None),
+            ((pnl.Mechanism, pnl.Logistic, pnl.Projection), None, {'apm', 'bpm', 'afunc'}),
+        ],
+    )
+    def test_get_entry(self, reg_test_components, name_or_types, types, expected):
+        apm, bpm, afunc = reg_test_components
+
+        res = pnl.global_registry.get_entry(name_or_types, types)
+        assert res == _get_expected_instances(expected, locals())
+
+    @pytest.mark.parametrize(
+        'types, exp_contains, exp_removed',
+        [
+            (pnl.Component, {}, {'A': {'apm', 'afunc'}, 'B': {'bpm'}}),
+            ((pnl.Mechanism, pnl.Logistic, pnl.Composition), {}, {'A': {'apm', 'afunc'}, 'B': {'bpm'}}),
+            (pnl.Projection, {'A': {'apm', 'afunc'}, 'B': {'bpm'}}, {}),
+            (pnl.Function, {'A': {'apm'}, 'B': {'bpm'}}, {'A': {'afunc'}}),
+        ],
+    )
+    def test_clear_entries(self, reg_test_components, types, exp_contains, exp_removed):
+        apm, bpm, afunc = reg_test_components
+
+        pnl.global_registry.clear_entries(types)
+        test_locals = locals()
+        exp_contains = {name: _get_expected_instances(exp_contains[name], test_locals) for name in exp_contains}
+        exp_removed = {name: _get_expected_instances(exp_removed[name], test_locals) for name in exp_removed}
+
+        for name, objs in exp_contains.items():
+            assert (
+                name in pnl.global_registry._instances
+                and set(pnl.global_registry._instances[name]).intersection(objs) == objs
+            )
+
+        for name, objs in exp_removed.items():
+            assert (
+                name not in pnl.global_registry._instances
+                or len(set(pnl.global_registry._instances[name]).intersection(objs)) == 0
+            )
+
+    def test_clear_entries_all(self, reg_test_components):
+        apm, bpm, afunc = reg_test_components  # noqa: F841, RUF059
+
+        pnl.global_registry.clear_entries()
+        assert pnl.global_registry._instances == {}
+
+    @pytest.mark.parametrize(
+        'new_name, old_name_or_entry, types, exp_renamed',
+        [
+            ('B', 'A', None, {'apm', 'afunc'}),
+            ('B', 'A', (pnl.Projection, pnl.Function), {'afunc'}),
+            ('B-1', 'B', pnl.Function, set()),  # types not ignored since old_name_or_entry is a name
+            ('B', 'A-1', None, set()),
+            ('B', 'A-1', pnl.Component, set()),
+            ('B', 'apm', None, {'apm'}),
+            ('B', 'apm', pnl.Function, {'apm'}),  # types ignored since old_name_or_entry is an object
+            ('B', 'afunc', pnl.Function, {'afunc'}),
+        ],
+    )
+    def test_rename_instance_in_registry(
+        self, reg_test_components, new_name, old_name_or_entry, types, exp_renamed
+    ):
+        apm, bpm, afunc = reg_test_components
+        try:
+            old_name_or_entry = _get_expected_instances(old_name_or_entry, locals())
+        except KeyError:
+            pass
+
+        pnl.global_registry.rename_instance_in_registry(new_name, old_name_or_entry, types)
+
+        exp_renamed = _get_expected_instances(exp_renamed, locals())
+        not_renamed = set(reg_test_components).difference(exp_renamed)
+
+        for obj in exp_renamed:
+            old_name = obj.name
+            assert new_name in pnl.global_registry._instances
+            assert obj in pnl.global_registry._instances[new_name]
+            assert (
+                old_name not in pnl.global_registry._instances
+                or len(pnl.global_registry._instances[old_name]) > 0
+            )
+
+        for obj in not_renamed:
+            assert obj.name in pnl.global_registry._instances
+            assert obj in pnl.global_registry._instances[obj.name]
+
+    @pytest.mark.parametrize(
+        'name_or_entry, types, exp_removed',
+        [
+            ('A', pnl.Component, {'apm', 'afunc'}),
+            ('A', pnl.Projection, set()),  # types not ignored since name_or_entry is a name
+            ('A', None, {'apm', 'afunc'}),
+            ('A', (pnl.Projection, pnl.Mechanism), {'apm'}),
+            ('apm', pnl.Component, {'apm'}),
+            ('apm', pnl.Function, {'apm'}),  # types ignored since name_or_entry is an object
+            ('nonexistent name', None, set()),
+            ('nonexistent name', pnl.Component, set()),
+        ],
+    )
+    def test_remove_instance_from_registry(
+        self, reg_test_components, name_or_entry, types, exp_removed
+    ):
+        apm, bpm, afunc = reg_test_components
+        try:
+            name_or_entry = _get_expected_instances(name_or_entry, locals())
+        except KeyError:
+            pass
+
+        pnl.global_registry.remove_instance_from_registry(name_or_entry, types)
+
+        exp_removed = _get_expected_instances(exp_removed, locals())
+        not_removed = set(reg_test_components).difference(exp_removed)
+
+        for obj in exp_removed:
+            if obj.name in pnl.global_registry._instances:
+                assert obj not in pnl.global_registry._instances[obj.name]
+                assert len(pnl.global_registry._instances[obj.name]) > 0
+
+        for obj in not_removed:
+            assert obj.name in pnl.global_registry._instances
+            assert obj in pnl.global_registry._instances[obj.name]


### PR DESCRIPTION
- stores weak references to all created Components
- adds `get` method to retrieve Component instances by name or type
- parallel register/remove/rename methods called within current registry functions

replace the more limited `get_from_registry` used in optimizer parameter resolution