### PR TITLE
Component: Add support for modulating nested Components

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -3553,20 +3553,22 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
         except TypeError:
             pass
 
-        parameter_port_list = None
         try:
             # parameter is SharedParameter and ultimately points to
             # something with a corresponding ParameterPort
             parameter_port_list = parameter.final_source._owner._owner.parameter_ports
         except AttributeError:
-            # prefer parameter ports from self over owner
             try:
-                parameter_port_list = self._parameter_ports
+                parameter_port_list = parameter.final_source.port._owner.parameter_ports
             except AttributeError:
+                # prefer parameter ports from self over owner
                 try:
-                    parameter_port_list = self.owner._parameter_ports
+                    parameter_port_list = self._parameter_ports
                 except AttributeError:
-                    pass
+                    try:
+                        parameter_port_list = self.owner._parameter_ports
+                    except AttributeError:
+                        parameter_port_list = None
 
         if parameter_port_list is not None:
             try:

--- a/tests/mechanisms/test_integrator_mechanism.py
+++ b/tests/mechanisms/test_integrator_mechanism.py
@@ -1218,8 +1218,6 @@ class TestIntegratorNoise:
           (pnl.STANDARD_DEVIATION, [[[10.], [27.06561325]], [[20.], [49.39917927]], [[10.], [10.76005365]], [[20.], [15.76534311]]]),
          ])
     def test_integrator_modulated_noise_fn(self, parameter, expected, comp_mode):
-        if not comp_mode.is_compiled():
-            pytest.skip("Python doesn't support modulating nested Parameters")
 
         # Use higher default mean to avoid rounding issues with lower precision (fp32)
         I = pnl.IntegratorMechanism(default_variable=[0], function=AccumulatorIntegrator(rate=0, noise=NormalDist(seed=[1], mean=15)))


### PR DESCRIPTION
Try to use the port associated with modulated Parameter directly.
Add test.