### PR TITLE
Fix/projections/dual projections between mechs

### DIFF
--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -6759,7 +6759,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
           of **projection**.
 
         • if **sender** and **receiver** are specified and one or more Projections already exists between them:
-          - if it is in the Composition:
+          - if they is in the Composition:
             - if there is only one, the request is ignored and the existing Projection is returned
             - if there is more than one, an exception is raised as this should never be the case
           - if it is NOT in the Composition:

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -617,17 +617,27 @@ comp.add_node(B)
             ocomp.run()
 
     def test_multiple_projections_between_mechs(self):
+        """Tests the addining of multiple legal Projections between two Mechanisms to Composition."""
         mech_a = ProcessingMechanism(input_ports=['ONE', 'TWO', 'THREE'])
         mech_b = ProcessingMechanism(input_ports=['ONE', 'TWO', 'THREE'])
         proj_one = MappingProjection(mech_a.output_ports['ONE'], mech_b.input_ports['ONE'])
         proj_two = MappingProjection(mech_a.output_ports['TWO'], mech_b.input_ports['TWO'])
         proj_three = MappingProjection(mech_a.output_ports['THREE'], mech_b.input_ports['THREE'])
         comp = pnl.Composition([mech_a, mech_b])
+        # CURRENTLY, ONLY THE LAST (proj_three) OF A SET OF PARALLEL PROJECTIONS BETWEEN TWO MECHANISMS
+        #    IS AUTOMATICALLY ADDED TO THE COMPOSITION
         assert proj_three in comp.projections
+        # BREADCRUMB: THESE ERROR TESTS WILL FAIL AND SHOULD BE REMOVED ONCE THE PROBLEM IS CORRECTED
+        # THE OTHER TWO ARE NOT AUTOMATICALLY ADDED:
         with pytest.raises(AssertionError):
             assert proj_one in comp.projections
         with pytest.raises(AssertionError):
             assert proj_two in comp.projections
+        # THEY CAN (AND MUST) BE ADDED "MANUALLY:"
+        comp.add_projection(proj_one)
+        comp.add_projection(proj_two)
+        assert proj_one in comp.projections
+        assert proj_two in comp.projections
 
 
 @pytest.mark.composition

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -616,6 +616,17 @@ comp.add_node(B)
             comp2.verbosePref = PreferenceEntry(True, PreferenceLevel.INSTANCE)
             ocomp.run()
 
+    def test_multiple_projections_between_mechs(self):
+        mech_a = ProcessingMechanism(input_ports=['ONE', 'TWO', 'THREE'])
+        mech_b = ProcessingMechanism(input_ports=['ONE', 'TWO', 'THREE'])
+        proj_one = MappingProjection(mech_a.output_ports['ONE'], mech_b.input_ports['ONE'])
+        proj_two = MappingProjection(mech_a.output_ports['TWO'], mech_b.input_ports['TWO'])
+        proj_three = MappingProjection(mech_a.output_ports['THREE'], mech_b.input_ports['THREE'])
+        comp = pnl.Composition([mech_a, mech_b])
+        assert proj_one in comp.projections
+        assert proj_two in comp.projections
+        assert proj_three in comp.projections
+
 
 @pytest.mark.composition
 @pytest.mark.pathways

--- a/tests/composition/test_composition.py
+++ b/tests/composition/test_composition.py
@@ -623,9 +623,11 @@ comp.add_node(B)
         proj_two = MappingProjection(mech_a.output_ports['TWO'], mech_b.input_ports['TWO'])
         proj_three = MappingProjection(mech_a.output_ports['THREE'], mech_b.input_ports['THREE'])
         comp = pnl.Composition([mech_a, mech_b])
-        assert proj_one in comp.projections
-        assert proj_two in comp.projections
         assert proj_three in comp.projections
+        with pytest.raises(AssertionError):
+            assert proj_one in comp.projections
+        with pytest.raises(AssertionError):
+            assert proj_two in comp.projections
 
 
 @pytest.mark.composition


### PR DESCRIPTION
• test_composition.py()
  - add: test_multiple_projections_between_mechs()
    asserts failure when adding more than one of a set of parallel projections from one Mechanism to another.
  - these should be removed when problem is resolved