### PR TITLE
Use SharedParameter for several EM/memory Parameters

### DIFF
--- a/psyneulink/core/components/functions/nonstateful/transformfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/transformfunctions.py
@@ -66,7 +66,11 @@ from psyneulink.core.globals.utilities import (
     is_numeric, is_matrix_keyword, is_numeric_scalar, np_array_less_than_2d, ValidParamSpecType)
 from psyneulink.core.globals.context import ContextFlags, handle_external_context
 from psyneulink.core.globals.parameters import (
-    Parameter, ParameterNoValueError, FunctionParameter, check_user_specified, copy_parameter_value)
+    FunctionParameter,
+    Parameter,
+    check_user_specified,
+    copy_parameter_value,
+)
 from psyneulink.core.globals.preferences.basepreferenceset import \
     REPORT_OUTPUT_PREF, ValidPrefSet, PreferenceEntry, PreferenceLevel
 
@@ -2366,11 +2370,10 @@ class MatrixMemory(TransformFunction): #
         #                                   function_parameter_name='operation',
         #                                   primary=True,
         #                                   stateful=True)
-        scores_metric = Parameter(DOT_PRODUCT, stateful=False)
-        normalize_memories = Parameter(True,
-                                       # getter = _normalize_memories_getter,
-                                       # setter = _normalize_memories_setter
-                                       )
+        scores_function = Parameter(MatrixTransform, stateful=False)
+        scores_function_matrix = FunctionParameter(None, function_name='scores_function', function_parameter_name='matrix')
+        scores_metric = FunctionParameter(DOT_PRODUCT, function_name='scores_function', function_parameter_name='operation', stateful=False)
+        normalize_memories = FunctionParameter(True, function_name='scores_function', function_parameter_name='normalize')
         # EM2 BREADCRUMB: MAKE THIS FunctionParameter??
         # normalize_memories = FunctionParameter(True,
         #                                        function_name='scores_function',
@@ -2408,11 +2411,6 @@ class MatrixMemory(TransformFunction): #
                  owner=None,
                  prefs:Optional[ValidPrefSet] = None):
 
-        self.scores_function = MatrixTransform(default_variable=default_variable[0], # MatrixTransform only uses query
-                                               operation=scores_metric,
-                                               normalize=normalize_memories,
-                                               matrix=memory.T)
-
         decay_rate = decay_rate or 0.0
         if decay_rate == AUTO:
             decay_rate = 1 / len(memory)
@@ -2420,7 +2418,8 @@ class MatrixMemory(TransformFunction): #
         super().__init__(
             default_variable=default_variable,
             memory=memory,
-            # scores_function=scores_function,
+            scores_function_matrix=memory.T,
+            scores_metric=scores_metric,
             normalize_memories=normalize_memories,
             decay_rate=decay_rate,
             storage_prob=storage_prob,
@@ -2451,6 +2450,9 @@ class MatrixMemory(TransformFunction): #
             raise FunctionError(f"The length of the 3rd item of variable for '{self.name}' should 1 "
                                 f"(index of weakest entry in memory), but got {len(variable[2])}.")
         return variable
+
+    def _parse_scores_function_variable(self, variable, context=None):  # noqa U100
+        return variable[0]  # MatrixTransform only uses query
 
     def _function(self,
                  variable:Optional[Union[list, np.array]]=None,
@@ -2519,22 +2521,7 @@ class MatrixMemory(TransformFunction): #
             scores_template = norms_template = np.zeros(len(memory))
             return scores_template, norms_template
 
-        try:
-            scores = self.scores_function(query, context)
-        except ParameterNoValueError:
-            # IMPLEMENTATION NOTE:
-            #   This is needed since _comput_scores() is called before _access_memory(),
-            #   so there are not yet entries in self.scores_function for matrix or normalize in the execution context;
-            #   therefore, call to self.scores_function() above raises the ParameterNoValueError.
-            self.scores_function.parameters.matrix._set(self.memory.T, context)
-            self.scores_function.parameters.normalize._set(self.normalize_memories, context)
-            # # For assignment to score_function (by way of setters)
-            # # EM2 BREADCRUMB: NOT CLEAR WHY, GIVEN SETTERS IT IS NOT ALREADY BEING SET
-            # #                 (ARE THEY GETTING ASSIGNED IN CALL TO EXECUTE?
-            # self.parameters.memory._set(memory, context)
-            # self.parameters.normalize_memories._set(self.normalize_memories, context)
-            scores = self.scores_function(query, context)
-
+        scores = self.scores_function(query, context)
         norms = np.linalg.norm(memory, axis=1)
 
         return scores, norms

--- a/psyneulink/library/components/mechanisms/modulatory/learning/EMstoragemechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/learning/EMstoragemechanism.py
@@ -215,14 +215,16 @@ def _memory_matrix_getter(owning_component=None, context=None) -> list:
     learning_signals_for_retrieved = owning_component.learning_signals[num_learning_signals - num_fields:]
 
     # Get memory from learning_signals that project to retrieved_nodes
-    if owning_component.is_initializing:
-        # If initializing, learning_signals are still MappingProjections used to specify them, so get from them
-        memory = [retrieved_learning_signal.parameters.matrix._get(context)
-                  for retrieved_learning_signal in learning_signals_for_retrieved]
-    else:
-        # Otherwise, get directly from the learning_signals
-        memory = [retrieved_learning_signal.efferents[0].receiver.owner.parameters.matrix._get(context)
-                  for retrieved_learning_signal in learning_signals_for_retrieved]
+    memory = []
+    for retrieved_learning_signal in learning_signals_for_retrieved:
+        try:
+            matrix = retrieved_learning_signal.efferents[0].receiver.owner.parameters.matrix._get(context)
+        except AttributeError:
+            # If initializing, learning_signals may still be MappingProjections used to specify them
+            # This shouldn't happen after initialization
+            assert owning_component.is_initializing
+            matrix = retrieved_learning_signal.parameters.matrix._get(context)
+        memory.append(matrix)
 
     # Get memory capacity from first length of first matrix (can use full set since might be ragged array)
     memory_capacity = len(memory[0])

--- a/psyneulink/library/components/mechanisms/processing/integrator/externalmemorymechanism.py
+++ b/psyneulink/library/components/mechanisms/processing/integrator/externalmemorymechanism.py
@@ -132,7 +132,8 @@ class ExternalMemoryMechanism(EpisodicMemoryMechanism):
                                           function_parameter_name='scores_metric',
                                           primary=True,
                                           stateful=False)
-        normalize_memories = Parameter(True, stateful=True, loggable=True)
+        memory = FunctionParameter(None, aliases='field_memory')
+        normalize_memories = FunctionParameter(True, stateful=True, loggable=True)
         # normalize_memories = FunctionParameter(True,
         #                                        BREADCRUMB:  THESE getter/setter MIGHT BE THE PROBLEM:
         #                                        # getter = _normalize_memories_getter,
@@ -147,7 +148,9 @@ class ExternalMemoryMechanism(EpisodicMemoryMechanism):
                                        function_parameter_name='decay_rate',
                                        primary=True,
                                        modulable=True,
-                                       stateful=True)
+                                       stateful=True,
+                                       dependencies=memory,
+                                       )
         storage_prob = FunctionParameter(1.0,
                                          function_name='function',
                                          function_parameter_name='storage_prob',
@@ -162,6 +165,13 @@ class ExternalMemoryMechanism(EpisodicMemoryMechanism):
                 return None
             if not is_numeric_scalar(decay_rate) or not 0 <= decay_rate <= 1:
                 return "must be a float in the interval [0, 1]."
+
+        def _parse_decay_rate(self, decay_rate):
+            if decay_rate == AUTO:
+                if self._owner.defaults.memory is not None:
+                    # not catching div0 error on purpose (unexpected input)
+                    return 1 / len(self._owner.defaults.memory)
+            return decay_rate
 
     @check_user_specified
     def __init__(
@@ -197,17 +207,6 @@ class ExternalMemoryMechanism(EpisodicMemoryMechanism):
             np.zeros(1),
         ], dtype=object)
 
-        function = MatrixMemory(default_variable=default_variable,
-                                memory=field_memory,
-                                normalize_memories=normalize_memories,
-                                scores_metric=scores_metric,
-                                decay_rate=decay_rate,
-                                storage_prob=storage_prob,
-                                params=params,
-                                owner=self,
-                                prefs=prefs
-                                )
-
         # EM2 BREADCRUMB: MOVE THESE BACK INTO _instantiate_<input/output>_ports():
         input_ports = [{NAME: QUERY, VARIABLE: np.zeros(field_shape)},
                        {NAME: COMBINED_SCORES, VARIABLE: np.zeros(self.memory_capacity)},
@@ -224,8 +223,11 @@ class ExternalMemoryMechanism(EpisodicMemoryMechanism):
             input_ports=input_ports,
             output_ports=output_ports,
             # EM2 BREADCRUMB END
-            function=function,
             # distance_function=distance_function,
+            decay_rate=decay_rate,
+            storage_prob=storage_prob,
+            normalize_memories=normalize_memories,
+            scores_metric=scores_metric,
             memory=field_memory,
             params=params,
             name=name,


### PR DESCRIPTION
`MatrixMemory.scores_function` context workaround will stop working in >2d changes