### PR TITLE
Component: fix resetting num_executions values

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -3700,6 +3700,10 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
         self.parameters.num_executions.set(curr_num_execs, override=True)
         return curr_num_execs
 
+    def _reset_num_executions(self, context: Context, time_scale: TimeScale):
+        curr_num_execs = self.parameters.num_executions._get(context)
+        curr_num_execs._set_by_time_scale(time_scale, 0)
+
     @property
     def current_execution_time(self):
         try:

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -3703,6 +3703,7 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
     def _reset_num_executions(self, context: Context, time_scale: TimeScale):
         curr_num_execs = self.parameters.num_executions._get(context)
         curr_num_execs._set_by_time_scale(time_scale, 0)
+        curr_num_execs._reset_by_time_scale(time_scale)
 
     @property
     def current_execution_time(self):

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -12045,7 +12045,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             if num_execs is None:
                 node.parameters.num_executions._set(Time(), context)
             else:
-                node.parameters.num_executions._get(context)._set_by_time_scale(TimeScale.RUN, 0)
+                node._reset_num_executions(context, TimeScale.RUN)
 
         if ContextFlags.SIMULATION_MODE not in context.runmode:
             try:
@@ -13056,7 +13056,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 reset_stateful_functions_to = {}
 
             for node in self.nodes:
-                node.parameters.num_executions.get(context)._set_by_time_scale(TimeScale.TRIAL, 0)
+                node._reset_num_executions(context, TimeScale.TRIAL)
                 if node.parameters.has_initializers._get(context):
                     try:
                         if (
@@ -13148,7 +13148,6 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
             # the scheduler terminates a trial immediately
             next_pass_before = 1
             next_pass_after = 1
-            last_pass = None
 
             if clamp_input:
                 soft_clamp_inputs = self._identify_clamp_inputs(SOFT_CLAMP, clamp_input, input_nodes)
@@ -13257,11 +13256,9 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
                 curr_pass = execution_scheduler.get_clock(context).get_total_times_relative(TimeScale.PASS,
                                                                                             TimeScale.TRIAL)
-                new_pass = False
-                if curr_pass != last_pass:
-                    new_pass = True
-                    last_pass = curr_pass
                 if next_pass_after == curr_pass:
+                    for n in self.nodes:
+                        n._reset_num_executions(context, TimeScale.PASS)
                     if call_after_pass:
                         logger.debug(f'next_pass_after {next_pass_after}\tscheduler pass {curr_pass}')
                         call_with_pruned_args(call_after_pass, context=context)
@@ -13347,11 +13344,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 # execute each node with EXECUTING in context
                 for (node_idx, node) in enumerate(next_execution_set):
 
-                    node.parameters.num_executions.get(context)._set_by_time_scale(TimeScale.TIME_STEP, 0)
-                    if new_pass:
-                        node.parameters.num_executions.get(context)._set_by_time_scale(TimeScale.PASS, 0)
-
-
+                    node._reset_num_executions(context, TimeScale.TIME_STEP)
                     # Store values of all nodes in this execution_set for use by other nodes in the execution set
                     #    throughout this timestep (e.g., for recurrent Projections)
                     frozen_values[node] = copy_parameter_value(node.get_output_values(context))

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -105,6 +105,20 @@ class TestComponent:
         assert T2.parameter_ports[pnl.SLOPE].execution_count == 0
         assert T2.output_port.execution_count == 0
 
+    def test_num_executions_reset_across_trials(self):
+        a = pnl.ProcessingMechanism()
+        b = pnl.TransferMechanism()
+
+        comp = pnl.Composition([a, b])
+        comp.run(inputs={a: [1, 1, 1]})
+
+        num_executions = b.parameters.num_executions.get(comp)
+        assert num_executions.life == 3
+        assert num_executions.run == 3
+        assert num_executions.trial == 1
+        assert num_executions.pass_ == 1
+        assert num_executions.time_step == 1
+
     def test__set_all_parameter_properties_recursively(self):
         A = pnl.ProcessingMechanism(name='A')
         A._set_all_parameter_properties_recursively(history_max_length=0)

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -1827,3 +1827,29 @@ def test_integrator_mode_reset_in_composition(comp_mode):
 
     comp.run([[1, 0], [0, 1]], execution_mode=comp_mode)
     np.testing.assert_allclose(comp.results, [[[0.52293998, 0.40526519]], [[0.4336115, 0.46026939]]])
+
+
+class TestTerminationMeasure:
+    # NOTE (as in TestOnResumeIntegratorMode::test_termination_measures above):
+    # '_LLVMPerNode' mode is not supported, because synchronization of compiler
+    # and python num_execution values during execution is not implemented.
+    @pytest.mark.usefixtures("comp_mode_no_per_node")
+    def test_measure_pass_as_non_input(self, comp_mode):
+        # derived from dupont/jongkees issue, 2026-03-31
+        drive = pnl.ProcessingMechanism()
+        pass_mech = pnl.TransferMechanism(
+            integrator_mode=True,
+            integrator_function=pnl.SimpleIntegrator,
+            integration_rate=1,
+            termination_threshold=5,
+            termination_measure=pnl.TimeScale.PASS,
+            execute_until_finished=True,
+        )
+        gate = pnl.ProcessingMechanism()
+
+        comp = pnl.Composition([drive, pass_mech, gate])
+        comp.scheduler.termination_conds[pnl.TimeScale.TRIAL] = pnl.AfterNCalls(gate, 3)
+        comp.run(inputs={drive: 1}, execution_mode=comp_mode)
+
+        # 3 passes of 5 executions each
+        np.testing.assert_array_equal(pass_mech.value, [[15]])

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -1659,7 +1659,7 @@ class TestOnResumeIntegratorMode:
         np.testing.assert_allclose(result, [[0.43636140750487973, 0.47074475219780554]])
         if comp_mode is pnl.ExecutionMode.Python:
             assert decision.num_executions.time_step == 1
-            assert decision.num_executions.pass_ == 2
+            assert decision.num_executions.pass_ == 1
             assert decision.num_executions.trial== 1
             assert decision.num_executions.run == 2
 


### PR DESCRIPTION
fixes an issue with incorrect early termination of `TransferMechanism.execute_until_finished` (see added test `test_measure_pass_as_non_input`)