### PR TITLE
treewide: Prefer ravel() instead of flatten()

### DIFF
--- a/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
+++ b/psyneulink/core/components/functions/nonstateful/optimizationfunctions.py
@@ -2136,8 +2136,7 @@ class GridSearch(OptimizationFunction):
 
                 # Find the optimal value(s)
                 optimal_value_count = 1
-                value_sample_pairs = zip(all_values.flatten(),
-                                         [all_samples[:,i] for i in range(all_samples.shape[1])])
+                value_sample_pairs = zip(all_values.ravel(), [all_samples[:,i] for i in range(all_samples.shape[1])])
                 optimal_value, optimal_sample = next(value_sample_pairs)
 
                 # The algorithm below implements "Reservoir sampling"[0]. This

--- a/psyneulink/core/compositions/parameterestimationcomposition.py
+++ b/psyneulink/core/compositions/parameterestimationcomposition.py
@@ -731,7 +731,7 @@ class ParameterEstimationComposition(Composition):
 
                 # If the include mask is 2D, make it 1D
                 if likelihood_include_mask.ndim == 2:
-                    likelihood_include_mask = likelihood_include_mask.flatten()
+                    likelihood_include_mask = likelihood_include_mask.ravel()
 
                 self.likelihood_include_mask = likelihood_include_mask
 

--- a/psyneulink/core/globals/parameters.py
+++ b/psyneulink/core/globals/parameters.py
@@ -2025,7 +2025,7 @@ class Parameter(ParameterBase, metaclass=_ParameterMeta):
                         context=execution_id,
                         value=ndArray(
                             shape=list(value.shape),
-                            data=list(value.flatten())
+                            data=list(value.ravel())
                         )
                     )
                 )

--- a/psyneulink/library/components/mechanisms/modulatory/learning/EMstoragemechanism.py
+++ b/psyneulink/library/components/mechanisms/modulatory/learning/EMstoragemechanism.py
@@ -682,7 +682,7 @@ class EMStorageMechanism(LearningMechanism):
         for i, learning_signal in enumerate(learning_signals[:num_match_fields]):
             learning_signal_shape = learning_signal.parameters.matrix._get(context).shape
             if concatenate_queries:
-                memory_matrix_field_shape = np.array([np.concatenate(row, dtype=object).flatten()
+                memory_matrix_field_shape = np.array([np.concatenate(row, dtype=object).ravel()
                                                       for row in memory_matrix[:, 0:num_keys]]).T.shape
             else:
                 memory_matrix_field_shape = np.array(memory_matrix[:, key_indices[i]].tolist()).T.shape

--- a/tests/composition/test_autodiffcomposition.py
+++ b/tests/composition/test_autodiffcomposition.py
@@ -2868,9 +2868,7 @@ class TestNestedNoLearning:
 
         # -----------------------------------------------------------------
 
-        xor_autodiff = AutodiffComposition(
-            learning_rate=learning_rate,
-        )
+        xor_autodiff = AutodiffComposition(learning_rate=learning_rate)
 
         xor_autodiff.add_node(xor_in)
         xor_autodiff.add_node(xor_hid)
@@ -2887,15 +2885,20 @@ class TestNestedNoLearning:
         parentComposition = pnl.Composition()
         parentComposition.add_node(xor_autodiff)
 
-        input = {xor_autodiff: input_dict}
         no_training_input = {xor_autodiff: no_training_input_dict}
 
         learning_context = Context()
-        xor_autodiff.learn(inputs=input_dict, execution_mode=autodiff_mode, epochs=num_epochs, context=learning_context, patience=patience, min_delta=min_delta)
-        result1 = np.array(xor_autodiff.learning_results).flatten()
-        np.testing.assert_allclose(result1, np.array(xor_targets).flatten(), atol=0.1)
-        result2 = parentComposition.run(inputs=no_training_input, execution_mode=autodiff_mode, context=learning_context)
+        xor_autodiff.learn(inputs=input_dict,
+                           execution_mode=autodiff_mode,
+                           epochs=num_epochs,
+                           context=learning_context,
+                           patience=patience,
+                           min_delta=min_delta)
 
+        result1 = np.array(xor_autodiff.learning_results).ravel()
+        np.testing.assert_allclose(result1, np.array(xor_targets).ravel(), atol=0.1)
+
+        result2 = parentComposition.run(inputs=no_training_input, execution_mode=autodiff_mode, context=learning_context)
         np.testing.assert_allclose(result2, [[0]], atol=0.1)
 
     @pytest.mark.parametrize(

--- a/tests/composition/test_control.py
+++ b/tests/composition/test_control.py
@@ -2464,7 +2464,7 @@ class TestControlMechanisms:
         ret = comp.run(inputs={mech: [2]}, num_trials=1, execution_mode=comp_mode)
         np.testing.assert_allclose(ret, expected)
         if comp_mode is pnl.ExecutionMode.Python:
-            np.testing.assert_allclose(comp.controller.function.saved_values.flatten(), exp_values)
+            np.testing.assert_allclose(comp.controller.function.saved_values.ravel(), exp_values)
 
     @pytest.mark.benchmark
     @pytest.mark.control
@@ -3354,7 +3354,7 @@ class TestModelBasedOptimizationControlMechanisms_Execution:
 
         np.testing.assert_array_equal(results, result)
         if mode is pnl.ExecutionMode.Python:
-            np.testing.assert_array_equal(saved_values.flatten(), [0.75, 1.5, 2.25])
+            np.testing.assert_array_equal(saved_values.ravel(), [0.75, 1.5, 2.25])
 
     def test_model_based_ocm_with_buffer(self):
 

--- a/tests/composition/test_emcomposition.py
+++ b/tests/composition/test_emcomposition.py
@@ -149,7 +149,7 @@ class TestConstruction:
             params.update({'softmax_gain': softmax_gain})
 
         em = EMComposition(**params)
-        assert np.hstack(np.array(em.memory, dtype=object).flatten()).size < 30
+        assert np.hstack(np.array(em.memory, dtype=object).ravel()).size < 30
 
         # Validate basic structure
         assert len(em.memory) == memory_capacity

--- a/tests/models/test_greedy_agent.py
+++ b/tests/models/test_greedy_agent.py
@@ -230,7 +230,7 @@ def test_predator_prey(benchmark, mode, ocm_mode, prng, samples, fp_type):
             # FIXME: The results are 'close' for both Philox and MT,
             #        because they're dominated by costs
             # FIX: Requires 1e-5 tolerance
-            np.testing.assert_allclose(np.asarray(ocm.function.saved_values).flatten(),
+            np.testing.assert_allclose(np.asarray(ocm.function.saved_values).ravel(),
                                        [-2.66258741, -22027.9970321, -22028.17515945, -44053.59867802,
                                         -22028.06045185, -44053.4048842, -44053.40736234, -66078.90687915],
                                        rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
Unless flatten()'s copying semantics are required.