### PR TITLE
Require Python >= 3.11

### DIFF
--- a/.github/workflows/pnl-ci-docs.yml
+++ b/.github/workflows/pnl-ci-docs.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
         os: [ubuntu-latest, windows-latest, macos-latest]
         pnl-version: ['head']
         include:

--- a/.github/workflows/pnl-ci.yml
+++ b/.github/workflows/pnl-ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
         extra-args: ['']
         os: [ubuntu, macos, windows]
         version-restrict: ['']
@@ -45,12 +45,12 @@ jobs:
         include:
           # --forked run of python only tests
           # Python tests are enough to test potential naming issues
-          - python-version: '3.9'
+          - python-version: '3.11'
             os: ubuntu
             extra-args: '--forked -m "not llvm"'
 
-          # --benchmark-enable run on macos python 3.9
-          - python-version: '3.9'
+          # --benchmark-enable run on macos python 3.11
+          - python-version: '3.11'
             os: macos
             # pytest needs both '--benchmark-only' and '-m benchmark'
             # The former fails the test if benchmarks cannot be enabled
@@ -59,29 +59,26 @@ jobs:
             # https://github.com/ionelmc/pytest-benchmark/issues/243
             extra-args: '-m benchmark --benchmark-enable --benchmark-only --benchmark-min-rounds=2 --benchmark-max-time=0.001 --benchmark-warmup=off -n0 --dist=no'
 
-          # fp32 run on linux python 3.10
-          - python-version: '3.10'
+          # fp32 run on linux python 3.11
+          - python-version: '3.11'
             os: ubuntu
             extra-args: '--fp-precision=fp32'
 
-          # code-coverage run on macos python 3.10
-          - python-version: '3.10'
+          # code-coverage run on macos python 3.11
+          - python-version: '3.11'
             os: macos
             extra-args: '--cov=psyneulink'
 
-          # run without pytorch on windows python 3.10
-          - python-version: '3.10'
+          # run without pytorch on windows python 3.11
+          - python-version: '3.11'
             os: windows
             torch: 'notorch'
 
-          # add python 3.8 with deps restricted to min supported package versions
-          - python-version: '3.8'
+          # run on the minimum supported python with deps restricted
+          # to min supported package versions
+          - python-version: '3.11'
             os: macos
             version-restrict: 'min'
-
-        exclude:
-          - python-version: '3.8'
-            os: macos
 
     steps:
     # increased fetch-depth and tag checkout needed to get correct

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # Python version in matrix for easier reference
-        python-version: [3.8]
+        python-version: ['3.11']
     environment: test-pypi
     outputs:
       sdist: ${{ steps.create_dist.outputs.sdist }}
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
         os: [ubuntu-latest, macos-latest, windows-latest]
         dist: [wheel, sdist]
 

--- a/broken_trans_deps.txt
+++ b/broken_trans_deps.txt
@@ -4,10 +4,6 @@
 # https://github.com/microsoft/onnxruntime/issues/14663
 onnxruntime != 1.14.0; platform_system == 'Darwin'
 
-# ipython == 8.13.0 uses incorrect python requires and only works with 3.9+
-# https://github.com/ipython/ipython/issues/14053
-ipython != 8.13.0; python_version < '3.9'
-
 # onnx == 1.14.0 removed a helper function that is needed by skl2onnx
 # https://github.com/onnx/onnx/issues/5202
 onnx != 1.14.0
@@ -16,18 +12,9 @@ onnx != 1.14.0
 # but modeci_mdf that's available for python 3.11 doesn't do that.
 onnxruntime != 1.16; python_version == '3.11'
 
-# torch wheels for win32 python3.10 are built against numpy>=1.23
-# and it's not reported in their dependency lists
-# https://github.com/pytorch/pytorch/issues/100690
-torch !=2.0.1, !=2.0.0, !=1.13.*, !=1.12.*; python_version == '3.10' and platform_system == 'Windows'
-
 # cattrs==23.2.{1,2} breaks json serialization
 # https://github.com/python-attrs/cattrs/issues/453
 cattrs != 23.2.1, != 23.2.2
-
-# beartype 0.17.1 is broken on older releases of python3.9
-# https://github.com/beartype/beartype/issues/324
-beartype != 0.17.1; python_version == '3.9'
 
 # coverage 7.6.5 is broken
 # https://github.com/nedbat/coveragepy/issues/1891
@@ -37,11 +24,3 @@ coverage != 7.6.5
 # https://pypi.org/project/torch/2.3.0/#files
 # the last available version (2.2.2) doesn't work with Numpy2.0
 numpy < 2; platform_system == 'Darwin' and platform_machine == 'x86_64'
-
-# mistune-3.3.1 is broken on Python 3.8
-# https://github.com/lepture/mistune/issues/455
-mistune != 3.3.1; python_version == '3.8'
-
-# fastjsonschema-2.22.1 is broken on python 3.8/3.9
-# https://github.com/horejsek/python-fastjsonschema/issues/216
-fastjsonschema != 2.22.1; python_version == '3.9' or python_version == '3.8'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,16 +12,13 @@ authors = [
     { name = "Jonathan Cohen, Princeton University", email = "jdc@princeton.edu" },
 ]
 keywords = ["cognitive modeling"]
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -184,6 +181,10 @@ ignore = [
     "E501", "E713", "E721", "E722", "E731", "E741",
     "F401", "F403", "F405", "F521", "F523", "F524", "F525", "F541", "F601", "F602", "F722", "F811", "F821", "F841",
     "UP006", "UP008", "UP009", "UP015", "UP030", "UP032", "UP034",
+    # Raising requires-python to 3.11 raises ruff's inferred target-version,
+    # which activates these rules across the whole codebase. Deferred to a
+    # separate modernization pass to keep this change reviewable.
+    "UP007", "UP035", "UP042", "UP045",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ llvmlite>=0.40, <0.49
 matplotlib>=3.7.0, <3.11.2
 modeci_mdf>=0.4.3, <0.4.14; (platform_machine == 'AMD64' or platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
 networkx>=2.6, <3.7
-numpy>=1.21.0, <2.3.6
+numpy>=1.23.2, <2.3.6
 optuna>=3.1.0, <4.10.0
 packaging>=23.0, <27.0
 pandas>=2.0.0, <3.0.6
@@ -19,6 +19,6 @@ pint>=0.20, <0.26.0
 protobuf>=3.20.2, <7.35.2
 psutil>=5.9.0, <7.2.3
 rich>=10.7, <15.1
-scipy>=1.7.3, <1.19
+scipy>=1.9.2, <1.19
 toposort>=1.7, <1.11
-torch>=1.13.0, <2.14.0; (platform_machine == 'AMD64' or platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'
+torch>=2.0.0, <2.14.0; (platform_machine == 'AMD64' or platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64') and platform_python_implementation == 'CPython' and implementation_name == 'cpython'


### PR DESCRIPTION
Python 3.8 (EOL Oct 2024), 3.9 (EOL Oct 2025), and 3.10 are no longer supported. Testing them meant testing a substantially different program: resolving requirements.txt on 3.8 pinned numpy 1.24.4, scipy 1.10.1, and llvmlite 0.41.1, seven llvmlite releases behind what 3.11+ resolves to. The [dask] extra was already uninstallable on 3.8, since no dask >= 2024.1 supports it.

 - pyproject: requires-python >= 3.11, drop stale classifiers
 - CI: drop the 3.8 jobs; move the special-purpose 3.9/3.10 jobs (--forked, benchmarks, fp32, coverage, notorch, min-deps) to 3.11. The min-deps job moves off the excluded 3.8/macos slot, so the exclude list is now empty.
 - broken_trans_deps: drop the five constraints that only applied to the removed versions (ipython, torch/win-3.10, beartype, mistune, fastjsonschema)
 - requirements: raise floors that cannot install on 3.11. numpy 1.21.0 and scipy 1.7.3 have no cp311 wheels (scipy 1.8.0 caps at <3.11), and torch 1.13.0 ships a cp311 wheel only for manylinux x86_64, which the macos min-deps job needs.
 - ruff: requires-python drives ruff's target-version, so raising it turns on UP007/UP035/UP042/UP045 across the codebase (90 findings). Ignored here and left to a separate modernization pass.