### PR TITLE
llvm: Cleanup and consolidate Mechanism reset functions

### DIFF
--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1630,10 +1630,10 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                 blacklist.add('integrator_function')
 
         else:
-            # Execute until finished is only used by mechanisms
+            # "execute_until_finished is only used by Mechanisms
             blacklist.update(["execute_until_finished", "max_executions_before_finished"])
 
-            # "has_initializers" is only used by RTM
+            # "has_initializers" is only used by Mechanisms
             blacklist.add('has_initializers')
 
             # OneHot:

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -1439,48 +1439,55 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
             if hasattr(self.parameters, 'random_state') and hasattr(self.function.parameters, 'random_state'):
                 whitelist.remove('random_state')
 
+            # Drop combination function params from RTM if not needed
+            if getattr(self.parameters, 'has_recurrent_input_port', False):
+                blacklist.add('combination_function')
 
-        # Compositions need to track number of executions
-        if hasattr(self, 'nodes'):
-            whitelist.add("num_executions")
+            # Drop integrator function if integrator_mode is not enabled
+            if not getattr(self, 'integrator_mode', False):
+                blacklist.add('integrator_function')
 
-        # Drop combination function params from RTM if not needed
-        if getattr(self.parameters, 'has_recurrent_input_port', False):
-            blacklist.add('combination_function')
+        else:
+            # OneHot:
+            # * runtime abs_val and indicator are only used in deterministic mode.
+            # * random_state and seed are only used in RANDOM tie resolution.
+            if (componentName := getattr(self, 'componentName', None)) == kw.ONE_HOT_FUNCTION:
+                if self.mode != kw.DETERMINISTIC:
+                    if self.mode not in {kw.PROB, kw.PROB_INDICATOR}:
+                        whitelist.remove('random_state')
 
-        # Drop integrator function if integrator_mode is not enabled
-        if not getattr(self, 'integrator_mode', False):
-            blacklist.add('integrator_function')
-
-        # Drop unused cost functions
-        if (cost_functions := getattr(self, 'enabled_cost_functions', None)) is not None:
-            if cost_functions.INTENSITY not in cost_functions:
-                blacklist.add('intensity_cost_fct')
-
-            if cost_functions.ADJUSTMENT not in cost_functions:
-                blacklist.add('adjustment_cost_fct')
-
-            if cost_functions.DURATION not in cost_functions:
-                blacklist.add('duration_cost_fct')
-
-        if (componentName := getattr(self, 'componentName', None)) == kw.ONE_HOT_FUNCTION:
-            if self.mode != kw.DETERMINISTIC:
-                if self.mode not in {kw.PROB, kw.PROB_INDICATOR}:
+                elif self.tie != kw.RANDOM:
                     whitelist.remove('random_state')
 
-            elif self.tie != kw.RANDOM:
+            # Dropout:
+            # * random state is only used in learning mode
+            elif componentName == kw.DROPOUT_FUNCTION:
                 whitelist.remove('random_state')
 
-        elif componentName == kw.DROPOUT_FUNCTION:
-            whitelist.remove('random_state')
+            # DictionaryMemory:
+            # * previous_value is not used (history of 'value' is used instead)
+            elif componentName == kw.DictionaryMemory_FUNCTION:
+                blacklist.add("previous_value")
 
-        # Drop previous_value from MemoryFunctions
-        if hasattr(self.parameters, 'duplicate_keys'):
-            blacklist.add("previous_value")
+            # TransferWithCosts:
+            # * drop unused cost functions
+            elif componentName == kw.TRANSFER_WITH_COSTS_FUNCTION:
+                if self.enabled_cost_functions.INTENSITY not in self.enabled_cost_functions:
+                    blacklist.add('intensity_cost_fct')
 
-        # Matrices of learnable projections are stateful
-        if getattr(self, 'owner', None) and getattr(self.owner, 'learnable', False):
-            whitelist.add('matrix')
+                if self.enabled_cost_functions.ADJUSTMENT not in self.enabled_cost_functions:
+                    blacklist.add('adjustment_cost_fct')
+
+                if self.enabled_cost_functions.DURATION not in self.enabled_cost_functions:
+                    blacklist.add('duration_cost_fct')
+
+            # Compositions need to track number of executions
+            if hasattr(self, 'nodes'):
+                whitelist.add("num_executions")
+
+            # Matrices of learnable projections are stateful
+            if getattr(self, 'owner', None) and getattr(self.owner, 'learnable', False):
+                whitelist.add('matrix')
 
         def _is_compilation_state(p):
             # FIXME: This should use defaults instead of 'p.get'
@@ -1600,23 +1607,6 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
                      "mask"
                      }
 
-        # OneHot:
-        # * runtime abs_val and indicator are only used in deterministic mode.
-        # * random_state and seed are only used in RANDOM tie resolution.
-        if (componentName := getattr(self, 'componentName', None)) == kw.ONE_HOT_FUNCTION:
-            if self.mode != kw.DETERMINISTIC:
-                blacklist.update(['abs_val', 'indicator'])
-                if self.mode not in {kw.PROB, kw.PROB_INDICATOR}:
-                    blacklist.add("seed")
-
-            elif self.tie != kw.RANDOM:
-                blacklist.add("seed")
-
-        # Dropout:
-        # random state is only used in learning mode
-        elif componentName == kw.DROPOUT_FUNCTION:
-            blacklist.update(["seed", "p"])
-
         # Mechanism's need few extra entries:
         # * matrix -- is never used directly
         # * integration_rate -- shape mismatch with param port input
@@ -1631,6 +1621,14 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
             if hasattr(self.parameters, 'random_state') and hasattr(self.function.parameters, 'random_state'):
                 blacklist.add("seed")
 
+            # Drop combination function params from RTM if not needed
+            if getattr(self.parameters, 'has_recurrent_input_port', False):
+                blacklist.add('combination_function')
+
+            # Drop integrator function if integrator_mode is not enabled
+            if not getattr(self, 'integrator_mode', False):
+                blacklist.add('integrator_function')
+
         else:
             # Execute until finished is only used by mechanisms
             blacklist.update(["execute_until_finished", "max_executions_before_finished"])
@@ -1638,28 +1636,38 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
             # "has_initializers" is only used by RTM
             blacklist.add('has_initializers')
 
-        # Drop combination function params from RTM if not needed
-        if getattr(self.parameters, 'has_recurrent_input_port', False):
-            blacklist.add('combination_function')
+            # OneHot:
+            # * runtime abs_val and indicator are only used in deterministic mode.
+            # * random_state and seed are only used in RANDOM tie resolution.
+            if (componentName := getattr(self, 'componentName', None)) == kw.ONE_HOT_FUNCTION:
+                if self.mode != kw.DETERMINISTIC:
+                    blacklist.update(['abs_val', 'indicator'])
+                    if self.mode not in {kw.PROB, kw.PROB_INDICATOR}:
+                        blacklist.add('seed')
 
-        # Drop integrator function if integrator_mode is not enabled
-        if not getattr(self, 'integrator_mode', False):
-            blacklist.add('integrator_function')
+                elif self.tie != kw.RANDOM:
+                    blacklist.add('seed')
 
-        # Drop unused cost functions
-        if (cost_functions := getattr(self, 'enabled_cost_functions', None)) is not None:
-            if cost_functions.INTENSITY not in cost_functions:
-                blacklist.add('intensity_cost_fct')
+            # Dropout:
+            # random state is only used in learning mode
+            elif componentName == kw.DROPOUT_FUNCTION:
+                blacklist.update(['seed', 'p'])
 
-            if cost_functions.ADJUSTMENT not in cost_functions:
-                blacklist.add('adjustment_cost_fct')
+            # TransferWithCosts:
+            # * drop unused cost functions
+            elif componentName == kw.TRANSFER_WITH_COSTS_FUNCTION:
+                if self.enabled_cost_functions.INTENSITY not in self.enabled_cost_functions:
+                    blacklist.add('intensity_cost_fct')
 
-            if cost_functions.DURATION not in cost_functions:
-                blacklist.add('duration_cost_fct')
+                if self.enabled_cost_functions.ADJUSTMENT not in self.enabled_cost_functions:
+                    blacklist.add('adjustment_cost_fct')
 
-        # Matrices of learnable projections are stateful
-        if getattr(self, 'owner', None) and getattr(self.owner, 'learnable', False):
-            blacklist.add('matrix')
+                if self.enabled_cost_functions.DURATION not in self.enabled_cost_functions:
+                    blacklist.add('duration_cost_fct')
+
+            # Matrices of learnable projections are stateful
+            if getattr(self, 'owner', None) and getattr(self.owner, 'learnable', False):
+                blacklist.add('matrix')
 
         def _is_compilation_param(p):
             return p.name not in blacklist and self._is_compilable_param(p)

--- a/psyneulink/core/components/functions/stateful/integratorfunctions.py
+++ b/psyneulink/core/components/functions/stateful/integratorfunctions.py
@@ -2620,7 +2620,7 @@ class DriftDiffusionIntegrator(IntegratorFunction):  # -------------------------
 
         builder = super()._gen_llvm_function_reset(ctx, builder, params, state, arg_in, arg_out, tags=tags)
 
-        # Return the reconstructed combination of previous value and previous tim
+        # Return the reconstructed combination of previous value and previous time
         prev_value_ptr = ctx.get_param_or_state_ptr(builder, self, PREVIOUS_VALUE, state_struct_ptr=state)
         value_out_ptr = builder.gep(arg_out, [ctx.int32_ty(0), ctx.int32_ty(0)])
         builder.store(builder.load(prev_value_ptr), value_out_ptr)

--- a/psyneulink/core/components/mechanisms/mechanism.py
+++ b/psyneulink/core/components/mechanisms/mechanism.py
@@ -3370,6 +3370,20 @@ class Mechanism_Base(Mechanism):
     def _gen_llvm_function_reset(self, ctx, builder, m_base_params, m_state, m_arg_in, m_arg_out, *, tags:frozenset):
         assert "reset" in tags
 
+        # Check if there are initializers to use. This should generally reflect
+        # the presence of StatefulFunction, but it can be changed explicitly
+        # by the user.
+        # Python checks this as part of reset invocation expression in
+        # Composition.execute, so do not apply modulation.
+        has_reinitializers_ptr = ctx.get_param_or_state_ptr(builder,
+                                                            self,
+                                                            "has_initializers",
+                                                            param_struct_ptr=m_base_params)
+        has_initializers = builder.load(has_reinitializers_ptr)
+        not_initializers = builder.fcmp_ordered("==", has_initializers, has_initializers.type(0))
+        with builder.if_then(not_initializers):
+            builder.ret_void()
+
         if hasattr(self, "integrator_function") and getattr(self, "integrator_mode", False):
             reinit_int_func = ctx.import_llvm_function(self.integrator_function, tags=tags)
             reinit_int_in = builder.alloca(reinit_int_func.args[2].type.pointee, name="integrator_reinit_in")

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1251,7 +1251,7 @@ class RecurrentTransferMechanism(TransferMechanism):
 
         # Initialize to OutputPort defaults.
         # That is what the recurrent projection finds.
-        retval_init = (tuple(op.parameters.value.get(context)) if not np.isscalar(op.parameters.value.get(context)) else op.parameters.value.get(context) for op in self.output_ports)
+        retval_init = (tuple(value) if not np.isscalar(value := op.parameters.value.get(context)) else value for op in self.output_ports)
         return (*transfer_init, tuple(retval_init))
 
     def _gen_llvm_input_ports(self, ctx, builder, params, state, arg_in):
@@ -1263,9 +1263,9 @@ class RecurrentTransferMechanism(TransferMechanism):
         recurrent_f = ctx.import_llvm_function(self.recurrent_projection)
 
         # Extract the correct output port value
-        prev_val_ptr = ctx.get_param_or_state_ptr(builder, self, "old_val", state_struct_ptr=state)
+        old_val_ptr = ctx.get_param_or_state_ptr(builder, self, "old_val", state_struct_ptr=state)
         recurrent_index = self.output_ports.index(self.recurrent_projection.sender)
-        recurrent_in = builder.gep(prev_val_ptr, [ctx.int32_ty(0), ctx.int32_ty(recurrent_index)])
+        recurrent_in = builder.gep(old_val_ptr, [ctx.int32_ty(0), ctx.int32_ty(recurrent_index)])
 
         # Get the correct recurrent output location
         recurrent_out = builder.gep(arg_in, [ctx.int32_ty(0),
@@ -1287,11 +1287,9 @@ class RecurrentTransferMechanism(TransferMechanism):
 
         return super()._gen_llvm_input_ports(ctx, builder, params, state, arg_in)
 
-    def _gen_llvm_output_ports(self, ctx, builder, value,
-                               mech_params, mech_state, mech_in, mech_out):
-        ret = super()._gen_llvm_output_ports(ctx, builder, value, mech_params,
-                                             mech_state, mech_in, mech_out)
+    def _gen_llvm_output_ports(self, ctx, builder, value, mech_params, mech_state, mech_in, mech_out):
+        ret = super()._gen_llvm_output_ports(ctx, builder, value, mech_params, mech_state, mech_in, mech_out)
 
-        prev_val_ptr = ctx.get_param_or_state_ptr(builder, self, "old_val", state_struct_ptr=mech_state)
-        builder.store(builder.load(mech_out), prev_val_ptr)
+        old_val_ptr = ctx.get_param_or_state_ptr(builder, self, "old_val", state_struct_ptr=mech_state)
+        builder.store(builder.load(mech_out), old_val_ptr)
         return ret

--- a/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/transfer/recurrenttransfermechanism.py
@@ -1254,47 +1254,6 @@ class RecurrentTransferMechanism(TransferMechanism):
         retval_init = (tuple(op.parameters.value.get(context)) if not np.isscalar(op.parameters.value.get(context)) else op.parameters.value.get(context) for op in self.output_ports)
         return (*transfer_init, tuple(retval_init))
 
-    def _gen_llvm_function_reset(self, ctx, builder, params, state, arg_in, arg_out, *, tags:frozenset):
-        assert "reset" in tags
-
-        # Check if we have reinitializers
-        has_reinitializers_ptr = ctx.get_param_or_state_ptr(builder,
-                                                            self,
-                                                            "has_initializers",
-                                                            param_struct_ptr=params)
-        has_initializers = builder.load(has_reinitializers_ptr)
-        not_initializers = builder.fcmp_ordered("==", has_initializers,
-                                                has_initializers.type(0))
-        with builder.if_then(not_initializers):
-            builder.ret_void()
-
-        # Reinit main function. This is a no-op if it's not a stateful function.
-        reinit_func = ctx.import_llvm_function(self.function, tags=tags)
-        reinit_params, reinit_state = ctx.get_param_or_state_ptr(builder,
-                                                                 self,
-                                                                 "function",
-                                                                 param_struct_ptr=params,
-                                                                 state_struct_ptr=state)
-        reinit_in = builder.alloca(reinit_func.args[2].type.pointee, name="reinit_in")
-        reinit_out = builder.alloca(reinit_func.args[3].type.pointee, name="reinit_out")
-        builder.call(reinit_func, [reinit_params, reinit_state, reinit_in, reinit_out])
-
-        # Reinit integrator function
-        if self.integrator_mode:
-            reinit_f = ctx.import_llvm_function(self.integrator_function, tags=tags)
-            reinit_in = builder.alloca(reinit_f.args[2].type.pointee, name="integ_reinit_in")
-            reinit_out = builder.alloca(reinit_f.args[3].type.pointee, name="integ_reinit_out")
-            reinit_params, reinit_state = ctx.get_param_or_state_ptr(builder,
-                                                                     self,
-                                                                     "integrator_function",
-                                                                     param_struct_ptr=params,
-                                                                     state_struct_ptr=state)
-            builder.call(reinit_f, [reinit_params, reinit_state, reinit_in, reinit_out])
-
-        prev_val_ptr = ctx.get_param_or_state_ptr(builder, self, "old_val", state_struct_ptr=state)
-        builder.store(prev_val_ptr.type.pointee(None), prev_val_ptr)
-        return builder
-
     def _gen_llvm_input_ports(self, ctx, builder, params, state, arg_in):
         recurrent_params, recurrent_state = ctx.get_param_or_state_ptr(builder,
                                                                        self,


### PR DESCRIPTION
Consolidate magic lists. Use component names and categories instead of querying correlated parameters.
Skip mechanism reset if "has_initializers" is not set for all Machanisms.
Remove overloaded reset generation for RecurrentTransferMechanism.
Codestyle.