### PR TITLE
OneHot: fix PROB sampling at the cumsum-rounding boundary

### DIFF
--- a/psyneulink/core/components/functions/nonstateful/selectionfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/selectionfunctions.py
@@ -434,6 +434,13 @@ class OneHot(SelectionFunction):
             prob_in = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(1)])
             arg_in = builder.gep(arg_in, [ctx.int32_ty(0), ctx.int32_ty(0)])
 
+            # The final prefix sum can drift just below 1.0 due to float
+            # rounding while the uniform() draw lives in [0, 1), so a draw in
+            # (cum_sum[-1], 1.0) misses every bucket and would otherwise leave
+            # arg_out at all zeros. Force the last iteration to win in that
+            # case by relaxing the upper bound only at the last index.
+            last_idx = ctx.int32_ty(arg_in.type.pointee.count - 1)
+
             with pnlvm.helpers.array_ptr_loop(builder, arg_in, "search") as (b1, idx):
 
                 current_ptr = b1.gep(arg_in, [ctx.int32_ty(0), idx])
@@ -445,8 +452,10 @@ class OneHot(SelectionFunction):
                 sum_new = b1.fadd(sum_old, b1.load(current_prob_ptr))
                 b1.store(sum_new, sum_ptr)
 
+                is_last = b1.icmp_signed("==", idx, last_idx)
                 old_below = b1.fcmp_ordered("<=", sum_old, random_draw)
-                new_above = b1.fcmp_ordered("<", random_draw, sum_new)
+                new_above = b1.or_(b1.fcmp_ordered("<", random_draw, sum_new),
+                                   is_last)
                 cond = b1.and_(new_above, old_below)
 
                 if self.mode == PROB:
@@ -730,8 +739,17 @@ class OneHot(SelectionFunction):
             cum_sum = np.cumsum(prob_dist)
             random_state = self._get_current_parameter_value("random_state", context)
             random_value = random_state.uniform()
-            chosen_item = next(element for element in cum_sum if element > random_value)
-            chosen_in_cum_sum = np.where(cum_sum == chosen_item, 1, 0)
+            # cum_sum[-1] can drift just under 1.0 due to float rounding (e.g.
+            # np.cumsum([0.7, 0.2, 0.1])[-1] == 0.9999999999999999), and
+            # uniform() returns from [0, 1); when random_value >= cum_sum[-1]
+            # no element is strictly greater than the draw. Use searchsorted
+            # to invert the CDF and clamp to the last index in that gap.
+            # Indexing by position also avoids a stale equality match in
+            # cum_sum when prob_dist contains zeros (which produce ties).
+            chosen_idx = min(int(np.searchsorted(cum_sum, random_value, side='right')),
+                             len(cum_sum) - 1)
+            chosen_in_cum_sum = np.zeros_like(cum_sum, dtype=int)
+            chosen_in_cum_sum[chosen_idx] = 1
             if mode == PROB:
                 result = v * chosen_in_cum_sum
             else:

--- a/tests/functions/test_selection.py
+++ b/tests/functions/test_selection.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import numpy as np
 import pytest
 
@@ -272,3 +274,76 @@ def test_one_hot_mode_deterministic(benchmark, variable, tie, indicator, directi
         expected = np.where(np.asarray(expected) != 0, np.ones_like(expected), expected)
 
     np.testing.assert_allclose(res, expected)
+
+
+# Regression test for the float-rounding edge case in OneHot's PROB sampling.
+# np.cumsum of a probability distribution can land just below 1.0 due to
+# float-rounding (e.g. cumsum([0.7, 0.2, 0.1])[-1] == 0.9999999999999999).
+# random_state.uniform() draws from [0, 1), so it can return a value >=
+# cum_sum[-1]. The pre-fix code did
+#     next(element for element in cum_sum if element > random_value)
+# which raised StopIteration when no element of cum_sum was strictly greater
+# than the draw. The fix uses np.searchsorted with a clamp so the last index
+# is selected in that case.
+@pytest.mark.function
+@pytest.mark.parametrize("mode, expected_factory", [
+    (kw.PROB, lambda data: data * np.array([0., 0., 1.])),
+    (kw.PROB_INDICATOR, lambda data: np.array([0., 0., 1.])),
+])
+def test_one_hot_prob_cumsum_below_one_due_to_float_rounding(mode, expected_factory):
+    # cumsum drifts below 1.0 in float64 -- np.allclose(sum, 1) is still True
+    # so OneHot validation accepts it.
+    prob_dist = np.array([0.7, 0.2, 0.1])
+    cum_sum_last = float(np.cumsum(prob_dist)[-1])
+    assert cum_sum_last < 1.0, "test premise: cumsum should drift under 1.0"
+
+    data = np.array([10.0, 20.0, 30.0])
+    f = pnl.OneHot(default_variable=[data, prob_dist], mode=mode)
+
+    # Force uniform() to return cum_sum[-1] exactly (a value uniform() can
+    # legally produce). Pre-fix this triggered StopIteration; post-fix the
+    # last index wins.
+    class _StubRandomState:
+        used_seed = [0]
+        def uniform(self, *args, **kwargs):
+            return cum_sum_last
+
+    real = pnl.OneHot._get_current_parameter_value
+    def patched(self, name, context=None):
+        if name == "random_state":
+            return _StubRandomState()
+        return real(self, name, context)
+
+    with mock.patch.object(pnl.OneHot, "_get_current_parameter_value", patched):
+        res = f([data, prob_dist])
+
+    np.testing.assert_allclose(res, expected_factory(data))
+
+
+# Same boundary case, exercised on both Python and LLVM paths. Validation runs
+# at construction against `default_variable`, so we construct OneHot with a
+# well-formed prob_dist and then call it with a runtime prob_dist whose
+# cumulative sum falls strictly under 1.0. About half of all uniform() draws
+# then land in the (cum_sum[-1], 1.0) gap. Pre-fix the Python path raised
+# StopIteration on those draws and the LLVM path silently produced an
+# all-zero output; post-fix both paths fall back to the last index and
+# return a valid one-hot.
+@pytest.mark.function
+def test_one_hot_prob_runtime_cumsum_under_one_never_all_zero(func_mode):
+    default_prob = np.array([0.7, 0.2, 0.1])
+    default_data = np.array([10.0, 20.0, 30.0])
+    f = pnl.OneHot(default_variable=[default_data, default_prob],
+                   mode=kw.PROB_INDICATOR)
+
+    # cum_sum = [0.5, 0.5, 0.5]; any uniform draw >= 0.5 misses every bucket.
+    runtime_prob = np.array([0.5, 0.0, 0.0])
+    runtime_data = np.array([10.0, 20.0, 30.0])
+
+    EX = pytest.helpers.get_func_execution(f, func_mode)
+
+    # 32 draws is enough that with overwhelming probability some draws fall
+    # in the gap (the seed is fixed by the conftest, so this is deterministic
+    # per CI run).
+    for _ in range(32):
+        res = np.asarray(EX([runtime_data, runtime_prob]))
+        assert res.sum() == 1.0, f"unexpected output (all-zero or invalid): {res}"

--- a/tests/functions/test_transfer.py
+++ b/tests/functions/test_transfer.py
@@ -183,7 +183,11 @@ test_data = [
                  id="SOFT_MAX MASK_THRESHOLD MAX_INDICATOR", marks=pytest.mark.llvm_not_implemented),
     pytest.param(pnl.SoftMax, test_var,
                  {kw.GAIN: RAND1, 'mask_threshold': RAND1 * .5, kw.OUTPUT_TYPE: kw.PROB, kw.PER_ITEM: False},
-                 [0.0, 0.0, 0.0, test_var[3], test_var[4], 0.0, 0.0, 0.0, 0.0, 0.0],
+                 # PROB sampling returns a single chosen sample. (Earlier
+                 # versions used a cum_sum equality match that incorrectly
+                 # selected every index whose cum_sum tied the chosen value
+                 # -- common when prob_dist contains zeros.)
+                 [0.0, 0.0, 0.0, test_var[3], 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
                  id="SOFT_MAX MASK_THRESHOLD PROB", marks=pytest.mark.llvm_not_implemented),
     #
     # # SoftMax 2D threshold testing per-item
@@ -209,7 +213,8 @@ test_data = [
                  id="SOFT_MAX MASK_THRESHOLD MAX_INDICATOR 2D", marks=pytest.mark.llvm_not_implemented),
     pytest.param(pnl.SoftMax, [test_var],
                  {kw.GAIN: RAND1, 'mask_threshold': RAND1 * .5, kw.OUTPUT_TYPE: kw.PROB, kw.PER_ITEM: True},
-                 [[0.0, 0.0, 0.0, test_var[3], test_var[4], 0.0, 0.0, 0.0, 0.0, 0.0]],
+                 # See note on SOFT_MAX MASK_THRESHOLD PROB above.
+                 [[0.0, 0.0, 0.0, test_var[3], 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
                  id="SOFT_MAX MASK_THRESHOLD PROB 2D", marks=pytest.mark.llvm_not_implemented),
 
     # SoftMax threshold per-item with 2 elements in input


### PR DESCRIPTION
## Summary

`OneHot` `PROB`/`PROB_INDICATOR` sampling could fail when `np.cumsum(prob_dist)[-1]` drifted just below 1.0 due to float rounding (e.g. `np.cumsum([0.7, 0.2, 0.1])[-1] == 0.9999999999999999`) and `random_state.uniform()` returned a value in the resulting `(cum_sum[-1], 1.0)` gap.

* **Python path** (`selectionfunctions.py:733`) raised `StopIteration` from the unguarded generator
  ```python
  chosen_item = next(element for element in cum_sum if element > random_value)
  ```
* **LLVM path** (`_gen_llvm_function_body` for `PROB`/`PROB_INDICATOR`) silently produced an all-zero output, because no iteration's `sum_old <= random_draw < sum_new` condition fired.

The Python path now uses `np.searchsorted(..., side='right')` clamped to the last index, and indexes the chosen position directly. This also fixes a second-order bug where `np.where(cum_sum == chosen_item, 1, 0)` selected multiple indices when `prob_dist` contained zeros (which produced duplicate `cum_sum` entries) — see the corrected `SOFT_MAX MASK_THRESHOLD PROB` expectations in `test_transfer.py`.

The LLVM path forces the upper-bound check to fire on the last iteration, ensuring the last index always wins when the draw exceeds the final prefix sum.

## Tests

* `test_one_hot_prob_cumsum_below_one_due_to_float_rounding` — deterministic Python regression test that stubs `random_state.uniform()` to return a value in the gap. Reproduces the `StopIteration` against the unfixed code.
* `test_one_hot_prob_runtime_cumsum_under_one_never_all_zero` — covers both Python and LLVM paths by constructing `OneHot` with a valid default `prob_dist` (so validation passes) and then calling it with a runtime `prob_dist` whose `cum_sum[-1] < 1.0`. About half of all uniform draws then land in the gap, deterministically triggering both bugs against the unfixed code (Python: `StopIteration`; LLVM: all-zero output).

## Test plan

- [x] `pytest tests/functions/test_selection.py` (Python + LLVM) passes
- [x] `pytest tests/functions/test_transfer.py` (Python + LLVM) passes — including the corrected `SOFT_MAX MASK_THRESHOLD PROB` cases
- [x] `pytest tests/functions/test_memory.py` passes
- [x] `pycodestyle` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)