### PR TITLE
Fix PEC degenerate-likelihood warning re-printing stale parameter sets

### DIFF
--- a/psyneulink/core/components/functions/nonstateful/fitfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/fitfunctions.py
@@ -630,14 +630,19 @@ class PECOptimizationFunction(OptimizationFunction):
             elapsed = time.time() - t0
             self.num_evals = self.num_evals + 1
 
-            # Keep a log of warnings and the parameters that caused them
-            if len(warns) > 0 and issubclass(warns[-1].category, PECObjectiveFuncWarning):
+            # Keep a log of warnings and the parameters that caused them. Only the warning(s)
+            # raised by this evaluation are relevant, so capture it before clearing the warns
+            # buffer below.
+            got_pec_warning = len(warns) > 0 and issubclass(
+                warns[-1].category, PECObjectiveFuncWarning
+            )
+            if got_pec_warning:
                 warns_with_params.append((warns[-1], params))
 
             # Are we displaying each iteration
             if display_iter:
                 # If we got a warning generating the objective function value, report it
-                if len(warns) > 0 and issubclass(warns[-1].category, PECObjectiveFuncWarning):
+                if got_pec_warning:
                     progress.console.print(f"Warning: ", style="bold red")
                     progress.console.print(f"{warns[-1].message}", style="bold red")
                     progress.console.print(
@@ -646,8 +651,6 @@ class PECOptimizationFunction(OptimizationFunction):
                         style="bold red",
                         highlight=False,
                     )
-                    # Clear the warnings
-                    warns.clear()
                 else:
                     progress.console.print(
                         f"{get_param_str(params)}, {self.obj_func_desc_str}: {obj_val}, "
@@ -679,9 +682,44 @@ class PECOptimizationFunction(OptimizationFunction):
                             % max_evals,
                         )
 
+            # Clear the recorded warnings so the next evaluation starts fresh and warns[-1]
+            # cannot be mis-attributed to a later (possibly warning-free) parameter set.
+            warns.clear()
+
             return p
 
         return objfunc_wrapper
+
+    def _report_degenerate_warnings(self, progress, warns_with_params):
+        """
+        Summarize any degenerate objective-function warnings accumulated since the last
+        optimizer callback, then clear them.
+
+        ``warns_with_params`` accumulates a ``(warning, params)`` tuple for every evaluation
+        that raised a ``PECObjectiveFuncWarning`` during the current iteration/trial. This
+        prints those parameter sets and then empties the list so that subsequent callbacks
+        only report newly degenerate parameter sets, rather than re-printing every degenerate
+        set seen since the search began.
+        """
+        if len(warns_with_params) == 0:
+            return
+
+        progress.console.print(
+            f"Warning: degenerate {self.obj_func_desc_str} values for the following parameter values ",
+            style="bold red",
+        )
+        for w in warns_with_params:
+            progress.console.print(f"\t{get_param_str(w[1])}", style="bold red")
+        progress.console.print(
+            "If these warnings are intermittent, check to see if search "
+            "space is appropriately bounded. If they are constant, and you are fitting to "
+            "data, make sure experimental data and output of your composition are similar.",
+            style="bold red",
+        )
+
+        # Clear the accumulated warnings so the next iteration/trial only reports the
+        # parameter sets that were degenerate during that iteration.
+        warns_with_params.clear()
 
     def _fit_differential_evolution(
         self,
@@ -750,21 +788,7 @@ class PECOptimizationFunction(OptimizationFunction):
                     )
 
                     # If we encounter any PECObjectiveFuncWarnings. Summarize them for the user
-                    if len(warns_with_params) > 0:
-                        progress.console.print(
-                            f"Warning: degenerate {self.obj_func_desc_str} values for the following parameter values ",
-                            style="bold red",
-                        )
-                        for w in warns_with_params:
-                            progress.console.print(
-                                f"\t{get_param_str(w[1])}", style="bold red"
-                            )
-                        progress.console.print(
-                            "If these warnings are intermittent, check to see if search "
-                            "space is appropriately bounded. If they are constant, and you are fitting to"
-                            "data, make sure experimental data and output of your composition are similar.",
-                            style="bold red",
-                        )
+                    self._report_degenerate_warnings(progress, warns_with_params)
 
                     progress.update(opt_task, completed=convergence_pct)
                     self.gen_count = self.gen_count + 1
@@ -842,21 +866,7 @@ class PECOptimizationFunction(OptimizationFunction):
                         )
 
                     # If we encounter any PECObjectiveFuncWarnings. Summarize them for the user
-                    if len(warns_with_params) > 0:
-                        progress.console.print(
-                            f"Warning: degenerate {self.obj_func_desc_str} values for the following parameter values ",
-                            style="bold red",
-                        )
-                        for w in warns_with_params:
-                            progress.console.print(
-                                f"\t{get_param_str(w[1])}", style="bold red"
-                            )
-                        progress.console.print(
-                            "If these warnings are intermittent, check to see if search "
-                            "space is appropriately bounded. If they are constant, and you are fitting to"
-                            "data, make sure experimental data and output of your composition are similar.",
-                            style="bold red",
-                        )
+                    self._report_degenerate_warnings(progress, warns_with_params)
 
                     progress.update(opt_task, advance=1)
 

--- a/tests/composition/pec/test_parameterestimationcomposition.py
+++ b/tests/composition/pec/test_parameterestimationcomposition.py
@@ -11,6 +11,7 @@ import psyneulink as pnl
 
 from psyneulink.core.components.functions.nonstateful.fitfunctions import (
     PECOptimizationFunction,
+    BadLikelihoodWarning,
 )
 
 # Set the number of threads to 1 for all tests in this module, tests are often run in parallel
@@ -721,3 +722,66 @@ def test_pec_lca_num_estimates_llvm_stochasticity(func_mode):
     assert "sim_data" in captured
     # sim_data shape: (num_trials, num_estimates, num_outcomes)
     assert np.mean(np.std(captured["sim_data"], axis=1)) > 0.0
+
+
+class _RecordingConsole:
+    """Minimal stand-in for a rich Console that records everything printed."""
+
+    def __init__(self):
+        self.lines = []
+
+    def print(self, *args, **kwargs):
+        self.lines.append(" ".join(str(a) for a in args))
+
+    @property
+    def text(self):
+        return "\n".join(self.lines)
+
+
+class _FakeProgress:
+    def __init__(self):
+        self.console = _RecordingConsole()
+
+
+def _make_warn_entry(value):
+    """Build a (warning, params) tuple as accumulated by the objective-function wrapper."""
+    params = {"gain": value}
+    warning = BadLikelihoodWarning("could not perform kernel density estimate")
+    return (warning, params)
+
+
+def test_pec_degenerate_warning_summary_cleared_between_callbacks():
+    """
+    Regression test: the degenerate-likelihood summary printed by the optimizer callback
+    must only report the parameter sets that were degenerate since the previous callback,
+    not re-print every degenerate set seen since the search began.
+
+    Previously ``warns_with_params`` was never cleared, so each callback re-printed the full
+    accumulated history -- pinning the first degenerate parameter set to the top of the log
+    on every subsequent iteration even though it was not just evaluated.
+    """
+    opt_func = PECOptimizationFunction(method="differential_evolution")
+    progress = _FakeProgress()
+
+    # Simulate the first iteration: a single degenerate parameter set was accumulated.
+    warns_with_params = [_make_warn_entry(21.3)]
+    opt_func._report_degenerate_warnings(progress, warns_with_params)
+
+    # The summary reports the degenerate set, and the buffer is cleared afterwards.
+    assert "21.30000" in progress.console.text
+    assert warns_with_params == []
+
+    # Simulate the next iteration: a *different* degenerate parameter set is accumulated.
+    progress = _FakeProgress()
+    warns_with_params.append(_make_warn_entry(16.0))
+    opt_func._report_degenerate_warnings(progress, warns_with_params)
+
+    # Only the new set is reported; the stale one from the prior iteration must not reappear.
+    assert "16.00000" in progress.console.text
+    assert "21.30000" not in progress.console.text
+    assert warns_with_params == []
+
+    # An iteration with no degenerate evaluations prints nothing at all.
+    progress = _FakeProgress()
+    opt_func._report_degenerate_warnings(progress, warns_with_params)
+    assert progress.console.text == ""


### PR DESCRIPTION
# Summary
The Parameter Estimation Composition (PEC) prints a warning summarizing parameter sets that produced degenerate objective-function values (e.g. BadLikelihoodWarning when a simulation has zero variance and the KDE can't be computed). A user reported that this warning repeatedly lists parameter sets that were not just evaluated — pinning the first bad set seen to the top of the log and re-printing it on every subsequent iteration, cluttering the output.

# Root cause
The optimizer callback (progress_callback in both _fit_differential_evolution and _fit_optuna) summarized warnings from a warns_with_params list that was never cleared. Each callback re-printed the entire accumulated history of degenerate parameter sets, so the earliest bad set kept reappearing regardless of what was actually evaluated in the current iteration/trial.

A related latent bug: the per-evaluation warns buffer was only cleared inside the display_iter branch, so with display_iter=False a stale warns[-1] could be mis-attributed to a later (possibly warning-free) parameter set.

# Changes
Extracted the duplicated "print summary + clear" logic into a new _report_degenerate_warnings helper, which clears warns_with_params after printing so each callback only reports sets that went degenerate since the last callback.
Always clear the per-evaluation warns buffer at the end of each evaluation (not just in the display_iter branch), and hoisted the warning check into a single got_pec_warning flag so the captured warning and parameters always come from the same evaluation.
Fixed a missing space in the footer text (fitting todata → fitting to data).