### PR TITLE
TransferMechanism: fix crash on using python function as function

### DIFF
--- a/psyneulink/core/components/mechanisms/processing/transfermechanism.py
+++ b/psyneulink/core/components/mechanisms/processing/transfermechanism.py
@@ -1419,7 +1419,7 @@ class TransferMechanism(ProcessingMechanism_Base):
             elif inspect.isclass(transfer_function):
                 transfer_function_class = transfer_function
 
-            if issubclass(transfer_function_class, Function):
+            if transfer_function_class is not None and issubclass(transfer_function_class, Function):
                 if not issubclass(transfer_function_class, (TransferFunction, SelectionFunction, UserDefinedFunction)):
                     raise TransferError(f"Function specified as {repr(FUNCTION)} param of '{self.name}' "
                                         f"({transfer_function_class.__name__}) must be a "

--- a/tests/mechanisms/test_transfer_mechanism.py
+++ b/tests/mechanisms/test_transfer_mechanism.py
@@ -348,6 +348,11 @@ class TestTransferMechanismFunctions:
         result = T.execute([[1.0, 2.0], [3.0, 4.0]])
         np.testing.assert_allclose(result, [[2.0, 4.0], [6.0, 8.0]])
 
+    def test_udf_without_wrapper(self):
+        T = pnl.TransferMechanism(input_shapes=(2, 2), function=lambda x, context: x * 3)  # noqa: U100
+        result = T.execute([[1.0, 2.0], [3.0, 4.0]])
+        np.testing.assert_allclose(result, [[3.0, 6.0], [9.0, 12.0]])
+
     def tests_invalid_udf(self):
         def sum_all_elements(variable):
             return sum(np.array(variable))


### PR DESCRIPTION
UserDefinedFunction is allowed in the check following the crash