### PR TITLE
LinearCombination: higher-dimension capable LLVM implementation

### DIFF
--- a/psyneulink/core/components/functions/nonstateful/transformfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/transformfunctions.py
@@ -112,8 +112,13 @@ class TransformFunction(Function_Base):
             return ctx.float_ty(default)
 
         elif isinstance(param_type, pnlvm.ir.ArrayType):
-            index = ctx.int32_ty(0) if len(param_type) == 1 else index
-            param_ptr = builder.gep(param_ptr, [ctx.int32_ty(0), index])
+            if len(param_type) == 1 and not isinstance(param_type.element, pnlvm.ir.ArrayType):
+                index = [ctx.int32_ty(0)]
+
+            if not isinstance(index, list):
+                index = [index]
+
+            param_ptr = builder.gep(param_ptr, [ctx.int32_ty(0), *index])
 
         return builder.load(param_ptr)
 
@@ -1533,10 +1538,92 @@ class LinearCombination(
         default_var = np.atleast_2d(self.defaults.variable)
         return ctx.convert_python_struct_to_llvm_ir(default_var)
 
-    def _gen_llvm_combine(self, builder, index, ctx, vi, vo, params):
-        scale = self._gen_llvm_load_param(ctx, builder, params, SCALE, index, 1.0)
-        offset = self._gen_llvm_load_param(ctx, builder, params, OFFSET, index, -0.0)
+    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tags: frozenset):
+        # for the frequent case where non-LLVM variable is 2D and value is cast
+        # up to 2D from 1D. arg_out is expected to have one fewer dimension than
+        # arg_in in _gen_llvm_combine_body.
+        if (arg_in.type.pointee.element == arg_out.type.pointee.element) and arg_out.type.pointee.count == 1:
+            arg_out = pnlvm.helpers.unwrap_2d_array(builder, arg_out)
 
+        self._gen_llvm_combine(builder, ctx=ctx, vi=arg_in, vo=arg_out, params=params)
+        return builder
+
+    def _gen_llvm_combine_body(self, builder, ctx, vi, vo, val, pow_f, comb_op, params, vo_idx):
+        ptro = builder.gep(vo, [ctx.int32_ty(0), *vo_idx])
+
+        if isinstance(ptro.type.pointee, pnlvm.ir.ArrayType):
+            # Recursion on output array dimensions stops when pointing to scalar
+            with pnlvm.helpers.array_ptr_loop(builder, ptro, f"combine_axis{len(vo_idx)}") as (b, idx):
+                self._gen_llvm_combine_body(b, ctx, vi, vo, val, pow_f, comb_op, params, [*vo_idx, idx])
+        else:
+            # val is the base value passed in according to the combination
+            # operation (0 for sum, 1 for product)
+            val_p = builder.alloca(val.type, name="combined_result")
+            builder.store(val, val_p)
+
+            assert isinstance(vi.type.pointee, pnlvm.ir.ArrayType)
+            with pnlvm.helpers.array_ptr_loop(builder, vi, "combine") as (b, idx):
+                # The recursion is on the output, so `vo_idx` corresponds to a
+                # scalar in the output array. This loop is over the input, which
+                # has shape (vi.type.pointee.count, <`vo` shape>) and assumes axis=0.
+                # So, we combine elements [0, `vo_idx`]...[`vi.type.pointee.count-1`, `vo_idx`]
+                # to get the result element (`vo_idx`) in the output.
+                in_idx = [idx, *vo_idx]
+                ptri = b.gep(vi, [ctx.int32_ty(0), *in_idx])
+                in_val = b.load(ptri)
+
+                # lower-dim array specification (ex: exponents [a, b]
+                # and var [[[1, 1]], [[2, 2]]], applying a to [[1, 1]]
+                # and b to [[2, 2]])
+                exponent = self._gen_llvm_load_param(ctx, b, params, EXPONENTS, idx, 1.0)
+                if (
+                    isinstance(exponent.type, pnlvm.ir.ArrayType)
+                    and len(exponent.type) == 1
+                    and not isinstance(exponent.type.element, pnlvm.ir.ArrayType)
+                ):
+                    exponent = b.extract_value(exponent, [0])
+                else:
+                    # variable (input) matching array specification
+                    exponent = self._gen_llvm_load_param(ctx, b, params, EXPONENTS, in_idx, 1.0)
+
+                # FIXME: Remove this micro-optimization,
+                #        it should be handled by the compiler
+                if not isinstance(exponent, pnlvm.ir.Constant) or exponent.constant != 1.0:
+                    in_val = b.call(pow_f, [in_val, exponent])
+
+                # lower-dim array specification (see exponent above)
+                weight = self._gen_llvm_load_param(ctx, b, params, WEIGHTS, idx, 1.0)
+                if (
+                    isinstance(weight.type, pnlvm.ir.ArrayType)
+                    and len(weight.type) == 1
+                    and not isinstance(weight.type.element, pnlvm.ir.ArrayType)
+                ):
+                    weight = b.extract_value(weight, [0])
+                else:
+                    # variable (input) matching array specification
+                    weight = self._gen_llvm_load_param(ctx, b, params, WEIGHTS, in_idx, 1.0)
+
+                in_val = b.fmul(in_val, weight)
+
+                # val_p points to a temp value that will be put in a specific
+                # element in the result. It's calculated sequentially by
+                # combining each in_val iterated over in this loop
+                val = b.load(val_p)
+                val = getattr(b, comb_op)(val, in_val)
+
+                b.store(val, val_p)
+
+            # value (output) matching
+            scale = self._gen_llvm_load_param(ctx, builder, params, SCALE, vo_idx, 1.0)
+            offset = self._gen_llvm_load_param(ctx, builder, params, OFFSET, vo_idx, -0.0)
+
+            val = builder.load(val_p)
+            val = builder.fmul(val, scale)
+            val = builder.fadd(val, offset)
+
+            builder.store(val, ptro)
+
+    def _gen_llvm_combine(self, builder, ctx, vi, vo, params):
         # assume operation does not change dynamically
         operation = self.parameters.operation.get()
         if operation == SUM:
@@ -1558,45 +1645,8 @@ class LinearCombination(
         else:
             assert False, "Unknown operation: {}".format(operation)
 
-        val_p = builder.alloca(val.type, name="combined_result")
-        builder.store(val, val_p)
-
         pow_f = ctx.get_builtin("pow", [ctx.float_ty])
-
-        with pnlvm.helpers.array_ptr_loop(builder, vi, "combine") as (b, idx):
-            ptri = b.gep(vi, [ctx.int32_ty(0), idx, index])
-            in_val = b.load(ptri)
-
-            exponent = self._gen_llvm_load_param(ctx, b, params, EXPONENTS,
-                                                 idx, 1.0)
-            # Vector of vectors (even 1-element vectors)
-            if isinstance(exponent.type, pnlvm.ir.ArrayType):
-                assert len(exponent.type) == 1 # FIXME: Add support for matrix weights
-                exponent = b.extract_value(exponent, [0])
-            # FIXME: Remove this micro-optimization,
-            #        it should be handled by the compiler
-            if not isinstance(exponent, pnlvm.ir.Constant) or exponent.constant != 1.0:
-                in_val = b.call(pow_f, [in_val, exponent])
-
-            weight = self._gen_llvm_load_param(ctx, b, params, WEIGHTS,
-                                               idx, 1.0)
-            # Vector of vectors (even 1-element vectors)
-            if isinstance(weight.type, pnlvm.ir.ArrayType):
-                assert len(weight.type) == 1 # FIXME: Add support for matrix weights
-                weight = b.extract_value(weight, [0])
-
-            in_val = b.fmul(in_val, weight)
-
-            val = b.load(val_p)
-            val = getattr(b, comb_op)(val, in_val)
-            b.store(val, val_p)
-
-        val = builder.load(val_p)
-        val = builder.fmul(val, scale)
-        val = builder.fadd(val, offset)
-
-        ptro = builder.gep(vo, [ctx.int32_ty(0), index])
-        builder.store(val, ptro)
+        self._gen_llvm_combine_body(builder, ctx, vi, vo, val, pow_f, comb_op, params, [])
 
     def _gen_pytorch_fct(self, device, context=None):
         weights = self._get_pytorch_fct_param_value('weights', device, context)

--- a/psyneulink/core/components/functions/nonstateful/transformfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/transformfunctions.py
@@ -108,8 +108,13 @@ class TransformFunction(Function_Base):
             return ctx.float_ty(default)
 
         elif isinstance(param_type, pnlvm.ir.ArrayType):
-            index = ctx.int32_ty(0) if len(param_type) == 1 else index
-            param_ptr = builder.gep(param_ptr, [ctx.int32_ty(0), index])
+            if len(param_type) == 1 and not isinstance(param_type.element, pnlvm.ir.ArrayType):
+                index = [ctx.int32_ty(0)]
+
+            if not isinstance(index, list):
+                index = [index]
+
+            param_ptr = builder.gep(param_ptr, [ctx.int32_ty(0), *index])
 
         return builder.load(param_ptr)
 
@@ -1529,10 +1534,92 @@ class LinearCombination(
         default_var = np.atleast_2d(self.defaults.variable)
         return ctx.convert_python_struct_to_llvm_ir(default_var)
 
-    def _gen_llvm_combine(self, builder, index, ctx, vi, vo, params):
-        scale = self._gen_llvm_load_param(ctx, builder, params, SCALE, index, 1.0)
-        offset = self._gen_llvm_load_param(ctx, builder, params, OFFSET, index, -0.0)
+    def _gen_llvm_function_body(self, ctx, builder, params, _, arg_in, arg_out, *, tags: frozenset):
+        # for the frequent case where non-LLVM variable is 2D and value is cast
+        # up to 2D from 1D. arg_out is expected to have one fewer dimension than
+        # arg_in in _gen_llvm_combine_body.
+        if (arg_in.type.pointee.element == arg_out.type.pointee.element) and arg_out.type.pointee.count == 1:
+            arg_out = pnlvm.helpers.unwrap_2d_array(builder, arg_out)
 
+        self._gen_llvm_combine(builder, ctx=ctx, vi=arg_in, vo=arg_out, params=params)
+        return builder
+
+    def _gen_llvm_combine_body(self, builder, ctx, vi, vo, val, pow_f, comb_op, params, vo_idx):
+        ptro = builder.gep(vo, [ctx.int32_ty(0), *vo_idx])
+
+        if isinstance(ptro.type.pointee, pnlvm.ir.ArrayType):
+            # Recursion on output array dimensions stops when pointing to scalar
+            with pnlvm.helpers.array_ptr_loop(builder, ptro, f"combine_axis{len(vo_idx)}") as (b, idx):
+                self._gen_llvm_combine_body(b, ctx, vi, vo, val, pow_f, comb_op, params, [*vo_idx, idx])
+        else:
+            # val is the base value passed in according to the combination
+            # operation (0 for sum, 1 for product)
+            val_p = builder.alloca(val.type, name="combined_result")
+            builder.store(val, val_p)
+
+            assert isinstance(vi.type.pointee, pnlvm.ir.ArrayType)
+            with pnlvm.helpers.array_ptr_loop(builder, vi, "combine") as (b, idx):
+                # The recursion is on the output, so `vo_idx` corresponds to a
+                # scalar in the output array. This loop is over the input, which
+                # has shape (vi.type.pointee.count, <`vo` shape>) and assumes axis=0.
+                # So, we combine elements [0, `vo_idx`]...[`vi.type.pointee.count-1`, `vo_idx`]
+                # to get the result element (`vo_idx`) in the output.
+                in_idx = [idx, *vo_idx]
+                ptri = b.gep(vi, [ctx.int32_ty(0), *in_idx])
+                in_val = b.load(ptri)
+
+                # lower-dim array specification (ex: exponents [a, b]
+                # and var [[[1, 1]], [[2, 2]]], applying a to [[1, 1]]
+                # and b to [[2, 2]])
+                exponent = self._gen_llvm_load_param(ctx, b, params, EXPONENTS, idx, 1.0)
+                if (
+                    isinstance(exponent.type, pnlvm.ir.ArrayType)
+                    and len(exponent.type) == 1
+                    and not isinstance(exponent.type.element, pnlvm.ir.ArrayType)
+                ):
+                    exponent = b.extract_value(exponent, [0])
+                else:
+                    # variable (input) matching array specification
+                    exponent = self._gen_llvm_load_param(ctx, b, params, EXPONENTS, in_idx, 1.0)
+
+                # FIXME: Remove this micro-optimization,
+                #        it should be handled by the compiler
+                if not isinstance(exponent, pnlvm.ir.Constant) or exponent.constant != 1.0:
+                    in_val = b.call(pow_f, [in_val, exponent])
+
+                # lower-dim array specification (see exponent above)
+                weight = self._gen_llvm_load_param(ctx, b, params, WEIGHTS, idx, 1.0)
+                if (
+                    isinstance(weight.type, pnlvm.ir.ArrayType)
+                    and len(weight.type) == 1
+                    and not isinstance(weight.type.element, pnlvm.ir.ArrayType)
+                ):
+                    weight = b.extract_value(weight, [0])
+                else:
+                    # variable (input) matching array specification
+                    weight = self._gen_llvm_load_param(ctx, b, params, WEIGHTS, in_idx, 1.0)
+
+                in_val = b.fmul(in_val, weight)
+
+                # val_p points to a temp value that will be put in a specific
+                # element in the result. It's calculated sequentially by
+                # combining each in_val iterated over in this loop
+                val = b.load(val_p)
+                val = getattr(b, comb_op)(val, in_val)
+
+                b.store(val, val_p)
+
+            # value (output) matching
+            scale = self._gen_llvm_load_param(ctx, builder, params, SCALE, vo_idx, 1.0)
+            offset = self._gen_llvm_load_param(ctx, builder, params, OFFSET, vo_idx, -0.0)
+
+            val = builder.load(val_p)
+            val = builder.fmul(val, scale)
+            val = builder.fadd(val, offset)
+
+            builder.store(val, ptro)
+
+    def _gen_llvm_combine(self, builder, ctx, vi, vo, params):
         # assume operation does not change dynamically
         operation = self.parameters.operation.get()
         if operation == SUM:
@@ -1554,45 +1641,8 @@ class LinearCombination(
         else:
             assert False, "Unknown operation: {}".format(operation)
 
-        val_p = builder.alloca(val.type, name="combined_result")
-        builder.store(val, val_p)
-
         pow_f = ctx.get_builtin("pow", [ctx.float_ty])
-
-        with pnlvm.helpers.array_ptr_loop(builder, vi, "combine") as (b, idx):
-            ptri = b.gep(vi, [ctx.int32_ty(0), idx, index])
-            in_val = b.load(ptri)
-
-            exponent = self._gen_llvm_load_param(ctx, b, params, EXPONENTS,
-                                                 idx, 1.0)
-            # Vector of vectors (even 1-element vectors)
-            if isinstance(exponent.type, pnlvm.ir.ArrayType):
-                assert len(exponent.type) == 1 # FIXME: Add support for matrix weights
-                exponent = b.extract_value(exponent, [0])
-            # FIXME: Remove this micro-optimization,
-            #        it should be handled by the compiler
-            if not isinstance(exponent, pnlvm.ir.Constant) or exponent.constant != 1.0:
-                in_val = b.call(pow_f, [in_val, exponent])
-
-            weight = self._gen_llvm_load_param(ctx, b, params, WEIGHTS,
-                                               idx, 1.0)
-            # Vector of vectors (even 1-element vectors)
-            if isinstance(weight.type, pnlvm.ir.ArrayType):
-                assert len(weight.type) == 1 # FIXME: Add support for matrix weights
-                weight = b.extract_value(weight, [0])
-
-            in_val = b.fmul(in_val, weight)
-
-            val = b.load(val_p)
-            val = getattr(b, comb_op)(val, in_val)
-            b.store(val, val_p)
-
-        val = builder.load(val_p)
-        val = builder.fmul(val, scale)
-        val = builder.fadd(val, offset)
-
-        ptro = builder.gep(vo, [ctx.int32_ty(0), index])
-        builder.store(val, ptro)
+        self._gen_llvm_combine_body(builder, ctx, vi, vo, val, pow_f, comb_op, params, [])
 
     def _gen_pytorch_fct(self, device, context=None):
         weights = self._get_pytorch_fct_param_value('weights', device, context)

--- a/tests/functions/test_combination.py
+++ b/tests/functions/test_combination.py
@@ -1,7 +1,11 @@
+from numbers import Number
+
 import numpy as np
 import pytest
 
 import psyneulink as pnl
+from psyneulink._typing import Union
+from psyneulink.core import llvm as pnlvm
 
 
 class TestRearrange:
@@ -152,30 +156,60 @@ class TestReduce:
     #
 
 
+def _as_fp32(x: Union[Number, np.ndarray]) -> Union[np.float32, np.ndarray]:
+    try:
+        return x.astype(np.float32)
+    except AttributeError:
+        return np.float32(x)
+
+
+def _rand(*args) -> np.ndarray:
+    res = np.random.rand(*args)
+    # work around get_current assertion fail from checking pytest.helpers.llvm_current_fp_precision() == 'fp32'
+    if pnlvm.LLVMBuilderContext.default_float_ty == pnlvm.ir.FloatType():
+        res = _as_fp32(res)
+    return res
+
+
 SIZE=5
 np.random.seed(0)
 #This gives us the correct 2d array
-test_varr1 = np.random.rand(1, SIZE)
-test_varr2 = np.random.rand(2, SIZE)
-test_varr3 = np.random.rand(3, SIZE)
+test_varr1 = _rand(1, SIZE)
+test_varr2 = _rand(2, SIZE)
+test_varr3 = _rand(3, SIZE)
 
 #This gives us the correct 2d column array
-test_varc1 = np.random.rand(SIZE, 1)
-test_varc2 = np.random.rand(SIZE, 1)
-test_varc3 = np.random.rand(SIZE, 1)
+test_varc1 = _rand(SIZE, 1)
+test_varc2 = _rand(SIZE, 1)
+test_varc3 = _rand(SIZE, 1)
 
 #This gives us the correct 2d matrix array
-test_varm1 = np.random.rand(SIZE, 3)
-test_varm2 = np.random.rand(SIZE, 3)
-test_varm3 = np.random.rand(SIZE, 3)
+test_varm1 = _rand(SIZE, 3)
+test_varm2 = _rand(SIZE, 3)
+test_varm3 = _rand(SIZE, 3)
 
-RAND1_V = np.random.rand(SIZE)
-RAND2_V = np.random.rand(SIZE)
-RAND3_V = np.random.rand(SIZE)
+RAND1_V = _rand(SIZE)
+RAND2_V = _rand(SIZE)
+RAND3_V = _rand(SIZE)
 
-RAND1_S = np.random.rand()
-RAND2_S = np.random.rand()
-RAND3_S = np.random.rand()
+RAND1_S = _rand()
+RAND2_S = _rand()
+RAND3_S = _rand()
+
+
+# higher dimension arrays
+test_varh1 = _rand(1, 1, SIZE)
+test_varh2 = _rand(2, 3, SIZE, SIZE)
+test_varh3 = _rand(5, 4, SIZE, SIZE, SIZE)
+
+RANDh_A = {
+    k: {
+        test_varh1.shape: _rand(*test_varh1.shape),
+        test_varh2.shape: _rand(*test_varh2.shape),
+        test_varh3.shape: _rand(*test_varh3.shape),
+    }
+    for k in ['exponents', 'weights', 'scale', 'offset']
+}
 
 
 @pytest.mark.benchmark(group="ReduceFunction")
@@ -268,6 +302,64 @@ def test_linear_combination_function(variable, operation, exponents, weights, sc
         expected = np.prod(tmp, axis=0) * scale + offset
 
     np.testing.assert_allclose(res, expected, rtol=1e-5, atol=1e-8)
+
+
+@pytest.mark.benchmark(group="LinearCombinationFunction higher dim")
+@pytest.mark.function
+@pytest.mark.combination_function
+@pytest.mark.parametrize("variable", [test_varh1, test_varh2, test_varh3], ids=["VAR1h", "VAR2h", "VAR3h"])
+@pytest.mark.parametrize("operation", [pnl.SUM, pnl.PRODUCT])
+@pytest.mark.parametrize("exponents", [None, 2.0, [3.0], 'A'], ids=["E_NONE", "E_SCALAR", "E_VECTOR1", "E_ARRAY"])
+@pytest.mark.parametrize("weights", [None, 0.5, 'A'], ids=["W_NONE", "W_SCALAR", "W_ARRAY"])
+@pytest.mark.parametrize("scale", [None, RAND1_S, 'A'], ids=["S_NONE", "S_SCALAR", "S_ARRAY"])
+@pytest.mark.parametrize("offset", [None, RAND2_S, 'A'], ids=["O_NONE", "O_SCALAR", "O_ARRAY"])
+def test_linear_combination_function_higher_dim(variable, operation, exponents, weights, scale, offset, func_mode, benchmark):
+    # arrays in shape of input
+    if weights == 'A':
+        # random 1/-1
+        weights = 2 * (np.round(RANDh_A['weights'][variable.shape]) - .5)
+    if exponents == 'A':
+        exponents = RANDh_A['exponents'][variable.shape]
+
+    # scalars in parametrization still may be created as float64
+    if pytest.helpers.llvm_current_fp_precision() == 'fp32':
+        exponents = _as_fp32(exponents)
+        weights = _as_fp32(weights)
+
+    # arrays in shape of output
+    if scale == 'A':
+        scale = RANDh_A['scale'][variable.shape][0]
+    if offset == 'A':
+        offset = RANDh_A['offset'][variable.shape][0]
+
+    f = pnl.LinearCombination(default_variable=variable,
+                              operation=operation,
+                              exponents=exponents,
+                              weights=weights,
+                              scale=scale,
+                              offset=offset)
+    EX = pytest.helpers.get_func_execution(f, func_mode)
+    res = benchmark(EX, variable)
+
+    scale = 1.0 if scale is None else scale
+    offset = 0.0 if offset is None else offset
+    exponent = 1.0 if exponents is None else exponents
+    weights = 1.0 if weights is None else weights
+
+    tmp = (variable ** exponent) * weights
+    if operation == pnl.SUM:
+        expected = np.sum(tmp, axis=0) * scale + offset
+    elif operation == pnl.PRODUCT:
+        expected = np.prod(tmp, axis=0) * scale + offset
+    else:
+        assert False, "Unknown operation"
+
+    # wider tolerances needed for fp32
+    if pytest.helpers.llvm_current_fp_precision() == 'fp32':
+        tolerance = {'rtol': 3e-5, 'atol': 2e-7}
+    else:
+        tolerance = {'rtol': 1e-5, 'atol': 1e-8}
+    np.testing.assert_allclose(res, expected, **tolerance)
 
 
 @pytest.mark.benchmark(group="LinearCombinationFunction in Mechanism")


### PR DESCRIPTION
supports parameter specifications as scalar, len-1 vector, or N-dim array matching shape of input (weights, exponents) or output (scale, offset)

(len-M vector elementwise for (M, ...) shape arrays is intended to work, but does not work in non-compiled PNL)