### PR TITLE
llvm, IntegratorMechanism: Extract value of the reset signal

### DIFF
--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3089,7 +3089,7 @@ class Mechanism_Base(Mechanism):
             return params_in, builder
 
         # Allocate a shadow structure to overload base parameters
-        params_out = builder.alloca(params_in.type.pointee, name="modulated_parameters")
+        params_out = builder.alloca(params_in.type.pointee, name="modulated_parameters_{}".format(self))
 
         # Copy base values to the new structure
         if len(param_ports) != len(obj.llvm_param_ids):

--- a/psyneulink/core/components/mechanisms/processing/integratormechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/integratormechanism.py
@@ -130,6 +130,7 @@ from psyneulink.core.globals.keywords import \
 from psyneulink.core.globals.parameters import Parameter, check_user_specified
 from psyneulink.core.globals.preferences.basepreferenceset import ValidPrefSet, REPORT_OUTPUT_PREF
 from psyneulink.core.globals.preferences.preferenceset import PreferenceEntry, PreferenceLevel
+from psyneulink.core import llvm as pnlvm
 
 __all__ = [
     'DEFAULT_RATE', 'IntegratorMechanism', 'IntegratorMechanismError'
@@ -304,7 +305,7 @@ class IntegratorMechanism(ProcessingMechanism_Base):
         params, builder = self._gen_llvm_param_ports_for_obj(self, base_params, ctx, builder, base_params, state, arg_in)
 
         reset_ptr = ctx.get_param_or_state_ptr(builder, self, "reset", param_struct_ptr=params)
-        reset_val = builder.load(reset_ptr)
+        reset_val = pnlvm.helpers.load_extract_scalar_array_one(builder, reset_ptr)
 
         # FIXME: Consider cases where reset_val is a vector (or generally not
         # just float scalar)

--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -23,18 +23,20 @@ class TestReset:
     test_args = [pytest.param(1,                None,           id='default'),
                  pytest.param(None,             pnl.OVERRIDE,   id='OVERRRIDE')]
     @pytest.mark.parametrize('reset_default, modulation', test_args)
-    def test_reset_integrator_mechanism(self, reset_default, modulation):
+    def test_reset_integrator_mechanism(self, reset_default, modulation, comp_mode):
         input = pnl.ProcessingMechanism(name='INPUT')
-        counter = IntegratorMechanism(function=SimpleIntegrator,
-                                      default_variable=1,
-                                      reset_default=reset_default,
-                                      name='COUNTER')
+        counter = pnl.IntegratorMechanism(function=SimpleIntegrator,
+                                          default_variable=1,
+                                          reset_default=reset_default,
+                                          name='COUNTER')
         ctl = pnl.ControlMechanism(monitor_for_control=input,
                                    modulation=modulation,
                                    control=('reset', counter))
         c = Composition(nodes=[input, ctl, counter])
-        c.run(inputs={input:[0,0,1,0,0]})
+
+        c.run(inputs={input:[0,0,1,0,0]}, execution_mode=comp_mode)
         expected = [[[0.],[1.]], [[0.],[2.]], [[1.],[0.]], [[0.],[1.]], [[0.],[2.]]]
+
         np.testing.assert_allclose(c.results, expected)
 
     def test_FitzHughNagumo_valid(self):


### PR DESCRIPTION
Modulated parameters have an extra dimension.
Add the component name to the buffer allocated for modulated parameters.
Enable test.