### PR TITLE
Add an internal _debugger execution hook

### DIFF
--- a/psyneulink/_debugger.py
+++ b/psyneulink/_debugger.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+# Princeton University licenses this file to You under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may obtain a copy of the License at:
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+#
+# **************************************  _debugger  *********************************************
+"""Internal debugger hook for stepping through PsyNeuLink execution.
+
+This module is **internal** (note the leading underscore). The surface here may
+change without notice until it is promoted to a public ``psyneulink.debugger``
+module after at least one external consumer has stabilized on it.
+
+Design
+------
+Replaces the inert ``assert 'DEBUGGING BREAK POINT: ...'`` literals that were
+sprinkled through the codebase with a pluggable hook. When no listener is
+registered, ``step()`` is a single ``is not None`` comparison and returns
+immediately — zero behavioral change and no measurable performance cost.
+
+A listener is a callable ``(category, locals_provider) -> None``. The locals
+provider is a zero-argument callable that returns a dict of relevant state
+captured at the call site; building that dict is deferred so listeners that
+ignore a category (or only inspect the category enum) pay nothing.
+
+Categories map to scheduler-level execution boundaries plus a handful of
+non-scheduler events (parameter setting, init completion, pytorch step). They
+are stable identifiers; new categories may be added but existing ones are not
+renamed or repurposed.
+
+Usage from a consumer (e.g. PsyNeuView's stepping worker)
+---------------------------------------------------------
+::
+
+    from psyneulink import _debugger
+
+    def listener(category, locals_provider):
+        if category is _debugger.BreakpointCategory.NODE_EXECUTION:
+            state = locals_provider()           # only built when consumed
+            archive.snapshot(state)
+
+    _debugger.set_listener(listener)
+    composition.run(inputs)
+    _debugger.set_listener(None)                # tear down when done
+
+Locals schema per category (informal — listeners key-check what they need)
+--------------------------------------------------------------------------
+BEGINNING_OF_TRIAL   trial_num, scheduler, context
+END_OF_TRIAL         trial_num, scheduler, context, outputs
+EXECUTION_SET        execution_set, scheduler, context
+INPUTS_TO_NODE       node, execution_set, scheduler, context
+NODE_EXECUTION       node, execution_set, scheduler, context  (fires post-execute)
+PARAMETER_SETTING    parameter, owner, value, context
+END_OF_INIT          component
+PYTORCH_STEP         wrapper, composition
+
+Categories may grow new keys over time without breaking existing listeners.
+"""
+
+from enum import Enum
+from typing import Callable, Optional
+
+
+class BreakpointCategory(Enum):
+    """Identifier for a breakpoint emission site."""
+    BEGINNING_OF_TRIAL = "beginning_of_trial"
+    END_OF_TRIAL       = "end_of_trial"
+    EXECUTION_SET      = "execution_set"
+    INPUTS_TO_NODE     = "inputs_to_node"
+    NODE_EXECUTION     = "node_execution"
+    PARAMETER_SETTING  = "parameter_setting"
+    END_OF_INIT        = "end_of_init"
+    PYTORCH_STEP       = "pytorch_step"
+
+
+Listener = Callable[["BreakpointCategory", Callable[[], dict]], None]
+
+_listener: Optional[Listener] = None
+
+
+def set_listener(listener: Optional[Listener]) -> None:
+    """Register the single global listener, or pass ``None`` to clear.
+
+    Single-listener by design; consumers that need to fan out can wrap multiple
+    callables themselves. Assignment is atomic in CPython so no lock is needed
+    for the common case (set once at startup, clear at teardown).
+    """
+    global _listener
+    _listener = listener
+
+
+def get_listener() -> Optional[Listener]:
+    """Return the currently registered listener (or ``None``)."""
+    return _listener
+
+
+def step(category: BreakpointCategory, locals_provider: Callable[[], dict]) -> None:
+    """Emit a breakpoint event. No-op when no listener is attached.
+
+    The hot path is a single ``is not None`` check; the locals_provider is only
+    invoked if a listener is registered (and then only if the listener chooses
+    to call it).
+    """
+    if _listener is not None:
+        _listener(category, locals_provider)

--- a/psyneulink/_debugger.py
+++ b/psyneulink/_debugger.py
@@ -47,14 +47,18 @@ Usage from a consumer (e.g. PsyNeuView's stepping worker)
 
 Locals schema per category (informal — listeners key-check what they need)
 --------------------------------------------------------------------------
-BEGINNING_OF_TRIAL   trial_num, scheduler, context
-END_OF_TRIAL         trial_num, scheduler, context, outputs
-EXECUTION_SET        execution_set, scheduler, context
-INPUTS_TO_NODE       node, execution_set, scheduler, context
-NODE_EXECUTION       node, execution_set, scheduler, context  (fires post-execute)
-PARAMETER_SETTING    parameter, owner, value, context
-END_OF_INIT          component
-PYTORCH_STEP         wrapper, composition
+BEGINNING_OF_RUN        scheduler, context, num_trials
+END_OF_RUN              scheduler, context, results
+BEGINNING_OF_TRIAL      trial_num, scheduler, context
+END_OF_TRIAL            trial_num, scheduler, context, outputs
+EXECUTION_SET           execution_set, scheduler, context
+END_OF_EXECUTION_SET    execution_set, scheduler, context, outputs
+INPUTS_TO_NODE          node, execution_set, scheduler, context
+NODE_EXECUTION          node, execution_set, scheduler, context  (fires post-execute)
+PARAMETER_SETTING       parameter, owner, value, context
+EXCEPTION               exception, scheduler, context, trial_num
+END_OF_INIT             component
+PYTORCH_STEP            wrapper, composition
 
 Categories may grow new keys over time without breaking existing listeners.
 """
@@ -65,14 +69,18 @@ from typing import Callable, Optional
 
 class BreakpointCategory(Enum):
     """Identifier for a breakpoint emission site."""
-    BEGINNING_OF_TRIAL = "beginning_of_trial"
-    END_OF_TRIAL       = "end_of_trial"
-    EXECUTION_SET      = "execution_set"
-    INPUTS_TO_NODE     = "inputs_to_node"
-    NODE_EXECUTION     = "node_execution"
-    PARAMETER_SETTING  = "parameter_setting"
-    END_OF_INIT        = "end_of_init"
-    PYTORCH_STEP       = "pytorch_step"
+    BEGINNING_OF_RUN     = "beginning_of_run"
+    END_OF_RUN           = "end_of_run"
+    BEGINNING_OF_TRIAL   = "beginning_of_trial"
+    END_OF_TRIAL         = "end_of_trial"
+    EXECUTION_SET        = "execution_set"
+    END_OF_EXECUTION_SET = "end_of_execution_set"
+    INPUTS_TO_NODE       = "inputs_to_node"
+    NODE_EXECUTION       = "node_execution"
+    PARAMETER_SETTING    = "parameter_setting"
+    EXCEPTION            = "exception"
+    END_OF_INIT          = "end_of_init"
+    PYTORCH_STEP         = "pytorch_step"
 
 
 Listener = Callable[["BreakpointCategory", Callable[[], dict]], None]

--- a/psyneulink/core/components/component.py
+++ b/psyneulink/core/components/component.py
@@ -523,6 +523,7 @@ import graph_scheduler
 import numpy as np
 
 from psyneulink._typing import Iterable, Union
+from psyneulink import _debugger
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.globals.context import \
     Context, ContextError, ContextFlags, INITIALIZATION_STATUS_FLAGS, _get_time, handle_external_context
@@ -1348,6 +1349,10 @@ class Component(MDFSerializable, metaclass=ComponentsMeta):
 
         # Delete the _user_specified_args attribute, we don't need it anymore
         del self._user_specified_args
+
+        _debugger.step(
+            _debugger.BreakpointCategory.END_OF_INIT,
+            lambda: {"component": self})
 
     def __repr__(self):
         return '({0} {1})'.format(type(self).__name__, self.name)

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -12547,7 +12547,7 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                                 report_num=report_num,
                                                 **kwargs
                                                 )
-                except BaseException as _debugger_exc:
+                except Exception as _debugger_exc:
                     _debugger.step(
                         _debugger.BreakpointCategory.EXCEPTION,
                         lambda exc=_debugger_exc, t=trial_num: {

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -3212,6 +3212,7 @@ from beartype import beartype
 import psyneulink
 from psyneulink._typing import Any, Callable, Dict, Literal, List, Mapping, Optional, Set, Tuple, Type, Union
 
+from psyneulink import _debugger
 from psyneulink.core import llvm as pnlvm
 from psyneulink.core.compositions.noderoles import NodeRole, NodeRolesManager
 from psyneulink.core.components.component import Component, ComponentError, ComponentsMeta
@@ -13395,7 +13396,11 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 for i in range(scheduler.get_clock(context).time.time_step):
                     execution_sets.__next__()
 
-            assert 'DEBUGGING BREAK POINT: BEGINNING OF TRIAL EXECUTION - EXECUTION_SETS ASSIGNED'
+            _debugger.step(
+                _debugger.BreakpointCategory.BEGINNING_OF_TRIAL,
+                lambda: {"trial_num": execution_scheduler.get_clock(context).time.trial,
+                         "scheduler": execution_scheduler,
+                         "context": context})
 
             for next_execution_set in execution_sets:
 
@@ -13408,7 +13413,11 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                 # have to run call_after_pass before the next PASS (here) or after this code block (see call to
                 # call_after_pass below)
 
-                assert 'DEBUGGING BREAK POINT: BEGINNING OF NODE / EXECUTION_SET EXECUTION'
+                _debugger.step(
+                    _debugger.BreakpointCategory.EXECUTION_SET,
+                    lambda: {"execution_set": next_execution_set,
+                             "scheduler": execution_scheduler,
+                             "context": context})
 
                 curr_pass = execution_scheduler.get_clock(context).get_total_times_relative(TimeScale.PASS,
                                                                                             TimeScale.TRIAL)
@@ -13561,11 +13570,24 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                                 if self.is_nested and node in input_nodes:
                                     for port in node.input_ports:
                                         port._update(context=context)
+                                _debugger.step(
+                                    _debugger.BreakpointCategory.INPUTS_TO_NODE,
+                                    lambda node=node, execution_set=next_execution_set, mech_context=mech_context:
+                                        {"node": node,
+                                         "execution_set": execution_set,
+                                         "scheduler": execution_scheduler,
+                                         "context": mech_context})
                                 node.execute(context=mech_context,
                                              report_num=report_num,
                                              runtime_params=execution_runtime_params,
                                              )
-                                assert 'DEBUGGING BREAK POINT: AFTER NODE EXECUTION'
+                                _debugger.step(
+                                    _debugger.BreakpointCategory.NODE_EXECUTION,
+                                    lambda node=node, execution_set=next_execution_set, mech_context=mech_context:
+                                        {"node": node,
+                                         "execution_set": execution_set,
+                                         "scheduler": execution_scheduler,
+                                         "context": mech_context})
 
                         # Set execution_phase for node's context back to IDLE
                         if self._is_learning(context):
@@ -13779,6 +13801,13 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                        context=context)
 
             # UPDATE TIME and RETURN ***********************************************************************************
+
+            _debugger.step(
+                _debugger.BreakpointCategory.END_OF_TRIAL,
+                lambda: {"trial_num": execution_scheduler.get_clock(context).time.trial,
+                         "scheduler": execution_scheduler,
+                         "context": context,
+                         "outputs": self.get_output_values(context)})
 
             execution_scheduler.get_clock(context)._increment_time(TimeScale.TRIAL)
 

--- a/psyneulink/core/compositions/composition.py
+++ b/psyneulink/core/compositions/composition.py
@@ -12476,6 +12476,12 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                    content='run_start',
                    context=context)
 
+            _debugger.step(
+                _debugger.BreakpointCategory.BEGINNING_OF_RUN,
+                lambda: {"scheduler": scheduler,
+                         "context": context,
+                         "num_trials": num_trials})
+
             self._trial_num = -1  # For debugging
 
             # Loop over the length of the list of inputs - each input represents a TRIAL
@@ -12521,25 +12527,35 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
                 # execute processing, passing stimuli for this trial
                 # IMPLEMENTATION NOTE: for autodiff, the following executes the forward pass for a single input
-                trial_output = self.execute(inputs=execution_stimuli,
-                                            optimization_num=optimization_num,
-                                            scheduler=scheduler,
-                                            termination_processing=termination_processing,
-                                            call_before_time_step=call_before_time_step,
-                                            call_before_pass=call_before_pass,
-                                            call_after_time_step=call_after_time_step,
-                                            call_after_pass=call_after_pass,
-                                            reset_stateful_functions_to=reset_stateful_functions_to,
-                                            context=context,
-                                            base_context=base_context,
-                                            clamp_input=clamp_input,
-                                            runtime_params=runtime_params,
-                                            skip_initialization=True,
-                                            execution_mode=execution_mode,
-                                            report=report,
-                                            report_num=report_num,
-                                            **kwargs
-                                            )
+                try:
+                    trial_output = self.execute(inputs=execution_stimuli,
+                                                optimization_num=optimization_num,
+                                                scheduler=scheduler,
+                                                termination_processing=termination_processing,
+                                                call_before_time_step=call_before_time_step,
+                                                call_before_pass=call_before_pass,
+                                                call_after_time_step=call_after_time_step,
+                                                call_after_pass=call_after_pass,
+                                                reset_stateful_functions_to=reset_stateful_functions_to,
+                                                context=context,
+                                                base_context=base_context,
+                                                clamp_input=clamp_input,
+                                                runtime_params=runtime_params,
+                                                skip_initialization=True,
+                                                execution_mode=execution_mode,
+                                                report=report,
+                                                report_num=report_num,
+                                                **kwargs
+                                                )
+                except BaseException as _debugger_exc:
+                    _debugger.step(
+                        _debugger.BreakpointCategory.EXCEPTION,
+                        lambda exc=_debugger_exc, t=trial_num: {
+                            "exception": exc,
+                            "scheduler": scheduler,
+                            "context": context,
+                            "trial_num": t})
+                    raise
 
                 # ---------------------------------------------------------------------------------
                 # store the result of this execution in case it will be the final result
@@ -12592,6 +12608,12 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
                    content='run_end',
                    context=context,
                    node=self)
+
+            _debugger.step(
+                _debugger.BreakpointCategory.END_OF_RUN,
+                lambda: {"scheduler": scheduler,
+                         "context": context,
+                         "results": results})
 
             # Reset input spec for next trial
             self.parameters.input_specification._set(None, context)
@@ -13716,6 +13738,14 @@ class Composition(Composition_Base, metaclass=ComponentsMeta):
 
                 if call_after_time_step:
                     call_with_pruned_args(call_after_time_step, context=context)
+
+                _debugger.step(
+                    _debugger.BreakpointCategory.END_OF_EXECUTION_SET,
+                    lambda execution_set=next_execution_set: {
+                        "execution_set": execution_set,
+                        "scheduler": execution_scheduler,
+                        "context": context,
+                        "outputs": {n: n.get_output_values(context) for n in execution_set}})
 
             context.remove_flag(ContextFlags.PROCESSING)
 

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -325,6 +325,7 @@ import numpy as np
 import toposort
 
 from psyneulink._typing import Iterable, Optional, Set, Union
+from psyneulink import _debugger
 from psyneulink.core.globals.context import Context, ContextError, ContextFlags, _get_time, handle_external_context
 from psyneulink.core.globals.context import time as time_object
 from psyneulink.core.globals.keywords import DEFAULT, SHARED_COMPONENT_TYPES
@@ -1831,7 +1832,12 @@ class Parameter(ParameterBase, metaclass=_ParameterMeta):
             compilation_sync=compilation_sync,
         )
 
-        assert 'DEBUGGING BREAK POINT: PARAMETER SETTING'
+        _debugger.step(
+            _debugger.BreakpointCategory.PARAMETER_SETTING,
+            lambda: {"parameter": self,
+                     "owner": getattr(self, '_owner', None),
+                     "value": value,
+                     "context": context})
 
         return value
 

--- a/psyneulink/library/compositions/pytorchwrappers.py
+++ b/psyneulink/library/compositions/pytorchwrappers.py
@@ -11,6 +11,7 @@
 from collections import namedtuple, OrderedDict
 
 from psyneulink._typing import Iterable, Literal, Optional, Union
+from psyneulink import _debugger
 
 import graph_scheduler
 import numpy as np
@@ -388,7 +389,10 @@ class PytorchCompositionWrapper(torch.nn.Module):
         )
 
         self._regenerate_torch_parameter_list()
-        assert 'DEBUGGING BREAK POINT' # END OF __init__()
+        _debugger.step(
+            _debugger.BreakpointCategory.PYTORCH_STEP,
+            lambda: {"wrapper": self,
+                     "composition": self.composition})
 
     def _early_init(self, composition, device):
         """Early initialization of PytorchCompositionWrapper"""

--- a/tests/misc/test_debugger.py
+++ b/tests/misc/test_debugger.py
@@ -1,0 +1,144 @@
+"""Tests for the psyneulink._debugger hook (Phase 1 of stepping/breakpoint work).
+
+The hook is intentionally minimal: a single global listener, lazy locals,
+and emission at well-defined call sites. These tests verify (a) no-listener
+is a true no-op, (b) registering a listener receives the expected categories
+when running a small composition, and (c) the locals provider produces the
+documented keys per category on demand.
+"""
+
+import pytest
+
+import psyneulink as pnl
+from psyneulink import _debugger
+from psyneulink._debugger import BreakpointCategory
+
+
+@pytest.fixture(autouse=True)
+def _clear_listener():
+    """Each test starts and ends with no listener registered."""
+    _debugger.set_listener(None)
+    yield
+    _debugger.set_listener(None)
+
+
+def test_no_listener_is_noop():
+    """``step()`` with no listener registered must do nothing and not raise.
+
+    The hot path is a single ``is not None`` comparison; this exercises it.
+    """
+    assert _debugger.get_listener() is None
+    _debugger.step(
+        BreakpointCategory.NODE_EXECUTION,
+        lambda: {"node": "would build this if asked"},
+    )
+
+
+def test_set_and_clear_listener():
+    calls = []
+
+    def listener(category, locals_provider):
+        calls.append(category)
+
+    _debugger.set_listener(listener)
+    assert _debugger.get_listener() is listener
+
+    _debugger.step(BreakpointCategory.EXECUTION_SET, lambda: {})
+    assert calls == [BreakpointCategory.EXECUTION_SET]
+
+    _debugger.set_listener(None)
+    _debugger.step(BreakpointCategory.EXECUTION_SET, lambda: {})
+    assert calls == [BreakpointCategory.EXECUTION_SET], \
+        "step() after clearing listener must not fire"
+
+
+def test_locals_provider_is_lazy():
+    """The locals dict is only built when the listener calls the provider."""
+    built = []
+
+    def builder():
+        built.append(True)
+        return {"key": "value"}
+
+    def ignoring_listener(category, locals_provider):
+        # Does NOT call locals_provider — provider must not have run yet.
+        pass
+
+    _debugger.set_listener(ignoring_listener)
+    _debugger.step(BreakpointCategory.EXECUTION_SET, builder)
+    assert built == [], "locals provider should not run when listener ignores it"
+
+    def consuming_listener(category, locals_provider):
+        locals_provider()
+
+    _debugger.set_listener(consuming_listener)
+    _debugger.step(BreakpointCategory.EXECUTION_SET, builder)
+    assert built == [True], "locals provider should run when listener consumes it"
+
+
+def test_categories_fire_during_composition_run():
+    """Run a one-trial 1-mechanism composition and check the core categories fire."""
+    fired = []
+
+    def listener(category, locals_provider):
+        fired.append((category, locals_provider()))
+
+    mech = pnl.TransferMechanism(name="T")
+    comp = pnl.Composition(name="comp")
+    comp.add_node(mech)
+
+    _debugger.set_listener(listener)
+    try:
+        comp.run(inputs={mech: [[1.0]]}, num_trials=1)
+    finally:
+        _debugger.set_listener(None)
+
+    fired_categories = {cat for cat, _ in fired}
+    # These four must fire at least once for any non-trivial composition run.
+    for required in (
+        BreakpointCategory.BEGINNING_OF_TRIAL,
+        BreakpointCategory.EXECUTION_SET,
+        BreakpointCategory.INPUTS_TO_NODE,
+        BreakpointCategory.NODE_EXECUTION,
+        BreakpointCategory.END_OF_TRIAL,
+    ):
+        assert required in fired_categories, f"expected {required} to fire, got {fired_categories}"
+
+    # Locals shape per category — informal schema check.
+    for cat, locs in fired:
+        if cat is BreakpointCategory.BEGINNING_OF_TRIAL:
+            assert {"trial_num", "scheduler", "context"} <= locs.keys()
+        elif cat is BreakpointCategory.END_OF_TRIAL:
+            assert {"trial_num", "scheduler", "context", "outputs"} <= locs.keys()
+        elif cat is BreakpointCategory.EXECUTION_SET:
+            assert {"execution_set", "scheduler", "context"} <= locs.keys()
+        elif cat is BreakpointCategory.INPUTS_TO_NODE:
+            assert {"node", "execution_set", "scheduler", "context"} <= locs.keys()
+        elif cat is BreakpointCategory.NODE_EXECUTION:
+            assert {"node", "execution_set", "scheduler", "context"} <= locs.keys()
+
+
+def test_end_of_init_fires_on_component_creation():
+    fired = []
+    _debugger.set_listener(lambda c, lp: fired.append((c, lp())))
+    pnl.TransferMechanism(name="end_of_init_probe")
+    cats = [c for c, _ in fired]
+    assert BreakpointCategory.END_OF_INIT in cats
+
+
+def test_run_results_unchanged_with_recording_listener():
+    """Listener attachment must not perturb composition behavior."""
+    mech = pnl.TransferMechanism(name="T_regression")
+    comp = pnl.Composition(name="comp_regression")
+    comp.add_node(mech)
+    inputs = {mech: [[1.0], [2.0], [3.0]]}
+
+    baseline = comp.run(inputs=inputs, num_trials=3)
+
+    _debugger.set_listener(lambda c, lp: None)
+    try:
+        with_listener = comp.run(inputs=inputs, num_trials=3)
+    finally:
+        _debugger.set_listener(None)
+
+    assert baseline == with_listener

--- a/tests/misc/test_debugger.py
+++ b/tests/misc/test_debugger.py
@@ -270,3 +270,121 @@ def test_run_results_unchanged_with_recording_listener():
         _debugger.set_listener(None)
 
     assert baseline == with_listener
+
+
+# ---------------------------------------------------------------------------
+# Extended coverage: real execution topologies and execution-mode boundaries.
+#
+# The fine-grained per-node hooks live in the Python execution loop. Compiled
+# (LLVM) and PyTorch execution bypass that loop, so they fire only run-level
+# bookends, PARAMETER_SETTING, and (for PyTorch) PYTORCH_STEP. These tests pin
+# both the "works in real topologies" behavior and that documented boundary.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.composition
+def test_nested_composition_fires_hooks_for_inner_nodes():
+    """Nodes inside a nested Composition emit NODE_EXECUTION like top-level ones."""
+    inner = pnl.Composition(name="inner")
+    a = pnl.TransferMechanism(name="inner_a")
+    b = pnl.TransferMechanism(name="inner_b")
+    inner.add_linear_processing_pathway([a, b])
+
+    outer = pnl.Composition(name="outer")
+    c = pnl.TransferMechanism(name="outer_c")
+    outer.add_linear_processing_pathway([inner, c])
+
+    executed = []
+
+    def listener(category, locals_provider):
+        if category is BreakpointCategory.NODE_EXECUTION:
+            executed.append(locals_provider()["node"])
+
+    _debugger.set_listener(listener)
+    outer.run(inputs={inner: [[1.0]]}, num_trials=1)
+
+    names = {getattr(n, "name", n) for n in executed}
+    assert {"inner_a", "inner_b", "outer_c"} <= names, \
+        f"expected inner + outer nodes to fire NODE_EXECUTION, got {names}"
+
+
+@pytest.mark.composition
+def test_multi_node_execution_set_fires_per_node():
+    """When several nodes run in one execution set, each fires its own NODE_EXECUTION."""
+    m1 = pnl.TransferMechanism(name="par_m1")
+    m2 = pnl.TransferMechanism(name="par_m2")
+    comp = pnl.Composition(name="parallel", nodes=[m1, m2])
+
+    executed = []
+
+    def listener(category, locals_provider):
+        if category is BreakpointCategory.NODE_EXECUTION:
+            executed.append(locals_provider()["node"])
+
+    _debugger.set_listener(listener)
+    comp.run(inputs={m1: [[1.0]], m2: [[2.0]]}, num_trials=1)
+
+    names = {getattr(n, "name", n) for n in executed}
+    assert {"par_m1", "par_m2"} <= names
+
+
+@pytest.mark.composition
+def test_parameter_setting_fires_with_documented_payload():
+    """PARAMETER_SETTING fires during a run and carries parameter/owner/value/context."""
+    captured = []
+
+    def listener(category, locals_provider):
+        if category is BreakpointCategory.PARAMETER_SETTING and not captured:
+            captured.append(locals_provider())
+
+    m = pnl.TransferMechanism(name="ps_probe")
+    comp = pnl.Composition(name="ps_comp", nodes=[m])
+    _debugger.set_listener(listener)
+    comp.run(inputs={m: [[1.0]]}, num_trials=1)
+
+    assert captured, "PARAMETER_SETTING should fire during a run"
+    assert {"parameter", "owner", "value", "context"} <= captured[0].keys()
+
+
+@pytest.mark.llvm
+@pytest.mark.composition
+def test_compiled_mode_bypasses_python_execution_hooks():
+    """Compiled (LLVM) execution skips the Python scheduler loop, so the
+    fine-grained per-node hooks do not fire. Documents the hook's scope."""
+    pytest.importorskip("llvmlite")
+    m = pnl.TransferMechanism(name="llvm_m")
+    comp = pnl.Composition(name="llvm_comp", nodes=[m])
+
+    fired = []
+    _debugger.set_listener(lambda c, lp: fired.append(c))
+    try:
+        comp.run(inputs={m: [[1.0]]}, num_trials=1,
+                 execution_mode=pnl.ExecutionMode.LLVMRun)
+    except Exception:
+        pytest.skip("LLVM backend not runnable in this environment")
+
+    assert BreakpointCategory.NODE_EXECUTION not in fired, \
+        "compiled mode must not fire the Python per-node execution hook"
+    assert BreakpointCategory.EXECUTION_SET not in fired
+
+
+@pytest.mark.pytorch
+def test_pytorch_mode_fires_pytorch_step_not_python_node_hooks():
+    """AutodiffComposition.learn in PyTorch mode fires PYTORCH_STEP but bypasses
+    the Python per-node execution hooks."""
+    pytest.importorskip("torch")
+    i = pnl.TransferMechanism(name="ad_i")
+    o = pnl.TransferMechanism(name="ad_o")
+    ac = pnl.AutodiffComposition(name="ad_comp")
+    ac.add_linear_processing_pathway([i, o])
+
+    fired = []
+    _debugger.set_listener(lambda c, lp: fired.append(c))
+    ac.learn(
+        inputs={"inputs": {i: [[1.0]]}, "targets": {o: [[1.0]]}},
+        execution_mode=pnl.ExecutionMode.PyTorch,
+        epochs=1,
+    )
+
+    assert BreakpointCategory.PYTORCH_STEP in fired
+    assert BreakpointCategory.NODE_EXECUTION not in fired

--- a/tests/misc/test_debugger.py
+++ b/tests/misc/test_debugger.py
@@ -94,28 +94,156 @@ def test_categories_fire_during_composition_run():
         _debugger.set_listener(None)
 
     fired_categories = {cat for cat, _ in fired}
-    # These four must fire at least once for any non-trivial composition run.
+    # These must fire at least once for any non-trivial composition run.
     for required in (
+        BreakpointCategory.BEGINNING_OF_RUN,
         BreakpointCategory.BEGINNING_OF_TRIAL,
         BreakpointCategory.EXECUTION_SET,
+        BreakpointCategory.END_OF_EXECUTION_SET,
         BreakpointCategory.INPUTS_TO_NODE,
         BreakpointCategory.NODE_EXECUTION,
         BreakpointCategory.END_OF_TRIAL,
+        BreakpointCategory.END_OF_RUN,
     ):
         assert required in fired_categories, f"expected {required} to fire, got {fired_categories}"
 
     # Locals shape per category — informal schema check.
     for cat, locs in fired:
-        if cat is BreakpointCategory.BEGINNING_OF_TRIAL:
+        if cat is BreakpointCategory.BEGINNING_OF_RUN:
+            assert {"scheduler", "context", "num_trials"} <= locs.keys()
+        elif cat is BreakpointCategory.END_OF_RUN:
+            assert {"scheduler", "context", "results"} <= locs.keys()
+        elif cat is BreakpointCategory.BEGINNING_OF_TRIAL:
             assert {"trial_num", "scheduler", "context"} <= locs.keys()
         elif cat is BreakpointCategory.END_OF_TRIAL:
             assert {"trial_num", "scheduler", "context", "outputs"} <= locs.keys()
         elif cat is BreakpointCategory.EXECUTION_SET:
             assert {"execution_set", "scheduler", "context"} <= locs.keys()
+        elif cat is BreakpointCategory.END_OF_EXECUTION_SET:
+            assert {"execution_set", "scheduler", "context", "outputs"} <= locs.keys()
         elif cat is BreakpointCategory.INPUTS_TO_NODE:
             assert {"node", "execution_set", "scheduler", "context"} <= locs.keys()
         elif cat is BreakpointCategory.NODE_EXECUTION:
             assert {"node", "execution_set", "scheduler", "context"} <= locs.keys()
+
+
+def test_run_level_categories_fire_once_per_run():
+    """BEGINNING_OF_RUN and END_OF_RUN bracket all trial-level events, once each."""
+    fired = []
+    _debugger.set_listener(lambda c, lp: fired.append(c))
+
+    mech = pnl.TransferMechanism(name="T_run_bookends")
+    comp = pnl.Composition(name="comp_run_bookends")
+    comp.add_node(mech)
+    try:
+        comp.run(inputs={mech: [[1.0], [2.0], [3.0]]}, num_trials=3)
+    finally:
+        _debugger.set_listener(None)
+
+    assert fired.count(BreakpointCategory.BEGINNING_OF_RUN) == 1
+    assert fired.count(BreakpointCategory.END_OF_RUN) == 1
+
+    # All trial-level events must fall between the run-level bookends.
+    # (PARAMETER_SETTING can fire outside — composition setup/teardown
+    # mutates parameters before/after the run proper.)
+    begin_idx = fired.index(BreakpointCategory.BEGINNING_OF_RUN)
+    end_idx = fired.index(BreakpointCategory.END_OF_RUN)
+    assert begin_idx < end_idx
+
+    trial_level = {
+        BreakpointCategory.BEGINNING_OF_TRIAL,
+        BreakpointCategory.EXECUTION_SET,
+        BreakpointCategory.END_OF_EXECUTION_SET,
+        BreakpointCategory.INPUTS_TO_NODE,
+        BreakpointCategory.NODE_EXECUTION,
+        BreakpointCategory.END_OF_TRIAL,
+    }
+    for i, cat in enumerate(fired):
+        if cat in trial_level:
+            assert begin_idx < i < end_idx, \
+                f"{cat} at index {i} fell outside [{begin_idx}, {end_idx}]"
+
+
+def test_end_of_execution_set_reports_outputs():
+    """END_OF_EXECUTION_SET fires per set with freshly-computed output values."""
+    captured = []
+
+    def listener(category, locals_provider):
+        if category is BreakpointCategory.END_OF_EXECUTION_SET:
+            captured.append(locals_provider())
+
+    mech = pnl.TransferMechanism(name="T_end_of_set")
+    comp = pnl.Composition(name="comp_end_of_set")
+    comp.add_node(mech)
+
+    _debugger.set_listener(listener)
+    try:
+        comp.run(inputs={mech: [[2.0]]}, num_trials=1)
+    finally:
+        _debugger.set_listener(None)
+
+    assert captured, "END_OF_EXECUTION_SET should fire at least once"
+    locs = captured[0]
+    assert mech in locs["execution_set"]
+    assert mech in locs["outputs"]
+    # TransferMechanism with input 2.0 and default linear function returns [[2.0]].
+    assert locs["outputs"][mech][0][0] == 2.0
+
+
+def test_exception_category_fires_then_reraises():
+    """A failing node execution fires EXCEPTION and re-raises the original error."""
+    fired = []
+
+    def listener(category, locals_provider):
+        if category is BreakpointCategory.EXCEPTION:
+            fired.append(locals_provider())
+
+    class _ExplodingError(RuntimeError):
+        pass
+
+    # The custom function is also invoked during _instantiate_value at __init__,
+    # so we gate the explosion behind a flag flipped only just before run().
+    state = {"armed": False}
+
+    def maybe_explode(variable, context=None):
+        if state["armed"]:
+            raise _ExplodingError("boom")
+        return variable
+
+    mech = pnl.ProcessingMechanism(name="T_explode", function=maybe_explode)
+    comp = pnl.Composition(name="comp_explode")
+    comp.add_node(mech)
+
+    _debugger.set_listener(listener)
+    try:
+        state["armed"] = True
+        with pytest.raises(_ExplodingError, match="boom"):
+            comp.run(inputs={mech: [[1.0]]}, num_trials=1)
+    finally:
+        state["armed"] = False
+        _debugger.set_listener(None)
+
+    assert fired, "EXCEPTION category should have fired"
+    locs = fired[0]
+    assert isinstance(locs["exception"], _ExplodingError)
+    assert locs["trial_num"] == 0
+    assert {"scheduler", "context"} <= locs.keys()
+
+
+def test_no_exception_means_no_exception_category():
+    """A clean run must not fire EXCEPTION."""
+    fired = []
+    _debugger.set_listener(lambda c, lp: fired.append(c))
+
+    mech = pnl.TransferMechanism(name="T_clean")
+    comp = pnl.Composition(name="comp_clean")
+    comp.add_node(mech)
+    try:
+        comp.run(inputs={mech: [[1.0]]}, num_trials=1)
+    finally:
+        _debugger.set_listener(None)
+
+    assert BreakpointCategory.EXCEPTION not in fired
 
 
 def test_end_of_init_fires_on_component_creation():


### PR DESCRIPTION
# Add an internal `_debugger` execution hook

`psyneulink._debugger` — an opt-in hook to observe execution at well-defined boundaries without monkey-patching. One global listener; with none attached, `step()` is a single `is not None` check (zero cost, zero behavior change). Fills the inert `assert 'DEBUGGING BREAK POINT: ...'` markers already present in the execution path. Internal API (leading underscore); nothing opts in by default.

**Motivation:** it powers **PsyNeuView**'s enhanced run-stepping / value-inspection UX — an external consumer the surface has already stabilized against — so upstreaming lets any PsyNeuLink user attach a debugger / tracer / visualizer without monkey-patching.

**Purely additive** except the `EXCEPTION` category (one `try/except`, detailed below). Backward-compat is otherwise guaranteed by the existing test matrix passing unchanged. **6 files, +603 / −24** on `devel@fd4854b`.

```python
from psyneulink import _debugger

def listener(category, locals_provider):
    if category is _debugger.BreakpointCategory.NODE_EXECUTION:
        archive.snapshot(locals_provider())   # dict built only when consumed

_debugger.set_listener(listener)
composition.run(inputs)
_debugger.set_listener(None)
```

<details><summary><b>Design</b></summary>

- **Single listener**, not a multicast bus — consumers needing fan-out wrap callables themselves. Assignment is atomic in CPython (set at startup, clear at teardown), so no lock.
- **Lazy locals** — the per-category state dict is built only inside `locals_provider()`, so a listener that ignores a category pays nothing.
- **Internal API** — the leading underscore is deliberate; the surface may evolve until promoted to a public `psyneulink.debugger`.
</details>

<details><summary><b>Categories &amp; payloads</b></summary>

| Category | Locals keys | Fires at |
|---|---|---|
| `BEGINNING_OF_RUN` | scheduler, context, num_trials | start of `Composition.run` |
| `END_OF_RUN` | scheduler, context, results | end of `Composition.run` |
| `BEGINNING_OF_TRIAL` | trial_num, scheduler, context | per-trial boundary |
| `END_OF_TRIAL` | trial_num, scheduler, context, outputs | per-trial boundary |
| `EXECUTION_SET` | execution_set, scheduler, context | scheduler step |
| `END_OF_EXECUTION_SET` | execution_set, scheduler, context, outputs | scheduler step boundary |
| `INPUTS_TO_NODE` | node, execution_set, scheduler, context | pre-node-execute |
| `NODE_EXECUTION` | node, execution_set, scheduler, context | post-node-execute |
| `PARAMETER_SETTING` | parameter, owner, value, context | setter callsite |
| `EXCEPTION` | exception, scheduler, context, trial_num | trial-execution failure |
| `END_OF_INIT` | component | end of `Component.__init__` |
| `PYTORCH_STEP` | wrapper, composition | autodiff path |

Listeners key-check what they need; new categories can be added without breaking existing ones.
</details>

<details><summary><b>Execution-mode scope (tested)</b></summary>

The fine-grained per-node hooks live in the **Python** execution loop. Compiled and PyTorch execution bypass that loop:

| Mode | Fires |
|---|---|
| Python | all categories |
| Compiled (LLVM) | run bookends + `PARAMETER_SETTING` |
| PyTorch / autodiff | run bookends + `PARAMETER_SETTING` + `PYTORCH_STEP` |

Intentional and pinned by tests, so consumers know what to expect per mode.
</details>

<details><summary><b>Backward compatibility</b></summary>

Purely additive; zero behavioral change when no listener is attached. **The strongest guarantee is your own CI:** if these hooks perturbed execution, the existing composition/execution/mode matrix would fail — it passes unchanged. The hooks replace inert `assert 'DEBUGGING BREAK POINT: ...'` string-literal asserts already in the code, so several insertion points were pre-staked.
</details>

<details><summary><b>The one behavioral change — <code>EXCEPTION</code></b></summary>

Every hook is a bare additive `step()` call **except** `EXCEPTION`, which wraps the per-trial `Composition.execute()`:

```python
try:
    trial_output = self.execute(...)
except Exception as _debugger_exc:
    _debugger.step(_debugger.BreakpointCategory.EXCEPTION, lambda ...: {...})
    raise
```

Observe-then-re-raise: the original exception propagates unchanged (bare `raise`, traceback preserved). It catches `Exception`, not `BaseException`, so `KeyboardInterrupt`/`SystemExit`/`GeneratorExit` propagate without running listener code. Happy to split this category into a follow-up PR to keep this one strictly additive.
</details>

<details><summary><b>Tests</b></summary>

`tests/misc/test_debugger.py` — 15 tests, all passing, `ruff`/`pycodestyle` clean, marked `@composition`/`@llvm`/`@pytorch`:

- **Mechanics** — no-op when unattached, set/clear listener, lazy locals provider.
- **Firing + payloads** — all categories fire with the documented keys; run bookends fire once and bracket trial events.
- **Topologies** — nested Compositions fire hooks for inner nodes; multi-node execution sets fire per node.
- **Exception path** — `EXCEPTION` fires with the error + trial and re-raises; a clean run fires no false `EXCEPTION`.
- **Modes** — compiled and PyTorch bypass the Python per-node hooks (documents the scope above).
- **Non-perturbation** — a run with a recording listener produces byte-identical results to one without.
</details>

<details><summary><b>Files changed</b></summary>

| File | Change |
|---|---|
| `psyneulink/_debugger.py` | new module (+115) |
| `psyneulink/core/compositions/composition.py` | 8 execution hooks + the `EXCEPTION` wrapper |
| `psyneulink/core/globals/parameters.py` | `PARAMETER_SETTING` hook |
| `psyneulink/core/components/component.py` | `END_OF_INIT` hook |
| `psyneulink/library/compositions/pytorchwrappers.py` | `PYTORCH_STEP` hook |
| `tests/misc/test_debugger.py` | 15 tests (+390) |
</details>
