### PR TITLE
mechanism: update output ports after execution count increments

### DIFF
--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -2594,14 +2594,15 @@ class Mechanism_Base(Mechanism):
 
                 self.parameters.value._set(value, context=context)
 
-            # UPDATE OUTPUTPORT(S)
-            self._update_output_ports(runtime_port_params[OUTPUT_PORT_PARAMS], context)
-
             # MANAGE MAX_EXECUTIONS_BEFORE_FINISHED AND DETERMINE WHETHER TO BREAK
             max_executions = self.parameters.max_executions_before_finished._get(context)
             num_executions = np.asarray(self.parameters.num_executions_before_finished._get(context) + 1)
 
             self.parameters.num_executions_before_finished._set(num_executions, override=True, context=context)
+
+            # OutputPorts that read num_executions_before_finished should see the
+            # execution count from the iteration that just completed.
+            self._update_output_ports(runtime_port_params[OUTPUT_PORT_PARAMS], context)
 
             if num_executions >= max_executions:
                 self.parameters.is_finished_flag._set(True, context)
@@ -3349,7 +3350,16 @@ class Mechanism_Base(Mechanism):
             new_val = builder.add(new_val, new_val.type(1))
             builder.store(new_val, num_exec_time_ptr)
 
-        # Run output ports after updating the mech state (num_executions and value)
+        # OutputPorts that read num_executions_before_finished should see the
+        # execution count from the iteration that just completed.
+        is_finished_count_ptr = ctx.get_param_or_state_ptr(
+            builder, self, "num_executions_before_finished", state_struct_ptr=m_state
+        )
+        is_finished_count = builder.load(is_finished_count_ptr)
+        is_finished_count = builder.fadd(is_finished_count, is_finished_count.type(1))
+        builder.store(is_finished_count, is_finished_count_ptr)
+
+        # Run output ports after updating the mechanism state used by port variable specs.
         builder = self._gen_llvm_output_ports(ctx, builder, value, m_base_params, m_state, arg_in, arg_out)
 
         # is_finished should be checked after output ports ran
@@ -3504,9 +3514,6 @@ class Mechanism_Base(Mechanism):
         #FIXME: Flag and count should be int instead of float
         # Check if we reached maximum iteration count
         is_finished_count = builder.load(is_finished_count_ptr)
-        is_finished_count = builder.fadd(is_finished_count, is_finished_count.type(1))
-
-        builder.store(is_finished_count, is_finished_count_ptr)
         is_finished_max = builder.load(is_finished_max_ptr)
         max_reached = builder.fcmp_ordered(">=", is_finished_count, is_finished_max)
 

--- a/tests/ports/test_output_ports.py
+++ b/tests/ports/test_output_ports.py
@@ -56,6 +56,31 @@ class TestOutputPorts:
 
         np.testing.assert_allclose(res, expected2)
 
+    @pytest.mark.mechanism
+    def test_output_port_variable_spec_num_executions_before_finished(self, mech_mode):
+        """OutputPorts should observe the final terminating iteration count."""
+        mech = pnl.TransferMechanism(
+            input_shapes=2,
+            integrator_mode=True,
+            termination_measure=max,
+            termination_threshold=0.9,
+            termination_comparison_op=pnl.GREATER_THAN_OR_EQUAL,
+            execute_until_finished=True,
+            output_ports=[
+                pnl.RESULT,
+                pnl.OutputPort(name="STEPS", variable="num_executions_before_finished"),
+            ],
+        )
+
+        EX = pytest.helpers.get_mech_execution(mech, mech_mode)
+        res = EX([0.5, 1.0])
+
+        np.testing.assert_allclose(res[0], [0.46875, 0.9375])
+        np.testing.assert_allclose(res[1], [4])
+
+        if mech_mode == "Python":
+            assert mech.num_executions_before_finished == 4
+
     @pytest.mark.composition
     @pytest.mark.mechanism
     @pytest.mark.parametrize('spec, expected1, expected2',


### PR DESCRIPTION
OutputPort variable specs can read num_executions_before_finished, but Mechanism execution updated output ports before incrementing that counter.

As a result, terminating executions exposed the previous iteration count through output ports in both Python and LLVM execution.

Move the counter update ahead of output-port evaluation in both paths and add a regression using a TransferMechanism with an OutputPort bound to num_executions_before_finished.